### PR TITLE
[WIP] cpu: binary: add post-ops support for binary select op

### DIFF
--- a/include/oneapi/dnnl/dnnl.h
+++ b/include/oneapi/dnnl/dnnl.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -736,6 +736,28 @@ dnnl_status_t DNNL_API dnnl_post_ops_get_params_dw(
 dnnl_status_t DNNL_API dnnl_post_ops_append_binary(dnnl_post_ops_t post_ops,
         dnnl_alg_kind_t alg_kind, const_dnnl_memory_desc_t src1_desc);
 
+/// Appends a binary post-op with ternary operators.
+///
+/// The kind of this post operation is #dnnl_binary.
+///
+/// In the simplest case when the binary is the only post operation, the
+/// computations would be:
+///
+///     dst[:] <- binary_op (dst[:], another_input1[:], another_input2[:])
+///
+/// where binary_op is configured with the given parameters. binary_op supports
+/// broadcast semantics for a second operand.
+///
+/// @param post_ops Post-ops.
+/// @param alg_kind Binary algorithm for the post-op.
+/// @param src1_desc Memory descriptor of a second operand.
+/// @param src2_desc Memory descriptor of a third operand (for ternary operators).
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_binary_v2(dnnl_post_ops_t post_ops,
+        dnnl_alg_kind_t alg_kind, const_dnnl_memory_desc_t src1_desc,
+        const_dnnl_memory_desc_t src2_desc);
+
 /// Returns the parameters of a binary post-op.
 ///
 /// @param post_ops Post-ops.
@@ -749,6 +771,22 @@ dnnl_status_t DNNL_API dnnl_post_ops_append_binary(dnnl_post_ops_t post_ops,
 dnnl_status_t DNNL_API dnnl_post_ops_get_params_binary(
         const_dnnl_post_ops_t post_ops, int index, dnnl_alg_kind_t *alg_kind,
         const_dnnl_memory_desc_t *src1_desc);
+
+/// Returns the parameters of a binary post-op with ternary operators.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the binary post-op.
+/// @param alg_kind Output binary algorithm kind.
+/// @param src1_desc Output memory descriptor of a second operand.
+/// @param src2_desc Output emory descriptor of a third operand.
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+/// @returns #dnnl_invalid_arguments if @p index does not refer to a binary
+///     post-op.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_binary_v2(
+        const_dnnl_post_ops_t post_ops, int index, dnnl_alg_kind_t *alg_kind,
+        const_dnnl_memory_desc_t *src1_desc,
+        const_dnnl_memory_desc_t *src2_desc);
 
 /// Appends a prelu forward post-op.
 ///

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -3859,9 +3859,35 @@ struct post_ops : public handle<dnnl_post_ops_t> {
     /// @param aalgorithm Binary algorithm for the post-op.
     /// @param src1_desc Memory descriptor of a second operand.
     void append_binary(algorithm aalgorithm, const memory::desc &src1_desc) {
-        error::wrap_c_api(dnnl_post_ops_append_binary(get(),
-                                  convert_to_c(aalgorithm), src1_desc.get()),
+        error::wrap_c_api(
+                dnnl_post_ops_append_binary_v2(get(), convert_to_c(aalgorithm),
+                        src1_desc.get(), nullptr),
                 "could not append a binary post-op");
+    }
+
+    /// Appends a binary post-op with ternary operators.
+    ///
+    /// The kind of this post operation is #dnnl_binary.
+    ///
+    /// In the simplest case when this is the only post operation, the
+    /// computations would be:
+    ///
+    ///     dst[:] <- binary_op (dst[:], another_input1[:], another_input2[:])
+    ///
+    /// where binary_op is configured with the given parameters. binary_op
+    /// supports broadcast semantics only for the second operand and not for the
+    /// third operand.
+    ///
+    /// @param aalgorithm Binary algorithm for the post-op.
+    /// @param src1_desc Memory descriptor of the second operand.
+    /// @param src2_desc Memory descriptor of the third operand.
+
+    void append_binary(algorithm aalgorithm, const memory::desc &src1_desc,
+            const memory::desc &src2_desc) {
+        error::wrap_c_api(
+                dnnl_post_ops_append_binary_v2(get(), convert_to_c(aalgorithm),
+                        src1_desc.get(), src2_desc.get()),
+                "could not append a binary post-op with ternary operators");
     }
 
     /// Returns the parameters of a binary post-op.
@@ -3873,14 +3899,41 @@ struct post_ops : public handle<dnnl_post_ops_t> {
             int index, algorithm &aalgorithm, memory::desc &src1_desc) const {
         dnnl_alg_kind_t c_alg;
         const_dnnl_memory_desc_t cdesc;
-        error::wrap_c_api(
-                dnnl_post_ops_get_params_binary(get(), index, &c_alg, &cdesc),
+        error::wrap_c_api(dnnl_post_ops_get_params_binary_v2(
+                                  get(), index, &c_alg, &cdesc, nullptr),
                 "could not get parameters of a binary post-op");
         aalgorithm = static_cast<dnnl::algorithm>(c_alg);
         dnnl_memory_desc_t cloned_md = nullptr;
         error::wrap_c_api(dnnl_memory_desc_clone(&cloned_md, cdesc),
                 "could not clone a memory descriptor");
         src1_desc = memory::desc(cloned_md);
+    }
+
+    /// Returns the parameters of a binary post-op with ternary operators.
+    ///
+    /// @param index Index of the binary post-op.
+    /// @param aalgorithm Output binary algorithm kind.
+    /// @param src1_desc Output memory descriptor of the second operand.
+    /// @param src2_desc Output memory descriptor of the third operand.
+    void get_params_binary(int index, algorithm &aalgorithm,
+            memory::desc &src1_desc, memory::desc &src2_desc) const {
+        dnnl_alg_kind_t c_alg;
+        const_dnnl_memory_desc_t cdesc1, cdesc2;
+        error::wrap_c_api(dnnl_post_ops_get_params_binary_v2(
+                                  get(), index, &c_alg, &cdesc1, &cdesc2),
+                "could not get parameters of a binary post-op with ternary "
+                "operators");
+        aalgorithm = static_cast<dnnl::algorithm>(c_alg);
+        dnnl_memory_desc_t cloned_md1 = nullptr;
+        dnnl_memory_desc_t cloned_md2 = nullptr;
+
+        error::wrap_c_api(dnnl_memory_desc_clone(&cloned_md1, cdesc1),
+                "could not clone a memory descriptor");
+        src1_desc = memory::desc(cloned_md1);
+
+        error::wrap_c_api(dnnl_memory_desc_clone(&cloned_md2, cdesc2),
+                "could not clone a memory descriptor");
+        src2_desc = memory::desc(cloned_md2);
     }
 
     /// Appends a prelu forward post-op.

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -252,14 +252,17 @@ status_t post_ops_t::append_dw(data_type_t wei_dt, data_type_t bias_dt,
     return success;
 }
 
-status_t post_ops_t::validate_binary(
-        alg_kind_t alg, const memory_desc_t *user_src1_desc) const {
+status_t post_ops_t::validate_binary(alg_kind_t alg,
+        const memory_desc_t *user_src1_desc,
+        const memory_desc_t *user_src2_desc) const {
 
     if (len() == post_ops_limit) return out_of_memory;
     using namespace alg_kind;
     bool alg_ok = one_of(alg, binary_add, binary_mul, binary_max, binary_min,
             binary_div, binary_sub, binary_ge, binary_gt, binary_le, binary_lt,
-            binary_eq, binary_ne);
+            binary_eq, binary_ne, binary_select);
+    bool is_ternary_op = (alg == binary_select);
+
     if (!alg_ok) return invalid_arguments;
     if (!memory_desc_sanity_check(*user_src1_desc)) return invalid_arguments;
 
@@ -269,34 +272,62 @@ status_t post_ops_t::validate_binary(
             return invalid_arguments;
     }
 
+    // Additional checks if the algorithm involves ternary inputs
+    if (is_ternary_op) {
+        if (!memory_desc_sanity_check(*user_src2_desc))
+            return invalid_arguments;
+        for (int d = 0; d < user_src2_desc->ndims; ++d) {
+            if (user_src2_desc->dims[d] == DNNL_RUNTIME_DIM_VAL)
+                return invalid_arguments;
+        }
+    } else {
+        if (user_src2_desc != nullptr) return invalid_arguments;
+    }
+
     return success;
 }
 
-status_t post_ops_t::append_binary(
-        alg_kind_t alg, const memory_desc_t *user_src1_desc) {
-    auto status = validate_binary(alg, user_src1_desc);
+status_t post_ops_t::append_binary(alg_kind_t alg,
+        const memory_desc_t *user_src1_desc,
+        const memory_desc_t *user_src2_desc) {
+    auto status = validate_binary(alg, user_src1_desc, user_src2_desc);
     if (status != success) return status;
 
     entry_.emplace_back();
     auto &e = entry_.back();
     e.kind = primitive_kind::binary;
     e.binary.alg = alg;
+    e.binary.is_ternary_op = (alg == alg_kind::binary_select);
+
     e.binary.user_src1_desc = *user_src1_desc;
     e.binary.src1_desc = *user_src1_desc;
+
+    if (e.binary.is_ternary_op) {
+        e.binary.user_src2_desc = *user_src2_desc;
+        e.binary.src2_desc = *user_src2_desc;
+    }
     return success;
 }
 
-status_t post_ops_t::prepend_binary(
-        alg_kind_t alg, const memory_desc_t *user_src1_desc) {
-    auto status = validate_binary(alg, user_src1_desc);
+status_t post_ops_t::prepend_binary(alg_kind_t alg,
+        const memory_desc_t *user_src1_desc,
+        const memory_desc_t *user_src2_desc) {
+    auto status = validate_binary(alg, user_src1_desc, user_src2_desc);
     if (status != success) return status;
 
     entry_.emplace(entry_.begin());
     auto &e = entry_[0];
     e.kind = primitive_kind::binary;
     e.binary.alg = alg;
+    e.binary.is_ternary_op = (alg == alg_kind::binary_select);
+
     e.binary.user_src1_desc = *user_src1_desc;
     e.binary.src1_desc = *user_src1_desc;
+
+    if (e.binary.is_ternary_op) {
+        e.binary.user_src2_desc = *user_src2_desc;
+        e.binary.src2_desc = *user_src2_desc;
+    }
     return success;
 }
 
@@ -316,17 +347,32 @@ status_t post_ops_t::set_default_formats(const memory_desc_t *dst_md) {
 
         auto &src1_md = entry_[idx].binary.src1_desc;
         const memory_desc_wrapper src1_mdw(src1_md);
-        if (!src1_mdw.format_any()) continue;
 
         const memory_desc_wrapper dst_mdw(dst_md);
-        assert(!dst_mdw.format_any());
 
         // 1D tensors should be plain abx.
-        if (src1_mdw.count_non_unit_dims(1))
-            CHECK(memory_desc_init_by_strides(src1_md, nullptr));
-        else
-            CHECK(memory_desc_init_by_blocking_desc(
-                    src1_md, dst_mdw.blocking_desc()));
+        if (src1_mdw.format_any()) {
+            assert(!dst_mdw.format_any());
+
+            if (src1_mdw.count_non_unit_dims(1))
+                CHECK(memory_desc_init_by_strides(src1_md, nullptr));
+            else
+                CHECK(memory_desc_init_by_blocking_desc(
+                        src1_md, dst_mdw.blocking_desc()));
+        }
+
+        auto &src2_md = entry_[idx].binary.src2_desc;
+        const memory_desc_wrapper src2_mdw(src2_md);
+
+        if (entry_[idx].binary.is_ternary_op && src2_mdw.format_any()) {
+            assert(!dst_mdw.format_any());
+
+            if (src1_mdw.count_non_unit_dims(1))
+                CHECK(memory_desc_init_by_strides(src2_md, nullptr));
+            else
+                CHECK(memory_desc_init_by_blocking_desc(
+                        src2_md, dst_mdw.blocking_desc()));
+        }
     }
 
     return status::success;
@@ -737,6 +783,14 @@ status_t dnnl_post_ops_append_binary(post_ops_t *post_ops, alg_kind_t alg_kind,
     return post_ops->append_binary(alg_kind, user_src1_desc);
 }
 
+status_t dnnl_post_ops_append_binary_v2(post_ops_t *post_ops,
+        alg_kind_t alg_kind, const memory_desc_t *user_src1_desc,
+        const memory_desc_t *user_src2_desc) {
+    if (post_ops == nullptr) return invalid_arguments;
+
+    return post_ops->append_binary(alg_kind, user_src1_desc, user_src2_desc);
+}
+
 status_t dnnl_post_ops_get_params_binary(const post_ops_t *post_ops, int index,
         alg_kind_t *alg_kind, const memory_desc_t **user_src1_desc) {
     if (!simple_get_params_check(post_ops, index, primitive_kind::binary))
@@ -745,6 +799,20 @@ status_t dnnl_post_ops_get_params_binary(const post_ops_t *post_ops, int index,
     const auto &b = post_ops->entry_[index].binary;
     if (alg_kind) *alg_kind = b.alg;
     if (user_src1_desc) *user_src1_desc = &b.user_src1_desc;
+
+    return success;
+}
+
+status_t dnnl_post_ops_get_params_binary_v2(const post_ops_t *post_ops,
+        int index, alg_kind_t *alg_kind, const memory_desc_t **user_src1_desc,
+        const memory_desc_t **user_src2_desc) {
+    if (!simple_get_params_check(post_ops, index, primitive_kind::binary))
+        return invalid_arguments;
+
+    const auto &b = post_ops->entry_[index].binary;
+    if (alg_kind) *alg_kind = b.alg;
+    if (user_src1_desc) *user_src1_desc = &b.user_src1_desc;
+    if (user_src2_desc) *user_src2_desc = &b.user_src2_desc;
 
     return success;
 }

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -305,14 +305,16 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
         };
 
         struct binary_t {
+            bool is_ternary_op;
             dnnl::impl::alg_kind_t alg;
             // This is an unmodifiable user copy of attributes which is used in
             // caching mechanism. Not to be used internally.
-            dnnl::impl::memory_desc_t user_src1_desc;
+            dnnl::impl::memory_desc_t user_src1_desc, user_src2_desc;
+
             // This is a modifiable copy of memory desc. It changes format kind
             // and tag of md in case user passed format_kind::any. To be used
             // everywhere internally.
-            dnnl::impl::memory_desc_t src1_desc;
+            dnnl::impl::memory_desc_t src1_desc, src2_desc;
         };
 
         struct prelu_t {
@@ -429,11 +431,13 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
             dnnl::impl::dim_t kernel_size, dnnl::impl::dim_t stride_size,
             dnnl::impl::dim_t padding_l_size);
     dnnl::impl::status_t append_binary(dnnl::impl::alg_kind_t alg,
-            const dnnl::impl::memory_desc_t *user_src1_desc);
+            const dnnl::impl::memory_desc_t *user_src1_desc,
+            const dnnl::impl::memory_desc_t *user_src2_desc = nullptr);
     dnnl::impl::status_t append_prelu(int mask);
 
     dnnl::impl::status_t prepend_binary(dnnl::impl::alg_kind_t alg,
-            const dnnl::impl::memory_desc_t *user_src1_desc);
+            const dnnl::impl::memory_desc_t *user_src1_desc,
+            const dnnl::impl::memory_desc_t *user_src2_desc = nullptr);
 
     int find(dnnl::impl::primitive_kind_t kind, int start = 0,
             int stop = -1) const {
@@ -507,7 +511,8 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
 
 private:
     dnnl::impl::status_t validate_binary(dnnl::impl::alg_kind_t alg,
-            const dnnl::impl::memory_desc_t *user_src1_desc) const;
+            const dnnl::impl::memory_desc_t *user_src1_desc,
+            const dnnl::impl::memory_desc_t *user_src2_desc = nullptr) const;
 
     bool check_sum_consistent_dt(const dnnl::impl::data_type_t dst_dt,
             const bool diverse_sum_dt_allowed = false) const;

--- a/src/cpu/primitive_attr_postops.cpp
+++ b/src/cpu/primitive_attr_postops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -306,11 +306,25 @@ void ref_post_ops_t::execute(float &res, const args_t &args) const {
 
                 const auto off = get_binary_src1_off(
                         src1_desc, args.l_offset, dst_d.dims(), dst_d.ndims());
+
                 const auto src1_binary_po = CTX_IN_MEM(const void *,
                         (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1));
+                const auto src2_binary_po = CTX_IN_MEM(const void *,
+                        (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2));
+
+                bool src2_val = false;
+                if (e.binary.is_ternary_op) {
+                    const auto &src2_desc = e.binary.src2_desc;
+                    const auto src2_off = get_binary_src1_off(src2_desc,
+                            args.l_offset, dst_d.dims(), dst_d.ndims());
+                    src2_val = static_cast<bool>(io::load_int_value(
+                            src2_desc.data_type, src2_binary_po, src2_off));
+                }
+
                 const float val_po = io::load_float_value(
                         src1_desc.data_type, src1_binary_po, off);
-                res = it_binary_po->compute_scalar(res, val_po, false);
+
+                res = it_binary_po->compute_scalar(res, val_po, src2_val);
                 ++it_binary_po;
             } break;
             case primitive_kind::prelu: {

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -323,6 +323,7 @@ struct attr_t {
 
                 dnnl_alg_kind_t alg = dnnl_alg_kind_undef;
                 dnnl_data_type_t src1_dt = dnnl_data_type_undef;
+                dnnl_data_type_t src2_dt = dnnl_data_type_undef;
                 policy_t policy = policy_t::COMMON;
                 int64_t mask = -1;
                 mask_input_t mask_input = mask_input_t::none;
@@ -336,6 +337,7 @@ struct attr_t {
             bool is_convolution_kind() const;
             bool is_eltwise_kind() const;
             bool is_binary_kind() const;
+            bool is_binary_kind_with_ternary_op() const;
             bool is_prelu_kind() const;
         };
 

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1722,15 +1722,25 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
                     = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE - 1;
             assert(bin_po_idx < attr.post_ops.len());
             const auto alg = attr.post_ops.entry[bin_po_idx].kind;
+            const bool is_src2_mem
+                    = ((exec_arg & DNNL_ARG_SRC_2) == DNNL_ARG_SRC_2);
+
             // Binary post-op filling.
-            fill_cfg_t def_binary_cfg(mem.dt(), -16.f, 16.f, /* int = */ true,
-                    alg, "def_binary_post_op");
-            const auto it = fill_cfg_map.find(DNNL_ARG_SRC_1);
-            const bool has_external_cfg = it != fill_cfg_map.end();
-            const fill_cfg_t &binary_fill_cfg
-                    = has_external_cfg ? (*it).second : def_binary_cfg;
-            TIME_FILL(SAFE(fill_random_real(mem, ref_mem, res, binary_fill_cfg),
-                    WARN));
+            if (!is_src2_mem
+                    || attr.post_ops.entry[bin_po_idx]
+                               .is_binary_kind_with_ternary_op()) {
+                const int f_min = is_src2_mem ? 0 : -16.f;
+                fill_cfg_t def_binary_cfg(mem.dt(), f_min, 16.f,
+                        /* int = */ true, alg, "def_binary_post_op");
+                const auto it = fill_cfg_map.find(
+                        is_src2_mem ? DNNL_ARG_SRC_2 : DNNL_ARG_SRC_1);
+                const bool has_external_cfg = it != fill_cfg_map.end();
+                const fill_cfg_t &binary_fill_cfg
+                        = has_external_cfg ? (*it).second : def_binary_cfg;
+                TIME_FILL(SAFE(
+                        fill_random_real(mem, ref_mem, res, binary_fill_cfg),
+                        WARN));
+            }
         } else if (exec_arg & DNNL_ARG_WEIGHTS) {
             // Prelu post-op filling.
             fill_cfg_t def_prelu_fill_cfg(mem.dt(), -2.f, 2.f, /* int = */ true,

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -868,9 +868,13 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
     for (int idx = 0; idx < dnnl_post_ops_len(const_po); ++idx) {
         if (dnnl_post_ops_get_kind(const_po, idx) != dnnl_binary) continue;
 
-        int po_arg = DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1;
-        const auto &po_md = query_md(const_pd, po_arg);
-        mem_map.emplace(po_arg, dnn_mem_t(po_md, test_engine));
+        int po_arg1 = DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1;
+        const auto &po_md1 = query_md(const_pd, po_arg1);
+        mem_map.emplace(po_arg1, dnn_mem_t(po_md1, test_engine));
+
+        int po_arg2 = DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2;
+        const auto &po_md2 = query_md(const_pd, po_arg2);
+        mem_map.emplace(po_arg2, dnn_mem_t(po_md2, test_engine));
     }
 
     // Prelu post-op.

--- a/tests/benchdnn/self/common.cpp
+++ b/tests/benchdnn/self/common.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -217,6 +217,9 @@ attr_t::post_ops_t parse_attr_post_ops_func(const std::string &s) {
         } else if (e.is_binary_kind()) {
             const auto dt_str = get_substr(subs, subs_pos, ':');
             e.binary.src1_dt = str2dt(dt_str.c_str());
+
+            if (e.is_binary_kind_with_ternary_op()) e.binary.src2_dt = dnnl_s8;
+
             if (e.binary.src1_dt == dnnl_data_type_undef) {
                 BENCHDNN_PRINT(0, "%s \'%s\' %s\n",
                         "Error: binary post-op data type", dt_str.c_str(),


### PR DESCRIPTION
(WORK IN PROGRESS - DO NOT REVIEW)

# Description

The PR adds updates post-ops implementations so that they support binary select operation as a  post-op. The updates accounts for the third conditional input that the select op requires for computation.

Implements MFDNN-12883.