### PR TITLE
benchdnn: inputs: graph: fix test cases related to int8/f8 add

### DIFF
--- a/tests/benchdnn/inputs/graph/pattern/f8/f8_conv_add_add_fusion.json
+++ b/tests/benchdnn/inputs/graph/pattern/f8/f8_conv_add_add_fusion.json
@@ -1,12 +1,13 @@
 {
-  "version": "3.6.0",
+  "version": "3.8.0",
   "engine_kind": "cpu",
   "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
   "input_ports": [
     0, 
     1, 
     2, 
-    3
+    10305
   ],
   "output_ports": [
     14512
@@ -135,128 +136,6 @@
       ]
     }, 
     {
-      "id": 8209,
-      "name": "DEQUANTIZE_4",
-      "kind": "Dequantize",
-      "attrs": {
-        "axis": {
-          "type": "s64",
-          "value": 1
-        },
-        "qtype": {
-          "type": "string",
-          "value": "per_tensor"
-        },
-        "scales": {
-          "type": "f32[]",
-          "value": [
-            1
-          ]
-        }
-      },
-      "inputs": [
-        {
-          "id": 2,
-          "dtype": "f8_e5m2",
-          "shape": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "stride": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ],
-      "outputs": [
-        {
-          "id": 6209,
-          "dtype": "f32",
-          "shape": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "stride": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ]
-    }, 
-    {
-      "id": 12305,
-      "name": "DEQUANTIZE_6",
-      "kind": "Dequantize",
-      "attrs": {
-        "axis": {
-          "type": "s64",
-          "value": 1
-        },
-        "qtype": {
-          "type": "string",
-          "value": "per_tensor"
-        },
-        "scales": {
-          "type": "f32[]",
-          "value": [
-            1
-          ]
-        }
-      },
-      "inputs": [
-        {
-          "id": 3,
-          "dtype": "f8_e5m2",
-          "shape": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "stride": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ],
-      "outputs": [
-        {
-          "id": 10305,
-          "dtype": "f32",
-          "shape": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "stride": [
-            1, 
-            1, 
-            1, 
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ]
-    }, 
-    {
       "id": 4,
       "name": "CONV_0",
       "kind": "Convolution",
@@ -358,6 +237,67 @@
             200704, 
             3136, 
             56, 
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }, 
+    {
+      "id": 8209,
+      "name": "DEQUANTIZE_4",
+      "kind": "Dequantize",
+      "attrs": {
+        "axis": {
+          "type": "s64",
+          "value": 1
+        },
+        "qtype": {
+          "type": "string",
+          "value": "per_tensor"
+        },
+        "scales": {
+          "type": "f32[]",
+          "value": [
+            1
+          ]
+        }
+      },
+      "inputs": [
+        {
+          "id": 2,
+          "dtype": "f8_e5m2",
+          "shape": [
+            1, 
+            1, 
+            1, 
+            1
+          ],
+          "stride": [
+            1, 
+            1, 
+            1, 
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 6209,
+          "dtype": "f32",
+          "shape": [
+            1, 
+            1, 
+            1, 
+            1
+          ],
+          "stride": [
+            1, 
+            1, 
+            1, 
             1
           ],
           "layout_type": "strided",

--- a/tests/benchdnn/inputs/graph/pattern/harness_int8_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_int8_all
@@ -14,7 +14,7 @@
 --reset --case=pattern/int8/int8_bf16_matmul_sum_add_mul_relu.json
 --reset --attr-fpmath=strict:false,bf16:false,tf32:false --case=pattern/int8/int8_avgpool_reshape_fusion.json
 --reset --case=pattern/int8/int8_avgpool_transpose_fusion.json
---reset --expected-n-partitions=0 --case=pattern/int8/int8_bf16_conv_add_relu_mul.json
+--reset --case=pattern/int8/int8_bf16_conv_add_relu_mul.json
 --reset --case=pattern/int8/int8_bf16_matmul_tc_add_quant_fusion.json
 --reset --case=pattern/int8/int8_bf16_conv_binary_add_fusion_2.json
 
@@ -23,7 +23,7 @@
 --reset --in-shapes=0:1x2048x14x14+1:2048x64x3x3+2:2048 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/int8/int8_conv_bias_mish_fusion.json
 --reset --in-shapes=0:1x2048x14x14+1:2048x64x3x3+2:2048 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/int8/int8_conv_bias_relu_fusion_2.json
 --reset --in-shapes=0:1x2048x14x14+1:2048x64x3x3+2:2048 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:1x1*pads_end:1x1*groups:32 --case=pattern/int8/int8_conv_bias_relu_fusion_3.json
---reset --expected-n-partitions=0 --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x1x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_add_add_fusion.json
+--reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x1x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_add_add_fusion.json
 --reset --expected-n-partitions=0 --op-attrs=8209:zps:1 --case=pattern/int8/int8_conv_add_add_fusion.json
 --reset --in-shapes=0:50x64x56x56+1:64x64x1x1+2:1x1x1x1+3:1x64x1x1 --op-attrs=4:strides:1x1*dilations:1x1*pads_begin:0x0*pads_end:0x0*groups:1 --case=pattern/int8/int8_conv_add_mul_fusion.json
 --reset --expected-n-partitions=0 --op-attrs=8209:zps:2 --case=pattern/int8/int8_conv_add_mul_fusion.json
@@ -46,7 +46,7 @@
 # matmul
 --reset --in-shapes=0:16x256+1:256x1+2:1x1+3:1x1 --case=pattern/int8/int8_matmul_add_mul_fusion.json
 --reset --expected-n-partitions=0 --op-attrs=8209:zps:3 --case=pattern/int8/int8_matmul_add_mul_fusion.json
---reset --expected-n-partitions=0 --in-shapes=0:16x256+1:256x1+2:1x1+3:1x1+4:1x1 --case=pattern/int8/int8_matmul_mul_add_mul_fusion.json
+--reset --in-shapes=0:16x256+1:256x1+2:1x1+3:1x1+4:1x1 --case=pattern/int8/int8_matmul_mul_add_mul_fusion.json
 --reset --in-shapes=0:16x256+1:256x1+2:1x1 --case=pattern/int8/int8_matmul_logistic_fusion.json
 --reset --in-shapes=0:16x1024+1:1024x1024+2:1x1024 --op-attrs=4113:scales:2 --case=pattern/int8/int8_matmul_logistic_fusion.json
 --reset --in-shapes=0:16x1024+1:1024x512+2:1x512 --op-attrs=4113:scales:2 --case=pattern/int8/int8_matmul_logistic_fusion.json

--- a/tests/benchdnn/inputs/graph/pattern/int8/int8_bf16_conv_add_relu_mul.json
+++ b/tests/benchdnn/inputs/graph/pattern/int8/int8_bf16_conv_add_relu_mul.json
@@ -1,7 +1,17 @@
 {
-  "version": "3.0.0",
+  "version": "3.8.0",
   "engine_kind": "cpu",
   "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    3,
+    10,
+    14
+  ],
+  "output_ports": [
+    15
+  ],
   "graph": [
     {
       "id": 0,
@@ -234,10 +244,6 @@
       "name": "CONV",
       "kind": "Convolution",
       "attrs": {
-        "weights_format": {
-          "type": "string",
-          "value": "OIX"
-        },
         "auto_pad": {
           "type": "string",
           "value": "None"
@@ -255,6 +261,10 @@
             0,
             0
           ]
+        },
+        "weights_format": {
+          "type": "string",
+          "value": "OIX"
         },
         "pads_begin": {
           "type": "s64[]",
@@ -335,119 +345,6 @@
           ],
           "layout_type": "strided",
           "property_type": "undef"
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "name": "DEQUANTIZE_ADD",
-      "kind": "Dequantize",
-      "attrs": {
-        "axis": {
-          "type": "s64",
-          "value": 1
-        },
-        "qtype": {
-          "type": "string",
-          "value": "per_tensor"
-        },
-        "zps": {
-          "type": "s64[]",
-          "value": [
-            0
-          ]
-        },
-        "scales": {
-          "type": "f32[]",
-          "value": [
-            1
-          ]
-        }
-      },
-      "inputs": [
-        {
-          "id": 8,
-          "dtype": "s8",
-          "shape": [
-            50,
-            64,
-            56,
-            56
-          ],
-          "stride": [
-            200704,
-            3136,
-            56,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "constant"
-        }
-      ],
-      "outputs": [
-        {
-          "id": 9,
-          "dtype": "f32",
-          "shape": [
-            50,
-            64,
-            56,
-            56
-          ],
-          "stride": [
-            200704,
-            3136,
-            56,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "constant"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "name": "TYPECAST_ADD",
-      "kind": "TypeCast",
-      "attrs": {},
-      "inputs": [
-        {
-          "id": 9,
-          "dtype": "f32",
-          "shape": [
-            50,
-            64,
-            56,
-            56
-          ],
-          "stride": [
-            200704,
-            3136,
-            56,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "constant"
-        }
-      ],
-      "outputs": [
-        {
-          "id": 10,
-          "dtype": "bf16",
-          "shape": [
-            50,
-            64,
-            56,
-            56
-          ],
-          "stride": [
-            200704,
-            3136,
-            56,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "constant"
         }
       ]
     },
@@ -541,7 +438,7 @@
             56,
             1
           ],
-          "layout_type": "undef",
+          "layout_type": "strided",
           "property_type": "undef"
         }
       ],
@@ -561,7 +458,7 @@
             56,
             1
           ],
-          "layout_type": "undef",
+          "layout_type": "strided",
           "property_type": "undef"
         }
       ]

--- a/tests/benchdnn/inputs/graph/pattern/int8/int8_conv_add_add_fusion.json
+++ b/tests/benchdnn/inputs/graph/pattern/int8/int8_conv_add_add_fusion.json
@@ -1,7 +1,17 @@
 {
-  "version": "3.0.0",
+  "version": "3.8.0",
   "engine_kind": "cpu",
   "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    2,
+    10305
+  ],
+  "output_ports": [
+    14512
+  ],
   "graph": [
     {
       "id": 2065,
@@ -142,10 +152,6 @@
       "name": "CONV_0",
       "kind": "Convolution",
       "attrs": {
-        "weights_format": {
-          "type": "string",
-          "value": "OIX"
-        },
         "auto_pad": {
           "type": "string",
           "value": "None"
@@ -163,6 +169,10 @@
             0,
             0
           ]
+        },
+        "weights_format": {
+          "type": "string",
+          "value": "OIX"
         },
         "pads_begin": {
           "type": "s64[]",
@@ -375,73 +385,6 @@
             200704,
             3136,
             56,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ]
-    },
-    {
-      "id": 12305,
-      "name": "DEQUANTIZE_6",
-      "kind": "Dequantize",
-      "attrs": {
-        "axis": {
-          "type": "s64",
-          "value": 1
-        },
-        "qtype": {
-          "type": "string",
-          "value": "per_tensor"
-        },
-        "zps": {
-          "type": "s64[]",
-          "value": [
-            0
-          ]
-        },
-        "scales": {
-          "type": "f32[]",
-          "value": [
-            1
-          ]
-        }
-      },
-      "inputs": [
-        {
-          "id": 3,
-          "dtype": "s8",
-          "shape": [
-            1,
-            1,
-            1,
-            1
-          ],
-          "stride": [
-            1,
-            1,
-            1,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ],
-      "outputs": [
-        {
-          "id": 10305,
-          "dtype": "f32",
-          "shape": [
-            1,
-            1,
-            1,
-            1
-          ],
-          "stride": [
-            1,
-            1,
-            1,
             1
           ],
           "layout_type": "strided",

--- a/tests/benchdnn/inputs/graph/pattern/int8/int8_matmul_mul_add_mul_fusion.json
+++ b/tests/benchdnn/inputs/graph/pattern/int8/int8_matmul_mul_add_mul_fusion.json
@@ -1,7 +1,18 @@
 {
-  "version": "3.0.0",
+  "version": "3.8.0",
   "engine_kind": "cpu",
   "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    2,
+    8257,
+    4
+  ],
+  "output_ports": [
+    14512
+  ],
   "graph": [
     {
       "id": 2065,
@@ -228,65 +239,6 @@
           "dtype": "f32",
           "shape": [
             16,
-            1
-          ],
-          "stride": [
-            1,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ]
-    },
-    {
-      "id": 10257,
-      "name": "DEQUANTIZE_5",
-      "kind": "Dequantize",
-      "attrs": {
-        "axis": {
-          "type": "s64",
-          "value": 1
-        },
-        "qtype": {
-          "type": "string",
-          "value": "per_tensor"
-        },
-        "zps": {
-          "type": "s64[]",
-          "value": [
-            0
-          ]
-        },
-        "scales": {
-          "type": "f32[]",
-          "value": [
-            1
-          ]
-        }
-      },
-      "inputs": [
-        {
-          "id": 3,
-          "dtype": "s8",
-          "shape": [
-            1,
-            1
-          ],
-          "stride": [
-            1,
-            1
-          ],
-          "layout_type": "strided",
-          "property_type": "undef"
-        }
-      ],
-      "outputs": [
-        {
-          "id": 8257,
-          "dtype": "f32",
-          "shape": [
-            1,
             1
           ],
           "stride": [


### PR DESCRIPTION
Mainly about int8/f8 Conv/matmul + Add fusions. Remove the dequantize op on the src1 of Add.

The original cases were executed with graph dump. Two graphs for two partitions will be dumped (1 for the main fusion, and 1 for the dequantize op). The graph of the main fusion pattern is used here to replace the original case. 

Fixes MFDNN-12928

