### PR TITLE
Bunch of functional fixes (fixes MFDNN-13193, fixes MFDNN-13282, fixes MFDNN-13236)

### DIFF
--- a/src/cpu/reorder/cpu_reorder_comp_s8_s8.cpp
+++ b/src/cpu/reorder/cpu_reorder_comp_s8_s8.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2023 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         // s8 -> s8
         {{s8, s8, 2}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))
+            DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, oi, s8, OI4i16o4i, fmt_order::keep, spec::conv_req_comp))
@@ -50,6 +51,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
         // s8 -> s8
         {{s8, s8, 3}, {
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))
+            DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, wio, fmt_order::keep, spec::conv_req_comp))
@@ -88,6 +90,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
             nullptr,
         }},
         {{s8, s8, 4}, {
+            DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, hwio, fmt_order::keep, spec::conv_req_comp))
@@ -137,6 +140,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
             nullptr,
         }},
         {{s8, s8, 5}, {
+            DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, hwigo, fmt_order::keep, spec::conv_req_comp))
@@ -183,6 +187,7 @@ const impl_list_map_t &comp_s8_s8_impl_list_map() {
             nullptr,
         }},
         {{s8, s8, 6}, {
+            DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
             DNNL_NON_X64_ONLY(REG_SR(s8, any, s8, dhwigo, fmt_order::keep, spec::conv_req_comp))

--- a/src/cpu/scale_utils.cpp
+++ b/src/cpu/scale_utils.cpp
@@ -91,13 +91,10 @@ const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
 
     const float *scales = nullptr;
     if (req_copy_scales(attr, scale_adjust_factor)) {
-        const int wei_scale_mask = attr_scales.get_mask(DNNL_ARG_WEIGHTS);
-        assert(wei_scale_mask >= 0);
-
         size_t size = 0;
         auto loc_scales
                 = scratchpad.template get<float>(key_precomputed_scales, &size);
-        if (wei_scale_mask == 0 || wei_scale_count == 1) {
+        if (wei_scale_count == 1) {
             const size_t count = nstl::min(size / sizeof(float), scales_simd_w);
             utils::array_set(loc_scales,
                     src_scales[0] * wei_scales[0] * scale_adjust_factor, count);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1771,9 +1771,11 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
 void jit_avx512_core_x8s8s32x_fwd_kernel::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
-    const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
-    const dim_t scales_count = wei_mask == 0 ? 1 : jcp.oc * jcp.ngroups;
-    dim_t count = wei_mask == 0 ? (dim_t)16 : scales_count;
+    dim_t count = 16;
+    if (!attr.scales_.has_default_values(DNNL_ARG_WEIGHTS)) {
+        const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
+        if (wei_mask > 0) count = jcp.oc * jcp.ngroups;
+    }
     scratchpad.book<float>(key_conv_adjusted_scales, count);
 }
 

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -241,7 +241,10 @@ static void zfree_protect(void *ptr) {
 
 void *zmalloc(size_t size, size_t align) {
 #ifdef BENCHDNN_MEMORY_CHECK
-    if (has_bench_mode_bit(mode_bit_t::exec)) { return zmalloc_protect(size); }
+    if (has_bench_mode_bit(mode_bit_t::exec)
+            && !has_bench_mode_bit(mode_bit_t::perf)) {
+        return zmalloc_protect(size);
+    }
 #endif
 
     void *ptr;
@@ -266,7 +269,8 @@ void *zmalloc(size_t size, size_t align) {
 void zfree(void *ptr) {
     if (!ptr) return;
 #ifdef BENCHDNN_MEMORY_CHECK
-    if (has_bench_mode_bit(mode_bit_t::exec)) {
+    if (has_bench_mode_bit(mode_bit_t::exec)
+            && !has_bench_mode_bit(mode_bit_t::perf)) {
         zfree_protect(ptr);
         return;
     }

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <fstream>
 #include <functional>
 #include <string>
@@ -206,6 +207,7 @@ static void *zmalloc_protect(size_t size) {
     // Protect one page right after the block of size bytes
     int err = mprotect(ptr_protect, page_sz, PROT_NONE);
     if (err != 0) {
+        printf("Error: mprotect returned \'%s\'.\n", strerror(errno));
         ::free(ptr_start);
         return nullptr;
     }

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ struct dnn_mem_t {
 
     void map() const;
     void unmap() const;
-    void memset(int value, size_t size) const;
+    void memset(int value, size_t size, int buffer_index) const;
 
     static dnn_mem_t create_from_host_ptr(
             const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr);

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -115,6 +115,11 @@ struct dnn_mem_t {
     const dnnl_dims_t &inner_blks() const;
     const dnnl_dims_t &inner_idxs() const;
 
+    // Sparse memories require special handling for `no_ref_memory` modifier
+    // because of indirect access. Thus, filling should apply to metadata and
+    // it must be meaningful. It implies unconditional mapping.
+    bool is_sparse_md() const;
+
     size_t sizeof_dt() const;
 
     template <typename T>
@@ -215,6 +220,8 @@ private:
 };
 
 using dnn_mem_map_t = std::unordered_map<int, dnn_mem_t>;
+
+bool has_sparse_md(const dnn_mem_map_t &dnn_mem_map);
 
 dnnl_memory_desc_t clone_md(const_dnnl_memory_desc_t md);
 

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -192,7 +192,7 @@ only. This mode targets forward and backward by data propagation kinds. When
 This targets any propagation kind but mostly bandwidth-limited functionality
 to emulate first access to data or branching cases. When `MODE` is set to
 `custom`, cold cache is enabled for specified arguments, but it requires source
-code adjustments. Refer to [cold cache](cold_cache.md) for more information.
+code adjustments. Refer to [cold cache](knob_cold_cache.md) for more information.
 
 ### --fix-times-per-prb
 `--fix-times-per-prb=N` specifies the `N` number of rounds per problem to run,

--- a/tests/benchdnn/inputs/reorder/harness_reorder_large
+++ b/tests/benchdnn/inputs/reorder/harness_reorder_large
@@ -1,0 +1,11 @@
+# test if jit kernels properly handle corner cases:
+# * large stride problems
+# * huge dimensions (UINT_MAX + 1)
+--reset
+--skip-impl=ref,simple # run only jit impl, won't iterate
+--sdt=f32
+--ddt=f32
+--stag=abx
+--dtag=aBx8b
+2x16x19200x19200
+1x4294967296x1

--- a/tests/benchdnn/inputs/reorder/test_reorder_all
+++ b/tests/benchdnn/inputs/reorder/test_reorder_all
@@ -60,16 +60,6 @@
 --stag=aBx4b,aBx8b --dtag=aBx16b 2x71x16x16 2x72x16x16 2x73x16x16
 --stag=aBx16b      --dtag=aBx8b  2x71x16x16 2x72x16x16 2x73x16x16
 
-# test if jit kernels properly handle corner cases:
-# * large stride problems
-# * huge dimensions (UINT_MAX + 1)
---reset
---skip-impl=ref,simple # ! test jit version only
---sdt=f32 --ddt=f32
---stag=abx --dtag=aBx8b 2x16x19200x19200
---skip-impl=
-1x4294967296x1
-
 # f16
 --batch=test_reorder_float16
 
@@ -102,3 +92,6 @@
 
 # Decompression quantization
 --batch=harness_reorder_decompression
+
+# large problems
+--batch=harness_reorder_large

--- a/tests/benchdnn/inputs/reorder/test_reorder_gpu
+++ b/tests/benchdnn/inputs/reorder/test_reorder_gpu
@@ -268,6 +268,7 @@
 
 # Catch overflows
 --reset
+--skip-impl=ref
 2147483648_n"int_overflow"
 4294967296_n"uint_overflow"
 2147483869_n"nd_range_overflow"

--- a/tests/benchdnn/reorder/reorder_aux.cpp
+++ b/tests/benchdnn/reorder/reorder_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +39,10 @@ flag_t str2flag(const char *str) {
     else if (sub.compare("zp_comp") == 0)
         flag = FLAG_ZP_COMP;
     else {
-        assert(!"unknown flag");
+        BENCHDNN_PRINT(0,
+                "Error: unsupported flag value \'%s\'. Supported values are "
+                "\'s8s8_comp\' and \'zp_comp\'.\n",
+                sub.c_str());
         SAFE_V(FAIL);
     }
 

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -195,8 +195,15 @@ cold_cache_t::cold_cache_t(
                 dnnl_status_t status = dnnl_reorder_primitive_desc_create(
                         &reorder_pd, orig_cc_mem_md, query_engine(orig_mem),
                         orig_cc_mem_md, query_engine(dst_memory), nullptr);
-                assert(status == dnnl_success);
-                if (status != dnnl_success) { return; }
+                if (status != dnnl_success) {
+                    BENCHDNN_PRINT(0,
+                            "Error: cold-cache reorder failed for %s arg and "
+                            "%zu buffer (out of %zu).\n",
+                            data_kind2str(exec_arg2data_kind(arg)), i,
+                            n_buffers_);
+                    assert(status == dnnl_success);
+                    return;
+                }
                 reorder_pdw.reset(reorder_pd);
 
                 benchdnn_dnnl_wrapper_t<dnnl_primitive_t> reorder_w;

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -442,7 +442,7 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
             if (args.dt == dnnl_f16) binary_comp_po_diff_trh = 5e-3f;
             if (args.dt == dnnl_f32) {
                 binary_comp_po_diff_trh = 4e-6f;
-                binary_comp_po_rdiff_trh = 8e-6f;
+                binary_comp_po_rdiff_trh = 1e-5f;
             }
             ok = has_binary_compute_po(attr)
                     && (args.diff <= binary_comp_po_diff_trh

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1025,12 +1025,25 @@ static bool parse_engine(
               "`cpu` or `gpu`.\n    `INDEX` is an integer value specifying "
               "which engine to use if several were identified.\n";
 
+    // Note: this is a special case because index and engine kind are parsed
+    // into separate global objects instead of one under a common parsing
+    // function.
+    // TODO: fix this.
+    //
+    // Because of this fact, need to extract kind separated by `:`. `:` can be
+    // valid dangling for certain options in the command line (--strides=::).
+    // Thus, extract the kind allowing dangling. Verify, it's `--engine` option,
+    // and if yes, perform a safe check for dangling after.
     size_t start_pos = 0;
-    std::string kind_str = get_substr(str, start_pos, ':');
+    std::string kind_str = get_substr(str, start_pos, ':', true);
 
     if (!parse_single_value_option(engine_tgt_kind, dnnl_cpu, str2engine_kind,
                 kind_str.c_str(), option_name, help))
         return false;
+
+    // This is to catch a dangling `:` at the end of `--engine`.
+    start_pos = 0;
+    kind_str = get_substr(str, start_pos, ':');
 
     if (start_pos != std::string::npos) {
         std::string index_str(str + start_pos);


### PR DESCRIPTION
* Remove mask retrieval for the lowest precompute_scales calls as it's already determined based on the number of scales needed for weights.
* Restored the memory usage for scratchpad size after the refactor for a single implementation.
* Adjusted softmax threshold a little more to fit Windows threadpool output values.
* Added support for mode-modifier=M for sparse functionality. Metadata can't be generated with random values - it leads to an access a random memory location which is prohibited. Fill metadata as for correctness mode, rest buffer are kept with random values.