### PR TITLE
xe: softmax: softmax reusable acceleration

### DIFF
--- a/src/gpu/intel/ocl/reusable_softmax.cl
+++ b/src/gpu/intel/ocl/reusable_softmax.cl
@@ -18,9 +18,10 @@
 #include "gpu/intel/ocl/ocl_types.h"
 #include "gpu/intel/ocl/types_interop.h"
 
+#ifdef USE_GENERAL_KERNEL
 #if ONE_REDUCTION_PER_SUBGROUP == 1
-__attribute__((reqd_work_group_size(16, 1, 1)))
-__attribute__((intel_reqd_sub_group_size(16)))
+__attribute__((reqd_work_group_size(SUBGROUP_SIZE, 1, 1)))
+__attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE)))
 #endif
 __kernel void
 reusable_softmax_fwd_generic(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
@@ -72,3 +73,158 @@ reusable_softmax_fwd_generic(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
         dst[c - begin] = TO_DST(unscaled * scale);
     }
 }
+#endif
+
+#define VECT_SIZE 8
+
+#define STORE_FLOAT8(prefix, ptr, val) \
+    WRITE_BLOCK8(prefix, (__global BLOCK_T(ALIAS(prefix)) *)(ptr), \
+            DATA_TO_BLOCK8(prefix, FLOAT_TO_DATA8(prefix, val)))
+
+#define STORE_DOUBLE8(prefix, ptr, val) \
+    WRITE_BLOCK8(prefix, (__global BLOCK_T(ALIAS(prefix)) *)(ptr), \
+            DATA_TO_BLOCK8(prefix, DOUBLE_TO_DATA8(prefix, val)))
+
+#if DST_DT_F64
+#define UP_CASE_DATA DOUBLE
+#define COMMON_DATA_T double
+#define COMMON_DATA_MAX DBL_MAX
+#define COMMON_DATA_ZERO 0.0
+#else
+#define UP_CASE_DATA FLOAT
+#define COMMON_DATA_T float
+#define COMMON_DATA_MAX FLT_MAX
+#define COMMON_DATA_ZERO 0.0f
+#endif
+
+#define COMMON_DATA_TO_X(x, y) CONCAT2(DATA_TO_, UP_CASE_DATA)(x, y)
+#define COMMON_STORE_DATA8(x, y, z) CONCAT3(STORE_, UP_CASE_DATA, 8)(x, y, z)
+
+#ifdef USE_VECTORIZED_KERNEL
+__attribute__((reqd_work_group_size(SUBGROUP_SIZE, 1, 1)))
+__attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) __kernel void
+reusable_softmax_fwd_generic(__global DATA_T *src, __global DST_DATA_T *dst,
+        __global float *src_scale, __global float *dst_scale,
+        dim_t softmax_axis_size, dim_t softmax_axis_stride,
+        dim_t softmax_axis_chunk_size, dispatch_gws_rt_params_t gws_params) {
+
+    float scale = 1.0f;
+
+    const off_t linear_thread_id = get_global_id(0);
+    const off_t data_off
+            = (linear_thread_id / SUBGROUP_SIZE) * softmax_axis_size;
+    global DATA_T *src_backup = src;
+    src += data_off;
+
+    VECT_FLOAT_T dk;
+    float max_ = -INFINITY;
+    float denom_ = 0.0f;
+    const bool has_tail = softmax_axis_size % (SUBGROUP_SIZE * VECT_SIZE);
+    int last_buf = div_up(softmax_axis_size, (SUBGROUP_SIZE * VECT_SIZE));
+    if (has_tail) last_buf--;
+
+    const off_t idx_end = has_tail
+            ? softmax_axis_size - (SUBGROUP_SIZE * VECT_SIZE + 1)
+            : softmax_axis_size;
+
+    for (off_t idx = 0; idx < idx_end; idx += SUBGROUP_SIZE * VECT_SIZE) {
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx])));
+        for (off_t i = 0; i < VECT_SIZE; ++i) {
+            max_ = max(dk[i], max_);
+        }
+    }
+
+    if (has_tail) {
+        const off_t idx_beg = last_buf * SUBGROUP_SIZE * VECT_SIZE
+                + get_sub_group_local_id();
+        const off_t idx_end = idx_beg + SUBGROUP_SIZE * VECT_SIZE;
+        for (off_t idx = idx_beg; idx < idx_end; idx += SUBGROUP_SIZE) {
+            float d = (idx < softmax_axis_size ? COMMON_DATA_TO_X(SRC, src[idx])
+                                               : -COMMON_DATA_MAX);
+            max_ = max(d, max_);
+        }
+    }
+
+    max_ = sub_group_reduce_max(max_);
+
+    for (off_t idx = 0; idx < idx_end; idx += SUBGROUP_SIZE * VECT_SIZE) {
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx])));
+        dk = exp(dk - max_);
+        for (off_t i = 0; i < VECT_SIZE; ++i)
+            denom_ += dk[i];
+    }
+
+    if (has_tail) {
+        const off_t idx_beg = last_buf * SUBGROUP_SIZE * VECT_SIZE
+                + get_sub_group_local_id();
+        const off_t idx_end = idx_beg + SUBGROUP_SIZE * VECT_SIZE;
+        for (off_t idx = idx_beg; idx < idx_end; idx += SUBGROUP_SIZE) {
+            if (idx < softmax_axis_size)
+                denom_ += exp(COMMON_DATA_TO_X(SRC, src[idx]) - max_);
+        }
+    }
+    denom_ = sub_group_reduce_add(denom_);
+    denom_ = LOGSOFTMAX ? log(denom_) : 1.0f / denom_;
+
+    dst += data_off;
+
+    for (off_t idx = 0; idx < idx_end; idx += SUBGROUP_SIZE * VECT_SIZE) {
+        dk = CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
+                VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[idx])));
+        dk = LOGSOFTMAX ? dk - max_ - denom_ : exp(dk - max_) * denom_;
+        COMMON_STORE_DATA8(DST, &dst[idx], scale * dk);
+    }
+
+    if (has_tail) {
+        const off_t idx_beg = last_buf * SUBGROUP_SIZE * VECT_SIZE
+                + get_sub_group_local_id();
+        const off_t idx_end = idx_beg + SUBGROUP_SIZE * VECT_SIZE;
+        for (off_t idx = idx_beg; idx < idx_end; idx += SUBGROUP_SIZE) {
+            if (idx < softmax_axis_size) {
+                float dk = COMMON_DATA_TO_X(SRC, src[idx]);
+                dk = LOGSOFTMAX ? dk - max_ - denom_ : exp(dk - max_) * denom_;
+                dst[idx] = TO_DST(scale * dk);
+            }
+        }
+    }
+}
+#endif
+
+#ifdef USE_SMALL_KERNEL
+__attribute__((reqd_work_group_size(SUBGROUP_SIZE, 1, 1)))
+__attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) __kernel void
+reusable_softmax_fwd_generic(__global DATA_T *src, __global DST_DATA_T *dst,
+        __global float *src_scale, __global float *dst_scale,
+        dim_t softmax_axis_size, dim_t softmax_axis_stride,
+        dim_t softmax_axis_chunk_size, dispatch_gws_rt_params_t gws_params) {
+    float scale = 1.0f;
+    if (src_scale) { scale = *src_scale; }
+    if (dst_scale) { scale /= *dst_scale; }
+    const off_t data_off
+            = (get_global_id(0) / SUBGROUP_SIZE) * softmax_axis_size;
+    float d;
+    float max_ = -INFINITY;
+    float denom_ = 0.0f;
+    src += data_off;
+
+    const off_t off = get_sub_group_local_id();
+
+    d = (off < softmax_axis_size ? COMMON_DATA_TO_X(SRC, src[off]) : -INFINITY);
+    max_ = sub_group_reduce_max(d);
+
+    if (off < softmax_axis_size) denom_ += exp(d - max_);
+
+    denom_ = sub_group_reduce_add(denom_);
+    denom_ = LOGSOFTMAX ? log(denom_) : 1.0f / denom_;
+    dst += data_off;
+
+    if (off < softmax_axis_size) {
+        float from_src = COMMON_DATA_TO_X(SRC, src[off]);
+        float thing = LOGSOFTMAX ? from_src - max_ - denom_
+                                 : exp(from_src - max_) * denom_;
+        dst[off] = TO_DST(scale * thing);
+    }
+}
+#endif

--- a/src/gpu/intel/ocl/reusable_softmax.cpp
+++ b/src/gpu/intel/ocl/reusable_softmax.cpp
@@ -23,6 +23,7 @@ namespace gpu {
 namespace intel {
 namespace ocl {
 
+using namespace compute;
 using namespace gpu_utils;
 
 class softmax_lws_strategy_t : public compute::lws_strategy_t {
@@ -78,6 +79,20 @@ static std::vector<dim_idx_t> get_dims(size_t ndims) {
     if (ndims >= 4) ret[idx++] = softmax_dims_t::sp1;
     if (ndims >= 5) ret[idx++] = softmax_dims_t::sp2;
     return ret;
+}
+
+status_t reusable_softmax_fwd_t::pd_t::init_dispatch_subgroup_per_reduction(
+        gpu::engine_t *engine) {
+    compute::range_t gws {(size_t)conf.subgroup_size};
+    compute::range_t lws {(size_t)conf.subgroup_size};
+    for (int i = 0; i < ndims(); i++) {
+        if (i == desc()->softmax_axis) { continue; }
+        gws[0] *= src_md()->dims[i];
+    }
+
+    rt_conf.gws_params.nd_range = compute::nd_range_t(gws, lws);
+
+    return status::success;
 }
 
 status_t reusable_softmax_fwd_t::pd_t::init_dispatch_default_reusable(
@@ -208,6 +223,19 @@ compute::kernel_ctx_t reusable_softmax_params_t::get_kernel_ctx() const {
     kernel_ctx.define_int("USE_WORKGROUP_REDUCTION",
             algorithm_number == one_reduction_per_workgroup);
     kernel_ctx.add_option("-cl-std=CL2.0");
+    kernel_ctx.define_int("WORKGROUP_SIZE", 128);
+
+    if (algorithm_number == vectorized) {
+        kernel_ctx.define_int("VECT_DT_N", 8);
+        kernel_ctx.define_int("USE_VECTORIZED_KERNEL", true);
+        kernel_ctx.define_int("SUBGROUP_SIZE", subgroup_size);
+    } else if (algorithm_number == small) {
+        kernel_ctx.define_int("VECT_DT_N", 8);
+        kernel_ctx.define_int("USE_SMALL_KERNEL", true);
+        kernel_ctx.define_int("SUBGROUP_SIZE", subgroup_size);
+    } else {
+        kernel_ctx.define_int("USE_GENERAL_KERNEL", true);
+    }
 
     kernel_ctx.set_data_type(src_data_type);
     def_data_type(kernel_ctx, src_data_type, "SRC");

--- a/src/gpu/intel/ocl/reusable_softmax.hpp
+++ b/src/gpu/intel/ocl/reusable_softmax.hpp
@@ -37,7 +37,9 @@ namespace ocl {
 enum softmax_algorithm_id_t {
     many_reductions_per_workgroup = 1,
     one_reduction_per_workgroup,
-    one_reduction_per_subgroup
+    one_reduction_per_subgroup,
+    vectorized,
+    small
 };
 
 struct reusable_softmax_params_t {
@@ -72,10 +74,11 @@ struct reusable_softmax_params_t {
     data_type_t src_data_type;
     data_type_t dst_data_type;
     int algorithm_number;
+    int subgroup_size;
     bool is_logsoftmax;
     bool is_softmax_inf_as_zero;
 
-    uint8_t padding[2] = {0};
+    uint8_t padding[6] = {0};
 
     compute::dispatch_compile_params_t gws_params;
 };
@@ -95,6 +98,7 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
         DECLARE_COMMON_PD_T("ocl:reusable", reusable_softmax_fwd_t);
 
         status_t init(impl::engine_t *engine) {
+            using arch_t = compute::gpu_arch_t;
             auto *compute_engine
                     = utils::downcast<compute::compute_engine_t *>(engine);
 
@@ -107,10 +111,11 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
             using namespace data_type;
             VDISPATCH_SOFTMAX(is_fwd(), VERBOSE_BAD_PROPKIND);
 
-            // reusable implementation still too slow for half-precision
-            VDISPATCH_SOFTMAX(utils::one_of(src_dt, f64, f32, u8, s8),
+            VDISPATCH_SOFTMAX(
+                    utils::one_of(src_dt, f64, f32, f16, bf16, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_SOFTMAX(utils::one_of(dst_dt, f64, f32, u8, s8),
+            VDISPATCH_SOFTMAX(
+                    utils::one_of(dst_dt, f64, f32, f16, bf16, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
 
             VDISPATCH_SOFTMAX(IMPLICATION(utils::one_of(f16, src_dt, dst_dt),
@@ -163,6 +168,22 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
             conf.src_data_type = src_dt;
             conf.dst_data_type = dst_dt;
 
+            // utilize largest supported subgroup size
+            conf.subgroup_size = [=] {
+                for (int size : {32, 16, 8}) {
+                    if (compute_engine->mayiuse_sub_group(size)
+                            && compute_engine
+                                       ->mayiuse_block_reads_writes_with_sub_group(
+                                               size))
+                        return size;
+                }
+                return 0;
+            }();
+            if (conf.subgroup_size == 0) {
+                assert(!"Device does not support a valid subgroup size");
+                return status::unimplemented;
+            }
+
             // run-time configuration setup
             rt_conf.softmax_axis_size = src_mdw.dims()[desc()->softmax_axis];
             for (const auto &block : layout) {
@@ -172,43 +193,66 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
                 }
             }
 
-            // empirically derived: select algorithm and parameters
+            const arch_t arch_ = compute_engine->device_info()->gpu_arch();
             const auto nelems = src_mdw.nelems();
-            if (rt_conf.softmax_axis_size < 6 && nelems > 64000) {
-                conf.algorithm_number = many_reductions_per_workgroup;
-                CHECK(init_dispatch_default_reusable(compute_engine));
-            } else if (rt_conf.softmax_axis_size > 128) {
-                conf.algorithm_number = one_reduction_per_workgroup;
 
-                // select workgroup size/num works per reduction
-                int elements_per_worker;
-                if (nelems <= 64000)
-                    elements_per_worker = 1;
-                else if (rt_conf.softmax_axis_size <= 1024)
-                    elements_per_worker = 4;
-                else
-                    elements_per_worker = 15;
-                const size_t num_workers_per_workgroup
-                        = dnnl::impl::utils::div_up(
-                                rt_conf.softmax_axis_size, elements_per_worker);
+            conf.algorithm_number = [&]() { // -> int
+                if (arch_ != arch_t::xe_hpg) {
+                    if (rt_conf.softmax_axis_stride == 1
+                            && rt_conf.softmax_axis_size >= 128
+                            && nelems > (1 << 17)
+                            && dnnl::impl::utils::div_up(
+                                       rt_conf.softmax_axis_size,
+                                       conf.subgroup_size)
+                                    <= 1024)
+                        return vectorized;
+                    if (rt_conf.softmax_axis_stride == 1
+                            && rt_conf.softmax_axis_size <= conf.subgroup_size
+                            && nelems < (1 << 15))
+                        return small;
+                }
+                if (rt_conf.softmax_axis_size < 6 && nelems > 64000)
+                    return many_reductions_per_workgroup;
+                if (rt_conf.softmax_axis_size > 128)
+                    return one_reduction_per_workgroup;
+                if (rt_conf.softmax_axis_size <= 128)
+                    return one_reduction_per_subgroup;
+                return many_reductions_per_workgroup;
+            }();
 
-                // do not solve problems beyond hardware workgroup limit
+            const size_t max_wg_size = [&]() {
                 auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
                         attr()->gpu_attr_.get());
-                const bool large_grf_mode
-                        = gpu_attr && gpu_attr->threads_per_eu() == 4;
-                const size_t max_wg_size
-                        = compute_engine->device_info()->max_wg_size(
-                                large_grf_mode);
-                VDISPATCH_SOFTMAX(num_workers_per_workgroup <= max_wg_size,
-                        "softmax axis size too large");
+                return compute_engine->device_info()->max_wg_size(
+                        gpu_attr && gpu_attr->threads_per_eu() == 4);
+            }();
 
-                CHECK(init_dispatch_workgroup_per_reduction(
-                        compute_engine, num_workers_per_workgroup));
-            } else { // rt_conf.softmax_axis_size <= 128
-                conf.algorithm_number = one_reduction_per_subgroup;
-                CHECK(init_dispatch_workgroup_per_reduction(
-                        compute_engine, 16));
+            const size_t num_workers_per_workgroup = dnnl::impl::utils::div_up(
+                    rt_conf.softmax_axis_size,
+                    (nelems <= 64000)
+                            ? 1
+                            : ((rt_conf.softmax_axis_size <= 1024) ? 4 : 15));
+
+            switch (conf.algorithm_number) {
+                case many_reductions_per_workgroup:
+                    CHECK(init_dispatch_default_reusable(compute_engine));
+                    break;
+                case one_reduction_per_workgroup:
+                    // do not solve problems beyond hardware workgroup limit
+                    VDISPATCH_SOFTMAX(num_workers_per_workgroup <= max_wg_size,
+                            "softmax axis size too large");
+
+                    CHECK(init_dispatch_workgroup_per_reduction(
+                            compute_engine, num_workers_per_workgroup));
+                    break;
+                case one_reduction_per_subgroup:
+                    CHECK(init_dispatch_workgroup_per_reduction(
+                            compute_engine, conf.subgroup_size));
+                    break;
+                case vectorized:
+                case small:
+                    CHECK(init_dispatch_subgroup_per_reduction(compute_engine));
+                    break;
             }
 
             return status::success;
@@ -217,6 +261,7 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
         status_t init_dispatch_default_reusable(gpu::engine_t *engine);
         status_t init_dispatch_workgroup_per_reduction(
                 gpu::engine_t *engine, const size_t num_workers_per_workgroup);
+        status_t init_dispatch_subgroup_per_reduction(gpu::engine_t *engine);
 
         reusable_softmax_params_t conf;
         reusable_softmax_runtime_params_t rt_conf;


### PR DESCRIPTION
This seeks to resolve JIRA issues [MFDNN-13238](https://jira.devtools.intel.com/browse/MFDNN-13238) (accelerate slow PyTorch SDPA shapes) and [MFDNN-12346](https://jira.devtools.intel.com/browse/MFDNN-12346) (accelerate and enable reusable half-precision softmax). This request includes two new optimized kernels in addition to the general case kernels for softmax computation:

  - vectorized: a kernel utilizing opencl block loads to quickly process longer-softmax-axis problems

  - small: a kernel stripped down to handle only up to 16 element softmax-axis-length problems

Disabled on XeHPG; more specialization required for that hardware.