### PR TITLE
[GPU] [conv:v2] add strided tensor support

### DIFF
--- a/src/gpu/intel/jit/conv/problem.cpp
+++ b/src/gpu/intel/jit/conv/problem.cpp
@@ -47,6 +47,18 @@ const std::vector<pvar_t> &conv_dims() {
     return _conv_dims;
 }
 
+pvar_t prb_stride(const pvar_t &dim, tensor_kind_t tensor_kind) {
+
+    auto dims = conv_layout_dims(tensor_kind, true);
+    for (auto &d : dims) {
+        if (d == dim) {
+            auto str = to_string(tensor_kind) + "_";
+            return pvar_t(str + dim.str() + "_stride");
+        }
+    }
+    return pvar_t();
+}
+
 const std::vector<pvar_t> &conv_index_dims(prop_kind_t prop) {
     auto get_dims = [&](prop_kind_t prop) {
         std::vector<pvar_t> ret;

--- a/src/gpu/intel/jit/conv/problem.hpp
+++ b/src/gpu/intel/jit/conv/problem.hpp
@@ -32,6 +32,7 @@ namespace jit {
 
 bool is_conv_index(const pvar_t &dim);
 bool is_conv_index(const pvar_t &dim, prop_kind_t prop);
+pvar_t prb_stride(const pvar_t &dim, tensor_kind_t tensor_kind);
 const std::vector<pvar_t> &conv_dims();
 const std::vector<pvar_t> &conv_index_dims(prop_kind_t prop);
 

--- a/src/gpu/intel/jit/ir/linear_expr.hpp
+++ b/src/gpu/intel/jit/ir/linear_expr.hpp
@@ -60,6 +60,10 @@ void split_to_linear(const expr_t &expr, const std::vector<expr_t> &idxs,
         const std::vector<expr_t> &start, expr_t &init,
         std::vector<expr_t> &incs);
 
+class linear_normalize_expander_t : public ir_mutator_t {
+public:
+    object_t _mutate(const binary_op_t &_obj) override;
+};
 } // namespace jit
 } // namespace intel
 } // namespace gpu

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -249,7 +249,11 @@ bool is_grf_usage_ok(const kernel_desc_t &desc) {
 }
 
 prb_reqs_t kernel_desc_t::reqs() const {
-    return generate_2d_reqs(*this);
+    auto reqs = generate_2d_reqs(*this);
+    set_stride_reqs(tensor_kind_t::src, src_tag, reqs);
+    set_stride_reqs(tensor_kind_t::wei, wei_tag, reqs);
+    set_stride_reqs(tensor_kind_t::dst, dst_tag, reqs);
+    return reqs;
 }
 
 bool kernel_desc_t::is_supported(const hw_t &hw, const problem_t *prb) const {
@@ -332,6 +336,15 @@ void kernel_desc_t::set_missing() {
     }
 }
 
+void kernel_desc_t::set_stride_reqs(const tensor_kind_t kind,
+        const layout_tag_t &desc_tag, prb_reqs_t &reqs) const {
+    if (!desc_tag.is_strided()) return;
+    auto tag = append_groups(kind, desc_tag, is_dw);
+    auto &entries = tag.raw_tag().entries();
+    auto dim = tag.desc().prb_dim(entries.rbegin()->index());
+    reqs.add(prb_stride(dim, kind).var() == expr_t(1));
+}
+
 bool is_compatible(tensor_kind_t abc, const kernel_desc_t &kernel_desc,
         const problem_t &prb, bool exact) {
     auto &desc_tag = kernel_desc.layout_tag(abc);
@@ -347,6 +360,10 @@ bool is_compatible(tensor_kind_t abc, const kernel_desc_t &kernel_desc,
     if (!type_ok && is_out && kernel_desc.use_stream_k) type_ok = true;
     gpu_check(type_ok) << to_string(abc) << " tag " << prb_tag
                        << " does not match kernel descriptor tag " << desc_tag;
+    if (prb_tag.is_strided())
+        gpu_check(prb_tag.matches(desc_tag, prb.shape(), /*check_type=*/false))
+                << to_string(abc) << " tag " << prb_tag
+                << " does not match kernel descriptor tag " << desc_tag;
     return true;
 }
 
@@ -403,9 +420,10 @@ void fit_tag_to(
     auto &prb_tag = prb.layout_tag(abc);
     bool is_out_stream_k
             = (abc == tensor_kind_t::c) && kernel_desc.use_stream_k;
-    if (desc_tag.type() != prb_tag.type() && !is_out_stream_k) {
-        desc_tag = layout_tag_t(
-                desc_tag.desc(), prb_tag.type(), desc_tag.raw_tag());
+    if ((desc_tag.type() != prb_tag.type() && !is_out_stream_k)
+            || prb_tag.is_strided()) {
+        desc_tag = layout_tag_t(desc_tag.desc(), prb_tag.type(),
+                desc_tag.raw_tag(), prb_tag.is_strided());
     }
 }
 
@@ -425,7 +443,11 @@ void fit_to_impl(kernel_desc_t &desc, const problem_t &prb) {
 }
 
 bool kernel_desc_t::can_fit(const problem_t &prb) const {
-    return is_compatible(*this, prb, /*exact=*/false);
+    auto desc = *this;
+    desc.src_tag.set_strided(prb.src_tag().is_strided());
+    desc.wei_tag.set_strided(prb.wei_tag().is_strided());
+    desc.dst_tag.set_strided(prb.dst_tag().is_strided());
+    return is_compatible(desc, prb, /*exact=*/false);
 }
 
 void kernel_desc_t::fit_to(const problem_t &prb) {
@@ -758,6 +780,19 @@ void kernel_desc_t::init_kernel_iface(kernel_iface_t &kernel_iface) const {
         kernel_iface.register_arg(var);
         if (d == pvars::sw)
             kernel_iface.register_arg("sw_magic", type_t::u64());
+        if (!is_conv_index(d)) continue;
+        for (auto &t_kind :
+                {tensor_kind_t::src, tensor_kind_t::wei, tensor_kind_t::dst}) {
+            auto &tag = layout_tag(t_kind);
+            if (!tag.is_strided()) continue;
+            auto inner_dim = tag.raw_tag().entries().back();
+            if (prb_stride(d, t_kind).is_undef()
+                    || tag.desc().prb_dim(inner_dim.index()) == d)
+                continue;
+            auto stride_var
+                    = var_t::make(type_t::s32(), prb_stride(d, t_kind).str());
+            kernel_iface.register_arg(stride_var);
+        }
     }
     if (use_stream_k) {
         kernel_iface.register_arg("sk_iters_per_tile_main", type_t::s32());
@@ -1021,7 +1056,9 @@ status_t kernel_desc_t::init_primitive_plan(primitive_init_plan_t &plan,
                                  : jit::layout_t(md, /*do_normalize=*/false));
         bool is_out_stream_k = use_stream_k && t.is_output;
         bool zero_out = is_out_stream_k;
-        if (compute_layout != user_layout) {
+        if (compute_layout != user_layout
+                && !compute_layout.normalize().is_strictly_equal(
+                        user_layout.normalize(), true, false)) {
             user_name += "_user";
             scratchpad_key++;
             pd->scratchpad_registry().registrar().book(
@@ -1034,7 +1071,8 @@ status_t kernel_desc_t::init_primitive_plan(primitive_init_plan_t &plan,
         plan.add_user_buffer(user_name, user_layout, t.is_input, t.is_output,
                 t.arg_key, zero_out);
         if (user_name == t.name) {
-            gpu_assert(user_layout == compute_layout)
+            gpu_assert(compute_layout.normalize().is_strictly_equal(
+                    user_layout.normalize(), true, false))
                     << "Incompatible user/kernel layouts. User: "
                     << user_layout.str()
                     << ", kernel: " << compute_layout.str();

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -301,6 +301,8 @@ public:
     prb_reqs_t reqs() const;
     void set(const std::string &s);
     void set_missing();
+    void set_stride_reqs(const tensor_kind_t kind, const layout_tag_t &tag,
+            prb_reqs_t &reqs) const;
     bool can_fit(const problem_t &prb) const;
     void fit_to(const problem_t &prb);
     status_t set_attr(const convolution_pd_t *pd, const primitive_attr_t *attr,

--- a/src/gpu/intel/jit/v2/conv/plan_registry.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan_registry.cpp
@@ -66,8 +66,9 @@ kernel_desc_t plan_registry_t::find_best(
         auto sk_desc = to_stream_k(e.desc);
         sk_desc.spec.mode = spec_mode;
         sk_desc.spec.specialize(prb);
+        if (sk_desc.is_empty()) continue;
         gpu_trace() << "Trying kernel desc: " << sk_desc.cmd_str();
-        if (sk_desc.is_empty() || !sk_desc.can_fit(prb)) continue;
+        if (!sk_desc.can_fit(prb)) continue;
         time = e.model_set.time(prb, sk_desc);
         if (time < min_time) {
             min_time = time;

--- a/src/gpu/intel/jit/v2/conv/problem.cpp
+++ b/src/gpu/intel/jit/v2/conv/problem.cpp
@@ -78,6 +78,9 @@ double problem_t::ops() const {
 
 void problem_t::normalize() {
 #define GET(name) shape_[pvars::name]
+    if (src_tag().is_strided() || wei_tag().is_strided()
+            || dst_tag().is_strided())
+        return;
     normalize_conv_shape(GET(od), GET(id), GET(kd), GET(sd), GET(dd), GET(pd),
             GET(oh), GET(ih), GET(kh), GET(sh), GET(dh), GET(ph), GET(ow),
             GET(iw), GET(kw), GET(sw), GET(dw), GET(pw),

--- a/src/gpu/intel/jit/v2/conv/tensor_utils.cpp
+++ b/src/gpu/intel/jit/v2/conv/tensor_utils.cpp
@@ -136,7 +136,8 @@ layout_tag_t append_groups(
         }
     }
     auto desc = make_conv_layout_desc(tensor_kind, /*src_dst_with_group=*/true);
-    return layout_tag_t(desc, layout_tag.type(), new_raw_tag);
+    return layout_tag_t(
+            desc, layout_tag.type(), new_raw_tag, layout_tag.is_strided());
 }
 
 uint32_t append_groups(tensor_kind_t tensor_kind, uint32_t mask, bool is_dw) {
@@ -174,7 +175,12 @@ layout_t make_conv_layout(tensor_kind_t tensor_kind, const layout_tag_t &_tag,
         } else {
             block_size_expr = rem_size(dim, blocks);
         }
-        ret.add_block(dim, block_size_expr);
+        if (tag.is_strided() && it != entries.rbegin()) {
+            auto stride = prb_stride(dim, tensor_kind);
+            ret.add_block(dim, block_size_expr,
+                    stride.is_undef() ? expr_t(0) : stride.var());
+        } else
+            ret.add_block(dim, block_size_expr);
     }
     return ret;
 }
@@ -201,18 +207,27 @@ std::string blocked_to_str_tag(const memory_desc_t &md) {
     for (int i = 0; i < ndims; i++) {
         bool found = false;
         dim_t min_dim = std::numeric_limits<dim_t>::max();
+        dim_t min_stride = std::numeric_limits<dim_t>::max();
         for (int j = 0; j < ndims; j++) {
-            if (!seen[j] && blk.strides[j] == stride) {
-                min_dim = std::min(min_dim, rem_dims[j]);
+            if (!seen[j]
+                    && ((blk.strides[j] == stride)
+                            || (blk.strides[j] > stride))) {
+                if (blk.strides[j] < min_stride)
+                    min_dim = rem_dims[j];
+                else if (blk.strides[j] == min_stride)
+                    min_dim = std::min(min_dim, rem_dims[j]);
+                min_stride = std::min(min_stride, blk.strides[j]);
             }
         }
         for (int j = ndims - 1; j >= 0; j--) {
-            if (!seen[j] && blk.strides[j] == stride) {
+            if (!seen[j]
+                    && (blk.strides[j] == stride
+                            || blk.strides[j] == min_stride)) {
                 // Size-one blocks have to be added first.
                 if (min_dim == 1 && rem_dims[j] != min_dim) continue;
                 bool is_blocked = (full_inner_blks[j] != 1);
                 parts.emplace_back(1, dim_idx::as_tag(j, is_blocked));
-                stride *= rem_dims[j];
+                stride = rem_dims[j] * blk.strides[j];
                 seen[j] = true;
                 found = true;
                 break;
@@ -247,13 +262,15 @@ layout_tag_t make_conv_layout_tag(tensor_kind_t tensor_kind,
     bool is_any = (md.format_kind == format_kind::any);
     bool is_blocked = (md.format_kind == format_kind::blocked);
     gpu_assert(is_any || is_blocked);
+    memory_desc_wrapper mdw(md);
+    bool is_strided = (mdw.is_plain() && !mdw.is_dense());
     auto desc = make_conv_layout_desc(tensor_kind);
     type_t type(md.data_type);
     if (is_any) return layout_tag_t(desc, type, layout_raw_tag_t::any());
     auto str_tag = blocked_to_str_tag(md);
     auto raw_tag = layout_raw_tag_t(str_tag);
     raw_tag = normalize_conv_tag(tensor_kind, conv_ndims, raw_tag);
-    return layout_tag_t(desc, type, raw_tag);
+    return layout_tag_t(desc, type, raw_tag, is_strided);
 }
 
 dim_mapper_manager_t::dim_mapper_manager_t(

--- a/src/gpu/intel/jit/v2/ir/tensor.cpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.cpp
@@ -423,7 +423,7 @@ bool layout_tag_t::matches(const layout_tag_t &other, const pvar_tile_t &sizes,
 std::string layout_tag_t::str() const {
     if (is_empty()) return "x";
     std::ostringstream oss;
-    oss << raw_tag_ << ":" << type_;
+    oss << raw_tag_ << ":" << type_ << ":" << is_strided_;
     return oss.str();
 }
 


### PR DESCRIPTION
addresses MFDNN-12455
Assumes innermost dimension has stride 1.
1) Add placeholder stride vars for each tensor.
2) use stride vars in layout_t instead of calcuating based off dims.
3) Infer stride_var reqs for mod and gt/lt reqs :
examples
`ic % 16 == 0  => stride_iw % 16 ==0, stride_ih % 16 ==0, stride_mb % 16 == 0`
`ic*iw < 256 => stride_iw*iw<256  stride_ih < 256 `

This approach was chosen as opposed to limiting spatial dimensions to be dense because it is more general
and reqs would still need to be inferred/generated for non-spatial dimension stride vars.