### PR TITLE
gpu: ocl: benchdnn: enable RNG memory fill in --mode=F

### DIFF
--- a/src/gpu/intel/ocl/ocl_philox.cl
+++ b/src/gpu/intel/ocl/ocl_philox.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2025 Intel Corporation
+* Copyright 2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-static const char *philox_rng_source = R"CLC(
-// Mask bits 30 & 14: 0xBFFFFFFF & 0xFFFFBFFF => 0xBFFFBFFF:
 #define INF_NAN_MASK 0xBFFFBFFF
 
 inline uint philox_4x32(long idx, uint seed) {
@@ -46,7 +44,7 @@ inline uint philox_4x32(long idx, uint seed) {
     return ctr[~idx & 3L];
 }
 
-__kernel void philox_fill_kernel(
+__kernel void ocl_philox_kernel(
         __global uint *data, 
         ulong nbytes, 
         ulong blockSize,
@@ -65,9 +63,7 @@ __kernel void philox_fill_kernel(
     if (startElement >= totalElements) return;
     if (endElement > totalElements) endElement = totalElements;
 
-    // Process each element in the block
     for (ulong i = startElement; i < endElement; i++) {
         data[i] = philox_4x32(i * sizeof(uint), seed) & INF_NAN_MASK;
     }
 }
-)CLC";

--- a/src/gpu/intel/ocl/ocl_philox.cl
+++ b/src/gpu/intel/ocl/ocl_philox.cl
@@ -45,12 +45,9 @@ inline uint philox_4x32(long idx, uint seed) {
 }
 
 __kernel void ocl_philox_kernel(
-        __global uint *data, 
-        ulong nbytes, 
-        ulong blockSize,
-        ulong seed) {
+        __global uint *data, ulong nbytes, ulong blockSize, ulong seed) {
     ulong gid = get_global_id(0);
-    
+
     // Compute number of elements from blockSize
     ulong blockSize_elements = blockSize / sizeof(uint);
     ulong startElement = gid * blockSize_elements;
@@ -58,7 +55,7 @@ __kernel void ocl_philox_kernel(
 
     // Compute total number of elements in the buffer
     ulong totalElements = nbytes / sizeof(uint);
-    
+
     // Clamp endElement to avoid buffer overflow
     if (startElement >= totalElements) return;
     if (endElement > totalElements) endElement = totalElements;

--- a/src/gpu/intel/ocl/ocl_philox.h
+++ b/src/gpu/intel/ocl/ocl_philox.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,35 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+#include "gpu/intel/ocl/ocl_philox.cl"
 
 #define DT_UNDEF 1
-#include "gpu/intel/ocl/ocl_types.h"
-
-uint philox_4x32(long idx, uint seed) {
-#define PHILOX_4UINT_ROUND(mul, ctr, key) \
-    as_uint4(convert_ulong2(ctr.s31) * mul) ^ (uint4)(ctr.s20 ^ key, 0, 0).s3120
-
-    uint4 ctr = 0;
-    const ulong2 ctr_mul = (ulong2)(0xD2511F53uL, 0xCD9E8D57uL);
-    const ulong key_add = as_ulong((uint2)(0x9E3779B9u, 0xBB67AE85u));
-    const uint16 key0 = (uint16)(seed)
-            + as_uint16((ulong8)(key_add))
-                    * (uint16)(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
-    const uint4 key1
-            = (uint4)(seed) + as_uint4((ulong2)(key_add)) * (uint4)(8, 8, 9, 9);
-    ctr = (uint4)(idx & ~3L) + (uint4)(3, 2, 1, 0);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s01);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s23);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s45);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s67);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s89);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sAB);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sCD);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sEF);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key1.s01);
-    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key1.s23);
-    return ctr[~idx & 3L];
-}
 
 ushort philox_8x16(long idx, uint seed) {
     return as_ushort2(philox_4x32(idx >> 1, seed))[idx & 1];

--- a/src/xpu/ocl/usm_utils.hpp
+++ b/src/xpu/ocl/usm_utils.hpp
@@ -36,7 +36,7 @@ void DNNL_API *malloc_device(impl::engine_t *engine, size_t size);
 void DNNL_API *malloc_shared(impl::engine_t *engine, size_t size);
 
 void DNNL_API free(impl::engine_t *engine, void *ptr);
-status_t set_kernel_arg(impl::engine_t *engine, cl_kernel kernel, int arg_index,
+status_t DNNL_API set_kernel_arg(impl::engine_t *engine, cl_kernel kernel, int arg_index,
         const void *arg_value);
 status_t memcpy(impl::stream_t *stream, void *dst, const void *src, size_t size,
         cl_uint num_events, const cl_event *events, cl_event *out_event);

--- a/src/xpu/ocl/usm_utils.hpp
+++ b/src/xpu/ocl/usm_utils.hpp
@@ -36,8 +36,8 @@ void DNNL_API *malloc_device(impl::engine_t *engine, size_t size);
 void DNNL_API *malloc_shared(impl::engine_t *engine, size_t size);
 
 void DNNL_API free(impl::engine_t *engine, void *ptr);
-status_t DNNL_API set_kernel_arg(impl::engine_t *engine, cl_kernel kernel, int arg_index,
-        const void *arg_value);
+status_t DNNL_API set_kernel_arg(impl::engine_t *engine, cl_kernel kernel,
+        int arg_index, const void *arg_value);
 status_t memcpy(impl::stream_t *stream, void *dst, const void *src, size_t size,
         cl_uint num_events, const cl_event *events, cl_event *out_event);
 status_t DNNL_API memcpy(

--- a/src/xpu/ocl/usm_utils.hpp
+++ b/src/xpu/ocl/usm_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ void DNNL_API *malloc_device(impl::engine_t *engine, size_t size);
 void DNNL_API *malloc_shared(impl::engine_t *engine, size_t size);
 
 void DNNL_API free(impl::engine_t *engine, void *ptr);
-status_t set_kernel_arg(impl::engine_t *engine, cl_kernel kernel, int arg_index,
+status_t DNNL_API set_kernel_arg(impl::engine_t *engine, cl_kernel kernel, int arg_index,
         const void *arg_value);
 status_t memcpy(impl::stream_t *stream, void *dst, const void *src, size_t size,
         cl_uint num_events, const cl_event *events, cl_event *out_event);

--- a/src/xpu/ocl/usm_utils.hpp
+++ b/src/xpu/ocl/usm_utils.hpp
@@ -36,8 +36,8 @@ void DNNL_API *malloc_device(impl::engine_t *engine, size_t size);
 void DNNL_API *malloc_shared(impl::engine_t *engine, size_t size);
 
 void DNNL_API free(impl::engine_t *engine, void *ptr);
-status_t DNNL_API set_kernel_arg(impl::engine_t *engine, cl_kernel kernel,
-        int arg_index, const void *arg_value);
+status_t set_kernel_arg(impl::engine_t *engine, cl_kernel kernel, int arg_index,
+        const void *arg_value);
 status_t memcpy(impl::stream_t *stream, void *dst, const void *src, size_t size,
         cl_uint num_events, const cl_event *events, cl_event *out_event);
 status_t DNNL_API memcpy(

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -628,12 +628,8 @@ int dnn_mem_t::memset_rng(size_t size) const {
                 cl_platform_id platform;
                 clGetDeviceInfo(ocl_device, CL_DEVICE_PLATFORM,
                         sizeof(cl_platform_id), &platform, nullptr);
-                auto clSetKernelArgMemPointerINTEL
-                        = (clSetKernelArgMemPointerINTEL_fn)
-                                clGetExtensionFunctionAddressForPlatform(
-                                        platform,
-                                        "clSetKernelArgMemPointerINTEL");
-                clSetKernelArgMemPointerINTEL(ocl_kernel, 0, mem_handle);
+                DNN_SAFE_V(dnnl::impl::xpu::ocl::usm::set_kernel_arg(
+                        engine_, ocl_kernel, 0, mem_handle));
                 clSetKernelArg(ocl_kernel, 1, sizeof(uint64_t), &buffSize);
                 clSetKernelArg(ocl_kernel, 2, sizeof(uint64_t), &blockSize);
                 clSetKernelArg(ocl_kernel, 3, sizeof(uint64_t), &DEFAULT_SEED);

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -17,10 +17,10 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <fstream>
 #include <memory>
 #include <numeric>
 #include <string>
-#include <fstream>
 
 #include "oneapi/dnnl/dnnl.h"
 
@@ -605,7 +605,8 @@ int dnn_mem_t::memset_rng(size_t size) const {
 
         assert(size <= UINT64_MAX);
         const uint64_t buffSize = static_cast<uint64_t>(size);
-        const uint64_t blockSize = std::max(MIN_BLOCK_SIZE, size / BLOCK_SIZE_DIVISOR);
+        const uint64_t blockSize
+                = std::max(MIN_BLOCK_SIZE, size / BLOCK_SIZE_DIVISOR);
         const size_t gws = size / blockSize + (size % blockSize > 0);
 
         switch (memory_kind) {
@@ -625,9 +626,13 @@ int dnn_mem_t::memset_rng(size_t size) const {
             case memory_kind_ext_t::usm_device:
             case memory_kind_ext_t::usm_shared: {
                 cl_platform_id platform;
-                clGetDeviceInfo(ocl_device, CL_DEVICE_PLATFORM, sizeof(cl_platform_id), &platform, nullptr);
-                auto clSetKernelArgMemPointerINTEL = (clSetKernelArgMemPointerINTEL_fn)
-                    clGetExtensionFunctionAddressForPlatform(platform, "clSetKernelArgMemPointerINTEL");
+                clGetDeviceInfo(ocl_device, CL_DEVICE_PLATFORM,
+                        sizeof(cl_platform_id), &platform, nullptr);
+                auto clSetKernelArgMemPointerINTEL
+                        = (clSetKernelArgMemPointerINTEL_fn)
+                                clGetExtensionFunctionAddressForPlatform(
+                                        platform,
+                                        "clSetKernelArgMemPointerINTEL");
                 clSetKernelArgMemPointerINTEL(ocl_kernel, 0, mem_handle);
                 clSetKernelArg(ocl_kernel, 1, sizeof(uint64_t), &buffSize);
                 clSetKernelArg(ocl_kernel, 2, sizeof(uint64_t), &blockSize);

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -572,12 +572,15 @@ dnnl_status_t dnn_mem_t::memset_rng(size_t size) const {
         cl_device_id ocl_device;
         cl_program philox_program;
         cl_kernel ocl_kernel;
-        cl_int err; 
-        DNN_SAFE_V(dnnl_ocl_interop_stream_get_command_queue(stream, &ocl_queue));
+        cl_int err;
+        DNN_SAFE_V(
+                dnnl_ocl_interop_stream_get_command_queue(stream, &ocl_queue));
         DNN_SAFE_V(dnnl_ocl_interop_engine_get_context(engine_, &ocl_ctx));
         DNN_SAFE_V(dnnl_ocl_interop_get_device(engine_, &ocl_device));
-        philox_program = clCreateProgramWithSource(ocl_ctx, 1, &philox_rng_source, nullptr, &err);
-        OCL_TEST(clBuildProgram(philox_program, 1, &ocl_device, nullptr, nullptr, nullptr));
+        philox_program = clCreateProgramWithSource(
+                ocl_ctx, 1, &philox_rng_source, nullptr, &err);
+        OCL_TEST(clBuildProgram(
+                philox_program, 1, &ocl_device, nullptr, nullptr, nullptr));
         ocl_kernel = clCreateKernel(philox_program, "philox_fill_kernel", &err);
 
         //TODO: generate random seed to avoid repeating values
@@ -592,9 +595,8 @@ dnnl_status_t dnn_mem_t::memset_rng(size_t size) const {
                 clSetKernelArg(ocl_kernel, 1, sizeof(uint64_t), &buffSize);
                 clSetKernelArg(ocl_kernel, 2, sizeof(uint64_t), &blockSize);
                 clSetKernelArg(ocl_kernel, 3, sizeof(uint64_t), &seed);
-                clEnqueueNDRangeKernel(ocl_queue, ocl_kernel,
-                                    1, nullptr, &gws, nullptr,
-                                    0, nullptr, nullptr);
+                clEnqueueNDRangeKernel(ocl_queue, ocl_kernel, 1, nullptr, &gws,
+                        nullptr, 0, nullptr, nullptr);
 
                 DNN_SAFE_V(dnnl_stream_wait(stream));
                 return dnnl_status_t::dnnl_success;
@@ -602,12 +604,14 @@ dnnl_status_t dnn_mem_t::memset_rng(size_t size) const {
             case memory_kind_ext_t::usm:
             case memory_kind_ext_t::usm_device:
             case memory_kind_ext_t::usm_shared: {
-                DNN_SAFE_V(dnnl::impl::xpu::ocl::usm::set_kernel_arg(engine_, ocl_kernel, 0, mem_handle));
+                DNN_SAFE_V(dnnl::impl::xpu::ocl::usm::set_kernel_arg(
+                        engine_, ocl_kernel, 0, mem_handle));
                 clSetKernelArg(ocl_kernel, 1, sizeof(uint64_t), &buffSize);
                 clSetKernelArg(ocl_kernel, 2, sizeof(uint64_t), &blockSize);
                 clSetKernelArg(ocl_kernel, 3, sizeof(uint64_t), &seed);
 
-                clEnqueueNDRangeKernel(ocl_queue, ocl_kernel, 1, nullptr, &gws, nullptr, 0, nullptr, nullptr);
+                clEnqueueNDRangeKernel(ocl_queue, ocl_kernel, 1, nullptr, &gws,
+                        nullptr, 0, nullptr, nullptr);
                 DNN_SAFE_V(dnnl_stream_wait(stream));
                 return dnnl_status_t::dnnl_success;
             }
@@ -615,8 +619,7 @@ dnnl_status_t dnn_mem_t::memset_rng(size_t size) const {
 #endif
     } else if (is_sycl) {
 #ifdef DNNL_WITH_SYCL
-        // TODO: add sycl support
-         return dnnl_status_t::dnnl_unimplemented;
+        return dnnl_status_t::dnnl_unimplemented;
 #endif
     }
     if (is_cpu(engine_)) return dnnl_status_t::dnnl_unimplemented;

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -36,11 +36,12 @@ struct dnn_mem_t {
     struct handle_info_t {
         bool is_host_ptr;
         void *ptr;
+        bool is_rng;
 
         bool is_allocate() const { return ptr == DNNL_MEMORY_ALLOCATE; }
 
         static handle_info_t allocate() {
-            return {false, DNNL_MEMORY_ALLOCATE};
+            return {false, DNNL_MEMORY_ALLOCATE, true};
         }
     };
 
@@ -151,6 +152,8 @@ struct dnn_mem_t {
     void map() const;
     void unmap() const;
     void memset(int value, size_t size) const;
+    
+    dnnl_status_t memset_rng(size_t size) const;
 
     static dnn_mem_t create_from_host_ptr(
             const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr);

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -36,12 +36,12 @@ struct dnn_mem_t {
     struct handle_info_t {
         bool is_host_ptr;
         void *ptr;
-        bool is_rng;
+        bool skip_initialization;
 
         bool is_allocate() const { return ptr == DNNL_MEMORY_ALLOCATE; }
 
-        static handle_info_t allocate() {
-            return {false, DNNL_MEMORY_ALLOCATE, true};
+        static handle_info_t allocate(bool skip_init = false) {
+            return {false, DNNL_MEMORY_ALLOCATE, skip_init};
         }
     };
 
@@ -153,7 +153,7 @@ struct dnn_mem_t {
     void unmap() const;
     void memset(int value, size_t size) const;
 
-    dnnl_status_t memset_rng(size_t size) const;
+    int memset_rng(size_t size) const;
 
     static dnn_mem_t create_from_host_ptr(
             const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr);

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ struct dnn_mem_t {
     void map() const;
     void unmap() const;
     void memset(int value, size_t size) const;
-    
+
     dnnl_status_t memset_rng(size_t size) const;
 
     static dnn_mem_t create_from_host_ptr(

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -163,9 +163,10 @@ cold_cache_t::cold_cache_t(
         auto &cc_entry = cache_[arg];
         cc_entry.resize(n_buffers_);
         auto orig_cc_mem_md = query_md(orig_mem);
+        const dnn_mem_t::handle_info_t no_rng_m_handle = {false, DNNL_MEMORY_ALLOCATE, true};
 
         for (size_t i = 0; i < n_buffers_; i++) {
-            cc_entry[i] = dnn_mem_t(orig_cc_mem_md, get_test_engine());
+            cc_entry[i] = dnn_mem_t(orig_cc_mem_md, get_test_engine(), no_rng_m_handle);
 
 #ifdef DNNL_EXPERIMENTAL_SPARSE
             // Sparse memories require this call to replicate the exact original
@@ -277,10 +278,13 @@ int cold_cache_t::thrash_reorder(size_t mem_size, size_t granularity) const {
     // Reduce the number of element by the the stride to keep the memory size
     // as requested.
     const dnnl_dims_t dims {div_up(nelems, stride)};
-    const dnnl_dims_t strides {stride};
+    const dims_t strides {stride};
 
-    dnn_mem_t src_m(1, dims, dnnl_f32, strides, engine);
-    dnn_mem_t dst_m(1, dims, dnnl_f32, strides, engine);
+    const dnn_mem_t::handle_info_t no_rng_handle
+                = {false, DNNL_MEMORY_ALLOCATE, true};
+    auto r_md = dnn_mem_t::init_md(1, dims, dnnl_f32, tag::any, strides);
+    dnn_mem_t src_m(r_md, engine, no_rng_handle);
+    dnn_mem_t dst_m(r_md, engine, no_rng_handle);
 
     dnnl_primitive_desc_t r_pd {};
     dnnl_primitive_attr_t attr {};

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -163,10 +163,12 @@ cold_cache_t::cold_cache_t(
         auto &cc_entry = cache_[arg];
         cc_entry.resize(n_buffers_);
         auto orig_cc_mem_md = query_md(orig_mem);
-        const dnn_mem_t::handle_info_t no_rng_m_handle = {false, DNNL_MEMORY_ALLOCATE, true};
+        const dnn_mem_t::handle_info_t no_rng_m_handle
+                = {false, DNNL_MEMORY_ALLOCATE, true};
 
         for (size_t i = 0; i < n_buffers_; i++) {
-            cc_entry[i] = dnn_mem_t(orig_cc_mem_md, get_test_engine(), no_rng_m_handle);
+            cc_entry[i] = dnn_mem_t(
+                    orig_cc_mem_md, get_test_engine(), no_rng_m_handle);
 
 #ifdef DNNL_EXPERIMENTAL_SPARSE
             // Sparse memories require this call to replicate the exact original
@@ -281,7 +283,7 @@ int cold_cache_t::thrash_reorder(size_t mem_size, size_t granularity) const {
     const dims_t strides {stride};
 
     const dnn_mem_t::handle_info_t no_rng_handle
-                = {false, DNNL_MEMORY_ALLOCATE, true};
+            = {false, DNNL_MEMORY_ALLOCATE, true};
     auto r_md = dnn_mem_t::init_md(1, dims, dnnl_f32, tag::any, strides);
     dnn_mem_t src_m(r_md, engine, no_rng_handle);
     dnn_mem_t dst_m(r_md, engine, no_rng_handle);

--- a/tests/benchdnn/utils/ocl_philox.h
+++ b/tests/benchdnn/utils/ocl_philox.h
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright 2020-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+static const char *philox_rng_source = R"CLC(
+// Clear bits 30 & 14: 0xBFFFFFFF & 0xFFFFBFFF => 0xBFFFBFFF:
+#define INF_NAN_MASK 0xBFFFBFFF
+
+inline uint philox_4x32(long idx, uint seed) {
+#define PHILOX_4UINT_ROUND(mul, ctr, key) \
+    as_uint4(convert_ulong2(ctr.s31) * mul) ^ (uint4)(ctr.s20 ^ key, 0, 0).s3120
+
+    uint4 ctr = 0;
+    const ulong2 ctr_mul = (ulong2)(0xD2511F53uL, 0xCD9E8D57uL);
+    const ulong key_add = as_ulong((uint2)(0x9E3779B9u, 0xBB67AE85u));
+    const uint16 key0 = (uint16)(seed)
+            + as_uint16((ulong8)(key_add))
+                    * (uint16)(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
+    const uint4 key1
+            = (uint4)(seed) + as_uint4((ulong2)(key_add)) * (uint4)(8, 8, 9, 9);
+
+    ctr = (uint4)(idx & ~3L) + (uint4)(3, 2, 1, 0);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s01);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s23);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s45);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s67);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.s89);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sAB);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sCD);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sEF);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key1.s01);
+    ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key1.s23);
+
+    return ctr[~idx & 3L];
+}
+
+__kernel void philox_fill_kernel(
+        __global uint *data, 
+        ulong nbytes, 
+        ulong blockSize,
+        ulong seed) {
+    ulong gid = get_global_id(0);
+    
+    // Compute number of elements from blockSize
+    ulong blockSize_elements = blockSize / sizeof(uint);
+    ulong startElement = gid * blockSize_elements;
+    ulong endElement = startElement + blockSize_elements;
+
+    // Compute total number of elements in the buffer
+    ulong totalElements = nbytes / sizeof(uint);
+    
+    // Clamp endElement to avoid buffer overflow
+    if (startElement >= totalElements) return;
+    if (endElement > totalElements) endElement = totalElements;
+
+    // Process each element in the block
+    for (ulong i = startElement; i < endElement; i++) {
+        data[i] = philox_4x32(i * sizeof(uint), seed) & INF_NAN_MASK;
+    }
+}
+)CLC";

--- a/tests/benchdnn/utils/ocl_philox.h
+++ b/tests/benchdnn/utils/ocl_philox.h
@@ -15,7 +15,7 @@
 *******************************************************************************/
 
 static const char *philox_rng_source = R"CLC(
-// Clear bits 30 & 14: 0xBFFFFFFF & 0xFFFFBFFF => 0xBFFFBFFF:
+// Mask bits 30 & 14: 0xBFFFFFFF & 0xFFFFBFFF => 0xBFFFBFFF:
 #define INF_NAN_MASK 0xBFFFBFFF
 
 inline uint philox_4x32(long idx, uint seed) {


### PR DESCRIPTION
# Description

Systems with data compression enabled by the driver by default wont generate meaningful performance data with `benchdnn ... --mode=F `

- Reuse [ocl_philox.h](https://github.com/oneapi-src/oneDNN/blob/main/src/gpu/intel/ocl/ocl_philox.h) kernel to directly fill gpu mem with random vals
- cold-cache support


Fixes [MFDNN-12589](https://jira.devtools.intel.com/browse/MFDNN-12589)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?
