### PR TITLE
xe: jit: gemm: reduced-cache stream-k implementation

### DIFF
--- a/src/gpu/intel/jit/gemm/gemm_walk_orders.hpp
+++ b/src/gpu/intel/jit/gemm/gemm_walk_orders.hpp
@@ -163,6 +163,10 @@ inline void gemm_linear_order_args(compute::kernel_arg_list_t &arg_list,
                     = group_count; /* disable variable k-slicing if indicated by kernel selector */
         if (k_parallel_start > 0 && k_parallel_start != group_count)
             k_parallel_start -= concurrent_tg;
+        uint32_t k_sliced_tiles = group_count - k_parallel_start;
+        uint32_t k_sliced_phases = 1; /* todo: use 2 phases where beneficial */
+        uint32_t tiles_per_phase
+                = utils::div_up(k_sliced_tiles, k_sliced_phases);
 
         int k_padding = info.kPadding(), old_k_padding = k_padding;
         auto k_padded = k;
@@ -171,7 +175,7 @@ inline void gemm_linear_order_args(compute::kernel_arg_list_t &arg_list,
 
         do {
             k_padded = utils::rnd_up(k + k_padding, info.unroll[LoopK]);
-            k_total = int64_t(k_padded) * (group_count - k_parallel_start);
+            k_total = int64_t(k_padded) * tiles_per_phase;
             if (k_total == 0) break;
 
             k0 = utils::div_up(k_total, concurrent_tg);
@@ -181,16 +185,31 @@ inline void gemm_linear_order_args(compute::kernel_arg_list_t &arg_list,
             k_padding = std::min<int>(k_padding, 2 * k0);
         } while (k_padding != old_k_padding);
 
-        uint32_t k_recip = uint32_reciprocal(k_padded);
-        uint32_t k0_recip = uint32_reciprocal(k0);
+        group_count = k_parallel_start;
+        uint32_t k_parallel_groups = 0;
+        uint32_t k_sync_slabs = 0;
+
+        if (k0 > 0) {
+            k_parallel_groups = uint32_t(utils::div_up(k_total, k0));
+            if (k_sliced_phases > 1) k_parallel_groups = concurrent_tg;
+            group_count += k_parallel_groups * k_sliced_phases;
+
+            if (tiles_per_phase > 0) {
+                k_sync_slabs = k_parallel_groups + (tiles_per_phase >> 1);
+                if (k_sync_slabs > 0) k_sync_slabs--;
+                k_sync_slabs = std::min(k_sync_slabs, (k_padded - 1) / k0);
+            }
+        }
+
+        uint32_t k_unsynced_padded = k_padded - k_sync_slabs * k0;
+        uint32_t k_recip = uint32_reciprocal(k_unsynced_padded);
+
+        uint32_t kv_config = k_sliced_tiles | (k_sync_slabs << 16);
+        if (k_sliced_phases > 1) kv_config |= 0x80000000u;
 
         arg_list.set(argn++, k0);
-        arg_list.set(argn++, k_parallel_start);
+        arg_list.set(argn++, kv_config);
         arg_list.set(argn++, k_recip);
-        if (info.fusedBeta()) arg_list.set(argn++, k0_recip);
-
-        group_count = k_parallel_start;
-        if (k0 > 0) group_count += utils::div_up(k_total, k0);
     }
 
     if (info.isPersistent()) {

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -919,9 +919,8 @@ void gen_gemm_kernel_t::init_interface() {
     }
     if (strategy.kParallelVariable) {
         interface_.newArgument("k0", DataType::ud);
-        interface_.newArgument("k_parallel_start", DataType::ud);
+        interface_.newArgument("kv_config", DataType::ud);
         interface_.newArgument("k_recip", DataType::ud);
-        if (strategy.fuseBeta) interface_.newArgument("k0_recip", DataType::ud);
     }
     if (strategy.persistent)
         interface_.newArgument("group_stride", DataType::ud);

--- a/src/gpu/intel/jit/gemm/generator/generator.cpp
+++ b/src/gpu/intel/jit/gemm/generator/generator.cpp
@@ -46,6 +46,7 @@
 #include "pieces/remask.cxx"
 #include "pieces/row_column_sums.cxx"
 #include "pieces/state_utils.cxx"
+#include "pieces/stream_k.cxx"
 #include "pieces/tlb_warmup.cxx"
 #include "pieces/walk_orders.cxx"
 

--- a/src/gpu/intel/jit/gemm/generator/pieces/atomic_fusions.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/atomic_fusions.cxx
@@ -16,13 +16,13 @@
 
 
 #include "alloc_utils.hpp"
+#include "atomic_fusions.hpp"
 #include "generator.hpp"
 
 using namespace ngen;
 using std::vector;
 
 #include "internal/namespace_start.hxx"
-
 
 // Preparatory work for fused beta/post-ops.
 // For fused beta, check whether this thread is responsible for performing beta scaling.
@@ -88,12 +88,7 @@ void BLASKernelGenerator<hw>::gemmFusedBetaPOInit(const Subregister &groupID, co
         auto temp1 = state.ra.alloc_sub<uint32_t>();
         auto temp2 = state.ra.alloc_sub<uint32_t>();
 
-        int stride = strategy.unroll[LoopM] * strategy.unroll[LoopN];
-        if (problem.sumA) stride += strategy.unroll[LoopM];
-        if (problem.sumB) stride += strategy.unroll[LoopN];
-        stride *= problem.Tc;
-        stride = align_up(stride, 64);
-
+        int stride = tempCThreadStride(problem, strategy);
         mulConstant(1, temp1, groupID, strategy.wg[LoopM] * strategy.wg[LoopN]);
         emad(1, temp2, state.lidM, state.lidN, strategy.wg[LoopM], strategy, state);
         add(1, temp1, temp1, temp2);
@@ -260,27 +255,6 @@ void BLASKernelGenerator<hw>::gemmFusedBetaScale(GEMMProblem problem, GEMMStrate
     std::swap(nested, state.isNested);
 }
 
-// Calculate number of non-scaling WGs for a C tile.
-template <HW hw>
-void BLASKernelGenerator<hw>::gemmFusedBetaCalcWGCount(const Subregister &count, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
-{
-    if (strategy.kParallelVariable) {
-        /* Count workgroups before this one. */
-        divUp(count, state.h0, state.inputs.k0, state.inputs.k0Recip, state.flagAP, strategy, state);
-        if (!strategy.altFusedBeta) {
-            /* Count workgroups after this one. TODO: vectorize divide. */
-            auto temp = state.ra.alloc_sub<uint32_t>();
-            auto temp2 = state.ra.alloc_sub<uint32_t>();
-            eadd3(1 | sat, temp2, state.fullK, -state.h0, -state.wgK);
-            divUp(temp, temp2, state.inputs.k0, state.inputs.k0Recip, state.flagAP, strategy, state);
-            add(1, count, count, temp);
-            state.ra.safeRelease(temp2);
-            state.ra.safeRelease(temp);
-        }
-    } else
-        add(1, count, state.inputs.groupCountK, -1);
-}
-
 // Notify other threads that beta scaling is complete for this tile.
 template <HW hw>
 void BLASKernelGenerator<hw>::gemmFusedBetaNotifyCompletion(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
@@ -306,7 +280,7 @@ void BLASKernelGenerator<hw>::gemmFusedBetaNotifyCompletion(const GEMMProblem &p
         else if (hw >= HW::Gen11)
             slmfence(temp, r0_info);
 
-        gemmFusedBetaCalcWGCount(data.ud(0), problem, strategy, state);
+        add(1 | sat, data.ud(0), state.fullK, -state.wgK);
 
         fencewait();
         activeThreadBarrierSignal(temp, r0_info, strategy);
@@ -334,11 +308,11 @@ void BLASKernelGenerator<hw>::gemmFusedBetaNotifyCompletion(const GEMMProblem &p
 template <HW hw>
 void BLASKernelGenerator<hw>::gemmFusedBetaWaitCompletion(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
-    Label lSkipCheck, lCheckAgain, lFinalDec, lCheckDone;
+    Label lSkipCheck, lCheckAgain, lReady, lFinalDec, lCheckDone;
     bool checkIfEnabled = strategy.kParallelVariable;
 
     auto header = state.ra.alloc().uq();
-    auto data = state.ra.alloc().ud();
+    auto data = state.ra.alloc().d();
     auto &addr = state.statusFlagAddr;
     bool simtCF = strategy.fused;
     int simt = simtCF ? 16 : 1;
@@ -353,6 +327,7 @@ void BLASKernelGenerator<hw>::gemmFusedBetaWaitCompletion(const GEMMProblem &pro
         and_(1 | nz | f0[1], null.ud(), state.inputs.flags, FlagSkipBetaCheck);
 
     emov(1, header, addr, strategy, state);
+    mov(1, data, -state.wgK);
 
     jmpi(1 | f1[0], lSkipCheck);            /* If we did beta scaling ourselves, no need to check */
     if (checkIfEnabled)
@@ -363,9 +338,9 @@ void BLASKernelGenerator<hw>::gemmFusedBetaWaitCompletion(const GEMMProblem &pro
         jmpi(1 | f0[1], lFinalDec);         /* If beta scaling known to be complete, just decrement counter */
 
     if (hw >= HW::XeHPG)
-        atomic(AtomicOp::dec, 1, data, D32 | CacheSettingsLSC::L1UC_L3C, A64, header);
+        atomic(AtomicOp::add, 1, data, D32 | CacheSettingsLSC::L1UC_L3C, A64, header, data);
     else
-        atomic(AtomicOp::dec, 1, data, scattered_dword(), A64, header);
+        atomic(AtomicOp::add, 1, data, scattered_dword(), A64, header, data);
 
     cmp(simt | gt | state.flagAP, data.d(0), 0);
     simtCF ? goto12(16 | state.flagAP, lCheckDone)
@@ -382,19 +357,22 @@ void BLASKernelGenerator<hw>::gemmFusedBetaWaitCompletion(const GEMMProblem &pro
         load(1, data, scattered_dword(), A64, header);     /* no L1 */
 
     cmp(simt | gt | state.flagAP, data.d(0), 0);
-    simtCF ? goto12(16 | state.flagAP, lFinalDec)
-           :   jmpi(1  | state.flagAP, lFinalDec);
+    simtCF ? goto12(16 | state.flagAP, lReady)
+           :   jmpi(1  | state.flagAP, lReady);
 
     pause(strategy);
     jmpi(1, lCheckAgain);
+
+    mark(lReady);
+    mov(1, data, -state.wgK);
 
     mark(lFinalDec);
     if (simtCF) join(16);
 
     if (hw >= HW::XeHPG)
-        atomic(AtomicOp::dec, 1, D32 | CacheSettingsLSC::L1UC_L3C, A64, header);
+        atomic(AtomicOp::add, 1, D32 | CacheSettingsLSC::L1UC_L3C, A64, header, data);
     else
-        atomic(AtomicOp::dec, 1, scattered_dword(), A64, header);
+        atomic(AtomicOp::add, 1, scattered_dword(), A64, header, data);
 
     mark(lCheckDone);
     if (simtCF) join(16);

--- a/src/gpu/intel/jit/gemm/generator/pieces/atomic_fusions.hpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/atomic_fusions.hpp
@@ -1,0 +1,45 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+
+#ifndef GEMMSTONE_GUARD_ATOMIC_FUSIONS_HPP
+#define GEMMSTONE_GUARD_ATOMIC_FUSIONS_HPP
+
+#include "problem.hpp"
+#include "strategy.hpp"
+
+#include "internal/namespace_start.hxx"
+
+// Calculate per-thread stride within temporary C memory.
+inline int tempCThreadStride(const GEMMProblem &problem, const GEMMStrategy &strategy)
+{
+    int stride = strategy.unroll[LoopM] * strategy.unroll[LoopN];
+    if (problem.sumA) stride += strategy.unroll[LoopM];
+    if (problem.sumB) stride += strategy.unroll[LoopN];
+    stride *= problem.Tc;
+    stride = align_up(stride, 64);
+    return stride;
+}
+
+
+// Calculate per-workgroup stride within temporary C memory.
+inline int tempCWGStride(const GEMMProblem &problem, const GEMMStrategy &strategy) {
+    return tempCThreadStride(problem, strategy) * strategy.wg[LoopM] * strategy.wg[LoopN];
+}
+
+#include "internal/namespace_end.hxx"
+
+#endif /* header guard */

--- a/src/gpu/intel/jit/gemm/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/c_update.cxx
@@ -2364,7 +2364,7 @@ void BLASKernelGenerator<hw>::gemmKReduce(const GEMMProblem &problem, const GEMM
     if (state.r0_info.isARF()) stub();
     GRF r0_info{state.r0_info.getBase()};
 
-    bool initialBarrier = (strategy.slmBuffers > 0 || strategy.persistent);
+    bool initialBarrier = (strategy.slmBuffers > 0 || strategy.persistentLoop());
     MOCK_BARRIERS if (initialBarrier)
         activeThreadBarrierSignal(barrierTemp, r0_info, strategy);
 

--- a/src/gpu/intel/jit/gemm/generator/pieces/gemm.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/gemm.cxx
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 
+#include "atomic_fusions.hpp"
 #include "cooperative_split.hpp"
 #include "generator.hpp"
 #include "hw_utils.hpp"
@@ -46,7 +47,7 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
     const bool inFusedGEMM = false;
     bool anyKParallelFixed = strategy.kParallelLocal || strategy.kParallel;
 
-    Label lKernelDone, lReentry, lLeavePersistentLoop, lPadThread;
+    Label lKernelDone, lReentry, lLeavePersistentLoop, lPadThread, lKVPhaseDone;
 
     // By default, don't use dispatch mask.
     setDefaultNoMask();
@@ -150,20 +151,34 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
                 || (strategy.prefetchA && strategy.A_prefetch.address2D)
                 || (strategy.prefetchB && strategy.B_prefetch.address2D);
     if (anyKParallelFixed || strategy.kParallelVariable) {
-        if (strategy.persistent || strategy.fusePostOps || anyAB2D) {
+        if (strategy.persistentLoop() || strategy.fuseBeta || strategy.fusePostOps || anyAB2D) {
             state.fullK = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
             mov(1, state.fullK, state.inputs.k);
         }
     } else
         state.fullK = state.inputs.k;
 
-    if (strategy.kParallelVariable)
-        state.k0Rem = copySubregister(state.inputs.k0, state, getHint(HintType::LongTerm, strategy));
+    // Variable k-slicing initialization.
+    if (strategy.kParallelVariable) {
+        state.k0Rem = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
+        state.inputs.kSlicedTiles = state.inputs.kvConfig.uw(0);
+        state.inputs.kSyncSlabs = state.inputs.kvConfig.uw(1);
+        and_(1 | nz | f1[0], null.uw(), state.inputs.kSyncSlabs, 0x8000);
+        and_(1, state.inputs.kSyncSlabs, state.inputs.kSyncSlabs, 0x7FFF);
+        or_(1 | f1[0], state.inputs.flags, state.inputs.flags, FlagKSlice2);
+    }
 
     // L3 prefetch warmup.
     if (strategy.prefetchABL3) {
         gemmInitL3Prefetch(false, problem, strategy, state);
         gemmWarmupL3Prefetch(problem, strategy, state);
+    }
+
+    // Compute group count if needed and not passed as an argument.
+    if (state.groupCountMN.isInvalid() && (strategy.persistent || strategy.kParallelVariable)) {
+        state.groupCountMN = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
+        if (strategy.kParallelVariable)
+            emul(1, state.groupCountMN, state.inputs.groupCountM, state.inputs.groupCountN, strategy, state);
     }
 
     // Surface handling for quantization parameters.
@@ -245,7 +260,7 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
     if (problem.bqGroupN == 0) problem.bqGroupN = 1;
 
     // Persistent thread preparation and re-entry.
-    if (strategy.persistent) {
+    if (strategy.persistentLoop()) {
         if (!strategy.linearOrder()) stub();
         if (problem.batch != BatchMode::None) stub();       // need to wrangle groupIDK also
 
@@ -260,159 +275,12 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
         gemmFoldOffsets(problem, strategy, state);
 
         mark(lReentry);
-
     }
 
-    // Variable k-slicing logic.
-    if (strategy.kParallelVariable) {
-        if (!strategy.persistent) stub();
+    gemmStreamKSetup(lKVPhaseDone, lKernelDone, problem, strategy, state);
 
-        state.h0 = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
-        Label lNoKSlice, lAlreadySliced;
-
-        auto slicedGroupIdx = state.ra.alloc_sub<int32_t>();
-        auto slicedGroups   = state.ra.alloc_sub<uint32_t>();
-        auto temp           = state.ra.alloc_sub<uint32_t>();
-        auto temp2          = state.ra.alloc_sub<uint32_t>();
-        auto temp3          = state.ra.alloc_sub<uint32_t>();
-        auto gcMNStorage    = state.ra.alloc_sub<uint32_t>();
-        auto kpad           = state.ra.alloc_sub<uint32_t>();
-
-        // Check if we have reached the k-sliced region yet, and if so,
-        //   if we need to do k-slicing computations.
-        and_(1 | nz | f0[1], null.ud(), state.inputs.flags, FlagKSlicing);
-        add(1 | ge | f0[0], slicedGroupIdx, state.groupIDMN, -state.inputs.kParallelStart);
-        mov(1, state.h0, 0);
-        mov(1 | lt | f1[1], temp, state.fullK);
-        jmpi(1 | f0[1], lAlreadySliced);
-        if (strategy.kParallelLocal)
-            mov(1, state.inputs.k, state.fullK);
-        jmpi(1 | ~f0[0], lNoKSlice);
-
-        // Reverse ordering of slices so each WG traverses its tiles in reverse order.
-        // For the alternate fused beta path, this helps ensure beta scaling completes
-        //   before the other WGs need its result.
-        eadd3(1, temp, state.inputs.groupStride, -slicedGroupIdx, -1);
-
-        auto groupCountMN = state.inputs.groupCountMN;
-        if (groupCountMN.isInvalid()) {
-            groupCountMN = gcMNStorage;
-            emul(1, groupCountMN, state.inputs.groupCountM, state.inputs.groupCountN, strategy, state);
-        }
-
-        // Split remaining GEMM work (slicedGroups' worth) among persistent workgroups.
-        // Each workgroup gets a k0-sized range in k space, which may span
-        //  multiple C workgroup tiles.
-        // Divide (k0 * groupID) by k...
-        //        h0 <- remainder
-        //   groupID <- quotient + kParallelStart
-        // Also save groupID - kParallelStart back in slicedGroupIdx.
-        Subregister effKPad;
-        if (strategy.kPadding)
-            effKPad = gemmCalcKPadding(problem, strategy, state);
-        alignUp(kpad, state.inputs.k, strategy.kAlign(problem), strategy, state);
-        mul(1, temp, state.inputs.k0, temp.uw());
-        if (strategy.kPadding)
-            add(1, kpad, kpad, effKPad);
-        or_(1, state.inputs.flags, state.inputs.flags, FlagKSlicing);
-        divDown(slicedGroupIdx.ud(), temp, kpad, state.inputs.kRecip, f1[0], strategy, state);
-        emad(1, state.h0, temp, -kpad, slicedGroupIdx.ud(), strategy, state);
-        eadd3(1, state.groupIDMN, groupCountMN, -slicedGroupIdx.ud(), -1);
-        if (strategy.altFusedBeta)
-            add(1 | gt | f0[1], temp3.d(), state.h0, -state.inputs.k0);
-        add(1 | le | f1[1], temp.d(), state.fullK, -state.h0);
-        if (strategy.altFusedBeta) {
-            eadd3(1 | ge | f1[0], temp2.d(), state.h0, state.inputs.k0, -kpad);
-            cmp(1 | f0[1] | lt | f0[1], null.ud(), temp3.ud(), state.fullK);
-        }
-        add(1, slicedGroupIdx, state.groupIDMN, -state.inputs.kParallelStart);
-        if (strategy.altFusedBeta) {
-            // Decide if we are responsible for beta scaling.
-            // If within padded region (h0 >= k, f1.1), scale if f0.1:
-            //   - we're the first one in the padded region (h0 - k0 < k), and
-            //   - no WG completely covers the computation for this tile (h0 - k0 > 0)
-            // Otherwise (h0 < k, ~f1.1), scale only if no later WGs on this tile (h0 + k0 >= kpad, f1.0).
-            mov(1 | f1[1], f1[0], f0[1]);
-            or_(1 | f1[0], state.inputs.flags, state.inputs.flags, FlagDidBeta);
-        }
-
-        mark(lAlreadySliced);
-
-        // In the tail case, it's possible that we don't have a full k0 chunk
-        //  of work to do. Bail if so.
-        // If bias enabled, do it if h0 = 0.
-        cmp(1 | lt | f0[0], state.groupIDMN.d(), state.inputs.kParallelStart);
-        if (problem.cOffset == COffset::Pre)
-            cmp(1 | gt | f0[1], state.h0, 0);
-        min_(1, state.inputs.k, temp.d(), state.k0Rem);     /* temp holds k - h0 */
-            jmpi(1 | f0[0], lLeavePersistentLoop);
-        if (problem.cOffset == COffset::Pre)
-            or_(1 | f0[1], state.inputs.flags, state.inputs.flags, FlagNonfinalKBlock);
-
-        // Update k0Rem with remaining work.
-        if (strategy.kPadding) {
-            auto temp4 = gemmCalcKPadding(problem, strategy, state);
-            add(1, temp4, state.inputs.k, temp4);
-            mov(1 | sat, state.inputs.k.ud(), state.inputs.k);  /* k may have been negative in padded region */
-            add(1 | sat, state.k0Rem.ud(), state.k0Rem, -temp4);
-            state.ra.safeRelease(temp4);
-        } else
-            add(1 | sat, state.k0Rem.ud(), state.k0Rem, -state.inputs.k);
-
-        // With k padding, we might have a zero-size slice. Handle appropriately.
-        if (strategy.kPadding) {
-            if (strategy.altFusedBeta) {
-                Label lContinue;
-                jmpi(1 | ~f1[1], lContinue);
-                jmpi(1 | ~f1[0], lKernelDone);                  // Skip if zero-size and not doing beta scaling.
-                mark(lContinue);
-            } else
-                jmpi(1 | f1[1], lKernelDone);                   // Skip if zero-size.
-        }
-
-        // Beta/post-op fusing: check if we need to do it.
-        if (strategy.fuseBeta || strategy.fusePostOps) {
-            Label lNoCheck;
-
-            cmp(1 | eq | f1[0], state.inputs.k, state.fullK);
-            or_(1 | ~f1[0], state.inputs.flags, state.inputs.flags, FlagKPartitioned);
-            jmpi(1 | f1[0], lNoCheck);
-            gemmFusedBetaPOInit(slicedGroupIdx, problem, strategy, state);
-            mark(lNoCheck);
-        }
-
-        mark(lNoKSlice);
-
-        // Further slice k range within workgroup if requested.
-        // k local size must be a power of 2.
-        state.wgK = state.inputs.k;
-        if (strategy.kParallelLocal) {
-            if (!is_zero_or_pow2(strategy.wg[LoopK])) stub();
-            if (strategy.kInterleave) stub();
-            state.threadK0 = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
-            if ((strategy.fuseBeta && !strategy.altFusedBeta) || strategy.fusePostOps) {
-                state.wgK = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
-                mov(1, state.wgK, state.inputs.k);
-            }
-            fbl(1, temp, state.lszK);
-            eadd3(1, state.threadK0, state.inputs.k, state.lszK, -1);
-            shr(1, state.threadK0, state.threadK0, temp);
-            alignUp(state.threadK0, state.threadK0, strategy.kAlign(problem), strategy, state);
-            mul(1, temp, state.threadK0, state.lidK.uw());
-            add(1 | sat, state.inputs.k.ud(), state.inputs.k, -temp);
-            add(1, state.h0, state.h0, temp);
-            min_(1, state.inputs.k, state.inputs.k, state.threadK0);
-        }
-
-        state.ra.safeRelease(effKPad);
-        state.ra.safeRelease(slicedGroupIdx);
-        state.ra.safeRelease(slicedGroups);
-        state.ra.safeRelease(kpad);
-        state.ra.safeRelease(temp);
-        state.ra.safeRelease(temp2);
-        state.ra.safeRelease(temp3);
-        state.ra.safeRelease(gcMNStorage);
-    }
+    if (state.groupCountMN.isValid() && state.inputs.groupCountMN.isInvalid())
+        state.ra.release(state.groupCountMN);
 
     if (strategy.kParallel && (strategy.fuseBeta || strategy.fusePostOps)) {
         if (!strategy.linearOrder()) stub();
@@ -462,17 +330,14 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
             add(1 | lt | state.flagAP, idK.d(), idK, -state.inputs.localSizeK);
             mov(1 | state.flagAP, state.inputs.k0, 0);
         }
-        if (strategy.fusePostOps) {
-            state.wgK = state.inputs.k;
-            if (strategy.kParallelLocal) {
-                state.wgK = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
-                auto temp = state.ra.alloc_sub<uint32_t>();
-                emul(1, state.wgK, idK, state.inputs.k0, strategy, state);
-                mul(1, temp, state.inputs.k0, state.inputs.localSizeK.uw());
-                add(1 | sat, state.wgK, state.inputs.k, -state.wgK);
-                min_(1, state.wgK, state.wgK, temp);
-                state.ra.safeRelease(temp);
-            }
+        if ((strategy.fuseBeta || strategy.fusePostOps) && strategy.kParallelLocal) {
+            state.wgK = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
+            auto temp = state.ra.alloc_sub<uint32_t>();
+            emul(1, state.wgK, idK, state.inputs.k0, strategy, state);
+            mul(1, temp, state.inputs.k0, state.inputs.localSizeK.uw());
+            add(1 | sat, state.wgK, state.inputs.k, -state.wgK);
+            min_(1, state.wgK, state.wgK, temp);
+            state.ra.safeRelease(temp);
         }
     }
 
@@ -514,16 +379,16 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
     state.ra.safeRelease(idM);
     state.ra.safeRelease(idN);
     state.ra.safeRelease(idK);
-    if (!strategy.persistent) {
+    if (!strategy.persistentLoop()) {
         state.ra.safeRelease(state.inputs.localSizeM);
         state.ra.safeRelease(state.inputs.localSizeN);
     }
     if (anyKParallelFixed) {
         state.ra.safeRelease(state.inputs.localIDK);
-        if (!strategy.persistent)
+        if (!strategy.persistentLoop())
             state.ra.safeRelease(state.inputs.localSizeK);
     }
-    if (strategy.linearOrder() || strategy.persistent) {
+    if (strategy.linearOrder() || strategy.persistentLoop()) {
         state.ra.safeRelease(state.inputs.groupIDM);
         state.ra.safeRelease(state.inputs.groupIDN);
         state.ra.claim(state.nextGroupIDM);
@@ -534,7 +399,7 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
 
     // Adjust k range for local/global k-reduction.
     if (anyKParallelFixed && !strategy.kParallelVariable) {
-        add(1 | sat, state.inputs.k.ud(), strategy.persistent ? state.fullK : state.inputs.k, -state.h0);
+        add(1 | sat, state.inputs.k.ud(), strategy.persistentLoop() ? state.fullK : state.inputs.k, -state.h0);
 
         if (strategy.kInterleave) {
             // k <- floor(k / (chunk * k local size)) * chunk + min(k % (chunk * k local size), chunk)
@@ -552,11 +417,15 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
             state.ra.safeRelease(temp2);
         }
 
+        if (strategy.kParallel && !strategy.kParallelLocal && (strategy.fuseBeta || strategy.fusePostOps)) {
+            state.wgK = state.ra.allocSub<uint32_t>(getHint(HintType::LongTerm));
+            min_(1, state.wgK, state.inputs.k, state.inputs.k0);
+        }
         min_(1, state.inputs.k, state.inputs.k, state.inputs.k0);
 
         bool keepK0 = false;
         keepK0 |= strategy.kParallelLocal && (strategy.barrierFreq > 0 || strategy.slmBuffers > 0);
-        keepK0 |= strategy.persistent;
+        keepK0 |= strategy.persistentLoop();
 
         if (keepK0)
             state.threadK0 = state.inputs.k0;
@@ -596,7 +465,7 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
     mark(lKernelDone);
 
     // Persistent thread loop. Advance group ID and re-enter kernel if there's more work to do.
-    if (strategy.persistent) {
+    if (strategy.persistentLoop()) {
         status << "Persistent loop" << status_stream::endl;
 
         GRF temp;
@@ -614,6 +483,13 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
             }
         };
 
+        // Recompute group count if needed.
+        if (state.inputs.groupCountMN.isInvalid()) {
+            state.ra.claim(state.groupCountMN);
+            emul(1, state.groupCountMN, state.inputs.groupCountM, state.inputs.groupCountN, strategy, state);
+        }
+
+        // Clear flags as needed.
         uint32_t flagsToClear = 0;
 
         if (strategy.fuseBeta)
@@ -634,32 +510,50 @@ void BLASKernelGenerator<hw>::gemm(GEMMProblem &problem, GEMMStrategy &strategy,
         if (strategy.kParallelVariable) {
             Label lNotKSliced;
             and_(1 | ze | f0[0], null.ud(), state.inputs.flags, FlagKSlicing);
+            if (strategy.persistent)
+                and_(1 | nz | f0[1], null.ud(), state.inputs.flags, FlagKSlice2);
             cmp(1 | gt | f1[0], state.k0Rem, 0);
+
             jmpi(1 | f0[0], lNotKSliced);
-            add(1, state.groupIDMN, state.groupIDMN, -1);
-            alignDown(1 | gt | f0[1], state.k0Rem.ud(), state.k0Rem.ud(), strategy.kAlign(problem), strategy, state);
+
+            // Continue work on this slice, if any remaining.
             persistentRestore();
-            jmpi(1 | f0[1], lReentry);
-            jmpi(1, lLeavePersistentLoop);
+            jmpi(1 | f1[0], lReentry);
+
+            // Otherwise, advance to next slice, if any.
+            if (strategy.persistent) {
+                Label lCheckSlice2;
+
+                mark(lCheckSlice2);
+                jmpi(1 | ~f0[1], lLeavePersistentLoop);
+                gemmStreamKPrepareSlice2(problem, strategy, state);
+                jmpi(1, lReentry);
+
+                mark(lKVPhaseDone);
+                and_(1 | nz | f0[1], null.ud(), state.inputs.flags, FlagKSlice2);
+                jmpi(1, lCheckSlice2);
+            } else
+                mark(lKVPhaseDone);
             mark(lNotKSliced);
         }
 
-        if (state.inputs.groupCountMN.isInvalid()) {
-            state.inputs.groupCountMN = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
-            emul(1, state.inputs.groupCountMN, state.inputs.groupCountM, state.inputs.groupCountN, strategy, state);
+        if (strategy.persistent) {
+            add(1, state.groupIDMN, state.groupIDMN, state.inputs.groupStride);
+            if (strategy.kParallelVariable)
+                cmp(1 | gt | f1[0], state.inputs.kSlicedTiles, 0);
+            cmp(1 | lt | f0[0], state.groupIDMN, state.groupCountMN);
+
+            persistentRestore();
+            if (strategy.kParallelVariable)
+                jmpi(1 | f1[0], lReentry);
+            jmpi(1 | f0[0], lReentry);
         }
 
-        add(1, state.groupIDMN, state.groupIDMN, state.inputs.groupStride);
-        cmp(1 | lt | f0[0], state.groupIDMN, state.inputs.groupCountMN);
-        state.ra.safeRelease(state.inputs.groupCountMN);
-
-        persistentRestore();
-        jmpi(1 | f0[0], lReentry);
-
-        if (strategy.kParallelVariable) {
-            jmpi(1 | f1[0], lReentry);
+        if (strategy.kParallelVariable)
             mark(lLeavePersistentLoop);
-        }
+
+        state.ra.safeRelease(state.inputs.groupCountMN);
+        state.ra.safeRelease(state.groupCountMN);
     }
 
     mark(lPadThread);

--- a/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
@@ -571,7 +571,7 @@ void BLASKernelGenerator<hw>::gemmOffsetBatchABC(const GEMMProblem &problem, con
                 auto offsetC = state.offsetC[q];
                 eadd(1, offsetC, offsetC, bOffsetC[b], strategy, state);
             }
-            if (!strategy.persistent) {
+            if (!strategy.persistentLoop()) {
                 state.ra.safeRelease(state.inputs.strideA[b]);
                 state.ra.safeRelease(state.inputs.strideB[b]);
                 state.ra.safeRelease(state.inputs.strideC[b]);
@@ -643,7 +643,7 @@ void BLASKernelGenerator<hw>::gemmRestoreOffsets(const GEMMProblem &problem, con
 template <HW hw>
 void BLASKernelGenerator<hw>::gemmSetupABC(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
 {
-    if (strategy.persistent) {
+    if (strategy.persistentLoop()) {
         state.effA = state.offsetA;
         state.effB = state.offsetB;
         for (int q = 0; q < state.C_count; q++)
@@ -658,7 +658,7 @@ void BLASKernelGenerator<hw>::gemmSetupABC(const GEMMProblem &problem, const GEM
                 state.effC[q] = state.inputs.C[q] = state.ra.alloc_sub<uint64_t>(getHint(HintType::LongTerm, strategy));
 
             eadd(1, state.effC[q], Csrc, state.offsetC[q], strategy, state);
-            if (strategy.persistent)
+            if (strategy.persistentLoop())
                 state.offsetC[q] = invalid;
             else
                 state.ra.safeRelease(state.offsetC[q]);
@@ -667,7 +667,7 @@ void BLASKernelGenerator<hw>::gemmSetupABC(const GEMMProblem &problem, const GEM
 
     if (problem.usesCO() && strategy.CO.base.isStateless()) {
         eadd(1, state.effCO, state.inputs.CO, state.offsetCO, strategy, state);
-        if (strategy.persistent)
+        if (strategy.persistentLoop())
             state.offsetCO = invalid;
         else
             state.ra.safeRelease(state.offsetCO);
@@ -706,7 +706,7 @@ void BLASKernelGenerator<hw>::gemmSetupABC(const GEMMProblem &problem, const GEM
             state.effA = state.inputs.A = state.ra.alloc_sub<uint64_t>(getHint(HintType::LongTerm, strategy));
 
         eadd(1, state.effA, Asrc, state.offsetA, strategy, state);
-        if (strategy.persistent)
+        if (strategy.persistentLoop())
             state.offsetA = invalid;
         else
             state.ra.safeRelease(state.offsetA);
@@ -714,7 +714,7 @@ void BLASKernelGenerator<hw>::gemmSetupABC(const GEMMProblem &problem, const GEM
 
     if (strategy.B.base.isStateless()) {
         eadd(1, state.effB, state.inputs.B, state.offsetB, strategy, state);
-        if (strategy.persistent)
+        if (strategy.persistentLoop())
             state.offsetB = invalid;
         else
             state.ra.safeRelease(state.offsetB);
@@ -747,7 +747,7 @@ void BLASKernelGenerator<hw>::gemmGetBatchIDs(const GEMMProblem &problem, const 
         if (i > 0) {
             divDown(div, div, state.inputs.batchSize[i - 1], state.inputs.recipBatchSize[i - 1], state.flagAP, strategy, state);
             emad(1, state.batchID[idx], state.batchID[idx], -div, state.inputs.batchSize[i - 1], strategy, state);
-            if (!strategy.persistent) {
+            if (!strategy.persistentLoop()) {
                 state.ra.safeRelease(state.inputs.batchSize[i - 1]);
                 state.ra.safeRelease(state.inputs.recipBatchSize[i - 1]);
             }
@@ -913,17 +913,6 @@ void BLASKernelGenerator<hw>::gemmCacheLDCMultiples(const GEMMProblem &problem, 
     int C_count = prefetch ? 1 : state.C_count;
     for (int q = 0; q < C_count; q++)
         state.ldcMultiples[q] = createLDMultiples(a64, nc, state.inputs.ldc[q], strategy, state);
-}
-
-// Calculate actual amount of k-padding for variable k-slicing.
-template <HW hw>
-Subregister BLASKernelGenerator<hw>::gemmCalcKPadding(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
-{
-    // kpad = min(strategy.kPadding, 2*k0).
-    auto effKPad = state.ra.alloc_sub<uint32_t>();
-    shl(1, effKPad, state.inputs.k0, 1);
-    min_(1, effKPad, effKPad, strategy.kPadding);
-    return effKPad;
 }
 
 template <HW hw>
@@ -1855,7 +1844,7 @@ bool BLASKernelGenerator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStr
         }
         gemmRepack2DOffsetData(problem.Ta_ext, problem.Tao, state.Tao_int, A_offsetLayout, state.Ar_offsetLayout, aoLoad, state.Ar_offsetRegs, problem, strategy, state);
         state.ra.safeRelease(aoLoad);
-        if (!strategy.persistent)
+        if (!strategy.persistentLoop())
             state.ra.safeRelease(state.inputs.aoPtr);
     }
     if (boTo2D) {
@@ -1883,7 +1872,7 @@ bool BLASKernelGenerator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStr
         }
         gemmRepack2DOffsetData(problem.Tb_ext, problem.Tbo, state.Tbo_int, B_offsetLayout, state.Br_offsetLayout, boLoad, state.Br_offsetRegs, problem, strategy, state);
         state.ra.safeRelease(boLoad);
-        if (!strategy.persistent)
+        if (!strategy.persistentLoop())
             state.ra.safeRelease(state.inputs.boPtr);
     }
     if (i0q != state.i0) state.ra.safeRelease(i0q);
@@ -2521,15 +2510,13 @@ void BLASKernelGenerator<hw>::gemmInitInterface(GEMMProblem &problem, GEMMStrate
         state.inputs.bslice = interface.getArgument("bslice");
         state.inputs.bthresh = interface.getArgument("bthresh");
     }
-    if (strategy.persistent) {
+    if (strategy.persistent)
         state.inputs.groupCountMN = interface.getArgumentIfExists("group_count");
+    if (strategy.persistent || strategy.kParallelVariable)
         state.inputs.groupStride = interface.getArgument("group_stride");
-        if (strategy.kParallelVariable) {
-            state.inputs.kParallelStart = interface.getArgument("k_parallel_start");
-            state.inputs.kRecip = interface.getArgument("k_recip");
-            if (strategy.fuseBeta)
-                state.inputs.k0Recip = interface.getArgument("k0_recip");
-        }
+    if (strategy.kParallelVariable) {
+        state.inputs.kvConfig = interface.getArgument("kv_config");
+        state.inputs.kRecip = interface.getArgument("k_recip");
     }
     if (strategy.kParallel && strategy.fuseBeta)
         state.inputs.groupCountK = interface.getArgument("group_count_k");
@@ -2577,6 +2564,7 @@ void BLASKernelGenerator<hw>::gemmInitInterface(GEMMProblem &problem, GEMMStrate
         state.groupIDMN = state.inputs.groupIDMN = tgids[0];
         state.inputs.groupIDM = invalid;
         state.inputs.groupIDN = invalid;
+        state.groupCountMN = state.inputs.groupCountMN;
     }
 
     // Move SLM pointers to offset arguments.
@@ -2769,17 +2757,15 @@ void BLASKernelGenerator<hw>::gemmInitInterface(GEMMProblem &problem, GEMMStrate
         state.ra.claim(state.inputs.bthresh);
     }
 
-    if (strategy.persistent) {
+    if (strategy.persistent || strategy.kParallelVariable)
         state.ra.claim(state.inputs.groupStride);
-        if (state.inputs.groupCountMN.isValid())
-            state.ra.claim(state.inputs.groupCountMN);
-    }
+
+    if (state.inputs.groupCountMN.isValid())
+        state.ra.claim(state.inputs.groupCountMN);
 
     if (strategy.kParallelVariable) {
-        state.ra.claim(state.inputs.kParallelStart);
+        state.ra.claim(state.inputs.kvConfig);
         state.ra.claim(state.inputs.kRecip);
-        if (strategy.fuseBeta)
-            state.ra.claim(state.inputs.k0Recip);
     }
 
     if (strategy.kParallel && strategy.fuseBeta)
@@ -2806,7 +2792,7 @@ void BLASKernelGenerator<hw>::gemmInitState(GEMMProblem &problem, GEMMStrategy &
         initState(problem, strategy, state);
         gemmInitInterface(problem, strategy, state, inSK);
         state.isNested |= strategy.fused;
-        state.isNested |= strategy.persistent;
+        state.isNested |= strategy.persistentLoop();
     }
 
     state.effA = strategy.A.base.isStateless() ? state.inputs.A
@@ -2858,7 +2844,7 @@ void BLASKernelGenerator<hw>::gemmInitState(GEMMProblem &problem, GEMMStrategy &
     if (strategy.kParallel || strategy.kParallelLocal)
         state.lidK = state.inputs.localIDK[0];
 
-    state.k = state.inputs.k;
+    state.k = state.wgK = state.inputs.k;
 
     state.lda = state.inputs.lda;
     state.ldb = state.inputs.ldb;

--- a/src/gpu/intel/jit/gemm/generator/pieces/k_loop.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/k_loop.cxx
@@ -1537,7 +1537,7 @@ void BLASKernelGenerator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMM
 
         state.ra.safeRelease(myBarriers);
         state.ra.safeRelease(k0Barriers);
-        if (!strategy.persistent && !strategy.fuseBeta && !strategy.kParallelVariable) {
+        if (!strategy.persistentLoop() && !strategy.fuseBeta && !strategy.kParallelVariable) {
             state.ra.safeRelease(state.threadK0);
             state.ra.safeRelease(state.inputs.k0);
         }

--- a/src/gpu/intel/jit/gemm/generator/pieces/post_ops.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/post_ops.cxx
@@ -398,7 +398,7 @@ bool BLASKernelGenerator<hw>::gemmApplyCOffsetDispatch(const GEMMProblem &proble
 
     mark(labelCODone);
 
-    if (!strategy.persistent) {
+    if (!strategy.persistentLoop()) {
         state.ra.safeRelease(ldco);
         state.ra.safeRelease(effCO);
     }
@@ -788,7 +788,7 @@ void BLASKernelGenerator<hw>::gemmApplyABOffset(const GEMMProblem &problem, cons
     state.ra.safeRelease(boData);
     safeReleaseRanges(state.As_regs, state);
     safeReleaseRanges(state.Bs_regs, state);
-    if (!strategy.persistent) {
+    if (!strategy.persistentLoop()) {
         state.ra.safeRelease(state.inputs.ao);
         state.ra.safeRelease(state.inputs.bo);
     }

--- a/src/gpu/intel/jit/gemm/generator/pieces/state.hpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/state.hpp
@@ -211,7 +211,8 @@ struct GEMMState : public CommonState {
         ngen::Subregister groupCountMN;                     // ud
         ngen::Subregister gcMNRecip;                        // ud
         ngen::Subregister groupStride;                      // ud
-        ngen::Subregister kParallelStart, kRecip, k0Recip;  // ud
+        ngen::Subregister kvConfig, kRecip;                 // ud
+        ngen::Subregister kSlicedTiles, kSyncSlabs;         // uw
         ngen::Subregister hilbertVD, hilbertUVDRecip;       // ud
         ngen::Subregister hilbertBail;                      // ud
         ngen::Subregister bslice, bthresh;                  // d
@@ -283,7 +284,7 @@ struct GEMMState : public CommonState {
     std::vector<MaskAssignment> AB_masks, AB_masksCoop;
     ngen::GRFRange broadcast_regs;
     std::vector<ngen::GRFRange> tempMul_regs;
-    ngen::Subregister groupIDMN;                            // d
+    ngen::Subregister groupCountMN, groupIDMN;              // ud
     ngen::Subregister i0, j0, h0;                           // d
     ngen::Subregister wgI0, wgJ0;                           // d
     ngen::Subregister threadK0, k0Rem, wgK;                 // ud

--- a/src/gpu/intel/jit/gemm/generator/pieces/stream_k.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/stream_k.cxx
@@ -1,0 +1,284 @@
+/*******************************************************************************
+* Copyright 2023-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+
+#include "atomic_fusions.hpp"
+#include "generator.hpp"
+
+
+#include "internal/namespace_start.hxx"
+
+using namespace ngen;
+using namespace ngen::utils;
+using std::vector;
+
+
+template <HW hw>
+void BLASKernelGenerator<hw>::gemmStreamKPrepareSlice2(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
+{
+    auto done = state.ra.alloc_sub<uint32_t>();
+    auto statusInc = state.ra.alloc_sub<uint32_t>();
+    auto tempCInc = state.ra.alloc_sub<uint32_t>();
+
+    avg(1, done, state.inputs.kSlicedTiles, 0);
+    if (strategy.persistent)
+        and_(1, state.inputs.flags, state.inputs.flags, ~uint32_t(FlagKSlicing | FlagKSlice2));
+    if (state.inputs.statusBuffer.isValid())
+        mulConstant(1, statusInc, done, strategy.statusFlagStride());
+    if (state.inputs.tempC.isValid())
+        mulConstant(1, tempCInc, done, tempCWGStride(problem, strategy));
+    add(1, state.inputs.kSlicedTiles, state.inputs.kSlicedTiles, -done);
+    if (state.inputs.statusBuffer.isValid())
+        eadd(1, state.inputs.statusBuffer, state.inputs.statusBuffer, statusInc, strategy, state);
+    if (state.inputs.tempC.isValid())
+        eadd(1, state.inputs.tempC, state.inputs.tempC, tempCInc, strategy, state);
+    if (strategy.persistent)
+        eadd3(1, state.groupIDMN, state.groupCountMN, -state.inputs.kSlicedTiles, state.inputs.groupIDMN);
+
+    state.ra.safeRelease(statusInc);
+    state.ra.safeRelease(tempCInc);
+    state.ra.safeRelease(done);
+}
+
+// Variable k-slicing/stream-k main logic.
+template <HW hw>
+void BLASKernelGenerator<hw>::gemmStreamKSetup(Label &lKVPhaseDone, Label &lKernelDone,
+                                               const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
+{
+    if (!strategy.kParallelVariable) return;
+
+    state.h0 = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
+    Label lNoKSlice, lAlreadySliced, lGotSlice, lSync, lFirst;
+
+    auto slicedTileIdx   = state.ra.alloc_sub<uint32_t>();
+    auto nonKSyncedWGs   = state.ra.alloc_sub<uint16_t>();
+    auto kSlicedTiles    = state.ra.alloc_sub<uint16_t>();
+    auto temp            = state.ra.alloc_sub<uint32_t>();
+    auto virtualKPadding = state.ra.alloc_sub<uint32_t>();
+    auto kPadStorage     = state.ra.alloc_sub<uint32_t>();
+    auto kUnsynced       = state.ra.alloc_sub<uint32_t>();
+    auto &h0             = state.h0;
+    auto h1              = state.ra.alloc_sub<uint32_t>();
+    auto &k0Rem          = state.k0Rem;
+
+    Subregister kPad = state.fullK;
+
+    status << "Variable k-slicing" << status_stream::endl;
+
+    // Find the size of our k-sliced region, if there are two regions ("phases").
+    and_(1 | nz | f1[1], null.ud(), state.inputs.flags, FlagKSlice2);
+    mov(1, kSlicedTiles, state.inputs.kSlicedTiles);
+    avg(1 | f1[1], kSlicedTiles, state.inputs.kSlicedTiles, 0);
+
+    // Check if we have reached the k-sliced region yet, and if so,
+    //   if we need to do k-slicing computations.
+    and_(1 | nz | f0[1], null.ud(), state.inputs.flags, FlagKSlicing);
+    eadd3(1 | ge | f0[0], slicedTileIdx.d(), state.groupIDMN, -state.groupCountMN, state.inputs.kSlicedTiles);
+    mov(1, state.h0, 0);
+    if (strategy.kParallelLocal)
+        mov(1, state.inputs.k, state.fullK);
+    jmpi(1 | ~f0[0], lNoKSlice);
+
+    if (!strategy.persistent) {
+        // Check if we are in the second phase, and adjust as needed.
+        add(1 | ge | f0[0], temp.d(), slicedTileIdx.d(), -state.inputs.groupStride);
+        jmpi(1 | f0[1], lFirst);
+        jmpi(1 | ~f0[0], lFirst);
+        mov(1, slicedTileIdx, temp);
+        gemmStreamKPrepareSlice2(problem, strategy, state);
+        mov(1, kSlicedTiles, state.inputs.kSlicedTiles);
+        mark(lFirst);
+    }
+
+    // Divide up k-space into two parts:
+    //   k-synchronized: WGs have aligned h0, one tile per WG
+    //   unsynchronized: scattered h0, possibly multiple tiles per WG.
+    // At the same time, compute any virtual k-padding.
+    emad(1, nonKSyncedWGs, state.inputs.groupStride, -state.inputs.kSyncSlabs, kSlicedTiles, strategy, state);
+    if (strategy.kPadding)
+        shl(1 | sat, virtualKPadding, state.inputs.k0, 1);
+    emad(1, kUnsynced, state.fullK, state.inputs.k0, -state.inputs.kSyncSlabs, strategy, state);
+    add(1 | ge | f0[0], temp.d(), slicedTileIdx, -nonKSyncedWGs);
+    if (strategy.kPadding)
+        min_(1, virtualKPadding, virtualKPadding, strategy.kPadding);
+    alignUp(kUnsynced, kUnsynced, strategy.kAlign(problem), strategy, state);
+    if (strategy.kPadding) {
+        add(1, kUnsynced, kUnsynced, virtualKPadding);
+        add(1, kPadStorage, state.fullK, virtualKPadding);
+        kPad = kPadStorage;
+    }
+
+    jmpi(1 | f0[1], lAlreadySliced);
+    jmpi(1 | f0[0], lSync);
+    {
+        // Unsynchronized section ("stream-k" part).
+        // Each workgroup gets a roughly k0-sized range in k space, which may span
+        //  multiple C tiles.
+
+        // Traverse tiles backward:
+        eadd3(1, temp, nonKSyncedWGs, -slicedTileIdx, -1);
+
+        // Locate ending tile and k value:
+        //    h1 <- (k0 * slicedTileIdx) % kUnsynced
+        //  tile <- (k0 * slicedTileIdx) / kUnsynced
+        mul(1, temp, state.inputs.k0, temp.uw());
+        divDown(slicedTileIdx, temp, kUnsynced, state.inputs.kRecip, f1[0], strategy, state);
+        emad(1, h1, temp, -kUnsynced, slicedTileIdx.uw(), strategy, state);
+
+        // Restore tile order:
+        eadd3(1 | lt | f0[0], slicedTileIdx.d(), kSlicedTiles, -slicedTileIdx, -1);
+        add(1, h1, kUnsynced, -h1);
+
+        // Keep track of total k work allotted to this WG.
+        mov(1, k0Rem, state.inputs.k0);
+
+        // Find beginning of k range:
+        add(1 | sat, h0.ud(), h1, -state.inputs.k0);
+    }
+    jmpi(1, lGotSlice);
+    mark(lSync);
+    {
+        // k-synchronized section. On entry, temp holds WG's index within this section.
+        //    h0 <- (temp / kSlicedTiles) * k0 + kUnsynced
+        //  tile <- (temp % kSlicedTiles)
+        divMod(h0, slicedTileIdx, temp, kSlicedTiles, strategy, state);
+        emad(1, h0, kUnsynced, state.inputs.k0, h0.uw(), strategy, state);
+        mov(1, h1, kPad);
+        mov(1, k0Rem, 0);
+        cmp(1 | ge | f0[0], h0, kPad);
+    }
+    jmpi(1, lGotSlice);
+    mark(lAlreadySliced);
+    {
+        // Starting a new tile in the unsynchronized section.
+        add(1 | lt | f0[0], slicedTileIdx.d(), slicedTileIdx, -1);
+        add(1 | sat, h0.ud(), kUnsynced, -k0Rem);
+        mov(1, h1, kUnsynced);
+    }
+    mark(lGotSlice);
+
+    or_(1, state.inputs.flags, state.inputs.flags, FlagKSlicing);
+
+    // Early exit if no work for this WG.
+    jmpi(1 | f0[0], lKVPhaseDone);
+
+    // Check if our WG is responsible for beta scaling.
+    // Choose the WG covering:
+    //     h = 0   (no virtual padding);
+    //     h = -1  (virtual padding).
+    if (strategy.altFusedBeta) {
+        if (strategy.kPadding)
+            cmp(1 | lt | f1[0], h0, virtualKPadding);
+        else
+            cmp(1 | eq | f1[0], h0, 0);
+    }
+
+    // Clamp k range.
+    add(1, temp, h0, state.inputs.k0);
+    min_(1, h1, h1, temp);
+
+    // Update remaining k work to do. TODO: can skip for k-sync'ed.
+    add(1 | sat, temp.ud(), h1, -h0);
+    add(1 | sat, k0Rem.ud(), k0Rem, -temp);
+
+    // If needed, check how much k work is left after us on this tile.
+    if (strategy.altFusedBeta && strategy.kPadding)
+        add(1 | sat, temp.ud(), kPad, -h1);
+
+    // Part 2 of beta scaling check.
+    if (strategy.altFusedBeta && strategy.kPadding)
+        cmp(1 | f1[0] | ge | f1[0], h1, virtualKPadding);
+
+    // Remove (virtual) padding from bottom of the k range.
+    if (strategy.kPadding) {
+        add(1 | sat, h1.ud(), h1, -virtualKPadding);
+        add(1 | sat, h0.ud(), h0, -virtualKPadding);
+    }
+
+    // Remove (alignment) padding from top of the k range.
+    min_(1, h1, h1, state.fullK);
+
+    // Determine physical k range for this slice, and update group ID.
+    add(1 | sat | ze | f1[1], state.inputs.k, h1, -h0);
+    eadd3(1, state.groupIDMN, slicedTileIdx, state.groupCountMN, -state.inputs.kSlicedTiles);
+    min_(1, state.inputs.k, state.inputs.k, state.inputs.k0);
+
+    // Assign responsibility for beta scaling.
+    if (strategy.altFusedBeta)
+        or_(1 | f1[0], state.inputs.flags, state.inputs.flags, FlagDidBeta);
+
+    // If needed, check if we are handling the entire tile.
+    if (strategy.fuseBeta || strategy.fusePostOps)
+        cmp(1 | eq | f0[1], state.inputs.k, state.fullK);
+
+    // With k padding, we might have a zero-size slice. Handle appropriately.
+    if (strategy.kPadding) {
+        if (strategy.altFusedBeta) {
+            Label lContinue;
+            jmpi(1 | ~f1[1], lContinue);
+            // This WG is wholly inside the padded region.
+            // We still need to do beta scaling if it's our responsibility, unless
+            //   there's only one other WG on the tile.
+            cmp(1 | ge | f0[1], state.inputs.k0, temp);
+            jmpi(1 | ~f1[0], lKernelDone);                  // Skip if zero-size and not doing beta scaling.
+            jmpi(1 | f0[1], lKernelDone);                   // Skip if another WG is taking care of this entire tile.
+            mark(lContinue);
+        } else
+            jmpi(1 | f1[1], lKernelDone);                   // Skip if zero-size.
+    }
+
+    // Beta/post-op fusing: check if we need to do it.
+    if (strategy.fuseBeta || strategy.fusePostOps) {
+        Label lNoCheck;
+        jmpi(1 | f0[1], lNoCheck);
+        or_(1, state.inputs.flags, state.inputs.flags, FlagKPartitioned);
+        gemmFusedBetaPOInit(slicedTileIdx, problem, strategy, state);
+        mark(lNoCheck);
+    }
+
+    mark(lNoKSlice);
+
+    // Further slice k range within workgroup if requested.
+    // k local size must be a power of 2.
+    if (strategy.kParallelLocal) {
+        if (!is_zero_or_pow2(strategy.wg[LoopK])) stub();
+        if (strategy.kInterleave) stub();
+        state.threadK0 = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
+        if (strategy.fuseBeta || strategy.fusePostOps) {
+            state.wgK = state.ra.alloc_sub<uint32_t>(getHint(HintType::LongTerm, strategy));
+            mov(1, state.wgK, state.inputs.k);
+        }
+        fbl(1, temp, state.lszK);
+        eadd3(1, state.threadK0, state.inputs.k, state.lszK, -1);
+        shr(1, state.threadK0, state.threadK0, temp);
+        alignUp(state.threadK0, state.threadK0, strategy.kAlign(problem), strategy, state);
+        mul(1, temp, state.threadK0, state.lidK.uw());
+        add(1 | sat, state.inputs.k.ud(), state.inputs.k, -temp);
+        add(1, state.h0, state.h0, temp);
+        min_(1, state.inputs.k, state.inputs.k, state.threadK0);
+    }
+
+    state.ra.safeRelease(slicedTileIdx);
+    state.ra.safeRelease(nonKSyncedWGs);
+    state.ra.safeRelease(kSlicedTiles);
+    state.ra.safeRelease(temp);
+    state.ra.safeRelease(virtualKPadding);
+    state.ra.safeRelease(kPadStorage);
+    state.ra.safeRelease(kUnsynced);
+    state.ra.safeRelease(h1);
+}
+
+#include "internal/namespace_end.hxx"

--- a/src/gpu/intel/jit/gemm/generator/strategy.cpp
+++ b/src/gpu/intel/jit/gemm/generator/strategy.cpp
@@ -58,7 +58,7 @@ bool GEMMStrategy::needsUnnamedBarrier(const GEMMProblem &problem) const
     if (needsKLoopBarrier() && (!namedBarriers[LoopM] || !namedBarriers[LoopN]))
         return true;
     if (slmBuffers > 0) {
-        if (persistent) return true;
+        if (persistentLoop()) return true;
         if (problem.needsASums() || problem.needsBSums()) return true;
     }
     if (kParallelLocal) return true;

--- a/src/gpu/intel/jit/gemm/generator/strategy_parser.cpp
+++ b/src/gpu/intel/jit/gemm/generator/strategy_parser.cpp
@@ -388,7 +388,6 @@ void parseStrategy(const char *str, HW hw, const GEMMProblem &problem, GEMMStrat
                 strategy.kParallelVariable = true;
                 strategy.fuseBeta = true;
                 strategy.fusePostOps = true;
-                strategy.persistent = true;
             }
             strategy.C.atomic = true;
             strategy.CO.atomic = problem.sumA || problem.sumB;
@@ -565,7 +564,7 @@ void parseStrategy(const char *str, HW hw, const GEMMProblem &problem, GEMMStrat
 
     if (strategy.block2DCRemainder && !gotSR) strategy.altCRemainder = true;
 
-    if (strategy.persistent && !strategy.linearOrder()) strategy.cWalkOrder = WalkOrder::SimpleLinear;
+    if (strategy.persistentLoop() && !strategy.linearOrder()) strategy.cWalkOrder = WalkOrder::SimpleLinear;
 
     // Use new LSC messages on Xe2+
     if (hw >= ngen::HW::Xe2) {

--- a/src/gpu/intel/jit/gemm/include/gemmstone/driver_info.hpp
+++ b/src/gpu/intel/jit/gemm/include/gemmstone/driver_info.hpp
@@ -143,6 +143,7 @@ enum {
     FlagKPartitioned = 0x4000,
     FlagDidBeta = 0x100,
     FlagSkipBetaCheck = 0x200,
+    FlagKSlice2 = 0x10000,
 };
 
 #include "internal/namespace_end.hxx"

--- a/src/gpu/intel/jit/gemm/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/jit/gemm/include/gemmstone/generator.hpp
@@ -182,6 +182,7 @@ protected:
     template <typename DT = void> void divDown(const ngen::Subregister &dst, const ngen::Subregister &src, uint16_t divisor, const CommonStrategy &strategy, CommonState &state);
     template <typename DT = void> void divDown(const ngen::Subregister &dst, const ngen::Subregister &src0, const ngen::Subregister &src1, const ngen::Subregister &src1Recip, const ngen::FlagRegister &flag, const CommonStrategy &strategy, CommonState &state);
     template <typename DT = void> void divUp(const ngen::Subregister &dst, const ngen::Subregister &src0, const ngen::Subregister &src1, const ngen::Subregister &src1Recip, const ngen::FlagRegister &flag, const CommonStrategy &strategy, CommonState &state);
+    void divMod(const ngen::Subregister &qot, const ngen::Subregister &rem, const ngen::Subregister &num, const ngen::Subregister &denom, const GEMMStrategy &strategy, CommonState &state, bool large = false);
 
     // common.cpp
     void duplicateScalar(SubregisterPair &val, CommonState &state);
@@ -435,15 +436,17 @@ protected:
     void gemmReorderLocalIDs(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
 
     // atomic_fusions.cpp
-    ngen::Subregister gemmCalcKPadding(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmStoreZeroC(GEMMProblem problem, GEMMStrategy strategy, GEMMState state, bool initialZeroing = true);
     void gemmFusedBetaPOInit(const ngen::Subregister &groupID, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmFusedBetaScale(GEMMProblem problem, GEMMStrategy strategy, GEMMState &state);
-    void gemmFusedBetaCalcWGCount(const ngen::Subregister &count, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmFusedBetaNotifyCompletion(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmFusedBetaWaitCompletion(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     bool gemmFusedPostOpsFinalize(ngen::Label &labelLateExit, GEMMProblem &problem, GEMMStrategy &strategy, GEMMState &state);
     void gemmRedirectToTempC(GEMMProblem &problem, GEMMStrategy &strategy, GEMMState &state);
+
+    // stream_k.cxx
+    void gemmStreamKPrepareSlice2(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
+    void gemmStreamKSetup(ngen::Label &lKVPhaseDone, ngen::Label &lKernelDone, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
 
     // tlb_warmup.cxx
     void tlbWarmup(ngen::AddressBase base, const ngen::Subregister &ptr, const ngen::Subregister &bytes, const ngen::Subregister &lid, int whose, const CommonProblem &problem, const CommonStrategy &strategy, CommonState &state);

--- a/src/gpu/intel/jit/gemm/include/gemmstone/strategy.hpp
+++ b/src/gpu/intel/jit/gemm/include/gemmstone/strategy.hpp
@@ -352,9 +352,11 @@ struct GEMMStrategy : public GEMMStrategyPOD
     int ka_inc() const { return slmA ? unrollKSLM : ka_load; }
     int kb_inc() const { return slmB ? unrollKSLM : kb_load; }
 
-    bool needsMNLocalIDs()    const { return xParallel || (slmBuffers > 0) || cooperativePF || kParallelLocal || persistent
+    bool persistentLoop()     const { return persistent || kParallelVariable; }
+
+    bool needsMNLocalIDs()    const { return xParallel || (slmBuffers > 0) || cooperativePF || kParallelLocal || persistentLoop()
                                                        || namedBarriers[LoopM] || namedBarriers[LoopN] || (dpasw && !fixedSystolic); }
-    bool needsKLocalIDs()     const { return kParallelLocal || persistent; }
+    bool needsKLocalIDs()     const { return kParallelLocal || persistentLoop(); }
     bool needsKLoopBarrier()  const { return (barrierFreq > 0) || (slmBuffers > 0); }
     bool needsBarrier()       const { return needsKLoopBarrier() || xParallel || kParallelLocal || fuseBeta || fusePostOps; }
 


### PR DESCRIPTION
A new version of the variable k-slicing ("stream-k") implementation in GEMM, with reduced L3$ footprint and HBM BW. The gemmstone implementation supports 2 separate stream-k phases, which can improve L3$ footprint further in some cases at the expense of sustained HBM/DDR BW. It is not yet enabled in oneDNN as that decision is trickier to make.