### PR TITLE
[rls-v3.6] xe: ocl: fix micro sdpa optional mask and tile_ops const correctness

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -202,7 +202,9 @@ micro_sdpa(const global half *K, const global half *Q, const global half *V,
     Q += QRY_OFF(b1, b0, 0, 0);
     V += VAL_OFF(b1, b0 / KV_GROUP_SIZE, 0, 0);
     A += DST_OFF(b1, b0, 0, 0, 0);
+#if WITH_ATTN_MASK
     msk += MSK_OFF(b1 % MSK_D0, b0 % MSK_D1, 0, 0);
+#endif
 
     /* Load Q tile, destined for SLM */
     q_tile_type Q_tile;

--- a/src/gpu/intel/ocl/tile_ops.h
+++ b/src/gpu/intel/ocl/tile_ops.h
@@ -118,7 +118,7 @@ DEF_BLOCK_LOAD_STORE16(uint, uint, )
                 pp, w - 1, h - 1, ld - 1, coord)); \
     } \
     __attribute__((overloadable)) void block2d_store(type##vl v, \
-            global type *p, int w, int h, int ld, int x, int y, int br, \
+            const global type *p, int w, int h, int ld, int x, int y, int br, \
             int bc, \
             int sg) __attribute__((enable_if(br == BR, "wrong #rows"))) \
             __attribute__((enable_if(bc == BC, "wrong #columns"))) \
@@ -542,8 +542,8 @@ DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
         tile_load_block2d(t, ptr, m, n, m, offset_r, offset_c); \
     } \
     __attribute__((overloadable)) void tile_store_block2d(tile_type t, \
-            global element_type *ptr, int m, int n, int ld, int offset_r, \
-            int offset_c) { \
+            const global element_type *ptr, int m, int n, int ld, \
+            int offset_r, int offset_c) { \
         const int e = sizeof(element_type); \
         _Pragma("unroll") for (int jj = 0; jj < nbc; jj++) { \
             _Pragma("unroll") for (int ii = 0; ii < nbr; ii++) block2d_store( \


### PR DESCRIPTION
Found the issues during testing SD1.5 with ov+oneDNN 3.6 rls branch.
- For sdpa without mask, kernel compilation will report 0 division error.
- c++ `discards qualifiers` error.

Actually, this is already fixed in main branch(rls-v3.7) in [commit1](https://github.com/oneapi-src/oneDNN/commit/541436c91243334f198b2ef6a40084c3eaacb199) and [commit2](https://github.com/oneapi-src/oneDNN/commit/17427b78734d6c801e4baa8d31e86ac5b06dff5f),  graph API and sdpa microkernel has already supported sdpa with optional mask since rls-v3.6, so I think we'd better to fix this issue in rls-v3.6. 