### PR TITLE
graph: backend: dnnl: fix genindex and causal mask issue

### DIFF
--- a/src/graph/backend/dnnl/patterns/single_op_pattern.cpp
+++ b/src/graph/backend/dnnl/patterns/single_op_pattern.cpp
@@ -291,6 +291,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, convtranspose_weights_bwd_pass)
         });
 #endif
 
+DNNL_BACKEND_SINGLE_OP_TRANSFORM(gen_index_pass, GenIndex, genindex_t)
 DNNL_BACKEND_SINGLE_OP_TRANSFORM(matmul_pass, MatMul, float_matmul)
 DNNL_BACKEND_SINGLE_OP_TRANSFORM(max_pool_pass, MaxPool, float_pooling_fwd)
 DNNL_BACKEND_SINGLE_OP_TRANSFORM(prelu_pass, PReLU, float_prelu_fwd)
@@ -423,16 +424,6 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reduce_pass)
         .set_attr<FCreateKernel>("FCreateKernel", []() -> kernel_ptr {
             return std::make_shared<float_reduction>();
         });
-
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, gen_index_pass)
-        .set_priority(DEFAULT_P)
-        .set_kind(partition_kind_t::misc_post_ops)
-        .set_attr<FCreatePattern>("FCreatePattern",
-                [](const std::shared_ptr<pb_graph_t> &pgraph) -> void {
-                    pgraph->append_op(graph::op_kind::GenIndex);
-                })
-        .set_attr<FCreateKernel>("FCreateKernel",
-                []() -> kernel_ptr { return std::make_shared<genindex_t>(); });
 
 // GreaterEqual currently is CPU only
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, greater_equal_pass)

--- a/src/graph/backend/dnnl/patterns/single_op_pattern.cpp
+++ b/src/graph/backend/dnnl/patterns/single_op_pattern.cpp
@@ -291,7 +291,6 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, convtranspose_weights_bwd_pass)
         });
 #endif
 
-DNNL_BACKEND_SINGLE_OP_TRANSFORM(greater_equal_pass, GreaterEqual, binary_t)
 DNNL_BACKEND_SINGLE_OP_TRANSFORM(matmul_pass, MatMul, float_matmul)
 DNNL_BACKEND_SINGLE_OP_TRANSFORM(max_pool_pass, MaxPool, float_pooling_fwd)
 DNNL_BACKEND_SINGLE_OP_TRANSFORM(prelu_pass, PReLU, float_prelu_fwd)
@@ -434,6 +433,18 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, gen_index_pass)
                 })
         .set_attr<FCreateKernel>("FCreateKernel",
                 []() -> kernel_ptr { return std::make_shared<genindex_t>(); });
+
+// GreaterEqual currently is CPU only
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, greater_equal_pass)
+        .set_priority(DEFAULT_P)
+        .set_kind(partition_kind_t::misc_post_ops)
+        .set_engine_kind(engine_kind::cpu)
+        .set_attr<FCreatePattern>("FCreatePattern",
+                [](const std::shared_ptr<pb_graph_t> &pgraph) -> void {
+                    pgraph->append_op(graph::op_kind::GreaterEqual);
+                })
+        .set_attr<FCreateKernel>("FCreateKernel",
+                []() -> kernel_ptr { return std::make_shared<binary_t>(); });
 
 #undef DNNL_BACKEND_SINGLE_OP_TRANSFORM
 #undef DEFAULT_P

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -416,7 +416,11 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
 
     // A list of ops that don't have DNNL backend support so far.
     static const std::vector<std::string> unimplemented_ops {"Pow"};
-
+    // A list of ops that don't have DNNL backend support so far on GPU.
+    static const std::vector<std::string> unimplemented_ops_gpu {
+            "GreaterEqual"};
+    const auto &eng = get_graph_engine();
+    bool is_gpu = eng.get_kind() == dnnl::engine::kind::gpu;
     // For an unsupported partition, retrieve all operation IDs, find a
     // correspondent operation kind in a deserialized_graph_t and match it against
     // a list of known unsupported ops.
@@ -434,6 +438,21 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
             res->state = SKIPPED;
             res->reason = skip_reason::case_not_supported;
             return;
+        }
+
+        if (is_gpu) {
+            const bool has_unimplemented_op_gpu = std::any_of(
+                    unimplemented_ops_gpu.begin(), unimplemented_ops_gpu.end(),
+                    [&dg_op_kind](const std::string &kind) {
+                        return dg_op_kind == kind;
+                    });
+            if (has_unimplemented_op_gpu) {
+                BENCHDNN_PRINT(2, "[INFO]: Unimplemented op on GPU: %s.\n",
+                        dg_op_kind.c_str());
+                res->state = SKIPPED;
+                res->reason = skip_reason::case_not_supported;
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
1. Fix the GenIndex sycl cpu dispatch issue. It should be dispatched to CPU implementation.
2. GreaterEqual w/ s32 dtype is not currently supported by GPU. Add the checking in the pattern definition and benchdnn.
