### PR TITLE
[GPU] Improve reference kernel coverage.

### DIFF
--- a/src/gpu/intel/ocl/gen9_pooling.cl
+++ b/src/gpu/intel/ocl/gen9_pooling.cl
@@ -165,12 +165,12 @@ __kernel void gen9_pooling_fwd(__global DATA_T *src, __global int *ws,
 #endif // ALG_AVG_P
 
 #if ALG_AVG_NP
-    const off_t id_start = max(od * SD - PD, 0);
-    const off_t ih_start = max(oh * SH - PH, 0);
-    const off_t iw_start = max(ow * SW - PW, 0);
-    const off_t id_end = min(od * SD - PD + KD, ID);
-    const off_t ih_end = min(oh * SH - PH + KH, IH);
-    const off_t iw_end = min(ow * SW - PW + KW, IW);
+    const off_t id_start = max(od * SD - PD, (off_t)0);
+    const off_t ih_start = max(oh * SH - PH, (off_t)0);
+    const off_t iw_start = max(ow * SW - PW, (off_t)0);
+    const off_t id_end = min(od * SD - PD + KD, (off_t)ID);
+    const off_t ih_end = min(oh * SH - PH + KH, (off_t)IH);
+    const off_t iw_end = min(ow * SW - PW + KW, (off_t)IW);
     const int num_summands = (int)(ih_end - ih_start) * (int)(iw_end - iw_start)
             * (int)(id_end - id_start);
     D0 = D0 / num_summands;
@@ -394,12 +394,12 @@ __kernel void gen9_pooling_bwd(__global DATA_T *diff_src, __global int *ws,
 #endif
 #endif
 #if ALG_AVG_NP
-                const off_t id_start = max(id - kd, 0);
-                const off_t ih_start = max(ih - kh, 0);
-                const off_t iw_start = max(iw - kw, 0);
-                const off_t id_end = min(id - kd + KD, ID);
-                const off_t ih_end = min(ih - kh + KH, IH);
-                const off_t iw_end = min(iw - kw + KW, IW);
+                const off_t id_start = max(id - kd, (off_t)0);
+                const off_t ih_start = max(ih - kh, (off_t)0);
+                const off_t iw_start = max(iw - kw, (off_t)0);
+                const off_t id_end = min(id - kd + KD, (off_t)ID);
+                const off_t ih_end = min(ih - kh + KH, (off_t)IH);
+                const off_t iw_end = min(iw - kw + KW, (off_t)IW);
                 const int num_summands = (int)(ih_end - ih_start)
                         * (int)(iw_end - iw_start) * (int)(id_end - id_start);
                 D0 /= num_summands;

--- a/src/gpu/intel/ocl/gen9_pooling.cl
+++ b/src/gpu/intel/ocl/gen9_pooling.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -219,27 +219,42 @@ __kernel void gen9_pooling_fwd(__global DATA_T *src, __global int *ws,
 #if USE_MB_C_BLOCK
         int c_sub_block_id = idx % CHUNKS_PER_C_BLOCK;
         int mb_sub_block_id = idx / CHUNKS_PER_C_BLOCK;
-        const off_t po_oc = c + c_sub_block_id * SUB_GROUP_SIZE + local_id;
-        off_t po_mb = (mb0 + mb_sub_block_id) % MB;
+        off_t po_oc = c + c_sub_block_id * SUB_GROUP_SIZE + local_id;
+        off_t po_mb = (mb0 + mb_sub_block_id);
 #else // USE_MB_C_BLOCK
-        const off_t po_oc = c + idx * SUB_GROUP_SIZE + local_id;
+        off_t po_oc = c + idx * SUB_GROUP_SIZE + local_id;
         off_t po_mb = mb0;
 #endif // USE_MB_C_BLOCK
 
-        if (po_mb >= MB || po_oc >= C_WO_PADDING) continue;
-
         float d0_i = USE_FLOATS ? D0[idx] : CONVERT_FLOAT_T(D0[idx]);
         POST_OP_DATA_T sum0_i = DATA_TO_REF(sum0[idx]);
-        APPLY_POST_OPS_SERIAL_BINARY_2D(
-                d0_i, float, sum0_i, POST_OP_DATA_T, po_mb, 1, po_oc, 1);
-        D0[idx] = USE_FLOATS ? d0_i : CONVERT_DATA_T(d0_i);
+        if (po_mb >= MB_WO_PADDING || po_oc >= C_WO_PADDING) {
+            D0[idx] = 0;
+            WS0[idx] = 0;
+        } else {
+            APPLY_POST_OPS_SERIAL_BINARY_2D(
+                    d0_i, float, sum0_i, POST_OP_DATA_T, po_mb, 1, po_oc, 1);
+            D0[idx] = USE_FLOATS ? d0_i : CONVERT_DATA_T(d0_i);
+        }
 
         float d1_i = USE_FLOATS ? D1[idx] : CONVERT_FLOAT_T(D1[idx]);
         POST_OP_DATA_T sum1_i = DATA_TO_REF(sum1[idx]);
-        po_mb += VECT_DT_N;
-        APPLY_POST_OPS_SERIAL_BINARY_2D(
-                d1_i, float, sum1_i, POST_OP_DATA_T, po_mb, 1, po_oc, 1);
-        D1[idx] = USE_FLOATS ? d1_i : CONVERT_DATA_T(d1_i);
+        if (UNROLL_MB_COUNT > 1)
+            po_mb += MB / 2;
+        else {
+            if (USE_MB_C_BLOCK)
+                po_oc += (VECT_DT_N % CHUNKS_PER_C_BLOCK) * SUB_GROUP_SIZE;
+            else
+                po_oc += VECT_DT_N * SUB_GROUP_SIZE;
+        }
+        if (po_mb >= MB_WO_PADDING || po_oc >= C_WO_PADDING) {
+            D1[idx] = 0;
+            WS1[idx] = 0;
+        } else {
+            APPLY_POST_OPS_SERIAL_BINARY_2D(
+                    d1_i, float, sum1_i, POST_OP_DATA_T, po_mb, 1, po_oc, 1);
+            D1[idx] = USE_FLOATS ? d1_i : CONVERT_DATA_T(d1_i);
+        }
     }
 #endif // #if VECT_DT_N == 1
 #if USE_FLOATS

--- a/src/gpu/intel/ocl/gen9_pooling.cpp
+++ b/src/gpu/intel/ocl/gen9_pooling.cpp
@@ -188,6 +188,7 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     } else {
         kernel_ctx.define_int("MB", conf.mb);
     }
+    kernel_ctx.define_int("MB_WO_PADDING", conf.mb);
     kernel_ctx.define_int("MB_BLOCK_SIZE", conf.mb_block_size);
     kernel_ctx.define_int("C_W_PADDING", conf.c_padded);
     kernel_ctx.define_int("C_WO_PADDING", conf.c);

--- a/src/gpu/intel/ocl/ocl_post_ops.h
+++ b/src/gpu/intel/ocl/ocl_post_ops.h
@@ -66,24 +66,24 @@ float fwd_Xnary(bool is_binary, unsigned algorithm, float x, float y,
     }
 
 #define FMA_BLOCK( \
-        block_size, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b) \
+        block_size, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b, c) \
     unroll_for(; nof_elems >= block_size; acc_ptr += block_size, \
                a_ptr += block_size, nof_elems -= block_size) { \
         CONCAT2(acc_elem_dt, block_size) \
         a_conv = CONCAT3(convert_, acc_elem_dt, block_size)( \
                 *((CONCAT2(a_elem_dt, block_size) *)a_ptr)); \
-        *((CONCAT2(acc_elem_dt, block_size) *)acc_ptr) = fma( \
-                a_conv, b, *((CONCAT2(acc_elem_dt, block_size) *)acc_ptr)); \
+        *((CONCAT2(acc_elem_dt, block_size) *)acc_ptr) = fma(a_conv - c, b, \
+                *((CONCAT2(acc_elem_dt, block_size) *)acc_ptr)); \
     }
 
-#define FMA_MIXED(acc_nof_elems, a, a_elem_dt, b, acc_ptr, acc_elem_dt) \
+#define FMA_MIXED(acc_nof_elems, a, a_elem_dt, b, acc_ptr, acc_elem_dt, c) \
     { \
         auto nof_elems = acc_nof_elems; \
         a_elem_dt *a_ptr = (a_elem_dt *)(&a); \
-        FMA_BLOCK(8, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b); \
-        FMA_BLOCK(4, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b); \
-        FMA_BLOCK(2, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b); \
-        if (nof_elems == 1) { *acc_ptr += (*a_ptr) * b; } \
+        FMA_BLOCK(8, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b, c); \
+        FMA_BLOCK(4, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b, c); \
+        FMA_BLOCK(2, nof_elems, acc_ptr, acc_elem_dt, a_ptr, a_elem_dt, b, c); \
+        if (nof_elems == 1) { *acc_ptr += (*a_ptr - c) * b; } \
     }
 
 #define po_dt(idx) CONCAT3(PO_, idx, _BIN_ARG_ACTUAL_DATA_T)
@@ -139,7 +139,7 @@ float fwd_Xnary(bool is_binary, unsigned algorithm, float x, float y,
 #define APPLY_PO_SUM( \
         idx, acc_size, accumulator, acc_elem_dt, sum_src, sum_elem_dt, ...) \
     FMA_MIXED(acc_size, sum_src, sum_elem_dt, CONCAT3(PO_, idx, _SUM_SCALE), \
-            accumulator, acc_elem_dt);
+            accumulator, acc_elem_dt, CONCAT3(PO_, idx, _SUM_ZP));
 
 // VA_ARGS are unused and maintained for interface compatibility
 #define APPLY_PO_ELTWISE(idx, nelems, accumulator, ...) \

--- a/src/gpu/intel/ocl/ref_convolution.hpp
+++ b/src/gpu/intel/ocl/ref_convolution.hpp
@@ -91,8 +91,8 @@ struct ref_convolution_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_CONV_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(post_ops_with_binary_ok(
-                                   attr(), dst_md_.data_type, 5, 0xffff),
+            VDISPATCH_CONV(
+                    post_ops_with_binary_ok(attr(), dst_md_.data_type, 5),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);

--- a/src/gpu/intel/ocl/ref_inner_product.hpp
+++ b/src/gpu/intel/ocl/ref_inner_product.hpp
@@ -57,26 +57,23 @@ struct ref_inner_product_fwd_t : public gpu_primitive_t {
             VDISPATCH_INNER_PRODUCT_SC(
                     set_default_params(), VERBOSE_UNSUPPORTED_TAG);
 
-            VDISPATCH_INNER_PRODUCT(
-                    utils::one_of(true,
-                            expect_data_types(
-                                    u8, s8, data_type::undef, s8, s32),
-                            expect_data_types(
-                                    u8, s8, data_type::undef, u8, s32),
-                            expect_data_types(
-                                    u8, s8, data_type::undef, s32, s32),
-                            expect_data_types(
-                                    s8, s8, data_type::undef, s8, s32),
-                            expect_data_types(
-                                    s8, s8, data_type::undef, u8, s32),
-                            expect_data_types(
-                                    s8, s8, data_type::undef, s32, s32),
-                            expect_data_types(
-                                    bf16, bf16, data_type::undef, bf16, f32),
-                            expect_data_types(
-                                    bf16, bf16, data_type::undef, f32, f32),
-                            expect_data_types(f32, f32, f32, f32, f32),
-                            expect_data_types(f16, f16, f16, f16, f32)),
+            auto src_dt = src_md()->data_type;
+            auto dst_dt = dst_md()->data_type;
+            auto wei_dt = weights_md(0)->data_type;
+
+            const bool is_f32 = src_dt == f32
+                    && utils::one_of(wei_dt, f32, s8, u8)
+                    && utils::one_of(dst_dt, f32, f16, bf16);
+            const bool is_f16 = src_dt == f16
+                    && utils::one_of(wei_dt, f16, s8, u8)
+                    && utils::one_of(dst_dt, u8, s8, f16, bf16);
+            const bool is_bf16 = src_dt == bf16
+                    && utils::one_of(wei_dt, bf16, s8, u8)
+                    && utils::one_of(dst_dt, bf16, f32);
+            const bool is_int8 = utils::one_of(src_dt, u8, s8)
+                    && utils::one_of(wei_dt, u8, s8)
+                    && utils::one_of(dst_dt, f32, s8, u8, s32, f16, bf16);
+            VDISPATCH_INNER_PRODUCT((is_int8 || is_f32 || is_f16 || is_bf16),
                     VERBOSE_UNSUPPORTED_DT);
 
             VDISPATCH_INNER_PRODUCT(
@@ -221,11 +218,16 @@ struct ref_inner_product_bwd_weights_t : public gpu_primitive_t {
                     this->set_default_params(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_INNER_PRODUCT(
                     utils::one_of(true,
-                            expect_data_types(f16, f16, f16, f16, f32),
-                            expect_data_types(f16, f32, f32, f16, f32),
-                            expect_data_types(bf16, bf16, bf16, bf16, f32),
-                            expect_data_types(bf16, f32, f32, bf16, f32),
-                            expect_data_types(f32, f32, f32, f32, f32)),
+                            expect_data_types(
+                                    f16, f16, data_type::undef, f16, f32),
+                            expect_data_types(
+                                    f16, f32, data_type::undef, f16, f32),
+                            expect_data_types(
+                                    bf16, bf16, data_type::undef, bf16, f32),
+                            expect_data_types(
+                                    bf16, f32, data_type::undef, bf16, f32),
+                            expect_data_types(
+                                    f32, f32, data_type::undef, f32, f32)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_INNER_PRODUCT(
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);

--- a/src/gpu/intel/ocl/ref_matmul.hpp
+++ b/src/gpu/intel/ocl/ref_matmul.hpp
@@ -75,13 +75,14 @@ struct ref_matmul_t : public gpu_primitive_t {
                     = utils::everyone_is(f64, src_dt_, wei_dt_, dst_dt_);
             const bool is_f32 = src_dt_ == f32
                     && utils::one_of(wei_dt_, f32, s8, u8, s4, u4)
-                    && dst_dt_ == f32;
+                    && utils::one_of(dst_dt_, f32, f16, bf16);
             const bool is_f16 = src_dt_ == f16
                     && utils::one_of(wei_dt_, f16, s8, u8, s4, u4)
-                    && utils::one_of(dst_dt_, u8, s8, f16, f32);
+                    && utils::one_of(dst_dt_, u8, s8, f16, bf16, f32);
             const bool is_bf16 = src_dt_ == bf16
                     && utils::one_of(wei_dt_, bf16, s8, u8, s4, u4)
-                    && utils::one_of(dst_dt_, u8, s8, bf16, f32);
+                    && utils::one_of(dst_dt_, u8, s8, f16, bf16, f32);
+
             const bool is_f8
                     = (utils::one_of(src_dt_, f8_e5m2, f8_e4m3)
                               || utils::one_of(wei_dt_, f8_e5m2, f8_e4m3))
@@ -93,13 +94,15 @@ struct ref_matmul_t : public gpu_primitive_t {
                                     f4_e2m1, src_dt_));
             const bool is_int8 = utils::one_of(src_dt_, u8, s8)
                     && utils::one_of(wei_dt_, u8, s8, u4, s4)
-                    && utils::one_of(dst_dt_, f32, s8, u8, s32, f16);
-            VDISPATCH_MATMUL((is_int8
-                                     || ((is_f32 || is_f64 || is_f16 || is_f8
-                                                 || is_f4 || is_bf16)
-                                             && IMPLICATION(with_bias(),
-                                                     utils::one_of(bia_dt_, f32,
-                                                             dst_dt_)))),
+                    && utils::one_of(dst_dt_, f32, s8, u8, s32, f16, bf16);
+            VDISPATCH_MATMUL(
+                    (is_int8
+                            || ((is_f32 || is_f64 || is_f16 || is_f8 || is_f4
+                                        || is_bf16)
+                                    && IMPLICATION(with_bias(),
+                                            utils::one_of(bia_dt_, f32, f16,
+                                                    bf16, f8_e5m2, f8_e4m3,
+                                                    f4_e2m1, dst_dt_)))),
                     VERBOSE_UNSUPPORTED_DT_CFG);
             VDISPATCH_MATMUL_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -552,7 +552,7 @@ bool post_ops_with_binary_ok(const primitive_attr_t *attr,
     const auto &p = attr->post_ops_;
 
     auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(false); };
-    auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(false); };
+    auto is_sum = [&](int idx) { return p.entry_[idx].is_sum(false, false); };
     auto is_binary = [&](int idx) { return p.entry_[idx].is_binary(); };
     auto is_prelu = [&](int idx) { return p.entry_[idx].is_prelu(); };
 
@@ -572,7 +572,6 @@ bool post_ops_with_binary_ok(const primitive_attr_t *attr,
             }
         }
         if (is_sum(po_idx)) {
-            if (p.entry_[po_idx].sum.zero_point != 0) return false;
             if (p.entry_[po_idx].sum.dt != dnnl_data_type_undef
                     && types::data_type_size(p.entry_[po_idx].sum.dt)
                             != types::data_type_size(dst_dt))
@@ -676,7 +675,7 @@ status_t def_post_ops_cfg(compute::kernel_ctx_t &kernel_ctx,
             kernel_ctx.define_float(
                     ("PO_" + std::to_string(idx) + "_ELTWISE_SCALE").c_str(),
                     e.eltwise.scale);
-        } else if (e.is_sum(false)) {
+        } else if (e.is_sum(false, false)) {
             kernel_ctx.add_option(
                     "-DAPPLY_PO_" + std::to_string(idx) + "=APPLY_PO_SUM");
             kernel_ctx.define_int(
@@ -684,6 +683,10 @@ status_t def_post_ops_cfg(compute::kernel_ctx_t &kernel_ctx,
             kernel_ctx.define_float(
                     ("PO_" + std::to_string(idx) + "_SUM_SCALE").c_str(),
                     e.sum.scale);
+            kernel_ctx.define_int(
+                    ("PO_" + std::to_string(idx) + "_SUM_ZP").c_str(),
+                    e.sum.zero_point);
+
         } else {
             return status::runtime_error;
         }

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -548,8 +548,7 @@ void def_eltwise_alg_kinds(compute::kernel_ctx_t &kernel_ctx) {
 }
 
 bool post_ops_with_binary_ok(const primitive_attr_t *attr,
-        const data_type_t dst_dt, const int max_ndims_supported,
-        const int prelu_mask_supported) {
+        const data_type_t dst_dt, const int max_ndims_supported) {
     const auto &p = attr->post_ops_;
 
     auto is_eltwise = [&](int idx) { return p.entry_[idx].is_eltwise(false); };
@@ -571,10 +570,6 @@ bool post_ops_with_binary_ok(const primitive_attr_t *attr,
                     if (bin_desc.dims[dim_idx] != 1) is_po_ok = false;
                 }
             }
-        }
-        if (is_prelu(po_idx)) {
-            if (p.entry_[po_idx].prelu.mask > prelu_mask_supported)
-                is_po_ok = false;
         }
         if (is_sum(po_idx)) {
             if (p.entry_[po_idx].sum.zero_point != 0) return false;

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -688,8 +688,7 @@ void def_binary_alg_kinds(compute::kernel_ctx_t &kernel_ctx);
 void def_eltwise_alg_kinds(compute::kernel_ctx_t &kernel_ctx);
 
 bool post_ops_with_binary_ok(const primitive_attr_t *attr,
-        const data_type_t dst_dt, const int max_ndims_supported = 2,
-        const int prelu_mask_supported = 3);
+        const data_type_t dst_dt, const int max_ndims_supported = 2);
 
 constexpr int prelu_max_ndims = 5;
 status_t get_prelu_md(int prelu_mask, const dim_t *dst_dims,

--- a/tests/benchdnn/inputs/conv/harness_conv_smoke_ref
+++ b/tests/benchdnn/inputs/conv/harness_conv_smoke_ref
@@ -1,0 +1,79 @@
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--check-ref-impl=
+
+--match=.*conv_basic_2d.* # Use 2d problems only from shapes_basic
+--mb=2
+--alg=direct
+--stag=any
+--wtag=any
+--dtag=any
+
+# Training
+## Forward
+--dir=FWD_B
+--dt=f32,bf16
+--attr-post-ops=,linear:2:1,sum:1.5:2+relu
+--batch=shapes_basic
+## Backward
+--dir=BWD_D,BWD_WB
+--attr-post-ops=
+--batch=shapes_basic
+
+# Inference
+--dir=FWD_I
+--attr-post-ops=,linear:2:1
+
+--dt=f16
+--batch=shapes_basic
+
+--dt=s8:s8:f32
+--attr-zero-points=src:common:1
+--attr-scales=src:common:0.25+wei:per_oc+dst:common:2
+--batch=shapes_basic
+
+--dt=u8:s8:s32
+--attr-zero-points=
+--attr-scales=src:common:0.25+wei:per_oc
+--batch=shapes_basic
+
+# fp8
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--match=.*conv_basic_2d.* # Use 2d problems only from shapes_basic
+--dt=f8_e5m2,f8_e4m3
+--mb=2,16
+--dir=FWD_B
+--attr-rounding-mode=dst:stochastic
+--batch=shapes_basic
+
+# mixed fp8
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--match=.*conv_basic_2d.* # Use 2d problems only from shapes_basic
+--mb=1 --dt=f8_e5m2:f8_e5m2:bf16,f8_e4m3:f8_e4m3:bf16 --dir=fwd_d --batch=shapes_basic
+--mb=1 --dt=f16:f8_e5m2:f8_e5m2,f32:f8_e4m3:f8_e4m3 --dir=bwd_d --batch=shapes_basic
+--mb=1 --dt=f8_e5m2:f16:f8_e5m2,f8_e4m3:f32:f8_e4m3 --dir=bwd_w --batch=shapes_basic
+--mb=1 --dt=f8_e5m2,f8_e4m3 --dir=fwd_d
+--attr-scales=wei:per_oc:bf16+dst:per_oc:bf16,\
+                      wei:common:2:bf16+src:common:2:bf16+dst:common:2:bf16,\
+                      wei:per_oc:f32+dst:per_oc:f32,\
+                      wei:common:2:f32+src:common:2:f32+dst:common:2:f32
+--batch=shapes_basic_gpu
+
+
+# strided conv
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--match=.*conv_basic_2d.* # Use 2d problems only from shapes_basic
+--dt=u8:s8:u8,f16,f32
+--mb=1,16
+--dir=FWD_B,BWD_D
+--batch=shapes_mem_strided
+
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--dt=bf16,f32
+--mb=1,16
+--dir=BWD_WB
+--batch=shapes_mem_strided

--- a/tests/benchdnn/inputs/conv/test_conv_gpu
+++ b/tests/benchdnn/inputs/conv/test_conv_gpu
@@ -192,6 +192,9 @@ mb128ic3ih230oc64oh112kh7sh2ph0
 --dir=BWD_WB
 --batch=shapes_mem_strided
 
+# ref smoke test
+--batch=harness_conv_smoke_ref
+
 
 # Test layers of some key GPU DL Frameworks
 --reset

--- a/tests/benchdnn/inputs/ip/harness_ip_smoke_ref
+++ b/tests/benchdnn/inputs/ip/harness_ip_smoke_ref
@@ -1,4 +1,6 @@
 --reset
+--impl=ref # Intentionally test reference impl coverage
+--check-ref-impl=
 
 --match=.*WnD.* # Use WnD problems only from shapes_ci
 --mb=2
@@ -12,6 +14,7 @@
 --dt=f32,bf16
 --attr-post-ops=,linear:2:1
 --batch=shapes_ci
+
 ## Backward
 --dir=BWD_D,BWD_WB
 --attr-post-ops=
@@ -21,7 +24,7 @@
 --dir=FWD_I
 --attr-post-ops=,linear:2:1
 
---dt=f16
+--dt=f16,f16:f16:s8,bf16:bf16:f32
 --batch=shapes_ci
 
 --dt=s8:s8:f32,u8:s8:f16

--- a/tests/benchdnn/inputs/ip/test_ip_gpu
+++ b/tests/benchdnn/inputs/ip/test_ip_gpu
@@ -96,6 +96,9 @@
 # regression tests
 --batch=harness_ip_regression
 
+# ref smoke test
+--batch=harness_ip_smoke_ref
+
 # Test CI in Nightly
 --reset
 --batch=test_ip_ci

--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -178,6 +178,7 @@
 --wtag=any,ab,ba
 --dt=s8:s8:f16
 --attr-scales=src:common:0.5:f32+wei:per_oc:f16
+--attr-fpmath=,f16:true
 4x256:256x64
 6x384:384x100
 
@@ -185,12 +186,14 @@
 --dt=s8:s4:f16
 --attr-scales=src:per_ocic:f16:1x256+wei:per_ocic:f16:128x1
 --attr-zero-points=wei:per_ocic:s4:128x1,src:per_ocic:s4:1x128+wei:per_ocic:s4:128x1
+--attr-fpmath=,f16:true
 4x256:256x64
 6x256:256x100
 
 --wtag=any,ab,ba
 --dt=s8:u8:f16
 --attr-scales=src:per_ocic:f16:1x256+wei:per_ocic:f16:128x1
+--attr-fpmath=,f16:true
 4x256:256x64
 6x256:256x100
 
@@ -198,6 +201,7 @@
 --dt=s8:u4:f32
 --attr-scales=src:per_ocic:f16:1x192+wei:per_ocic:f16:192x1
 --attr-zero-points=wei:per_ocic:u4:192x1,src:per_ocic:s4:1x192+wei:per_ocic:u4:192x1
+--attr-fpmath=,f16:true
 12x4x576:12x576x192
 12x6x192:12x192x100
 
@@ -205,5 +209,6 @@
 --dt=s8:s4:f16
 --attr-scales=src:per_ocic:f16:1x256+wei:per_tensor:f16:128x1
 --attr-zero-points=wei:per_tensor:s4:128x1,src:per_ocic:u4:1x256+wei:per_tensor:s4:128x1
+--attr-fpmath=,f16:true
 2x3x4x256:2x3x256x64
 2x3x6x256:2x3x256x100

--- a/tests/benchdnn/inputs/matmul/harness_matmul_smoke_ref
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_smoke_ref
@@ -1,0 +1,119 @@
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--check-ref-impl=
+
+--match=.*NCF.* # Use NCF problems only from shapes_2d_ci
+--stag=any
+--wtag=any
+--dtag=any
+
+--dt=f32,bf16,f16
+--bia_dt=undef,f32
+--bia_mask=2
+--attr-post-ops=,linear:2:1
+--batch=shapes_2d_ci
+
+--dt=s8:s8:f32
+--attr-zero-points=src:common:1+wei:common:-1+dst:common:2
+--attr-scales=src:common:0.25+wei:per_oc+dst:common:2
+--batch=shapes_2d_ci
+
+--dt=u8:s8:s32
+--attr-zero-points=
+--attr-scales=src:common:0.25+wei:per_oc
+--batch=shapes_2d_ci
+
+# Run-time dimensions
+--stag=ab
+--wtag=ab
+--dtag=ab
+--dt=f32,bf16,f16,u8:s8:s32
+--bia_dt=undef,f32
+--bia_mask=2
+--attr-scales=
+--attr-zero-points=
+--attr-post-ops=,linear:2:1
+--runtime_dims_masks=1:0,3:3
+--batch=shapes_2d_ci
+
+# Decompression
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--wtag=any,abc,acb
+--dt=s8:u4:f32,f16:s4:f16,s8:s8:f16,f16:s4:f32
+--attr-scales=wei:per_ocic:f16:192x1
+--attr-zero-points=wei:per_ocic:s4:192x1
+--attr-fpmath=f16:true
+12x4x576:12x576x192
+12x6x192:12x192x100
+
+--wtag=any,abcd,abdc
+--dt=s8:s4:f16
+--attr-fpmath=f16:true
+--attr-scales=src:per_ocic:f16:1x256+wei:per_tensor:f16:128x1
+--attr-zero-points=wei:per_tensor:s4:128x1,src:per_ocic:u4:1x256+wei:per_tensor:s4:128x1
+2x3x4x256:2x3x256x64
+2x3x6x256:2x3x256x100
+
+# Bias / DataType Combinations
+
+--reset
+--impl=ref # Intentionally test reference impl coverage
+
+--dt=f64,f32
+--bia-dt=undef,f32
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+--dt=bf16,bf16:bf16:f32
+--bia-dt=undef,f32,bf16
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+--dt=f16,f16:f16:f32
+--bia-dt=undef,f32,f16
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+--dt=f8_e5m2,f8_e5m2:f8_e5m2:f32
+--bia-dt=undef,f32,f8_e5m2
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+--dt=f8_e4m3,f8_e4m3:f8_e4m3:f32
+--bia-dt=undef,f32,f8_e4m3
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+--dt=u8:s8:f32,u8:s8:s32,u8:s8:s8,u8:s8:u8,\
+     s8:s8:f32,s8:s8:s32,s8:s8:s8,s8:s8:u8
+--bia-dt=undef,f32,u8,s8,s32
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+--dt=u8:s8:bf16,u8:s8:f16,\
+     s8:s8:bf16,s8:s8:f16
+--bia-dt=undef,f32
+--bia_mask=2,3  77x133:133x117
+--bia_mask=4,6  15x24x16:15x16x32
+--bia_mask=8,12 7x16x24x8:7x16x8x24
+
+# Strided
+--dt=u8:s8:u8,f16,f32
+--batch=shapes_mem_strided
+
+# Dropout
+--reset
+--impl=ref # Intentionally test reference impl coverage
+--match=.*NCF.* # Use NCF problems only from shapes_2d_ci
+--dt=f32,bf16
+--attr-fpmath=,bf16
+--attr-dropout=0.5:12345678
+--stag=ab --dtag=ab
+--batch=shapes_2d_ci

--- a/tests/benchdnn/inputs/matmul/test_matmul_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_gpu
@@ -100,6 +100,9 @@
 --dt=u8:s8:u8,f16,f32
 --batch=shapes_mem_strided
 
+# ref smoke test
+--batch=harness_matmul_smoke_ref
+
 # Test CI in Nightly
 --reset
 --batch=test_matmul_ci

--- a/tests/benchdnn/inputs/pool/harness_pool_smoke_ref
+++ b/tests/benchdnn/inputs/pool/harness_pool_smoke_ref
@@ -1,0 +1,19 @@
+--reset
+--skip-impl=ir # Intentionally test ocl impl coverage
+--check-ref-impl=
+--match=.*pool_ci_2d.* # Use 2d problems only from shapes_basic
+--mb=2
+--tag=axb
+--alg=max,avg_np,avg_p
+
+# Training
+--dt=f32,bf16,f16
+--dir=FWD_D,BWD_D
+--batch=shapes_basic
+
+# Inference
+--dir=FWD_I
+--tag=axb
+--dt=f16,s8,u8
+--attr-post-ops=,add:f32:per_oc
+--batch=shapes_basic

--- a/tests/benchdnn/inputs/pool/test_pool_gpu
+++ b/tests/benchdnn/inputs/pool/test_pool_gpu
@@ -85,6 +85,10 @@
 --reset
 --batch=test_pool_ci
 
+# Test ref smoke
+--reset
+--batch=harness_pool_smoke_ref
+
 # Test layers of some key and ext GPU DL Frameworks
 --reset
 --batch=option_set_fwks_key_gpu

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -930,6 +930,10 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                     }
                 }
             } break;
+            case DNNL_ARG_ATTR_DROPOUT_SEED: {
+                ref_mem = dnn_mem_t(mem.md_, dnnl_s32, tag::abx, ref_engine);
+                // No break to fall back into `default` call with initialization.
+            }
             default:
                 SAFE(init_ref_memory_args_default_case(
                              exec_arg, mem, ref_mem, prb->attr, res),


### PR DESCRIPTION
Addresses https://jira.devtools.intel.com/browse/MFDNN-12444. 
Broaden ocl:ref coverage and add some smoke tests for key compute bound primitives.