### PR TITLE
Update clang-format version

### DIFF
--- a/.github/automation/clang-format.sh
+++ b/.github/automation/clang-format.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #===============================================================================
 
-CLANG_FORMAT=clang-format-11
+CLANG_FORMAT=clang-format-17
 
 echo "Checking ${CLANG_FORMAT}"
 if ! ${CLANG_FORMAT} --version; then

--- a/.github/automation/clang-format.sh
+++ b/.github/automation/clang-format.sh
@@ -33,7 +33,10 @@ echo $(git status) | grep "nothing to commit" > /dev/null
 
 if [ $? -eq 1 ]; then
     echo "Clang-format check FAILED! Found not formatted files!"
+    echo "Impacted files: "
     echo "$(git status)"
+    echo "Changes:"
+    echo "$(git diff)"
     RETURN_CODE=3
 else
     echo "Clang-format check PASSED! Not formatted files not found..."

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   pr-formatting:
     name: Formatting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -42,7 +42,7 @@ jobs:
       - name: Check commit messages
         run: python3 ./.github/automation/commit-msg-check.py "${{ github.event.pull_request.head.sha }}" "${{ github.event.pull_request.base.sha }}"
       - name: Install clang-format
-        run: sudo apt update && sudo apt install -y "clang-format-11"
+        run: sudo apt update && sudo apt install -y "clang-format-17"
       - name: Check code formatting
         run: .github/automation/clang-format.sh
 


### PR DESCRIPTION
We are stuck at clang-format-11, which is quite old, because of behavior differences with newer version. The intent of this PR is to update version in CI and address formatting differences that arise.
