### PR TITLE
src: cpu: x64: jit_brdgmm_dw_conw: make brdgmm support fusing sum op

### DIFF
--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -152,8 +152,8 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
     VDISPATCH_CONV(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
     VDISPATCH_CONV(
             (isa != isa_undef) && mayiuse(isa), "undefined or unsupported isa");
-    VDISPATCH_CONV(
-            attr()->has_default_values(skip_mask), VERBOSE_UNSUPPORTED_ATTR);
+    VDISPATCH_CONV(attr()->has_default_values(skip_mask, dst_type),
+            VERBOSE_UNSUPPORTED_ATTR);
 
     auto &jcp = jcp_;
 


### PR DESCRIPTION
Brdgmm kernel could not be selected when using the **--attr-post-ops=sum** flag. jit_dw was used instead.
This PR makes it possible to use brdgmm kernel with **sum post-op**

The changes look trivial, In fact, there was already support, but brdgmm could not be dispatched because the function(has_default_values) signature was updated a long time ago but the function call was not updated. As a result, data_type_undef was always used inside, which prevented the brdgmm kernel from being selected