### PR TITLE
cpu: aarch64: make lowpmatmul  use stateless acl interface

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -199,6 +199,7 @@ enum {
     key_conv_bwd_w_1st_wei_reorder,
     key_conv_gemm_acc,
     key_conv_gemm_col,
+    key_conv_gemm_row,
     key_conv_gemm_imtr,
     key_conv_gemm_zp_src_comp,
     key_conv_int_dat_in_acc_dt,

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "cpu/aarch64/matmul/acl_lowp_matmul.hpp"
+#include "cpu/cpu_primitive.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -22,42 +23,23 @@ namespace cpu {
 namespace aarch64 {
 namespace matmul {
 
-status_t acl_lowp_matmul_resource_t::configure(
-        const acl_lowp_matmul_conf_t &almc) {
+namespace {
+// Keys are anonymous. So deduce the type automagically.
+using lowp_matmul_key_t = decltype(memory_tracking::names::key_gemm_tmp_buffer);
 
-    if (!acl_obj_) return status::out_of_memory;
-
-    acl_obj_->src_tensor.allocator()->init(almc.src_tensor_info);
-    acl_obj_->wei_tensor.allocator()->init(almc.wei_tensor_info);
-    if (almc.with_bias) {
-        acl_obj_->bia_tensor.allocator()->init(almc.bia_tensor_info);
-    }
-    acl_obj_->dst_tensor.allocator()->init(almc.dst_tensor_info);
-    acl_obj_->dst_s8_tensor.allocator()->init(almc.dst_s8_tensor_info);
-
-    acl_obj_->gemm.configure(&acl_obj_->src_tensor, &acl_obj_->wei_tensor,
-            almc.with_bias ? &acl_obj_->bia_tensor : nullptr,
-            &acl_obj_->dst_tensor, almc.gemm_info);
-
-    if (almc.dst_is_s8) {
-        if (almc.sum_is_fused) {
-            acl_obj_->dequant.configure(
-                    &acl_obj_->dst_s8_tensor, &acl_obj_->dst_tensor);
-        }
-        if (almc.use_cast_acc) {
-            acl_obj_->dequant.configure(
-                    &acl_obj_->dst_s8_tensor, &acl_obj_->dst_cast_tensor);
-            acl_obj_->quant.configure(
-                    &acl_obj_->dst_cast_tensor, &acl_obj_->dst_s8_tensor);
-        } else {
-            acl_obj_->quant.configure(
-                    &acl_obj_->dst_tensor, &acl_obj_->dst_s8_tensor);
-        }
-    }
-
-    return status::success;
-}
-
+const std::vector<lowp_matmul_key_t> lowp_matmul_keys = {
+        memory_tracking::names::key_gemm_asm_tmp_buffer,
+        memory_tracking::names::key_gemm_pretranspose_b,
+        memory_tracking::names::key_gemm_pretranspose,
+        memory_tracking::names::key_conv_gemm_col,
+        memory_tracking::names::key_conv_gemm_row,
+        memory_tracking::names::key_gemm_blocked_a,
+        memory_tracking::names::key_gemm_blocked_b,
+        memory_tracking::names::key_gemm_mm_result_s32,
+        memory_tracking::names::key_gemm_mm_signed_a,
+        memory_tracking::names::key_gemm_mm_signed_output,
+};
+} // namespace
 status_t acl_lowp_matmul_t::pd_t::init(engine_t *engine) {
     VDISPATCH_MATMUL(set_default_formats(), "failed to set default formats");
     using smask_t = primitive_attr_t::skip_mask_t;
@@ -147,7 +129,9 @@ status_t acl_lowp_matmul_t::pd_t::init(engine_t *engine) {
             = arm_compute::TensorInfo(arm_compute::TensorShape(N, K, wei_batch),
                     1, arm_compute::DataType::QASYMM8_SIGNED,
                     arm_compute::QuantizationInfo(1.0, 0, true));
-    almc_.wei_tensor_info.set_are_values_constant(false);
+
+    almc_.wei_tensor_info.set_are_values_constant(
+            false); // disables persistent aux memory
 
     almc_.bia_tensor_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(), 1, arm_compute::DataType::F32);
@@ -219,31 +203,51 @@ status_t acl_lowp_matmul_t::pd_t::init(engine_t *engine) {
             arm_compute::DataType::QASYMM8_SIGNED,
             arm_compute::QuantizationInfo(1.0, 0, true));
 
-    ACL_CHECK_VALID(arm_compute::NEGEMMLowpMatrixMultiplyCore::validate(
+    ACL_CHECK_VALID(arm_compute::experimental::op::CpuGEMMLowp::validate(
             &almc_.src_tensor_info, &almc_.wei_tensor_info,
             almc_.with_bias ? &almc_.bia_tensor_info : nullptr,
             &almc_.dst_tensor_info, almc_.gemm_info));
 
     if (almc_.dst_is_s8) {
         if (almc_.sum_is_fused) {
-            ACL_CHECK_VALID(arm_compute::NEDequantizationLayer::validate(
-                    &almc_.dst_s8_tensor_info, &almc_.dst_tensor_info));
+            ACL_CHECK_VALID(
+                    arm_compute::experimental::op::CpuDequantize::validate(
+                            &almc_.dst_s8_tensor_info, &almc_.dst_tensor_info));
         } else if (almc_.use_cast_acc) {
-            ACL_CHECK_VALID(arm_compute::NEDequantizationLayer::validate(
-                    &almc_.dst_s8_tensor_info, &almc_.dst_cast_tensor_info));
+            ACL_CHECK_VALID(
+                    arm_compute::experimental::op::CpuDequantize::validate(
+                            &almc_.dst_s8_tensor_info,
+                            &almc_.dst_cast_tensor_info));
         }
-        ACL_CHECK_VALID(arm_compute::NEQuantizationLayer::validate(
+        ACL_CHECK_VALID(arm_compute::experimental::op::CpuQuantize::validate(
                 &almc_.dst_tensor_info, &almc_.dst_s8_tensor_info));
     }
+    arm_compute::experimental::op::CpuGEMMLowp gemm;
+    gemm.configure(&almc_.src_tensor_info, &almc_.wei_tensor_info,
+            almc_.with_bias ? &almc_.bia_tensor_info : nullptr,
+            &almc_.dst_tensor_info, almc_.gemm_info);
 
+    auto aux_mem_req = gemm.workspace();
+    // quantization/dequantization layer has empty workspace.
     auto scratchpad = scratchpad_registry().registrar();
-    CHECK(init_scratchpad(scratchpad));
+    CHECK(init_scratchpad(scratchpad, aux_mem_req));
 
     return status::success;
 }
 
 status_t acl_lowp_matmul_t::pd_t::init_scratchpad(
-        memory_tracking::registrar_t &scratchpad) {
+        memory_tracking::registrar_t &scratchpad,
+        const arm_compute::experimental::MemoryRequirements &aux_mem_req) {
+
+    if (aux_mem_req.size() != 0) {
+        for (size_t id = 0; id < lowp_matmul_keys.size(); id++) {
+            if (aux_mem_req[id].size > 0) {
+                scratchpad.book(lowp_matmul_keys[id], aux_mem_req[id].size, 1,
+                        aux_mem_req[id].alignment, aux_mem_req[id].alignment);
+            }
+        }
+    }
+
     const memory_desc_wrapper dst_d(&dst_md_);
     if (almc_.use_dst_acc) {
         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
@@ -256,31 +260,47 @@ status_t acl_lowp_matmul_t::pd_t::init_scratchpad(
     return status::success;
 }
 
-status_t acl_lowp_matmul_t::create_resource(
-        engine_t *engine, resource_mapper_t &mapper) const {
+status_t acl_lowp_matmul_t::init(engine_t *engine) {
+    auto almc = pd()->almc_;
 
-    if (mapper.has_resource(this)) return status::success;
+    gemm_ = std::make_unique<arm_compute::experimental::op::CpuGEMMLowp>();
+    gemm_->configure(&almc.src_tensor_info, &almc.wei_tensor_info,
+            almc.with_bias ? &almc.bia_tensor_info : nullptr,
+            &almc.dst_tensor_info, almc.gemm_info);
 
-    auto r = utils::make_unique<acl_lowp_matmul_resource_t>();
-    if (!r) return status::out_of_memory;
+    if (almc.dst_is_s8) {
+        if (almc.sum_is_fused) {
+            dequant_ = std::make_unique<
+                    arm_compute::experimental::op::CpuDequantize>();
+            dequant_->configure(
+                    &almc.dst_s8_tensor_info, &almc.dst_tensor_info);
+        }
+        if (almc.use_cast_acc) {
+            quant_ = std::make_unique<
+                    arm_compute::experimental::op::CpuQuantize>();
+            dequant_ = std::make_unique<
+                    arm_compute::experimental::op::CpuDequantize>();
+            dequant_->configure(
+                    &almc.dst_s8_tensor_info, &almc.dst_cast_tensor_info);
 
-    CHECK(r->configure(pd()->almc_));
-
-    mapper.add(this, std::move(r));
+            quant_->configure(
+                    &almc.dst_cast_tensor_info, &almc.dst_s8_tensor_info);
+        } else {
+            quant_ = std::make_unique<
+                    arm_compute::experimental::op::CpuQuantize>();
+            quant_->configure(&almc.dst_tensor_info, &almc.dst_s8_tensor_info);
+        }
+    }
 
     return status::success;
 }
 
 status_t acl_lowp_matmul_t::execute(const exec_ctx_t &ctx) const {
-    std::lock_guard<std::mutex> _lock {this->mtx};
+    std::lock_guard<std::mutex> _lock {this->mtx_};
     const auto scratchpad = ctx.get_scratchpad_grantor();
 
+    auto alcm = pd()->almc_;
     bool with_bias = pd()->almc_.with_bias;
-
-    acl_lowp_matmul_obj_t &acl_obj
-            = ctx.get_resource_mapper()
-                      ->get<acl_lowp_matmul_resource_t>(this)
-                      ->get_acl_obj();
 
     DEFINE_ARG_SCALES_BUFFER(src_scale, DNNL_ARG_SRC);
     DEFINE_ZERO_POINT_VALUE(src_zero_point, DNNL_ARG_SRC);
@@ -289,57 +309,92 @@ status_t acl_lowp_matmul_t::execute(const exec_ctx_t &ctx) const {
     DEFINE_ARG_SCALES_BUFFER(dst_scale, DNNL_ARG_DST);
     DEFINE_ZERO_POINT_VALUE(dst_zero_point, DNNL_ARG_DST);
 
+    arm_compute::Tensor src_tensor, dst_tensor, wei_tensor, bia_tensor,
+            dst_cast_tensor, dst_s8_tensor;
     auto src = CTX_IN_MEM(const int8_t *, DNNL_ARG_SRC);
-    acl_obj.src_tensor.allocator()->import_memory(const_cast<int8_t *>(src));
+    src_tensor.allocator()->init(alcm.src_tensor_info);
+    src_tensor.allocator()->import_memory(const_cast<int8_t *>(src));
 
     auto wei = CTX_IN_MEM(const int8_t *, DNNL_ARG_WEIGHTS);
-    acl_obj.wei_tensor.allocator()->import_memory(const_cast<int8_t *>(wei));
+    wei_tensor.allocator()->init(alcm.wei_tensor_info);
+    wei_tensor.allocator()->import_memory(const_cast<int8_t *>(wei));
 
     if (with_bias) {
         auto bias = CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
-        acl_obj.bia_tensor.allocator()->import_memory(
-                const_cast<float *>(bias));
+        bia_tensor.allocator()->init(alcm.bia_tensor_info);
+        bia_tensor.allocator()->import_memory(const_cast<float *>(bias));
     }
 
     auto dst = pd()->almc_.use_dst_acc ? scratchpad.get<void>(
                        memory_tracking::names::key_matmul_dst_in_acc_dt)
                                        : CTX_OUT_MEM(float *, DNNL_ARG_DST);
-    acl_obj.dst_tensor.allocator()->import_memory(dst);
+    dst_tensor.allocator()->init(alcm.dst_tensor_info);
+    dst_tensor.allocator()->import_memory(dst);
 
     auto dst_cast = pd()->almc_.use_cast_acc ? scratchpad.get<void>(
                             memory_tracking::names::key_matmul_dst_cast_acc)
                                              : nullptr;
-    if (dst_cast) acl_obj.dst_cast_tensor.allocator()->import_memory(dst_cast);
+    if (dst_cast) {
+        dst_cast_tensor.allocator()->init(alcm.dst_cast_tensor_info);
+        dst_cast_tensor.allocator()->import_memory(dst_cast);
+    }
 
     if ((pd()->almc_.dst_is_s8 && pd()->almc_.sum_is_fused) || dst_cast) {
         auto dst_s8 = CTX_OUT_MEM(int8_t *, DNNL_ARG_DST);
-        acl_obj.dst_s8_tensor.allocator()->import_memory(
-                const_cast<int8_t *>(dst_s8));
+        dst_s8_tensor.allocator()->init(alcm.dst_s8_tensor_info);
+        dst_s8_tensor.allocator()->import_memory(const_cast<int8_t *>(dst_s8));
         // oneDNN expects all intermediate operations to be performed
         // before taking dst scale and offset into account
-        acl_obj.dst_s8_tensor.info()->set_quantization_info(
+        dst_s8_tensor.info()->set_quantization_info(
                 arm_compute::QuantizationInfo(1, 0, true));
-        acl_obj.dequant.run();
+
+        arm_compute::ITensorPack pack;
+        pack.add_tensor(arm_compute::TensorType::ACL_SRC, &dst_s8_tensor);
+        pack.add_tensor(arm_compute::TensorType::ACL_DST, &dst_tensor);
+        dequant_->run(pack);
     }
 
     // Note that we set the offset to be -zero_point, this is a known
     // inconsistency with most other operators in the ACL API
-    acl_obj.src_tensor.info()->set_quantization_info(
+    src_tensor.info()->set_quantization_info(
             arm_compute::QuantizationInfo(*src_scale, -src_zero_point, true));
 
-    acl_obj.wei_tensor.info()->set_quantization_info(
+    wei_tensor.info()->set_quantization_info(
             arm_compute::QuantizationInfo(*wei_scale, -wei_zero_point, true));
 
-    acl_obj.gemm.run();
+    arm_compute::ITensorPack gemm_pack {
+            {arm_compute::TensorType::ACL_SRC_0, &src_tensor},
+            {arm_compute::TensorType::ACL_SRC_1, &wei_tensor},
+            {arm_compute::TensorType::ACL_DST, &dst_tensor}};
 
-    auto src_post_ops = acl_obj.dst_tensor.buffer();
+    if (with_bias) {
+        gemm_pack.add_tensor(arm_compute::TensorType::ACL_SRC_2, &bia_tensor);
+    }
+
+    // Hold onto tmp tensors while we need pack.
+    auto aux_mem = gemm_->workspace();
+    std::vector<arm_compute::Tensor> tmp_tensors(aux_mem.size());
+    for (size_t id = 0; id < lowp_matmul_keys.size(); id++) {
+        if (aux_mem[id].size > 0) {
+            const auto info = arm_compute::TensorInfo(
+                    arm_compute::TensorShape(aux_mem[id].size), 1,
+                    arm_compute::DataType::U8);
+            auto buffer = scratchpad.get<void>(lowp_matmul_keys[id]);
+            tmp_tensors[id].allocator()->init(info, aux_mem[id].alignment);
+            tmp_tensors[id].allocator()->import_memory(buffer);
+            gemm_pack.add_tensor(aux_mem[id].slot, &tmp_tensors[id]);
+        }
+    }
+    gemm_->run(gemm_pack);
+
+    auto src_post_ops = dst_tensor.buffer();
     // Here we select the output destination for post-ops. By default,
     // these are in-place so that dst=src. However, when there is a non-fused
     // sum, we set dst to be the tensor where data to be summed is stored.
     void *dst_post_ops;
     if (pd()->acl_post_ops.has_sum() && !pd()->almc_.sum_is_fused) {
         if (pd()->almc_.dst_is_s8) {
-            dst_post_ops = acl_obj.dst_cast_tensor.buffer();
+            dst_post_ops = dst_cast_tensor.buffer();
         } else {
             dst_post_ops = CTX_OUT_MEM(void *, DNNL_ARG_DST);
         }
@@ -349,22 +404,25 @@ status_t acl_lowp_matmul_t::execute(const exec_ctx_t &ctx) const {
     pd()->acl_post_ops.execute(ctx, src_post_ops, dst_post_ops);
 
     // free() here tells ACL it can no longer use it, it does not deallocate
-    acl_obj.src_tensor.allocator()->free();
-    acl_obj.wei_tensor.allocator()->free();
-    if (with_bias) { acl_obj.bia_tensor.allocator()->free(); }
+    src_tensor.allocator()->free();
+    wei_tensor.allocator()->free();
+    if (with_bias) { bia_tensor.allocator()->free(); }
 
     if (pd()->almc_.dst_is_s8) {
         auto dst_s8 = CTX_OUT_MEM(int8_t *, DNNL_ARG_DST);
-        acl_obj.dst_s8_tensor.allocator()->import_memory(
-                const_cast<int8_t *>(dst_s8));
-        acl_obj.dst_s8_tensor.info()->set_quantization_info(
+        dst_s8_tensor.allocator()->init(alcm.dst_s8_tensor_info);
+        dst_s8_tensor.allocator()->import_memory(const_cast<int8_t *>(dst_s8));
+        dst_s8_tensor.info()->set_quantization_info(
                 arm_compute::QuantizationInfo(
                         1.0 / (*dst_scale), dst_zero_point, true));
-        acl_obj.quant.run();
-        acl_obj.dst_s8_tensor.allocator()->free();
+        arm_compute::ITensorPack pack;
+        pack.add_tensor(arm_compute::TensorType::ACL_SRC, &dst_tensor);
+        pack.add_tensor(arm_compute::TensorType::ACL_DST, &dst_s8_tensor);
+        quant_->run(pack);
+        dst_s8_tensor.allocator()->free();
     }
 
-    acl_obj.dst_tensor.allocator()->free();
+    dst_tensor.allocator()->free();
 
     return status::success;
 };

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.hpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Arm Ltd. and affiliates
+* Copyright 2024-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,17 +17,13 @@
 #ifndef CPU_AARCH64_MATMUL_ACL_LOWP_MATMUL_HPP
 #define CPU_AARCH64_MATMUL_ACL_LOWP_MATMUL_HPP
 
-#include "cpu/cpu_primitive.hpp"
-#include "cpu/matmul/cpu_matmul_pd.hpp"
-#include "cpu/matmul/matmul_utils.hpp"
-
-#include "arm_compute/core/CPP/CPPTypes.h"
-#include "arm_compute/runtime/NEON/functions/NEDequantizationLayer.h"
-#include "arm_compute/runtime/NEON/functions/NEGEMMLowpMatrixMultiplyCore.h"
-#include "arm_compute/runtime/NEON/functions/NEQuantizationLayer.h"
-
+#include "arm_compute/runtime/experimental/operators/CpuDequantize.h"
+#include "arm_compute/runtime/experimental/operators/CpuGEMMLowp.h"
+#include "arm_compute/runtime/experimental/operators/CpuQuantize.h"
 #include "cpu/aarch64/acl_post_ops.hpp"
 #include "cpu/aarch64/acl_utils.hpp"
+#include "cpu/matmul/cpu_matmul_pd.hpp"
+#include "cpu/matmul/matmul_utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -35,17 +31,7 @@ namespace cpu {
 namespace aarch64 {
 namespace matmul {
 
-struct acl_lowp_matmul_obj_t {
-    arm_compute::Tensor src_tensor;
-    arm_compute::Tensor wei_tensor;
-    arm_compute::Tensor bia_tensor;
-    arm_compute::Tensor dst_tensor;
-    arm_compute::Tensor dst_s8_tensor;
-    arm_compute::Tensor dst_cast_tensor;
-    arm_compute::NEGEMMLowpMatrixMultiplyCore gemm;
-    arm_compute::NEQuantizationLayer quant;
-    arm_compute::NEDequantizationLayer dequant;
-};
+using arm_compute::experimental::MemoryLifetime;
 
 struct acl_lowp_matmul_conf_t {
     arm_compute::TensorInfo src_tensor_info;
@@ -62,20 +48,6 @@ struct acl_lowp_matmul_conf_t {
     bool sum_is_fused {false};
 };
 
-struct acl_lowp_matmul_resource_t : public resource_t {
-    acl_lowp_matmul_resource_t()
-        : acl_obj_(utils::make_unique<acl_lowp_matmul_obj_t>()) {}
-
-    status_t configure(const acl_lowp_matmul_conf_t &almc);
-
-    acl_lowp_matmul_obj_t &get_acl_obj() const { return *acl_obj_; }
-
-    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_lowp_matmul_resource_t);
-
-private:
-    std::unique_ptr<acl_lowp_matmul_obj_t> acl_obj_;
-};
-
 struct acl_lowp_matmul_t : public primitive_t {
     struct pd_t : public dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
         using cpu_matmul_pd_t::cpu_matmul_pd_t;
@@ -85,7 +57,9 @@ struct acl_lowp_matmul_t : public primitive_t {
 
         status_t init(engine_t *engine);
 
-        status_t init_scratchpad(memory_tracking::registrar_t &scratchpad);
+        status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
+                const arm_compute::experimental::MemoryRequirements
+                        &aux_mem_req);
 
         acl_lowp_matmul_conf_t almc_ = utils::zero<decltype(almc_)>();
         acl_post_ops_t acl_post_ops;
@@ -93,13 +67,17 @@ struct acl_lowp_matmul_t : public primitive_t {
 
     acl_lowp_matmul_t(const pd_t *apd) : primitive_t(apd) {}
 
-    status_t create_resource(engine_t *engine, resource_mapper_t &mapper) const;
+    status_t init(engine_t *engine) override;
 
-    status_t execute(const exec_ctx_t &ctx) const;
+    status_t execute(const exec_ctx_t &ctx) const override;
 
 private:
-    mutable std::mutex mtx;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<arm_compute::experimental::op::CpuQuantize> quant_;
+    std::unique_ptr<arm_compute::experimental::op::CpuDequantize> dequant_;
+    std::unique_ptr<arm_compute::experimental::op::CpuGEMMLowp> gemm_;
+
+    mutable std::mutex mtx_;
 };
 
 } // namespace matmul


### PR DESCRIPTION
# Description

This pr is to change arm lowp matmul to use latest acl stateless api.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
```
./tests/benchdnn/benchdnn --mode=p --matmul --dt=s8:s8:f32 

OMP_NUM_THREADS=4

origin:
1x512:512x512: min(ms):0.0273438 avg(ms):0.0297922
1024x512:512x1024: min(ms):0.535645 avg(ms):0.547256
4096x4096:4096x4096: min(ms):67.917 avg(ms):68.0218
512x512:512x512: min(ms):0.152832 avg(ms):0.157268



stateless lowpmatmul:
1x512:512x512: min(ms):0.0283203 avg(ms):0.0301788
1024x512:512x1024: min(ms):0.546875 avg(ms):0.56036
4096x4096:4096x4096: min(ms):67.8574 avg(ms):67.9895
512x512:512x512: min(ms):0.152588 avg(ms):0.157321



OMP_NUM_THREADS=16

origin:
1x512:512x512: min(ms):0.0334473 avg(ms):0.0356632
1024x512:512x1024: min(ms):0.209717 avg(ms):0.220023
4096x4096:4096x4096: min(ms):23.1809 avg(ms):23.2551
512x512:512x512: min(ms):0.074707 avg(ms):0.0785226



stateless lowpmatmul:
1x512:512x512: min(ms):0.0336914 avg(ms):0.0357582
1024x512:512x1024: min(ms):0.212646 avg(ms):0.223197
4096x4096:4096x4096: min(ms):23.2639 avg(ms):23.3418
512x512:512x512: min(ms):0.0756836 avg(ms):0.0799105
```
