### PR TITLE
graph: backend: dnnl: fix some issue about fuse_src_tranpose to_matmul and mqa decompose kernel

### DIFF
--- a/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,7 +87,6 @@ status_t mqa_decomp_kernel_t<quantized, dt>::compile_impl(
         BACKEND_DNNL_ADD_PASS(pipeline, remove_quant_data_with_no_effect);
     }
     pipeline.reset_visualize_arg(true, false);
-    BACKEND_DNNL_ADD_PASS(pipeline, fuse_src_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, layout_propagation);
 

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,6 +48,8 @@ public:
         reorder_ = dnnl::reorder(pd);
         return status::success;
     }
+
+    bool get_inplace() const { return is_inplace_; }
 
     status_t execute(const dnnl::stream &astream,
             const std::unordered_map<int, dnnl::memory> &args) const {

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -92,7 +92,6 @@ status_t sdp_primitive_kernel_t<quantized>::compile_impl(
 
     pipeline.reset_visualize_arg(true, false);
     BACKEND_DNNL_ADD_PASS(pipeline, infer_shape);
-    BACKEND_DNNL_ADD_PASS(pipeline, fuse_src_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, layout_propagation);
 

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -3796,8 +3796,22 @@ impl::status_t fuse_src_transpose_to_matmul(std::shared_ptr<subgraph_t> &sg) {
             break;
         }
 
-        std::vector<int> axes = dnnl_impl::utils::fmap(order,
-                [](int64_t index) { return static_cast<int32_t>(index); });
+        /// The order in spec op is used as:
+        /// for (i = 0; i < ndims(); i++)
+        ///     new_shape[i] = org_shape[order[i]];
+        ///
+        /// The axes for permute_axes function is used as:
+        /// for (i = 0; i < ndims(); i++)
+        ///     new_shape[axes[i]] = org_shape[i];
+        ///
+        /// So, we need to convert the order to axes
+        std::vector<int> axes(order.size(), -1);
+        for (size_t i = 0; i < order.size(); i++) {
+            size_t new_shape_idx = i;
+            size_t org_shape_idx = order[i];
+            axes[org_shape_idx] = static_cast<int>(new_shape_idx);
+        }
+
         // calculate the expected transposed layout by permuting the md
         auto expected_stride = get_dense_strides(ltw(in_lt).vdims());
         auto &consumer = transpose_op->get_output_value(0)


### PR DESCRIPTION
# Description

1. Fix the pass `fuse_src_transpose_to_matmul`, it is aimed to optimize pattern like "softmax+transpose+reshape/reorder+matmul". But the order in the `in_md.permute_axes` needs to be converted. 
2. `fuse_src_transpose_to_matmul` is not used in `mqa_decomp` and `sdp_primitive` kernels. So removed.
3. Fix the kernel the dst pointer issue in the `mqa_decomp` kernel. 
