### PR TITLE
[GPU] Shapeless conv: improve 1st BWD_W performance

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -1025,6 +1025,17 @@ public:
 
     void _visit(const float_imm_t &obj) override { bind(obj, to_ngen(obj)); }
 
+    void _visit(const iif_t &obj) override {
+        auto dst_op = alloc_dst_op(obj);
+        auto cond_op = eval(obj.cond);
+        auto true_expr_op = eval(obj.true_expr);
+        auto false_expr_op = eval(obj.false_expr);
+        auto mod = dst_op.mod();
+        host_->esel(mod | cond_op.flag_register_mod(), dst_op, true_expr_op,
+                false_expr_op);
+        bind(obj, dst_op);
+    }
+
     void _visit(const int_imm_t &obj) override { bind(obj, to_ngen(obj)); }
 
     void _visit(const load_t &obj) override {

--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -1259,7 +1259,7 @@ private:
     void ebinary(const binary_op_t &obj, const ngen::InstructionModifier &mod,
             const ngen_operand_t &_dst, const ngen_operand_t &_src0,
             const ngen_operand_t &_src1) {
-        auto dst = _dst;
+        auto &dst = _dst;
         auto src0 = _src0;
         auto src1 = _src1;
         align_src_dst_offset(host_, scope_, mod, dst, src0, src1);

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -1079,6 +1079,20 @@ public:
                 *this, mod, dst, src0, src1, emu_strategy, emu_state);
     }
 
+    void esel(const ngen::InstructionModifier &mod, const ngen_operand_t &dst,
+            const ngen_operand_t &src0, const ngen_operand_t &src1) {
+        if (ngen_is_qw(dst.type())) {
+            auto neg_mod = mod;
+            neg_mod.setPredInv(!mod.isPredInv());
+            emov(mod, dst, src0);
+            emov(neg_mod, dst, src1);
+        } else if (src1.is_reg_data()) {
+            sel(mod, dst.reg_data(), src0.reg_data(), src1.reg_data());
+        } else {
+            sel(mod, dst.reg_data(), src0.reg_data(), src1.immediate());
+        }
+    }
+
 protected:
     // Helper RAII class allocating a temporary GRF buffer aligned at a
     // register boundary for instructions that require aligned operands.

--- a/src/gpu/intel/jit/conv/problem.cpp
+++ b/src/gpu/intel/jit/conv/problem.cpp
@@ -129,6 +129,9 @@ tensor_kind_t to_abc(prop_kind_t prop, tensor_kind_t tensor) {
         case tensor_kind_t::src: return kinds[0];
         case tensor_kind_t::wei: return kinds[1];
         case tensor_kind_t::dst: return kinds[2];
+        case tensor_kind_t::a:
+        case tensor_kind_t::b:
+        case tensor_kind_t::c: return tensor;
         default: gpu_error_not_expected();
     }
     return kinds[0];

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -1703,6 +1703,11 @@ inline expr_t ternary_add3(const expr_t &a, const expr_t &b, const expr_t &c) {
     return ternary_op_t::make(op_kind_t::_add3, a, b, c);
 }
 
+inline expr_t ternary_idiv(
+        const expr_t &a, const expr_t &b, const expr_t &magic) {
+    return ternary_op_t::make(op_kind_t::_idiv, a, b, magic);
+}
+
 // Unary operation: (op a).
 class unary_op_t : public expr_impl_t {
 public:

--- a/src/gpu/intel/jit/ir/problem.hpp
+++ b/src/gpu/intel/jit/ir/problem.hpp
@@ -208,6 +208,15 @@ public:
         return !operator==(other);
     }
 
+    pvar_map_t drop_defaults() const {
+        pvar_map_t ret;
+        for (auto &d : *this) {
+            if (at(d) == ValueT()) continue;
+            ret[d] = at(d);
+        }
+        return ret;
+    }
+
     size_t get_hash() const { return ir_utils::get_hash(map_); }
 
     void stringify(std::ostream &out) const {

--- a/src/gpu/intel/jit/v2/conv/bridge.hpp
+++ b/src/gpu/intel/jit/v2/conv/bridge.hpp
@@ -102,6 +102,18 @@ inline jit::layout_t to_conv_layout(const layout_tag_t &_tag,
     return jit::layout_t(md, tag.str(), /*do_normalize=*/false);
 }
 
+inline jit::layout_t to_conv_layout(
+        const layout_tag_t &_tag, const pvar_tile_t &shape) {
+    int ndims = _tag.desc().ndims();
+    auto tag = _tag.raw_tag();
+    std::vector<dim_t> dims(ndims);
+    for (int i = 0; i < ndims; i++) {
+        auto d = _tag.desc().prb_dim(i);
+        dims[i] = shape.at(d);
+    }
+    return jit::layout_t(_tag.type(), expr_t(0), tag.str(), dims);
+}
+
 inline jit::grid_info_t to_grid_info(
         const grid_t &grid, const pvar_tile_t &tile) {
     std::vector<dim_t> dims;

--- a/src/gpu/intel/jit/v2/conv/builder.cpp
+++ b/src/gpu/intel/jit/v2/conv/builder.cpp
@@ -375,36 +375,29 @@ private:
         const auto &b_buf = buf_info_.reg_buf("b");
         const auto &c_buf = buf_info_.reg_buf("c");
 
-        for (auto &d : a_layout.dims())
-            gpu_assert(fma.inst_tile.has(d)) << d;
-        for (auto &d : b_layout.dims())
-            gpu_assert(fma.inst_tile.has(d)) << d;
-
-        // BMNK order.
-        pvar_t dims[4];
-        dim_t blocks[4] = {1, 1, 1, 1};
-        int sizes[4] = {1, 1, 1, 1};
-        pvar_map_t<int> bmnk_map;
-        bmnk_map[pvars::b] = 0;
-        bmnk_map[pvars::m] = 1;
-        bmnk_map[pvars::n] = 2;
-        bmnk_map[pvars::k] = 3;
-        for (auto &d : fma.inst_tile) {
-            int idx = bmnk_map.at(to_gemm(d, desc_.prop));
-            dims[idx] = d;
-            blocks[idx] = fma.inst_tile[d];
-            sizes[idx] = (idx != 2 ? a_layout : b_layout).int_dim_size(d);
+        pvar_tile_t sizes = a_layout.int_dim_sizes();
+        auto b_sizes = b_layout.int_dim_sizes();
+        for (auto &d : b_sizes) {
+            if (sizes.has(d)) gpu_assert(sizes[d] == b_sizes[d]);
+            sizes[d] = b_sizes[d];
         }
 
-        // BKNM order.
-        int i0 = 0;
-        int i1 = 3;
-        int i2 = 2;
-        int i3 = 1;
-        stmt_t stmt;
-        pvar_coord_t<dim_t> off;
-        bool is_a_bcast = (blocks[0] * blocks[1] * blocks[3] == 1);
-        bool is_b_bcast = (blocks[0] * blocks[2] * blocks[3] == 1);
+        // BMNK order (outer -> inner).
+        std::vector<pvar_t> dim_order;
+        for (auto bmnk : {pvars::m, pvars::n, pvars::k, pvars::b}) {
+            for (auto &d : sizes) {
+                if (to_gemm(d, desc_.prop) != bmnk) continue;
+                dim_order.push_back(d);
+            }
+        }
+
+        auto bmnk_inst_tile = to_gemm(fma.inst_tile, desc_.prop);
+        dim_t B = bmnk_inst_tile.get(pvars::b, 1);
+        dim_t M = bmnk_inst_tile.get(pvars::m, 1);
+        dim_t N = bmnk_inst_tile.get(pvars::n, 1);
+        dim_t K = bmnk_inst_tile.get(pvars::k, 1);
+        bool is_a_bcast = (B * M * K == 1);
+        bool is_b_bcast = (B * K * N == 1);
         func_t fma_func;
         switch (fma.fma) {
             case fma_kind_t::mad: {
@@ -422,27 +415,19 @@ private:
             default: gpu_error_not_expected();
         }
         stmt_t call_stmt;
-        for (int b = 0; b < sizes[i0]; b += blocks[i0]) {
-            off[dims[i0]] = b;
-            for (int k = 0; k < sizes[i1]; k += blocks[i1]) {
-                off[dims[i1]] = k;
-                for (int n = 0; n < sizes[i2]; n += blocks[i2]) {
-                    off[dims[i2]] = n;
-                    for (int m = 0; m < sizes[i3]; m += blocks[i3]) {
-                        off[dims[i3]] = m;
-                        dim_t a_off = a_layout.offset_in_bytes(off);
-                        dim_t b_off = b_layout.offset_in_bytes(off);
-                        dim_t c_off = c_layout.offset_in_bytes(off);
-                        auto dst = c_buf[c_off];
-                        auto src1 = a_buf[a_off];
-                        auto src2 = b_buf[b_off];
-                        if (fma.fma == fma_kind_t::dpas) std::swap(src1, src2);
-                        call_stmt = call_stmt.append(fma_func.call(
-                                {dst, dst, std::move(src1), std::move(src2)}));
-                    }
-                }
-            }
-        }
+        for_each(sizes, fma.inst_tile, dim_order,
+                [&](const pvar_coord_t<dim_t> &coord) {
+                    dim_t a_off = a_layout.offset_in_bytes(coord);
+                    dim_t b_off = b_layout.offset_in_bytes(coord);
+                    dim_t c_off = c_layout.offset_in_bytes(coord);
+                    auto dst = c_buf[c_off];
+                    auto src1 = a_buf[a_off];
+                    auto src2 = b_buf[b_off];
+                    if (fma.fma == fma_kind_t::dpas) std::swap(src1, src2);
+                    call_stmt = call_stmt.append(fma_func.call(
+                            {dst, dst, std::move(src1), std::move(src2)}));
+                });
+
         if (fma.fma == fma_kind_t::dpas) {
             call_stmt
                     = inject_dpas_atomic(call_stmt, /*filter_by_label=*/false);

--- a/src/gpu/intel/jit/v2/conv/builder.cpp
+++ b/src/gpu/intel/jit/v2/conv/builder.cpp
@@ -201,10 +201,16 @@ struct stream_k_params_t {
     expr_t iters_per_tg;
     // Iterations per one output tile, div_up(k, k_blk).
     expr_t iters_per_tile;
+    // Number of reduction batches.
+    expr_t k_batches;
 
     // The following values are thread-specific.
     // Index of this threadgroup.
     expr_t tg_idx;
+    // Index of the current k-batch. Reduction is done in batches (i.e. the 1st
+    // thread wave reduces all tiles for k in [0, x), the 2nd wave reduces all
+    // tiles for k in [x, 2 * x), etc);
+    expr_t k_batch_idx;
     // Index of the first threadgroup for the current output tile.
     expr_t tg_beg;
     // Index of the last threadgroup for the current output tile.
@@ -783,33 +789,75 @@ public:
         stream_k_params_t sk_params(desc.use_stream_k, desc_.loop_desc);
         emit_thread_index_let();
         if (desc.use_stream_k) {
-            sk_params.total_iters
-                    = const_var_t::make(type_t::s32(), "sk_total_iters");
-            sk_params.iters_per_tg
-                    = const_var_t::make(type_t::s32(), "sk_iters_per_tg");
-            sk_params.iters_per_tile
-                    = const_var_t::make(type_t::s32(), "sk_iters_per_tile");
             sk_params.tg_idx = plan_.tg_grid.index_var(0);
+            sk_params.k_batch_idx = plan_.tg_grid.index_var(1);
 
+            auto total_iters_main
+                    = const_var_t::make(type_t::s32(), "sk_total_iters_main");
+            auto total_iters_tail
+                    = const_var_t::make(type_t::s32(), "sk_total_iters_tail");
+            auto iters_per_tg_main
+                    = const_var_t::make(type_t::s32(), "sk_iters_per_tg_main");
+            auto iters_per_tg_tail
+                    = const_var_t::make(type_t::s32(), "sk_iters_per_tg_tail");
+            auto iters_per_tg_main_magic = const_var_t::make(
+                    type_t::u64(), "sk_iters_per_tg_main_magic");
+            auto iters_per_tg_tail_magic = const_var_t::make(
+                    type_t::u64(), "sk_iters_per_tg_tail_magic");
+            auto iters_per_tile_main = const_var_t::make(
+                    type_t::s32(), "sk_iters_per_tile_main");
+            auto iters_per_tile_tail = const_var_t::make(
+                    type_t::s32(), "sk_iters_per_tile_tail");
+            auto iters_per_tile_main_magic = const_var_t::make(
+                    type_t::u64(), "sk_iters_per_tile_main_magic");
+            auto iters_per_tile_tail_magic = const_var_t::make(
+                    type_t::u64(), "sk_iters_per_tile_tail_magic");
+
+            sk_params.k_batches
+                    = const_var_t::make(type_t::s32(), "sk_k_batches");
+            auto cond = (sk_params.k_batch_idx == sk_params.k_batches - 1);
+            sk_params.total_iters = let("sk_total_iters",
+                    iif_t::make(cond, total_iters_tail, total_iters_main));
+            sk_params.iters_per_tg = let("sk_iters_per_tg",
+                    iif_t::make(cond, iters_per_tg_tail, iters_per_tg_main));
+            sk_params.iters_per_tile = let("sk_iters_per_tile",
+                    iif_t::make(
+                            cond, iters_per_tile_tail, iters_per_tile_main));
+            auto iters_per_tg_magic = let("sk_iters_per_tg_magic",
+                    iif_t::make(cond, iters_per_tg_tail_magic,
+                            iters_per_tg_main_magic));
+            auto iters_per_tile_magic = let("sk_iters_per_tile_magic",
+                    iif_t::make(cond, iters_per_tile_tail_magic,
+                            iters_per_tile_main_magic));
             auto iter = alloc_var(type_t::s32(), "sk_iter");
             iter = sk_params.tg_idx * sk_params.iters_per_tg;
             auto iter_end = let("sk_iter_end",
                     min(sk_params.total_iters, iter + sk_params.iters_per_tg));
 
             _while(iter < iter_end, [&]() {
-                sk_params.tile_idx
-                        = let("sk_tile_idx", iter / sk_params.iters_per_tile);
+                sk_params.tile_idx = let("sk_tile_idx",
+                        ternary_idiv(iter,
+                                cast(sk_params.iters_per_tile, type_t::u32()),
+                                iters_per_tile_magic));
                 auto global_beg = let("sk_global_beg",
                         sk_params.tile_idx * sk_params.iters_per_tile);
                 auto global_end = let(
                         "sk_global_end", global_beg + sk_params.iters_per_tile);
-                let(sk_params.local_beg, iter - global_beg);
+                let(sk_params.local_beg,
+                        iter - global_beg
+                                + sk_params.k_batch_idx * iters_per_tile_main);
                 let(sk_params.local_end,
-                        min(iter_end, global_end) - global_beg);
-                sk_params.tg_beg
-                        = let("sk_tg_beg", global_beg / sk_params.iters_per_tg);
+                        min(iter_end, global_end) - global_beg
+                                + sk_params.k_batch_idx * iters_per_tile_main);
+                sk_params.tg_beg = let("sk_tg_beg",
+                        ternary_idiv(global_beg,
+                                cast(sk_params.iters_per_tg, type_t::u32()),
+                                iters_per_tg_magic));
                 sk_params.tg_end = let("sk_tg_beg",
-                        (global_beg - 1) / sk_params.iters_per_tg + 1);
+                        ternary_idiv(global_beg - 1,
+                                cast(sk_params.iters_per_tg, type_t::u32()),
+                                iters_per_tg_magic)
+                                + 1);
                 emit_thread_group_index_let(sk_params.tile_idx);
                 pipeline(sk_params);
                 epilogue();

--- a/src/gpu/intel/jit/v2/conv/builder.cpp
+++ b/src/gpu/intel/jit/v2/conv/builder.cpp
@@ -390,7 +390,7 @@ private:
 
         // BMNK order (outer -> inner).
         std::vector<pvar_t> dim_order;
-        for (auto bmnk : {pvars::m, pvars::n, pvars::k, pvars::b}) {
+        for (const auto &bmnk : {pvars::m, pvars::n, pvars::k, pvars::b}) {
             for (auto &d : sizes) {
                 if (to_gemm(d, desc_.prop) != bmnk) continue;
                 dim_order.push_back(d);

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -712,7 +712,8 @@ tensor_config_t get_tensor_config(
 
 send_kind_t kernel_desc_t::access_kind(
         send_op_t op, tensor_kind_t tensor) const {
-    if (use_2d_access && tensor != tensor_kind_t::undef && !is_atomic(op))
+    if (use_2d_access && tensor != tensor_kind_t::undef && !is_atomic(op)
+            && can_use_2d(*this, tensor))
         return send_kind_t::_2d;
     return send_kind_t::undef;
 }
@@ -1096,6 +1097,30 @@ grid_t create_thread_grid(const kernel_desc_t &desc) {
         if (!desc.thread_group_tile.has(d)) grid.unset(d);
     }
     return grid;
+}
+
+bool can_use_2d(const kernel_desc_t &desc, tensor_kind_t tensor) {
+    auto abc = to_abc(desc.prop, tensor);
+    auto &tag = desc.layout_tag(tensor);
+    // No block 2D access with atomics.
+    if (abc == tensor_kind_t::c && desc.use_stream_k) return false;
+    // No block 2D access with blocked layouts.
+    if (tag.is_blocked()) return false;
+    auto &e_inner = tag.raw_tag().entries().back();
+    auto inner_dim = tag.desc().prb_dim(e_inner.index());
+    int ndims = 0;
+    bool found_inner_dim = false;
+    for (auto &d : desc.iter_tile) {
+        auto bmnk = to_gemm(d, desc.prop);
+        if (abc == tensor_kind_t::a && bmnk == pvars::n) continue;
+        if (abc == tensor_kind_t::b && bmnk == pvars::m) continue;
+        if (abc == tensor_kind_t::c && bmnk == pvars::k) continue;
+        if (d == inner_dim) found_inner_dim = true;
+        ndims++;
+    }
+    // Tile has too many dimensions or does not include the innermost dimension.
+    if (ndims > 2 || !found_inner_dim) return false;
+    return true;
 }
 
 } // namespace conv

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -754,11 +754,19 @@ void kernel_desc_t::init_kernel_iface(kernel_iface_t &kernel_iface) const {
             kernel_iface.register_arg("sw_magic", type_t::u64());
     }
     if (use_stream_k) {
-        kernel_iface.register_arg("sk_iters_per_tile", type_t::s32());
-        kernel_iface.register_arg("sk_iters_per_tile_magic", type_t::u64());
-        kernel_iface.register_arg("sk_total_iters", type_t::s32());
-        kernel_iface.register_arg("sk_iters_per_tg", type_t::s32());
-        kernel_iface.register_arg("sk_iters_per_tg_magic", type_t::u64());
+        kernel_iface.register_arg("sk_iters_per_tile_main", type_t::s32());
+        kernel_iface.register_arg(
+                "sk_iters_per_tile_main_magic", type_t::u64());
+        kernel_iface.register_arg("sk_total_iters_main", type_t::s32());
+        kernel_iface.register_arg("sk_iters_per_tg_main", type_t::s32());
+        kernel_iface.register_arg("sk_iters_per_tg_main_magic", type_t::u64());
+        kernel_iface.register_arg("sk_iters_per_tile_tail", type_t::s32());
+        kernel_iface.register_arg(
+                "sk_iters_per_tile_tail_magic", type_t::u64());
+        kernel_iface.register_arg("sk_total_iters_tail", type_t::s32());
+        kernel_iface.register_arg("sk_iters_per_tg_tail", type_t::s32());
+        kernel_iface.register_arg("sk_iters_per_tg_tail_magic", type_t::u64());
+        kernel_iface.register_arg("sk_k_batches", type_t::s32());
         for (auto &e : loop_desc) {
             dim_t dummy;
             if (_reqs.get_value(e.dim, dummy)) continue;
@@ -830,6 +838,14 @@ dim_t stream_k_thread_groups(
     return std::min(ref_iters, max_thread_groups_per_wave);
 }
 
+dim_t stream_k_k_batches(const kernel_desc_t &desc, const problem_t &prb) {
+    const size_t l3_size = prb.hw().l3_cache_size();
+    auto a = to_conv_layout(desc.layout_tag(tensor_kind_t::a), prb.shape());
+    auto b = to_conv_layout(desc.layout_tag(tensor_kind_t::b), prb.shape());
+    dim_t ab_size = a.size() + b.size();
+    return utils::div_up(2 * ab_size, l3_size);
+}
+
 type_t accumulator_type(const type_t &a_type, const type_t &b_type) {
     gpu_assert(a_type.size() == b_type.size());
     return a_type.is_fp() ? type_t::f32() : type_t::s32();
@@ -864,26 +880,41 @@ kernel_desc_t to_stream_k(const kernel_desc_t &desc, bool check_ext) {
 
 void init_kernel_info(kernel_info_t &kernel_info, const problem_t &prb,
         const kernel_desc_t &desc, const grid_t &tg_grid,
-        const pvar_tile_t &grid_dims, dim_t max_tgs, dim_t &stream_k_tgs) {
+        const pvar_tile_t &grid_dims, dim_t max_tgs, dim_t &stream_k_tg0,
+        dim_t &stream_k_tg1) {
     auto pvar_map = prb.shape();
     for (auto &d : grid_dims) {
         pvar_map[pvar_t(d.str() + "_grid_size")] = grid_dims.at(d);
     }
     if (desc.use_stream_k) {
-        dim_t iters_per_tile = 1;
+        dim_t k_iters = 1;
         for (auto &e : desc.loop_desc) {
             dim_t tg_size = desc.thread_group_tile.get(e.dim, 1);
             dim_t iter_size = desc.iter_tile.get(e.dim, 1);
             dim_t dim_iters_per_tile
                     = utils::div_up(prb.shape().at(e.dim), tg_size * iter_size);
-            iters_per_tile *= dim_iters_per_tile;
+            k_iters *= dim_iters_per_tile;
         }
-        dim_t total_iters = iters_per_tile * tg_grid.size(0, grid_dims);
-        stream_k_tgs = stream_k_thread_groups(total_iters, max_tgs);
-        dim_t iters_per_tg = utils::div_up(total_iters, stream_k_tgs);
-        pvar_map[pvar_t("sk_iters_per_tile")] = iters_per_tile;
-        pvar_map[pvar_t("sk_total_iters")] = total_iters;
-        pvar_map[pvar_t("sk_iters_per_tg")] = iters_per_tg;
+        dim_t k_batches = std::min(k_iters, stream_k_k_batches(desc, prb));
+        dim_t bmn_tiles = tg_grid.size(0, grid_dims);
+        dim_t iters_per_tile = utils::div_up(k_iters, k_batches);
+        dim_t iters_per_tile_tail = iters_per_tile
+                - (utils::rnd_up(k_iters, k_batches) - k_iters);
+        if (iters_per_tile_tail == 0) iters_per_tile_tail = iters_per_tile;
+        stream_k_tg0
+                = stream_k_thread_groups(bmn_tiles * iters_per_tile, max_tgs);
+        stream_k_tg1 = k_batches;
+        dim_t total_iters = bmn_tiles * iters_per_tile;
+        dim_t total_iters_tail = bmn_tiles * iters_per_tile_tail;
+        dim_t iters_per_tg = utils::div_up(total_iters, stream_k_tg0);
+        dim_t iters_per_tg_tail = utils::div_up(total_iters_tail, stream_k_tg0);
+        pvar_map[pvar_t("sk_iters_per_tile_main")] = iters_per_tile;
+        pvar_map[pvar_t("sk_total_iters_main")] = total_iters;
+        pvar_map[pvar_t("sk_iters_per_tg_main")] = iters_per_tg;
+        pvar_map[pvar_t("sk_iters_per_tile_tail")] = iters_per_tile_tail;
+        pvar_map[pvar_t("sk_total_iters_tail")] = total_iters_tail;
+        pvar_map[pvar_t("sk_iters_per_tg_tail")] = iters_per_tg_tail;
+        pvar_map[pvar_t("sk_k_batches")] = stream_k_tg1;
     }
     for (int i = 0; i < kernel_info.nargs(); i++) {
         auto &var = kernel_info.arg_var(i);
@@ -909,9 +940,10 @@ void kernel_desc_t::init_kernel_info(kernel_info_t &kernel_info,
     }
     dim_t max_tgs = prim_config_t::get_max_threadgroups_per_wave(
             exec_cfg(engine), thread_group_tile.elems());
-    dim_t stream_k_tgs = 0;
-    conv::init_kernel_info(
-            kernel_info, prb, *this, tg_grid, grid_dims, max_tgs, stream_k_tgs);
+    dim_t stream_k_tg0 = 0;
+    dim_t stream_k_tg1 = 0;
+    conv::init_kernel_info(kernel_info, prb, *this, tg_grid, grid_dims, max_tgs,
+            stream_k_tg0, stream_k_tg1);
     compute::range_t gws = compute::range_t::empty();
     compute::range_t lws = compute::range_t::empty();
     for (size_t i = 0; i < compute::range_t::max_ndims; i++) {
@@ -920,7 +952,8 @@ void kernel_desc_t::init_kernel_info(kernel_info_t &kernel_info,
         gws[i] = lws[i];
     }
     if (use_stream_k) {
-        gws[0] *= stream_k_tgs;
+        gws[0] *= stream_k_tg0;
+        gws[1] *= stream_k_tg1;
     } else {
         for (size_t i = 0; i < compute::range_t::max_ndims; i++) {
             gws[i] *= tg_grid.size(i, grid_dims);

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -1123,6 +1123,7 @@ grid_t create_thread_grid(const kernel_desc_t &desc) {
         case prop_kind::backward_weights:
             grid.add_mapping(pvars::oc, 0);
             grid.add_mapping(pvars::ic, 1);
+            grid.add_mapping(pvars::kh, 2);
             break;
         default: gpu_error_not_expected();
     }

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -479,6 +479,7 @@ dim_t stream_k_thread_groups(
 type_t accumulator_type(const type_t &a_type, const type_t &b_type);
 kernel_desc_t to_stream_k(const kernel_desc_t &desc, bool check_ext = true);
 prb_reqs_t generate_2d_reqs(const kernel_desc_t &desc);
+bool can_use_2d(const kernel_desc_t &desc, tensor_kind_t tensor);
 
 class kernel_params_t : public kernel_params_base_t {
 public:

--- a/src/gpu/intel/jit/v2/conv/kernel_desc_2d_reqs.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc_2d_reqs.cpp
@@ -148,15 +148,12 @@ block_2d_params_t to_block_2d_params(const prop_kind_t &prop,
 void generate_2d_reqs(const kernel_desc_t &desc, tensor_kind_t tensor_kind,
         prb_reqs_t &reqs) {
     using ir_utils::safe_div;
-    if (to_abc(desc.prop, tensor_kind) == tensor_kind_t::c
-            && desc.use_stream_k) {
-        // No block 2D access with atomics.
-        return;
-    }
+    if (!can_use_2d(desc, tensor_kind)) return;
     bool is_fwd = (desc.prop == prop_kind::forward);
     bool is_bwd_w = (desc.prop == prop_kind::backward_weights);
     auto tag = append_groups(
             tensor_kind, desc.layout_tag(tensor_kind), desc.is_dw);
+    if (tag.raw_tag().is_blocked()) return;
     pvar_map_t<stride_t> strides;
     stride_t stride(1);
     for (int i = tag.raw_tag().nentries() - 1; i >= 0; i--) {

--- a/src/gpu/intel/jit/v2/conv/plan.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan.cpp
@@ -513,12 +513,15 @@ private:
             virt_grid.add(kv.first, kv.second);
         }
         // Try 2D messages first.
-        auto params = get_send_params(
-                abc, send_op_t::prefetch, view, send_kind_t::_2d);
-        prefetch = create_send_plan(params, view, /*allow_fail=*/true);
-        if (!prefetch || !reqs_.implies(prefetch.reqs())) {
+        bool try_2d = can_use_2d(desc_, abc);
+        if (try_2d) {
+            auto params = get_send_params(
+                    abc, send_op_t::prefetch, view, send_kind_t::_2d);
+            prefetch = create_send_plan(params, view, /*allow_fail=*/true);
+        }
+        if (!try_2d || !prefetch || !reqs_.implies(prefetch.reqs())) {
             // If 2D failed, try compressed prefetch.
-            params = get_send_params(abc, send_op_t::prefetch, view,
+            auto params = get_send_params(abc, send_op_t::prefetch, view,
                     send_kind_t::compressed_prefetch);
             prefetch = try_create_send_plan(__func__, params, view);
             if (!prefetch) return false;

--- a/src/gpu/intel/jit/v2/conv/plan.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan.cpp
@@ -301,7 +301,7 @@ private:
                 default: gpu_error_not_expected();
             }
         }
-        gpu_check(m_dim.ndims() == 1 && n_dim.ndims() == 1
+        gpu_check(utils::one_of(m_dim.ndims(), 1, 2) && n_dim.ndims() == 1
                 && utils::one_of(k_dim.ndims(), 1, 2))
                 << "init_dpas: cannot initialize MNK dimensions.";
         if (k_dim.ndims() == 2) {

--- a/src/gpu/intel/jit/v2/conv/plan.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan.cpp
@@ -681,7 +681,7 @@ private:
             auto store_layout = store.reg_layout();
             if (bias_reg_layout != store_layout) {
                 plan.bias_reorder = reorder_plan_t(hw_);
-                plan.bias_reorder.src = std::move(bias_reg_layout);
+                plan.bias_reorder.src = bias_reg_layout;
                 plan.bias_reorder.dst = std::move(store_layout);
             }
         }

--- a/src/gpu/intel/jit/v2/conv/plan_registry_data.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan_registry_data.cpp
@@ -136,6 +136,8 @@ const char** get_plan_registry_entries() {
         "hw=xehpc prop=fwd src=ABx32a2b:f16 wei=aCBx32b2c:f16 dst=axb:f16 fma=dpas simd=16 regs=256 iter=ic2kw8mb32oc64 spec=oc@64 ext=out_b1,out_b4 model=013AF19F443000793E00306E3F9A01903F1680903E02AF4066478BEFC33F",
         "hw=xehpc prop=fwd src=axb:s8 wei=aCBx16b4c:s8 dst=axb:s8 fma=dpas simd=16 regs=256 iter=ic4kw8oc32ow16 tg=oc2ow4 spec=oc@64 ext=out_b2,out_b4 model=01E33E004505E0223F0280553F68728B3FFB3F6D3F0200489F46DFE60C41",
         "hw=xehpc prop=fwd src=axb:f16 wei=aCBx16b2c:f16 dst=axb:f16 fma=dpas simd=16 regs=256 iter=ic2kw8oc32ow16 tg=oc2ow4 spec=oc@64 ext=out_b1,out_b4 model=0158E2DE440400303F0180783F99E3873F04C0293F02E6FE60463C8CE840",
+        "hw=xehpc prop=bwd_w src=ABx16a4b:bf16 wei=axcb:bf16 dst=axb:bf16 fma=dpas simd=16 regs=256 iter=ic4kw8mb16oc64 tg=kh4 2d=1 prefetch=x3.b spec=dd0id1kd1od1pd0sd1oc@64 ext=out_b4,bias,stream_k model=019B9A1B463600153E0040723F0060A93FF6FFA7410270844E48863BE041",
+        "hw=xehpc prop=bwd_w src=axb:f32 wei=axcb:f32 dst=axb:f32 fma=mad simd=32 regs=128 iter=kw8mb16oc32 iter_outer=kw2 tg=kh8oc2 2d=1 spec=dd0id1kd1od1pd0sd1 ext=bias,stream_k model=0128328F4438E00C3E02905E3F99E52C42F6FFA741026F63C54663EA0C41",
         nullptr,
     };
     return entries;

--- a/src/gpu/intel/jit/v2/conv/planner/bench.cpp
+++ b/src/gpu/intel/jit/v2/conv/planner/bench.cpp
@@ -226,22 +226,22 @@ dim_t opp_pad(dim_t i, dim_t o, dim_t k, dim_t s, dim_t p, dim_t d) {
 
 class bench_task_t : public bench_task_base_t {
 public:
-    bench_task_t(const problem_t &prb) : prb_(prb) {
-        g = prb.shape()[pvars::g];
-        mb = prb.shape()[pvars::mb];
-        oc = prb.shape()[pvars::oc];
-        ic = prb.shape()[pvars::ic];
-        ih = prb.shape()[pvars::ih];
-        iw = prb.shape()[pvars::iw];
-        oh = prb.shape()[pvars::oh];
-        ow = prb.shape()[pvars::ow];
-        kh = prb.shape()[pvars::kh];
-        kw = prb.shape()[pvars::kw];
-        sh = prb.shape()[pvars::sh];
-        sw = prb.shape()[pvars::sw];
-        ph = prb.shape()[pvars::ph];
-        pw = prb.shape()[pvars::pw];
-    }
+    bench_task_t(const problem_t &prb)
+        : prb_(prb)
+        , g(prb.shape()[pvars::g])
+        , mb(prb.shape()[pvars::mb])
+        , oc(prb.shape()[pvars::oc])
+        , ic(prb.shape()[pvars::ic])
+        , ih(prb.shape()[pvars::ih])
+        , iw(prb.shape()[pvars::iw])
+        , oh(prb.shape()[pvars::oh])
+        , ow(prb.shape()[pvars::ow])
+        , kh(prb.shape()[pvars::kh])
+        , kw(prb.shape()[pvars::kw])
+        , sh(prb.shape()[pvars::sh])
+        , sw(prb.shape()[pvars::sw])
+        , ph(prb.shape()[pvars::ph])
+        , pw(prb.shape()[pvars::pw]) {}
 
     const problem_t &prb() const { return prb_; }
 
@@ -420,7 +420,7 @@ private:
     }
 
     problem_t prb_;
-    memory::dim mb, g;
+    memory::dim g, mb;
     memory::dim oc, ic;
     memory::dim ih, iw;
     memory::dim oh, ow;
@@ -650,7 +650,7 @@ public:
 
     bench_data_t bench(const kernel_desc_t &_kernel_desc) {
         if (tasks_.empty()) return bench_data_t();
-        auto kernel_desc = _kernel_desc;
+        const auto &kernel_desc = _kernel_desc;
         if (!create_conv_plan(kernel_desc, bench_mger_.hw())) return {};
         return planner::bench(bench_mger_, kernel_desc, tasks_, &mem_pool_);
     }
@@ -670,8 +670,7 @@ bench_data_t bench_runner_t::bench(const kernel_desc_t &kernel_desc) {
 }
 
 bench_data_t bench(const bench_manager_t &bench_mger,
-        const kernel_desc_t &_kernel_desc, int nprbs) {
-    auto kernel_desc = _kernel_desc;
+        const kernel_desc_t &kernel_desc, int nprbs) {
     if (!create_conv_plan(kernel_desc, bench_mger.hw())) return {};
     bench_runner_t runner(bench_mger,
             bench_input_params_t(kernel_desc, bench_mger.hw(), nprbs));
@@ -683,7 +682,7 @@ bool try_create(
     bench_input_params_t params(kernel_desc, bench_mger.hw(), /*nprbs=*/1);
     bench_task_t task(generate_problems(params)[0]);
     auto engine = bench_mger.get_engine();
-    auto guard = debug_t::instance().make_kernel_desc_setter(kernel_desc);
+    auto guard = debug_t::make_kernel_desc_setter(kernel_desc);
     return task.init_primitive(engine);
 }
 

--- a/src/gpu/intel/jit/v2/ir/builder.cpp
+++ b/src/gpu/intel/jit/v2/ir/builder.cpp
@@ -169,7 +169,8 @@ stmt_t create_stmt(const send_1d_plan_t &plan, const expr_t &mem_buf,
         int entry_idx = plan.reg_layout.to_linear_index(
                 plan.entry_tile, coord + sub_coord);
         auto &e = plan.entries[entry_idx];
-        gpu_assert(e.coord == coord + sub_coord);
+        gpu_assert(
+                e.coord.drop_defaults() == (coord + sub_coord).drop_defaults());
         auto header
                 = off_ctx.add_header(plan.desc, mem_buf, plan.addr, e.addr_inc);
         auto mask = off_ctx.add_mask(plan.mask, e.mask_incs);

--- a/src/gpu/intel/jit/v2/ir/tensor.cpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.cpp
@@ -206,6 +206,13 @@ bool layout_raw_tag_t::is_blocked(char letter) const {
     return false;
 }
 
+bool layout_raw_tag_t::is_blocked() const {
+    for (auto &e : entries_) {
+        if (e.is_blocked) return true;
+    }
+    return false;
+}
+
 dim_idx_t layout_raw_tag_t::ndims() const {
     gpu_assert(!is_any() && !has_x());
     dim_idx_t max_index = 0;

--- a/src/gpu/intel/jit/v2/ir/tensor.cpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.cpp
@@ -836,7 +836,7 @@ int layout_t::to_linear_index(
     std::vector<int> idx(nblocks());
     for (int i = 0; i < ntiles; i++) {
         auto i_coord = to_coord(idx);
-        if (i_coord == coord) return i;
+        if (i_coord.drop_defaults() == coord.drop_defaults()) return i;
         advance(idx, blocks_, tile_blocks);
     }
     gpu_error_not_expected();

--- a/src/gpu/intel/jit/v2/ir/tensor.cpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.cpp
@@ -905,14 +905,15 @@ std::string layout_t::str_with_size(const hw_t &hw) const {
     return oss.str();
 }
 
-void for_each(const pvar_tile_t &base_tile, pvar_tile_t tile,
+void for_each(const pvar_tile_t &base_tile, const pvar_tile_t &tile,
         const std::function<void(const pvar_coord_t<dim_t> &)> &func) {
     for_each(base_tile, tile, {}, func);
 }
 
-void for_each(const pvar_tile_t &base_tile, pvar_tile_t tile,
+void for_each(const pvar_tile_t &base_tile, const pvar_tile_t &_tile,
         const std::vector<pvar_t> &idx_order,
         const std::function<void(const pvar_coord_t<dim_t> &)> &func) {
+    auto tile = _tile;
     for (auto &d : tile) {
         gpu_assert(base_tile.has(d));
         gpu_assert(base_tile[d] % tile[d] == 0);
@@ -1210,8 +1211,8 @@ std::string mask_desc_t::str() const {
     return oss.str();
 }
 
-plane_t::plane_t(const layout_t &layout, const mask_desc_t &mask_desc) {
-    type = layout.type();
+plane_t::plane_t(const layout_t &layout, const mask_desc_t &mask_desc)
+    : type(layout.type()) {
     const block_t *w_block = nullptr;
     const block_t *h_block = nullptr;
     for (auto &b : layout.blocks()) {

--- a/src/gpu/intel/jit/v2/ir/tensor.hpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.hpp
@@ -240,6 +240,7 @@ public:
     void add_dim(char letter, int pos);
     void remove_dim(char letter);
     bool is_blocked(char letter) const;
+    bool is_blocked() const;
     dim_idx_t ndims() const;
     dim_idx_t non_x_ndims() const;
     std::string str() const;
@@ -294,6 +295,7 @@ public:
 
     bool is_empty() const { return raw_tag_.is_empty(); }
     bool is_any() const { return raw_tag_.is_any(); }
+    bool is_blocked() const { return raw_tag_.is_blocked(); }
     const layout_desc_t &desc() const { return desc_; }
     const type_t &type() const { return type_; }
     const layout_raw_tag_t &raw_tag() const { return raw_tag_; }

--- a/src/gpu/intel/jit/v2/ir/tensor.hpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.hpp
@@ -438,6 +438,9 @@ private:
 
 void for_each(const pvar_tile_t &base_tile, pvar_tile_t tile,
         const std::function<void(const pvar_coord_t<dim_t> &)> &func);
+void for_each(const pvar_tile_t &base_tile, pvar_tile_t tile,
+        const std::vector<pvar_t> &idx_order,
+        const std::function<void(const pvar_coord_t<dim_t> &)> &func);
 
 class block_iterator_t {
 public:

--- a/src/gpu/intel/jit/v2/ir/tensor.hpp
+++ b/src/gpu/intel/jit/v2/ir/tensor.hpp
@@ -436,9 +436,9 @@ private:
     int stride_pad_ = 1;
 };
 
-void for_each(const pvar_tile_t &base_tile, pvar_tile_t tile,
+void for_each(const pvar_tile_t &base_tile, const pvar_tile_t &tile,
         const std::function<void(const pvar_coord_t<dim_t> &)> &func);
-void for_each(const pvar_tile_t &base_tile, pvar_tile_t tile,
+void for_each(const pvar_tile_t &base_tile, const pvar_tile_t &tile,
         const std::vector<pvar_t> &idx_order,
         const std::function<void(const pvar_coord_t<dim_t> &)> &func);
 


### PR DESCRIPTION
Jira: [MFDNN-13025](https://jira.devtools.intel.com/browse/MFDNN-13025)

Changes:

- Added support for fused M dimension (for combined kw/ic blocking for BWD_W)
- Added outer K blocking for better data reuse with Stream-K
    - The idea is to split K dimensions into batches and handle every batch in a separate thread wave. This reduced the footprint of A/B tensors accessed by the current thread wave
    - Number of K batches is determined by a simple heuristic based on the L3 cache size
- Added more checks for block 2D enabling. This allows to enable 2D loads/stores partially, for one tensor only

Performance data for ResNet-50 on PVC:

| Propagation | Batch size | Data Type | # of layers | Ratio v2-new to v1 | Ratio v2-new to v2-old |
|-------------|------------|-----------|-------------|--------------------------------------------|--------------------------------------------
| FWD_I | 1 | s8 | 23 | 0.89 | 1.00 |
| FWD_I | 1 | bf16 | 23 | 0.81 | 1.00 |
| FWD_I | 1 | f32 | 23 | 0.73 | 0.92 |
| FWD_I | 32 | s8 | 23 | 0.99 | 0.98 |
| FWD_I | 32 | bf16 | 23 | 0.87 | 1.02 |
| FWD_I | 32 | f32 | 23 | 0.80 | 0.97 |
| BWD_D | 32 | bf16 | 16 | 0.96 | 0.92 |
| BWD_D | 32 | f32 | 16 | 1.02 | 1.02 |
| BWD_W | 32 | bf16 | 23 | 0.67 | 1.51 |
| BWD_W | 32 | f32 | 23 | 0.72 | 0.99 |
| FWD_I | 128 | s8 | 23 | 0.88 | 0.96 |
| FWD_I | 128 | bf16 | 23 | 0.79 | 1.07 |
| FWD_I | 128 | f32 | 23 | 0.79 | 1.01 |
| BWD_D | 128 | bf16 | 16 | 0.90 | 1.00 |
| BWD_D | 128 | f32 | 16 | 0.86 | 0.99 |
| BWD_W | 128 | bf16 | 23 | 0.64 | 2.26 |
| BWD_W | 128 | f32 | 23 | 0.71 | 1.19 |


BWD_W is still at 65-70% of the JIT implementation so additional optimization work is needed.