### PR TITLE
clang-tidy fixes in common headers

### DIFF
--- a/examples/example_utils.hpp
+++ b/examples/example_utils.hpp
@@ -79,7 +79,7 @@ inline void finalize() {
 #endif
 }
 
-dnnl::engine::kind validate_engine_kind(dnnl::engine::kind akind) {
+inline dnnl::engine::kind validate_engine_kind(dnnl::engine::kind akind) {
     // Checking if a GPU exists on the machine
     if (akind == dnnl::engine::kind::gpu) {
         if (dnnl::engine::get_count(dnnl::engine::kind::gpu) == 0) {
@@ -94,6 +94,7 @@ dnnl::engine::kind validate_engine_kind(dnnl::engine::kind akind) {
 // Exception class to indicate that the example uses a feature that is not
 // available on the current systems. It is not treated as an error then, but
 // just notifies a user.
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct example_allows_unimplemented : public std::exception {
     example_allows_unimplemented(const char *message) noexcept
         : message(message) {}
@@ -107,7 +108,7 @@ inline const char *engine_kind2str_upper(dnnl::engine::kind kind);
 // Returns `0` on success, `1` or oneDNN error, and `2` on example error.
 inline int handle_example_errors(
         std::initializer_list<dnnl::engine::kind> engine_kinds,
-        std::function<void()> example) {
+        const std::function<void()> &example) {
     int exit_code = 0;
 
     try {

--- a/examples/graph/graph_example_utils.hpp
+++ b/examples/graph/graph_example_utils.hpp
@@ -535,7 +535,7 @@ public:
 #endif
             ptr = sh_ptr.get();
             // record the map of mm size and its ptr for reuse
-            map_size_ptr_.emplace(std::make_pair(size, sh_ptr));
+            map_size_ptr_.emplace(size, sh_ptr);
             is_free_ptr_[ptr] = false;
         }
         return ptr;
@@ -566,7 +566,7 @@ public:
                     = std::shared_ptr<void> {malloc(size), cpu_deletor_t {}};
             ptr = sh_ptr.get();
             // record the map of mm size and its ptr for reuse
-            map_size_ptr_.emplace(std::make_pair(size, sh_ptr));
+            map_size_ptr_.emplace(size, sh_ptr);
             is_free_ptr_[ptr] = false;
         }
         return ptr;

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -4201,7 +4201,7 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
     /// Returns post-ops previously set via set_post_ops().
     ///
     /// @returns Post-ops.
-    const post_ops get_post_ops() const {
+    post_ops get_post_ops() const {
         const_dnnl_post_ops_t const_c_post_ops;
         error::wrap_c_api(
                 dnnl_primitive_attr_get_post_ops(get(), &const_c_post_ops),
@@ -4220,7 +4220,7 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
     ///     by the respective primitive descriptor constructor.
     ///
     /// @param ops Post-ops object to copy post-ops from.
-    void set_post_ops(const post_ops ops) {
+    void set_post_ops(const post_ops &ops) {
         error::wrap_c_api(dnnl_primitive_attr_set_post_ops(get(), ops.get()),
                 "could not set post-ops primitive attribute");
     }

--- a/include/oneapi/dnnl/dnnl_common.hpp
+++ b/include/oneapi/dnnl/dnnl_common.hpp
@@ -128,7 +128,7 @@ template <typename T, typename traits = handle_traits<T>>
 struct handle {
 private:
     static dnnl_status_t dummy_destructor(T) { return dnnl_success; }
-    std::shared_ptr<typename std::remove_pointer<T>::type> data_ {0};
+    std::shared_ptr<typename std::remove_pointer<T>::type> data_ {nullptr};
 
 protected:
     bool operator==(const T other) const { return other == data_.get(); }
@@ -371,6 +371,7 @@ struct stream : public handle<dnnl_stream_t> {
     }
 };
 
+//NOLINTBEGIN(bugprone-macro-parentheses)
 #define DNNL_DEFINE_BITMASK_OPS(enum_name) \
     inline enum_name operator|(enum_name lhs, enum_name rhs) { \
         return static_cast<enum_name>( \
@@ -408,6 +409,7 @@ struct stream : public handle<dnnl_stream_t> {
     inline enum_name operator~(enum_name rhs) { \
         return static_cast<enum_name>(~static_cast<unsigned>(rhs)); \
     }
+//NOLINTEND(bugprone-macro-parentheses)
 
 DNNL_DEFINE_BITMASK_OPS(stream::flags)
 

--- a/include/oneapi/dnnl/dnnl_threadpool_iface.hpp
+++ b/include/oneapi/dnnl/dnnl_threadpool_iface.hpp
@@ -61,7 +61,7 @@ struct threadpool_iface {
     /// waiting for the submitted closures to finish execution on its own.
     static constexpr uint64_t ASYNCHRONOUS = 1;
 
-    virtual ~threadpool_iface() {}
+    virtual ~threadpool_iface() = default;
 };
 
 } // namespace threadpool_interop

--- a/include/oneapi/dnnl/dnnl_ukernel.hpp
+++ b/include/oneapi/dnnl/dnnl_ukernel.hpp
@@ -19,6 +19,7 @@
 
 #ifndef ONEAPI_DNNL_DNNL_UKERNEL_HPP
 #define ONEAPI_DNNL_DNNL_UKERNEL_HPP
+// NOLINTBEGIN(readability-identifier-naming)
 
 #include "oneapi/dnnl/dnnl.hpp"
 #include "oneapi/dnnl/dnnl_ukernel.h"
@@ -467,4 +468,5 @@ struct transform : public handle<dnnl_transform_t> {
 
 /// @} dnnl_api
 
+// NOLINTEND(readability-identifier-naming)
 #endif /* ONEAPI_DNNL_DNNL_UKERNEL_HPP */

--- a/src/common/batch_normalization_pd.hpp
+++ b/src/common/batch_normalization_pd.hpp
@@ -148,6 +148,7 @@ protected:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct batch_normalization_fwd_pd_t : public batch_normalization_pd_t {
     using base_class = batch_normalization_fwd_pd_t;
     using hint_class = batch_normalization_fwd_pd_t;
@@ -246,7 +247,9 @@ protected:
                 weights_md()->data_type == data_type::f32);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct batch_normalization_bwd_pd_t : public batch_normalization_pd_t {
     using base_class = batch_normalization_bwd_pd_t;
     using hint_class = batch_normalization_fwd_pd_t;
@@ -365,6 +368,7 @@ protected:
                         diff_weights_md()->data_type));
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/binary_pd.hpp
+++ b/src/common/binary_pd.hpp
@@ -37,6 +37,7 @@
 namespace dnnl {
 namespace impl {
 
+// NOLINTBEGIN(google-default-arguments)
 struct binary_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::binary;
 
@@ -200,6 +201,7 @@ private:
                     = (dims_A[d] == dims_B[d] && dims_A[d] != 1) ? 0 : 1;
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/concat_pd.hpp
+++ b/src/common/concat_pd.hpp
@@ -112,14 +112,14 @@ protected:
         init_desc();
     }
 
-    concat_pd_t(const concat_pd_t &other) : primitive_desc_t(other) {
-        n_ = other.n_;
-        concat_dim_ = other.concat_dim_;
-        dst_md_ = other.dst_md_;
-        original_dst_ = other.original_dst_;
-        src_mds_ = other.src_mds_;
-        src_image_mds_ = other.src_image_mds_;
-
+    concat_pd_t(const concat_pd_t &other)
+        : primitive_desc_t(other)
+        , n_(other.n_)
+        , concat_dim_(other.concat_dim_)
+        , dst_md_(other.dst_md_)
+        , original_dst_(other.original_dst_)
+        , src_mds_(other.src_mds_)
+        , src_image_mds_(other.src_image_mds_) {
         init_desc();
     }
 

--- a/src/common/concat_pd.hpp
+++ b/src/common/concat_pd.hpp
@@ -37,6 +37,7 @@
 namespace dnnl {
 namespace impl {
 
+// NOLINTBEGIN(google-default-arguments)
 struct concat_pd_t : public primitive_desc_t {
     const concat_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {
@@ -265,6 +266,7 @@ private:
             desc_.src_mds.push_back(&md);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 #define DECLARE_CONCAT_PD_t(impl_name, ...) \
     static status_t create(concat_pd_t **concat_pd, \

--- a/src/common/convolution_pd.hpp
+++ b/src/common/convolution_pd.hpp
@@ -256,6 +256,7 @@ protected:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct convolution_fwd_pd_t : public convolution_pd_t {
     using base_class = convolution_fwd_pd_t;
     using hint_class = convolution_fwd_pd_t;
@@ -335,7 +336,9 @@ protected:
                                                                           : 2;
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct convolution_bwd_data_pd_t : public convolution_pd_t {
     using base_class = convolution_bwd_data_pd_t;
     using hint_class = convolution_fwd_pd_t;
@@ -406,7 +409,9 @@ protected:
                 weights_md_, wei_tag, diff_dst_md_, diff_dst_tag, bias_md_);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct convolution_bwd_weights_pd_t : public convolution_pd_t {
     using base_class = convolution_bwd_weights_pd_t;
     using hint_class = convolution_fwd_pd_t;
@@ -479,6 +484,7 @@ protected:
                 diff_bias_md_);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/deconvolution_pd.hpp
+++ b/src/common/deconvolution_pd.hpp
@@ -201,6 +201,7 @@ protected:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct deconvolution_fwd_pd_t : public deconvolution_pd_t {
     using base_class = deconvolution_fwd_pd_t;
     using hint_class = deconvolution_fwd_pd_t;
@@ -264,7 +265,9 @@ protected:
         , bias_md_(desc_.bias_desc)
         , dst_md_(desc_.dst_desc) {}
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct deconvolution_bwd_data_pd_t : public deconvolution_pd_t {
     using base_class = deconvolution_bwd_data_pd_t;
     using hint_class = deconvolution_fwd_pd_t;
@@ -324,7 +327,9 @@ protected:
         , weights_md_(desc_.weights_desc)
         , diff_dst_md_(desc_.diff_dst_desc) {}
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct deconvolution_bwd_weights_pd_t : public deconvolution_pd_t {
     using base_class = deconvolution_bwd_weights_pd_t;
     using hint_class = deconvolution_fwd_pd_t;
@@ -390,6 +395,7 @@ protected:
         , diff_bias_md_(desc_.diff_bias_desc)
         , diff_dst_md_(desc_.diff_dst_desc) {}
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/eltwise_pd.hpp
+++ b/src/common/eltwise_pd.hpp
@@ -116,6 +116,7 @@ private:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct eltwise_fwd_pd_t : public eltwise_pd_t {
     using base_class = eltwise_fwd_pd_t;
     using hint_class = eltwise_fwd_pd_t;
@@ -190,7 +191,9 @@ protected:
                         == status::success);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct eltwise_bwd_pd_t : public eltwise_pd_t {
     using base_class = eltwise_bwd_pd_t;
     using hint_class = eltwise_fwd_pd_t;
@@ -298,6 +301,7 @@ protected:
                                 == status::success);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/float16.hpp
+++ b/src/common/float16.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ struct float16_t {
     float16_t &operator=(float f);
 
     operator float() const;
-    float f() { return (float)(*this); }
+    float f() const { return (float)(*this); }
 
     float16_t &operator+=(float16_t a) {
         (*this) = float(f() + a.f());

--- a/src/common/gemm_pd.hpp
+++ b/src/common/gemm_pd.hpp
@@ -36,6 +36,7 @@ namespace impl {
     VCHECK(primitive, create, dispatch, gemm, (f), "%s," msg, \
             this->info(engine), ##__VA_ARGS__)
 
+// NOLINTBEGIN(google-default-arguments)
 struct gemm_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::gemm;
 
@@ -122,6 +123,7 @@ protected:
         return ok;
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/gemm_types.hpp
+++ b/src/common/gemm_types.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -57,10 +57,10 @@ struct gemm_desc_t : public op_desc_t {
         return utils::make_unique<gemm_desc_t>(*this);
     }
 
-    memory_desc_t a_desc {};
-    memory_desc_t b_desc {};
-    memory_desc_t c_desc {};
-    memory_desc_t bias_desc {};
+    memory_desc_t a_desc;
+    memory_desc_t b_desc;
+    memory_desc_t c_desc;
+    memory_desc_t bias_desc;
     // Type for accumulating A*B.
     dnnl_data_type_t acc_type {};
     // Sum across k dimension in either A or B tensor

--- a/src/common/group_normalization_pd.hpp
+++ b/src/common/group_normalization_pd.hpp
@@ -111,6 +111,7 @@ protected:
         , scaleshift_md_(desc_.scaleshift_desc) {}
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct group_normalization_fwd_pd_t : public group_normalization_pd_t {
     using base_class = group_normalization_fwd_pd_t;
     using hint_class = group_normalization_fwd_pd_t;
@@ -206,7 +207,9 @@ protected:
         return ok;
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct group_normalization_bwd_pd_t : public group_normalization_pd_t {
     using base_class = group_normalization_bwd_pd_t;
     using hint_class = group_normalization_fwd_pd_t;
@@ -309,6 +312,7 @@ protected:
                         diff_weights_md()->data_type));
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/inner_product_pd.hpp
+++ b/src/common/inner_product_pd.hpp
@@ -196,6 +196,7 @@ protected:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct inner_product_fwd_pd_t : public inner_product_pd_t {
     using base_class = inner_product_fwd_pd_t;
     using hint_class = inner_product_fwd_pd_t;
@@ -265,7 +266,9 @@ protected:
                 weights_md_, wei_tag, dst_md_, dst_tag, bias_md_);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct inner_product_bwd_data_pd_t : public inner_product_pd_t {
     using base_class = inner_product_bwd_data_pd_t;
     using hint_class = inner_product_fwd_pd_t;
@@ -331,7 +334,9 @@ protected:
                 weights_md_, wei_tag, diff_dst_md_, diff_dst_tag, dummy_md);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct inner_product_bwd_weights_pd_t : public inner_product_pd_t {
     using base_class = inner_product_bwd_weights_pd_t;
     using hint_class = inner_product_fwd_pd_t;
@@ -404,6 +409,7 @@ protected:
                 diff_bias_md_);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/ittnotify.hpp
+++ b/src/common/ittnotify.hpp
@@ -24,7 +24,9 @@ namespace dnnl {
 namespace impl {
 namespace itt {
 
-typedef enum {
+// GCC treats using and typedef differently for enums and structs
+// https://stackoverflow.com/questions/48613758
+typedef enum { // NOLINT(modernize-use-using)
     __itt_task_level_none = 0,
     __itt_task_level_low,
     __itt_task_level_high

--- a/src/common/layer_normalization_pd.hpp
+++ b/src/common/layer_normalization_pd.hpp
@@ -156,6 +156,7 @@ private:
     const memory_desc_t &src_desc() const { return desc_.src_desc; }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct layer_normalization_fwd_pd_t : public layer_normalization_pd_t {
     using base_class = layer_normalization_fwd_pd_t;
     using hint_class = layer_normalization_fwd_pd_t;
@@ -265,7 +266,9 @@ protected:
         return ok;
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct layer_normalization_bwd_pd_t : public layer_normalization_pd_t {
     using base_class = layer_normalization_bwd_pd_t;
     using hint_class = layer_normalization_fwd_pd_t;
@@ -376,6 +379,7 @@ protected:
         return false;
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/lrn_pd.hpp
+++ b/src/common/lrn_pd.hpp
@@ -97,6 +97,7 @@ protected:
         , src_md_(desc_.src_desc) {}
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct lrn_fwd_pd_t : public lrn_pd_t {
     using base_class = lrn_fwd_pd_t;
     using hint_class = lrn_fwd_pd_t;
@@ -155,7 +156,9 @@ protected:
                         == status::success);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct lrn_bwd_pd_t : public lrn_pd_t {
     using base_class = lrn_bwd_pd_t;
     using hint_class = lrn_fwd_pd_t;
@@ -230,6 +233,7 @@ protected:
                                 == status::success);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -45,6 +45,7 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
         const memory_desc_t *src_desc, const memory_desc_t *weights_desc,
         const memory_desc_t *bias_desc, const memory_desc_t *dst_desc);
 
+// NOLINTBEGIN(google-default-arguments)
 struct matmul_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::matmul;
 
@@ -281,6 +282,7 @@ protected:
                 {&src_md_, &weights_md_, &bias_md_, &dst_md_, &reduce_md_});
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/memory_desc_wrapper.hpp
+++ b/src/common/memory_desc_wrapper.hpp
@@ -34,6 +34,7 @@ namespace impl {
 
 /** thin wrapper class over \struct memory_desc_t which allows easy
  * manipulations with underlying C structure, which is taken by reference */
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct memory_desc_wrapper : public c_compatible {
     const memory_desc_t *md_;
 

--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -428,14 +428,8 @@ struct registry_t {
     public:
         common_iterator_t(const void *base_ptr_,
                 const std::unordered_map<key_t, entry_t> &map,
-                bool is_begin = true) {
-            base_ptr = base_ptr_;
-            if (is_begin) {
-                iter = map.cbegin();
-            } else {
-                iter = map.cend();
-            }
-        }
+                bool is_begin = true)
+            : base_ptr(base_ptr_), iter(is_begin ? map.cbegin() : map.cend()) {}
         common_iterator_t &operator++(int) {
             iter++;
             return *this;

--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -55,7 +55,7 @@ void *malloc(size_t size, int alignment);
 #endif
 void free(void *p);
 
-struct c_compatible {
+struct c_compatible { // NOLINT(readability-identifier-naming)
     enum { default_alignment = 64 };
     static void *operator new(size_t sz) {
         return MALLOC(sz, default_alignment);

--- a/src/common/opdesc.hpp
+++ b/src/common/opdesc.hpp
@@ -106,7 +106,7 @@ struct concat_desc_t : public op_desc_t {
     const memory_desc_t *dst_md {};
     dim_t n {};
     dim_t concat_dimension {};
-    std::vector<const memory_desc_t *> src_mds {};
+    std::vector<const memory_desc_t *> src_mds;
 };
 
 // A descriptor of a sum operation.
@@ -124,7 +124,7 @@ struct sum_desc_t : public op_desc_t {
     const memory_desc_t *dst_md {};
     dim_t n {};
     const float *scales {};
-    std::vector<const memory_desc_t *> src_mds {};
+    std::vector<const memory_desc_t *> src_mds;
 };
 
 // A descriptor of a zero padding operation.
@@ -145,21 +145,21 @@ struct inner_product_desc_t : public op_desc_t {
     // backward_weights, and backward_bias.
     prop_kind_t prop_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Weights memory descriptor.
-    memory_desc_t weights_desc {};
+    memory_desc_t weights_desc;
     // Weights gradient memory descriptor.
-    memory_desc_t diff_weights_desc {};
+    memory_desc_t diff_weights_desc;
     // Bias memory descriptor.
-    memory_desc_t bias_desc {};
+    memory_desc_t bias_desc;
     // Bias gradient memory descriptor.
-    memory_desc_t diff_bias_desc {};
+    memory_desc_t diff_bias_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // The accumulator data type.
     data_type_t accum_data_type {};
 };
@@ -178,21 +178,21 @@ struct convolution_desc_t : public op_desc_t {
     // #dnnl_convolution_direct.
     alg_kind_t alg_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Weights memory descriptor.
-    memory_desc_t weights_desc {};
+    memory_desc_t weights_desc;
     // Weights gradient memory descriptor.
-    memory_desc_t diff_weights_desc {};
+    memory_desc_t diff_weights_desc;
     // Bias memory descriptor.
-    memory_desc_t bias_desc {};
+    memory_desc_t bias_desc;
     // Bias gradient memory descriptor.
-    memory_desc_t diff_bias_desc {};
+    memory_desc_t diff_bias_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // Convolution strides in each spatial dimension.
     dims_t strides {};
     // Convolution dilates in each spatial dimension.
@@ -220,9 +220,9 @@ struct shuffle_desc_t : public op_desc_t {
     // #dnnl_forward_inference, and #dnnl_backward_data.
     prop_kind_t prop_kind {};
     // Source or source gradient memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Destination or destination gradient memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Axis for shuffling.
     int axis {};
     // Number of groups.
@@ -242,13 +242,13 @@ struct resampling_desc_t : public op_desc_t {
     // #dnnl_resampling_nearest, #dnnl_resampling_linear.
     alg_kind_t alg_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // Resampling factor in each spatial dimension.
     float factors[DNNL_MAX_NDIMS] {};
 };
@@ -266,15 +266,15 @@ struct matmul_desc_t : public op_desc_t {
     DECLARE_COMMON_OP_DESC_CLONE(matmul_desc_t);
 
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Weights memory descriptor.
-    memory_desc_t weights_desc {};
+    memory_desc_t weights_desc;
     // Bias memory descriptor.
-    memory_desc_t bias_desc {};
+    memory_desc_t bias_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Reduce memory descriptor;
-    memory_desc_t reduce_desc {};
+    memory_desc_t reduce_desc;
     // Reduce kind.
     matmul_reduce_kind_t reduce_kind {};
     // The accumulator data type. Initialized automatically.
@@ -306,13 +306,13 @@ struct eltwise_desc_t : public op_desc_t {
     // #dnnl_eltwise_clip_v2_use_dst_for_bwd.
     alg_kind_t alg_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // Algorithm specific parameter.
     // Accordance table:
     //  - #dnnl_eltwise_relu: @p alpha -- negative slope, @p beta ignored
@@ -351,21 +351,21 @@ struct batch_normalization_desc_t : public op_desc_t {
     // #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
     prop_kind_t prop_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // Scale and/or shift data and gradient memory descriptor.
     // Scaleshift memory descriptor uses 1D #dnnl_x format[Channels].
-    memory_desc_t scaleshift_desc {};
-    memory_desc_t diff_scaleshift_desc {};
+    memory_desc_t scaleshift_desc;
+    memory_desc_t diff_scaleshift_desc;
     // Statistics memory descriptor.
     //
     // Statistics (mean or variance) descriptor use 1D #dnnl_x format[Channels].
-    memory_desc_t stat_desc {};
+    memory_desc_t stat_desc;
     // Batch normalization epsilon parameter.
     float batch_norm_epsilon {};
     unsigned flags {};
@@ -382,26 +382,26 @@ struct group_normalization_desc_t : public op_desc_t {
     // #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
     prop_kind_t prop_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Scale and/or shift data and gradient memory descriptor.
     // Scaleshift memory descriptor uses 1D #dnnl_x format[Channels].
-    memory_desc_t scaleshift_desc {};
-    memory_desc_t diff_scaleshift_desc {};
+    memory_desc_t scaleshift_desc;
+    memory_desc_t diff_scaleshift_desc;
     // Mean and variance data memory descriptors.
     // Statistics (mean and variance) memory descriptor uses 2D #dnnl_ab
     // format[Batch, groups].
-    memory_desc_t stat_desc {};
+    memory_desc_t stat_desc;
     // Group normalization groups parameter.
     dim_t groups {};
     // Group normalization epsilon parameter.
     float group_norm_epsilon {};
     unsigned flags {};
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
 };
 
 // A descriptor of a Layer Normalization operation.
@@ -415,28 +415,28 @@ struct layer_normalization_desc_t : public op_desc_t {
     // #dnnl_forward_inference, #dnnl_backward, and #dnnl_backward_data.
     prop_kind_t prop_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Scale and shift data and gradient memory descriptors.
     // Scaleshift memory descriptor uses 1D #dnnl_x format[normalized_dim].
     // Normalized_dim is equal to the last logical dimension of the source
     // tensor across which normalization is performed.
-    memory_desc_t data_scaleshift_desc {};
-    memory_desc_t diff_data_scaleshift_desc {};
+    memory_desc_t data_scaleshift_desc;
+    memory_desc_t diff_data_scaleshift_desc;
     // Mean and variance data memory descriptors.
     //
     // Statistics (mean and variance) memory descriptor is the k-dimensional tensor
     // where k is equal to data_tensor_ndims - 1 and may have any plain
     // (stride[last_dim] == 1) user-provided format.
-    memory_desc_t stat_desc {};
+    memory_desc_t stat_desc;
     // Layer normalization epsilon parameter.
     float layer_norm_epsilon {};
     unsigned flags {};
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
 };
 
 // A descriptor of a Local Response Normalization (LRN) operation.
@@ -452,13 +452,13 @@ struct lrn_desc_t : public op_desc_t {
     // #dnnl_lrn_across_channels.
     alg_kind_t alg_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // The number of channels to sum over (for cross-channel LRN) or the side
     // length of the square region to sum over (for within-channel LRN).
     dim_t local_size {};
@@ -483,9 +483,9 @@ struct reduction_desc_t : public op_desc_t {
     // #dnnl_reduction_norm_lp_power_p_sum.
     alg_kind_t alg_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Algorithm specific parameters.
     // Accordance table:
     // #dnnl_reduction_max: @p p and @p eps are ignored
@@ -511,18 +511,18 @@ struct softmax_desc_t : public op_desc_t {
     // #dnnl_forward_inference, and #dnnl_backward_data.
     prop_kind_t prop_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // The axis along which to perform the softmax.
     int softmax_axis {};
     // Softmax algorithm. Possible values: #dnnl_softmax_accurate and
     // #dnnl_softmax_log.
     alg_kind_t alg_kind {};
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
 };
 
 // A descriptor of a binary operation.
@@ -540,7 +540,7 @@ struct binary_desc_t : public op_desc_t {
     // Source memory descriptors.
     memory_desc_t src_desc[3] {};
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
 };
 
 /// A descriptor of a PReLU operation.
@@ -553,18 +553,18 @@ struct prelu_desc_t : public op_desc_t {
     // #dnnl_forward_inference, #dnnl_backward
     prop_kind_t prop_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Learnable parameter alpha memory descriptor.
     // Alpha describes negative slope.
-    memory_desc_t weights_desc {};
+    memory_desc_t weights_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Learnable parameter alpha gradient memory descriptor.
-    memory_desc_t diff_weights_desc {};
+    memory_desc_t diff_weights_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
 };
 
 // A descriptor of a pooling operation.
@@ -582,13 +582,13 @@ struct pooling_desc_t : public op_desc_t {
     // #dnnl_pooling_avg_exclude_padding.
     alg_kind_t alg_kind {};
     // Source memory descriptor.
-    memory_desc_t src_desc {};
+    memory_desc_t src_desc;
     // Source gradient memory descriptor.
-    memory_desc_t diff_src_desc {};
+    memory_desc_t diff_src_desc;
     // Destination memory descriptor.
-    memory_desc_t dst_desc {};
+    memory_desc_t dst_desc;
     // Destination gradient memory descriptor.
-    memory_desc_t diff_dst_desc {};
+    memory_desc_t diff_dst_desc;
     // Pooling kernel strides for spatial dimensions.
     dims_t strides {};
     // Pooling kernel spatial dimensions.
@@ -618,58 +618,58 @@ struct rnn_desc_t : public op_desc_t {
     // The direction of RNN primitive execution.
     rnn_direction_t direction {};
     // Source layer memory descriptor.
-    memory_desc_t src_layer_desc {};
+    memory_desc_t src_layer_desc;
     // Source iteration memory descriptor for hidden state.
-    memory_desc_t src_iter_desc {};
+    memory_desc_t src_iter_desc;
     // Source iteration memory descriptor for cell state.
-    memory_desc_t src_iter_c_desc {};
+    memory_desc_t src_iter_c_desc;
     // Weights layer memory descriptor.
-    memory_desc_t weights_layer_desc {};
+    memory_desc_t weights_layer_desc;
     // Weights iteration memory descriptor.
-    memory_desc_t weights_iter_desc {};
+    memory_desc_t weights_iter_desc;
     // Bias memory descriptor.
-    memory_desc_t bias_desc {};
+    memory_desc_t bias_desc;
     // Destination layer memory descriptor.
-    memory_desc_t dst_layer_desc {};
+    memory_desc_t dst_layer_desc;
     // Destination iter memory descriptor for hidden state.
-    memory_desc_t dst_iter_desc {};
+    memory_desc_t dst_iter_desc;
     // Destination iter memory descriptor for cell state.
-    memory_desc_t dst_iter_c_desc {};
+    memory_desc_t dst_iter_c_desc;
     // Weights peephole memory descriptor.
     // This memory descriptor is equal to zero memory descriptor in case of
     // non-peephole LSTMs and other non-LSTM RNNs.
-    memory_desc_t weights_peephole_desc {};
+    memory_desc_t weights_peephole_desc;
     // Weights projection memory descriptor.
     // This memory descriptor is equal to zero memory descriptor in case of
     // non-projection LSTMs and other non-LSTM RNNs.
-    memory_desc_t weights_projection_desc {};
+    memory_desc_t weights_projection_desc;
 
     // Source gradient layer memory descriptor.
-    memory_desc_t diff_src_layer_desc {};
+    memory_desc_t diff_src_layer_desc;
     // Source gradient iter memory descriptor for hidden state.
-    memory_desc_t diff_src_iter_desc {};
+    memory_desc_t diff_src_iter_desc;
     // Source gradient iter memory descriptor for cell state.
-    memory_desc_t diff_src_iter_c_desc {};
+    memory_desc_t diff_src_iter_c_desc;
     // Weights gradient layer memory descriptor.
-    memory_desc_t diff_weights_layer_desc {};
+    memory_desc_t diff_weights_layer_desc;
     // Weights gradient iter memory descriptor.
-    memory_desc_t diff_weights_iter_desc {};
+    memory_desc_t diff_weights_iter_desc;
     // Bias gradient memory descriptor.
-    memory_desc_t diff_bias_desc {};
+    memory_desc_t diff_bias_desc;
     // Destination gradient layer memory descriptor.
-    memory_desc_t diff_dst_layer_desc {};
+    memory_desc_t diff_dst_layer_desc;
     // Destination gradient iteration memory descriptor for hidden state.
-    memory_desc_t diff_dst_iter_desc {};
+    memory_desc_t diff_dst_iter_desc;
     // Destination gradient iteration memory descriptor for cell state.
-    memory_desc_t diff_dst_iter_c_desc {};
+    memory_desc_t diff_dst_iter_c_desc;
     // Weights gradient peephole memory descriptor.
     // This memory descriptor is equal to zero memory descriptor in case of
     // non-peephole LSTMs and other non-LSTM RNNs.
-    memory_desc_t diff_weights_peephole_desc {};
+    memory_desc_t diff_weights_peephole_desc;
     // Weights gradient projection memory descriptor.
     // This memory descriptor is equal to zero memory descriptor in case of
     // non-projection LSTMs and other non-LSTM RNNs.
-    memory_desc_t diff_weights_projection_desc {};
+    memory_desc_t diff_weights_projection_desc;
 
     // RNN cell flags
     unsigned flags {};

--- a/src/common/optional.hpp
+++ b/src/common/optional.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public:
 
     optional_t(const nullopt_t nullopt_) : has_value_(false), dummy {} {}
     optional_t() : optional_t(nullopt) {}
-    optional_t(T object) : has_value_(true), value_(object) {}
+    optional_t(const T &object) : has_value_(true), value_(object) {}
     optional_t(const optional_t &other)
         : has_value_(other.has_value_), dummy {} {
         if (has_value_) new (std::addressof(value_)) T(other.value_);

--- a/src/common/pooling_pd.hpp
+++ b/src/common/pooling_pd.hpp
@@ -175,6 +175,7 @@ private:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct pooling_fwd_pd_t : public pooling_pd_t {
     using base_class = pooling_fwd_pd_t;
     using hint_class = pooling_fwd_pd_t;
@@ -244,7 +245,9 @@ protected:
                 dst_md_, src_md_.format_desc.blocking);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct pooling_bwd_pd_t : public pooling_pd_t {
     using base_class = pooling_bwd_pd_t;
     using hint_class = pooling_fwd_pd_t;
@@ -337,6 +340,7 @@ protected:
 private:
     std::vector<memory_desc_t> hint_mds_;
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/prelu_pd.hpp
+++ b/src/common/prelu_pd.hpp
@@ -87,6 +87,7 @@ protected:
         , weights_md_(desc_.weights_desc) {}
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct prelu_fwd_pd_t : public prelu_pd_t {
     using base_class = prelu_fwd_pd_t;
     using hint_class = prelu_fwd_pd_t;
@@ -148,7 +149,9 @@ protected:
                                 == status::success);
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct prelu_bwd_pd_t : public prelu_pd_t {
     using base_class = prelu_bwd_pd_t;
     using hint_class = prelu_fwd_pd_t;
@@ -242,6 +245,7 @@ protected:
                                 == status::success);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -47,6 +47,7 @@ static int po_inputs(const post_ops_t &post_ops, const primitive_kind_t kind) {
 struct impl_list_item_t;
 struct primitive_t;
 // Primitive descriptor implementation
+// NOLINTBEGIN(google-default-arguments)
 struct primitive_desc_t : public c_compatible {
     primitive_desc_t(const primitive_attr_t *attr, primitive_kind_t kind)
         : attr_(*attr), kind_(kind), pd_iterator_offset_(0), skip_idx_(-1) {
@@ -482,6 +483,7 @@ protected:
 
     friend struct dnnl::impl::impl_list_item_t;
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/profiler.hpp
+++ b/src/common/profiler.hpp
@@ -108,14 +108,14 @@ struct profiler_t {
     // Recording data
     void stamp(const char *name) {
         optimization_barrier();
-        _run_data.emplace_back(record_t<const char *>(name, get_msec()));
+        _run_data.emplace_back(name, get_msec());
         assert(_state == RUNNING);
         optimization_barrier();
     }
 
     void stop(const char *name) {
         optimization_barrier();
-        _run_data.emplace_back(record_t<const char *>(name, get_msec()));
+        _run_data.emplace_back(name, get_msec());
         stop();
     }
 
@@ -171,7 +171,7 @@ private:
         T name;
         prof_time_t time;
         record_t(T name, prof_time_t time) : name(name), time(time) {}
-        record_t(std::pair<T, prof_time_t> record)
+        record_t(const std::pair<T, prof_time_t> &record)
             : name(record.first), time(record.second) {}
         // Reversed time ordering
         bool operator<(const record_t &b) const { return this->time > b.time; }

--- a/src/common/reduction_pd.hpp
+++ b/src/common/reduction_pd.hpp
@@ -37,6 +37,7 @@ status_t reduction_desc_init(reduction_desc_t *reduction_desc,
         alg_kind_t alg_kind, const memory_desc_t *src_desc,
         const memory_desc_t *dst_desc, float p, float eps);
 
+// NOLINTBEGIN(google-default-arguments)
 struct reduction_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::reduction;
 
@@ -165,6 +166,7 @@ protected:
         return status::success;
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/reorder_pd.hpp
+++ b/src/common/reorder_pd.hpp
@@ -160,10 +160,10 @@ protected:
         init_desc(src_engine_kind, dst_engine_kind, false);
     }
 
-    reorder_pd_t(const reorder_pd_t &other) : primitive_desc_t(other) {
-        src_md_ = other.src_md_;
-        dst_md_ = other.dst_md_;
-
+    reorder_pd_t(const reorder_pd_t &other)
+        : primitive_desc_t(other)
+        , src_md_(other.src_md_)
+        , dst_md_(other.dst_md_) {
         init_desc(other.desc_.src_engine_kind, other.desc_.dst_engine_kind,
                 other.desc_.is_cross_engine);
     }

--- a/src/common/reorder_pd.hpp
+++ b/src/common/reorder_pd.hpp
@@ -102,6 +102,7 @@ private:
     dnnl::impl::engine_t *scratchpad_engine_;
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct reorder_pd_t : public primitive_desc_t {
     const reorder_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {
@@ -188,6 +189,7 @@ protected:
         desc_.is_cross_engine = is_cross_engine;
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/resampling_pd.hpp
+++ b/src/common/resampling_pd.hpp
@@ -111,6 +111,7 @@ private:
     }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct resampling_fwd_pd_t : public resampling_pd_t {
     using base_class = resampling_fwd_pd_t;
     using hint_class = resampling_fwd_pd_t;
@@ -168,7 +169,9 @@ protected:
         }
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct resampling_bwd_pd_t : public resampling_pd_t {
     using base_class = resampling_bwd_pd_t;
     using hint_class = resampling_fwd_pd_t;
@@ -229,6 +232,7 @@ protected:
                 diff_src_md_, diff_dst_md_.format_desc.blocking);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/rnn_pd.hpp
+++ b/src/common/rnn_pd.hpp
@@ -39,6 +39,7 @@ namespace impl {
 
 struct rnn_fwd_pd_t;
 
+// NOLINTBEGIN(google-default-arguments)
 struct rnn_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::rnn;
 
@@ -247,7 +248,9 @@ protected:
         , dst_iter_md_(desc_.dst_iter_desc)
         , dst_iter_c_md_(desc_.dst_iter_c_desc) {}
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct rnn_fwd_pd_t : public rnn_pd_t {
     using base_class = rnn_fwd_pd_t;
     using hint_class = rnn_fwd_pd_t;
@@ -326,7 +329,9 @@ protected:
             const rnn_fwd_pd_t *hint_fwd_pd)
         : rnn_pd_t(adesc, attr, hint_fwd_pd) {}
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct rnn_bwd_pd_t : public rnn_pd_t {
     using base_class = rnn_bwd_pd_t;
     using hint_class = rnn_fwd_pd_t;
@@ -535,6 +540,7 @@ protected:
         , diff_dst_iter_md_(desc_.diff_dst_iter_desc)
         , diff_dst_iter_c_md_(desc_.diff_dst_iter_c_desc) {}
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -36,6 +36,7 @@ namespace impl {
     VCHECK(primitive, create, dispatch, sdpa, (f), "%s," msg, \
             this->info(engine), ##__VA_ARGS__)
 
+// NOLINTBEGIN(google-default-arguments)
 struct sdpa_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::sdpa;
 
@@ -241,6 +242,7 @@ private:
         return static_cast<int>(out);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -41,19 +41,19 @@ struct sdpa_desc_t : public op_desc_t {
         return utils::make_unique<sdpa_desc_t>(*this);
     }
 
-    memory_desc_t q_desc {}; /* queries */
-    memory_desc_t k_desc {}; /* keys */
-    memory_desc_t v_desc {}; /* values */
+    memory_desc_t q_desc; /* queries */
+    memory_desc_t k_desc; /* keys */
+    memory_desc_t v_desc; /* values */
 
     // primitive_attr_t can't be used because of deleted copy-ctor, but desc_t
     // must be copyable.
-    quant_entry_t kq_scales {};
-    zero_points_t kq_zero_points {};
-    quant_entry_t vs_scales {};
-    zero_points_t vs_zero_points {};
+    quant_entry_t kq_scales;
+    zero_points_t kq_zero_points;
+    quant_entry_t vs_scales;
+    zero_points_t vs_zero_points;
 
-    memory_desc_t dst_desc {};
-    memory_desc_t attn_mask_desc {};
+    memory_desc_t dst_desc;
+    memory_desc_t attn_mask_desc;
     data_type_t scale_dt {};
     // invert_scale = false: multiply by scale
     // invert_scale = true:  divide by scale

--- a/src/common/shuffle_pd.hpp
+++ b/src/common/shuffle_pd.hpp
@@ -34,6 +34,7 @@
 namespace dnnl {
 namespace impl {
 
+// NOLINTBEGIN(google-default-arguments)
 struct shuffle_pd_t : public primitive_desc_t {
     static constexpr auto base_pkind = primitive_kind::shuffle;
 
@@ -179,6 +180,7 @@ private:
         return is_fwd() ? src_md() : diff_src_md();
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/softmax_pd.hpp
+++ b/src/common/softmax_pd.hpp
@@ -119,6 +119,7 @@ private:
     const memory_desc_t &dst_desc() const { return dst_md_; }
 };
 
+// NOLINTBEGIN(google-default-arguments)
 struct softmax_fwd_pd_t : public softmax_pd_t {
     using base_class = softmax_fwd_pd_t;
     using hint_class = softmax_fwd_pd_t;
@@ -192,7 +193,9 @@ protected:
         return ok;
     }
 };
+// NOLINTEND(google-default-arguments)
 
+// NOLINTBEGIN(google-default-arguments)
 struct softmax_bwd_pd_t : public softmax_pd_t {
     using base_class = softmax_bwd_pd_t;
     using hint_class = softmax_fwd_pd_t;
@@ -267,6 +270,7 @@ protected:
         return status::success;
     }
 };
+// NOLINTEND(google-default-arguments)
 
 } // namespace impl
 } // namespace dnnl

--- a/src/common/sum_pd.hpp
+++ b/src/common/sum_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -116,14 +116,14 @@ protected:
         init_desc();
     }
 
-    sum_pd_t(const sum_pd_t &other) : primitive_desc_t(other) {
-        n_ = other.n_;
-        scales_ = other.scales_;
-        dst_md_ = other.dst_md_;
-        dst_acc_md_ = other.dst_acc_md_;
-        src_mds_ = other.src_mds_;
-        original_dst_md_ = other.original_dst_md_;
-
+    sum_pd_t(const sum_pd_t &other)
+        : primitive_desc_t(other)
+        , n_(other.n_)
+        , scales_(other.scales_)
+        , dst_md_(other.dst_md_)
+        , dst_acc_md_(other.dst_acc_md_)
+        , src_mds_(other.src_mds_)
+        , original_dst_md_(other.original_dst_md_) {
         init_desc();
     }
     sum_pd_t &operator=(const sum_pd_t &other) {

--- a/src/common/sum_pd.hpp
+++ b/src/common/sum_pd.hpp
@@ -40,6 +40,7 @@
 namespace dnnl {
 namespace impl {
 
+// NOLINTBEGIN(google-default-arguments)
 struct sum_pd_t : public primitive_desc_t {
     const sum_desc_t *desc() const { return &desc_; }
     const op_desc_t *op_desc() const override {
@@ -195,6 +196,7 @@ private:
             desc_.src_mds.push_back(&md);
     }
 };
+// NOLINTEND(google-default-arguments)
 
 #define DECLARE_SUM_PD_t(impl_name, ...) \
     static status_t create(sum_pd_t **sum_pd, dnnl::impl::engine_t *engine, \

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -62,7 +62,7 @@ status_t safe_ptr_assign(
 }
 
 template <typename T, typename U>
-struct is_subset {
+struct is_subset { // NOLINT(readability-identifier-naming)
     static constexpr bool value = false;
 };
 template <typename T>

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -124,7 +124,7 @@ struct conditional<false, T, F> {
 };
 
 template <bool, typename, bool, typename, typename>
-struct conditional3 {};
+struct conditional3 {}; // NOLINT(readability-identifier-naming)
 template <typename T, typename FT, typename FF>
 struct conditional3<true, T, false, FT, FF> {
     using type = T;
@@ -139,7 +139,7 @@ struct conditional3<false, T, false, FT, FF> {
 };
 
 template <bool, typename U, U, U>
-struct conditional_v {};
+struct conditional_v {}; // NOLINT(readability-identifier-naming)
 template <typename U, U t, U f>
 struct conditional_v<true, U, t, f> {
     static constexpr U value = t;
@@ -182,6 +182,7 @@ std::unique_ptr<T> make_unique(Args &&...args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
+// NOLINTBEGIN(performance-unnecessary-value-param)
 template <typename T, typename P>
 constexpr bool everyone_is(T val, P item) {
     return val == item;
@@ -190,7 +191,9 @@ template <typename T, typename P, typename... Args>
 constexpr bool everyone_is(T val, P item, Args... item_others) {
     return val == item && everyone_is(val, item_others...);
 }
+// NOLINTEND(performance-unnecessary-value-param)
 
+// NOLINTBEGIN(performance-unnecessary-value-param)
 template <typename T, typename P>
 constexpr bool one_of(T val, P item) {
     return val == item;
@@ -199,6 +202,7 @@ template <typename T, typename P, typename... Args>
 constexpr bool one_of(T val, P item, Args... item_others) {
     return val == item || one_of(val, item_others...);
 }
+// NOLINTEND(performance-unnecessary-value-param)
 
 template <typename T, typename P>
 constexpr P map(T pat, P def) {
@@ -252,7 +256,7 @@ inline void array_set(T *arr, const U &val, size_t size) {
 
 namespace product_impl {
 template <size_t>
-struct int2type {};
+struct int2type {}; // NOLINT(readability-identifier-naming)
 
 template <typename T>
 constexpr int product_impl(const T *arr, int2type<0>) {
@@ -479,11 +483,10 @@ T pick_by_prop_kind(prop_kind_t prop_kind, const T &val_fwd, const T &val_bwd_d,
 }
 
 template <typename Telem, size_t Tdims>
-struct array_offset_calculator {
+struct array_offset_calculator { // NOLINT(readability-identifier-naming)
     template <typename... Targs>
-    array_offset_calculator(Telem *base, Targs... Fargs) : _dims {Fargs...} {
-        _base_ptr = base;
-    }
+    array_offset_calculator(Telem *base, Targs... Fargs)
+        : _base_ptr(base), _dims {Fargs...} {}
 
     template <typename... Targs>
     array_offset_calculator(std::nullptr_t, Targs... Fargs) = delete;
@@ -722,7 +725,7 @@ public:
     constexpr setting_t(const T init) : value_ {init}, initialized_ {false} {}
     bool initialized() { return initialized_; }
     T get() { return value_; }
-    void set(T new_value) {
+    void set(const T &new_value) {
         value_ = new_value;
         initialized_ = true;
     }
@@ -824,16 +827,10 @@ using maybe_unique_ptr = std::unique_ptr<T, nop_deleter_t>;
 struct nibble2_t {
 
     // constructs a nibble pair from a pair of uint8_t values
-    nibble2_t(uint8_t low_, uint8_t high_) {
-        low = low_;
-        high = high_;
-    }
+    nibble2_t(uint8_t low_, uint8_t high_) : low(low_), high(high_) {}
 
     // constructs a nibble pairs from an uin8_t, taking its low and high part
-    nibble2_t(uint8_t pack_) {
-        low = pack_ & 0xf;
-        high = (pack_ >> 4) & 0xf;
-    }
+    nibble2_t(uint8_t pack_) : low(pack_ & 0xf), high((pack_ >> 4) & 0xf) {}
 
     // sets low (idx=0) or high (idx=1)  nibble.
     inline void set(uint8_t val, int idx) {
@@ -869,7 +866,7 @@ static_assert(sizeof(nibble2_t) == 1, "nibble2_t must be 1 byte");
 ///     printf("%d\t", idx);
 /// }
 /// output: 0  2  3
-class mask_iterator {
+class mask_iterator { // NOLINT(readability-identifier-naming)
     int mask_;
     int index_;
 

--- a/src/graph/backend/dnnl/fusion_info.cpp
+++ b/src/graph/backend/dnnl/fusion_info.cpp
@@ -328,7 +328,7 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
             // not reachable
         }
     }
-    attr.set_post_ops(std::move(dnnl_pops));
+    attr.set_post_ops(dnnl_pops);
 
     return attr;
 }

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -149,7 +149,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     auto alg
             = static_cast<algorithm>(ori_dnnl_pops.get()->entry_[0].binary.alg);
     dnnl_pops.append_binary(alg, sub_mm1_post_add_md);
-    sub_matmul1_attr.set_post_ops(std::move(dnnl_pops));
+    sub_matmul1_attr.set_post_ops(dnnl_pops);
     auto sub_mm1_pd = matmul::primitive_desc(p_engine, sub_mm1_src_md,
             sub_mm1_wei_md, sub_mm1_dst_md, sub_matmul1_attr);
     sub_mm1_prim = matmul(sub_mm1_pd);

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -191,7 +191,7 @@ impl::status_t sdp_decomp_config_t::construct_params(
         sub_mm1_post_md.emplace_back(new_sub_md);
         dnnl_pops.append_binary(alg, new_sub_md);
     }
-    sub_matmul1_attr.set_post_ops(std::move(dnnl_pops));
+    sub_matmul1_attr.set_post_ops(dnnl_pops);
     auto sub_mm1_pd = matmul::primitive_desc(p_engine, sub_mm1_src_md,
             sub_mm1_wei_md, sub_mm1_dst_md, sub_matmul1_attr);
     sub_mm1_prim = matmul(sub_mm1_pd);

--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -1653,7 +1653,7 @@ bn_folding_t::desc_t bn_folding_t::create_desc(std::shared_ptr<op_t> &op,
     add_post_ops.append_eltwise(algorithm::eltwise_sqrt, 0.0f, 0.0f);
 
     primitive_attr add_attr;
-    add_attr.set_post_ops(std::move(add_post_ops));
+    add_attr.set_post_ops(add_post_ops);
     desc.add_pd_ = dnnl::binary::primitive_desc(p_engine, algorithm::binary_add,
             variance, desc.epsilon_desc_, variance, add_attr);
 
@@ -1689,7 +1689,7 @@ bn_folding_t::desc_t bn_folding_t::create_desc(std::shared_ptr<op_t> &op,
     mul_post_ops.append_binary(algorithm::binary_div, desc.new_variance_desc_);
 
     primitive_attr mul_attr;
-    mul_attr.set_post_ops(std::move(mul_post_ops));
+    mul_attr.set_post_ops(mul_post_ops);
     desc.mul_pd_ = dnnl::binary::primitive_desc(p_engine, algorithm::binary_mul,
             weights, desc.new_scale_desc_, weights, mul_attr);
 
@@ -1707,7 +1707,7 @@ bn_folding_t::desc_t bn_folding_t::create_desc(std::shared_ptr<op_t> &op,
     sub_post_ops.append_binary(algorithm::binary_add, shift);
 
     primitive_attr sub_attr;
-    sub_attr.set_post_ops(std::move(sub_post_ops));
+    sub_attr.set_post_ops(sub_post_ops);
     desc.sub_pd_ = dnnl::binary::primitive_desc(p_engine, algorithm::binary_sub,
             valid_bias, mean, valid_bias, sub_attr);
 


### PR DESCRIPTION
This PR addresses clang-tidy warnings detected with `ONEDNN_USE_CLANG_TIDY=CHECK_ALL` in API, examples, and common.
