### PR TITLE
common, xe: fix fp4 aliasing issues

### DIFF
--- a/src/common/float4.cpp
+++ b/src/common/float4.cpp
@@ -32,7 +32,7 @@ uint8_t float2e2m1(float f) {
     // There is no NaN or infinity in e2m1, for now we just return zero
     // TODO: figure if there is a standard value to return
     uint32_t naninf_mask = 0x7f800000;
-    if ((f_raw & naninf_mask) == naninf_mask) return 0x00;
+    if ((f_raw & naninf_mask) == naninf_mask) return 0x07 | (sign >> 28);
 
     // we convert with naive closest value computation out of 8
     float e2m1_val_table[8] = {0.0f, .5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
@@ -97,7 +97,7 @@ uint8_t float2e3m0(float f) {
 
     // There is no NaN or infinity in e3m0, we just return maxval
     uint32_t naninf_mask = 0x7f800000;
-    if ((f_raw & naninf_mask) == naninf_mask) return 0x7;
+    if ((f_raw & naninf_mask) == naninf_mask) return 0x7 | (sign >> 28);
 
     // we convert with naive closest value computation out of 8
     float e3m0_val_table[8] = {0.0f, .25f, .5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f};

--- a/src/common/float4.cpp
+++ b/src/common/float4.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ uint8_t float2e2m1(float f) {
     // we convert with naive closest value computation out of 8
     float e2m1_val_table[8] = {0.0f, .5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
 
-    float abs_f = int2float(f_raw ^ sign);
+    float abs_f = fmin(e2m1_val_table[7], int2float(f_raw ^ sign));
 
     int idx = 0;
     float min_diff = ::fabsf(e2m1_val_table[idx] - abs_f);
@@ -102,7 +102,7 @@ uint8_t float2e3m0(float f) {
     // we convert with naive closest value computation out of 8
     float e3m0_val_table[8] = {0.0f, .25f, .5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f};
 
-    float abs_f = int2float(f_raw ^ sign);
+    float abs_f = fmin(e3m0_val_table[7], int2float(f_raw ^ sign));
 
     int idx = 0;
     float min_diff = ::fabsf(e3m0_val_table[idx] - abs_f);

--- a/src/gpu/intel/jit/gemm/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/copy_plan.cpp
@@ -883,20 +883,19 @@ void CopyPlan::planS4ToHF(CopyInstruction &i)
 void CopyPlan::planEmulatedHFToF4E2M1(CopyInstruction &i)
 {
     // Emulation sequence for mov y:f4 x:hf:
-    //   and (nz)fN.N   x:uw                0x7C00        /* NaN/inf check */
-    //   sel fN.N       t1:uw    x:uw       0x0
-    //   sel (lt)fN.N   t2:hf    t1:uw      0x4600:hf     /* Clamp/round */
-    //   mul t2:hf      t2:hf               0x400:hf
-    //   and (nz)fN.N   null     t2:uw      0x200
-    //   add            t2:uw    t2:uw      0x100
-    //   shr            t1:uw    x:uw       0x8
-    //   shr            t2:uw    t2:uw      0x5
-    //   bfn.0xCA       t2:uw    t2:uw      t1:uw  0x8000 /* copy sign */
-    //   and            t2:uw    t2:uw      0x00f0:uw     /* byte pack */
-    //   shr            t2:uw<2> t2:uw<2>   0x4:uw
-    //   or             t2:uw    t2.1:uw<2> t2:uw<2>
-    //   mov            t2:ub    t2:ub<2>
-    //   mov            y:uw     t2:ub
+    //        sel (lt)     t1:hf    (abs)x:hf  0x4600:hf     /* Clamp */
+    //        mul          t1:hf    t1:hf      0x400:hf
+    //        add          t1:uw    t1:uw      -0x100
+    //        and (nz)f0   null     t1:uw      0x3ff:uw
+    //   (f0) add          t1:uw    t1:uw      0x200
+    //        shl          t1:uw    t1:uw      3
+    //        bfn.0xCA     t1:uw    t1:uw      x:uw   0x8000 /* copy sign */
+    //        shr          t1:uw    t1:uw      8
+    //        and          t1:uw    t1:uw      0x00f0:uw     /* byte pack */
+    //        shr          t1:uw<2> t1:uw<2>   4
+    //        or           t1:uw    t1.1:uw<2> t1:uw<2>
+    //        mov          t1:ub    t1:ub<2>
+    //        mov          y:uw     t1:ub
     //
 
     if (i.src0.neg || i.sat || i.hasCMod()) stub("Unsupported modifier");
@@ -904,53 +903,48 @@ void CopyPlan::planEmulatedHFToF4E2M1(CopyInstruction &i)
 
     auto ie = splitMultiple<14>(i);
     auto tmp = newTemp(DataType::ud, simd, 1);
-    auto tmp2 = newTemp(DataType::ud, simd, 1);
 
     auto convFlag = newFlag(simd);
-    auto ddst = CopyOperand(i.dst);
-    auto invSrc = CopyOperand(i.src0);
-    auto ssrc = CopyOperand(i.src0);
-    invSrc.inv = true;
+    auto ddst = i.dst;
+    auto ssrc = i.src0;
 
-    // Check for NaN/infs.
-    ie[0]->op = Opcode::and_;
-    ie[0]->simd = simd;
-    ie[0]->flag = convFlag;
-    ie[0]->cmod = ConditionModifier::nz;
-    ie[0]->dst = CopyOperand();
-    ie[0]->dst.type = DataType::uw;
-    ie[0]->src0 = invSrc;
-    ie[0]->src0.type = DataType::uw;
-    ie[0]->src1 = Immediate::uw(0x7c00);
-
-    ie[1]->op = Opcode::sel;
-    ie[1]->flag = convFlag;
-    ie[1]->simd = simd;
-    ie[1]->dst = tmp;
-    ie[1]->dst.type = DataType::uw;
-    ie[1]->src0 = ssrc;
-    ie[1]->src0.type = DataType::uw;
-    ie[1]->src1 = Immediate::uw(0x0);
+    if (ssrc.stride > 1) {
+        ie[0]->op = Opcode::mov;
+        ie[0]->dst = ssrc;
+        ie[0]->dst.stride = 1;
+        ie[0]->src0 = ssrc;
+        ssrc.stride = 1;
+    } else {
+        ie[0]->invalidate();
+    }
 
     // Clamp and round.
-    ie[2]->op = Opcode::sel;
-    ie[2]->flag = convFlag;
-    ie[2]->cmod = ConditionModifier::lt;
+    ie[1]->op = Opcode::sel;
+    ie[1]->flag = convFlag;
+    ie[1]->cmod = ConditionModifier::lt;
+    ie[1]->simd = simd;
+    ie[1]->dst = tmp;
+    ie[1]->dst.type = DataType::hf;
+    ie[1]->src0 = ssrc;
+    ie[1]->src0.type = DataType::hf;
+    ie[1]->src0.abs = true;
+    ie[1]->src1 = Immediate::hf(0x4600);
+
+    ie[2]->op = Opcode::mul;
     ie[2]->simd = simd;
-    ie[2]->dst = tmp2;
+    ie[2]->dst = tmp;
     ie[2]->dst.type = DataType::hf;
     ie[2]->src0 = tmp;
     ie[2]->src0.type = DataType::hf;
-    ie[2]->src0.abs = true;
-    ie[2]->src1 = Immediate::hf(0x4600);
+    ie[2]->src1 = Immediate::hf(0x0400);
 
-    ie[3]->op = Opcode::mul;
+    ie[3]->op = Opcode::add;
     ie[3]->simd = simd;
-    ie[3]->dst = tmp2;
-    ie[3]->dst.type = DataType::hf;
-    ie[3]->src0 = tmp2;
-    ie[3]->src0.type = DataType::hf;
-    ie[3]->src1 = Immediate::hf(0x0400);
+    ie[3]->dst = tmp;
+    ie[3]->dst.type = DataType::uw;
+    ie[3]->src0 = tmp;
+    ie[3]->src0.type = DataType::uw;
+    ie[3]->src1 = Immediate::w(-0x0100);
 
     ie[4]->op = Opcode::and_;
     ie[4]->simd = simd;
@@ -958,84 +952,84 @@ void CopyPlan::planEmulatedHFToF4E2M1(CopyInstruction &i)
     ie[4]->cmod = ConditionModifier::nz;
     ie[4]->dst = CopyOperand();
     ie[4]->dst.type = DataType::uw;
-    ie[4]->src0 = tmp2;
+    ie[4]->src0 = tmp;
     ie[4]->src0.type = DataType::uw;
-    ie[4]->src1 = Immediate::uw(0x0200);
+    ie[4]->src1 = Immediate::uw(0x03ff);
 
     ie[5]->op = Opcode::add;
     ie[5]->simd = simd;
     ie[5]->flag = convFlag;
-    ie[5]->dst = tmp2;
+    ie[5]->dst = tmp;
     ie[5]->dst.type = DataType::uw;
-    ie[5]->src0 = tmp2;
+    ie[5]->src0 = tmp;
     ie[5]->src0.type = DataType::uw;
-    ie[5]->src1 = Immediate::uw(0x0100);
+    ie[5]->src1 = Immediate::uw(0x0200);
 
-    ie[6]->op = Opcode::shr;
+    ie[6]->op = Opcode::shl;
     ie[6]->simd = simd;
     ie[6]->dst = tmp;
     ie[6]->dst.type = DataType::uw;
-    ie[6]->src0 = ssrc;
+    ie[6]->src0 = tmp;
     ie[6]->src0.type = DataType::uw;
-    ie[6]->src1 = Immediate::uw(8);
-
-    ie[7]->op = Opcode::shr;
-    ie[7]->simd = simd;
-    ie[7]->dst = tmp2;
-    ie[7]->dst.type = DataType::uw;
-    ie[7]->src0 = tmp2;
-    ie[7]->src0.type = DataType::uw;
-    ie[7]->src1 = Immediate::uw(5);
+    ie[6]->src1 = Immediate::uw(3);
 
     // Restore sign.
-    ie[8]->op = Opcode::bfn;
-    ie[8]->dst = tmp2;
-    ie[8]->dst.stride = 1;
+    ie[7]->op = Opcode::bfn;
+    ie[7]->dst = tmp;
+    ie[7]->dst.stride = 1;
+    ie[7]->dst.type = DataType::uw;
+    ie[7]->src0 = tmp;
+    ie[7]->src0.type = DataType::uw;
+    ie[7]->src1 = ssrc;
+    ie[7]->src1.type = DataType::uw;
+    ie[7]->src2 = 0x8000;
+    ie[7]->ctrl = 0xCA;
+
+    ie[8]->op = Opcode::shr;
+    ie[8]->simd = simd;
+    ie[8]->dst = tmp;
     ie[8]->dst.type = DataType::uw;
-    ie[8]->src0 = tmp2;
+    ie[8]->src0 = tmp;
     ie[8]->src0.type = DataType::uw;
-    ie[8]->src1 = tmp;
-    ie[8]->src1.type = DataType::uw;
-    ie[8]->src2 = 0x80;
-    ie[8]->ctrl = 0xCA;
+    ie[8]->src1 = Immediate::uw(8);
 
     // Pack into byte.
     ie[9]->op = Opcode::and_;
     ie[9]->simd = simd;
-    ie[9]->dst = tmp2;
+    ie[9]->dst = tmp;
     ie[9]->dst.type = DataType::uw;
-    ie[9]->src0 = tmp2;
+    ie[9]->src0 = tmp;
     ie[9]->src0.type = DataType::uw;
     ie[9]->src1 = Immediate(0x00f0);
 
     ie[10]->op = Opcode::shr;
     ie[10]->simd = simd/2;
-    ie[10]->dst = tmp2;
+    ie[10]->dst = tmp;
     ie[10]->dst.type = DataType::uw;
     ie[10]->dst.stride = 2;
-    ie[10]->src0 = tmp2;
+    ie[10]->src0 = tmp;
     ie[10]->src0.type = DataType::uw;
     ie[10]->src0.stride = 2;
     ie[10]->src1 = Immediate::uw(4);
 
     ie[11]->op = Opcode::or_;
     ie[11]->simd = simd/2;
-    ie[11]->dst = tmp2;
+    ie[11]->dst = tmp;
     ie[11]->dst.type = DataType::uw;
-    ie[11]->src0 = tmp2;
+    ie[11]->src0 = tmp;
     ie[11]->src0.offset = 1;
     ie[11]->src0.type = DataType::uw;
     ie[11]->src0.stride = 2;
-    ie[11]->src1 = tmp2;
+    ie[11]->src1 = tmp;
     ie[11]->src1.type = DataType::uw;
     ie[11]->src1.stride = 2;
 
     ie[12]->op = Opcode::mov;
     ie[12]->simd = simd/2;
-    ie[12]->dst = tmp2;
+    ie[12]->dst = tmp;
     ie[12]->dst.stride = 1;
     ie[12]->dst.type = DataType::ub;
-    ie[12]->src0 = tmp2;
+    ie[12]->src0 = tmp;
     ie[12]->src0.stride = 2;
     ie[12]->src0.type = DataType::ub;
 
@@ -1047,9 +1041,8 @@ void CopyPlan::planEmulatedHFToF4E2M1(CopyInstruction &i)
     ie[13]->dst.type = DataType::ub;
     if (ie[13]->dst.offset != 0)
             ie[13]->dst.offset /= 2;
-    ie[13]->src0 = tmp2;
+    ie[13]->src0 = tmp;
     ie[13]->src0.type = DataType::ub;
-
 }
 
 // Emulated f->bf or hf->bf8 sequence.

--- a/src/gpu/intel/ocl/ocl_math_utils.h
+++ b/src/gpu/intel/ocl/ocl_math_utils.h
@@ -717,7 +717,7 @@ uchar __attribute__((overloadable)) cvt_f32_to_f4_e3m0(float f) {
     // we convert with naive closest value computation out of 8
     float e3m0_val_table[8] = {0.0f, .25f, .5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f};
 
-    float abs_f = as_float(f_raw ^ sign);
+    float abs_f = fmin(e3m0_val_table[7], as_float(f_raw ^ sign));
 
     int idx = 0;
     float min_diff = fabs(e3m0_val_table[idx] - abs_f);

--- a/src/gpu/intel/ocl/ocl_math_utils.h
+++ b/src/gpu/intel/ocl/ocl_math_utils.h
@@ -679,18 +679,37 @@ float __attribute__((overloadable)) cvt_s4_to_s32(char a) {
 #if MATH_UTILS_DECLARE_F4_E2M1
 
 uchar __attribute__((overloadable)) cvt_f32_to_f4_e2m1(float a) {
-    // Rounding boundaries
-    const ushort8 boundaries
-            = {0x800, 0x3e8, 0x3f4, 0x3fa, 0x3fe, 0x402, 0x406, 0x40a};
-    ushort b = as_uint(a) >> 20;
-    ushort val = b & 0x7ff;
-    short cmp_mask = (val & 0x7f8) != 0x7f8;
-    short8 gt = (val > boundaries) & cmp_mask;
-    short4 eq = (val == boundaries.s0246) & cmp_mask;
-    short4 r0 = gt.s0123 + gt.s4567 + eq;
-    short2 r1 = r0.s01 + r0.s23;
-    uchar sign = (b >> 8) & (cmp_mask << 3);
-    return sign | (uchar)(r1.s0 + r1.s1);
+    const float f4_e2m1_max = as_float(0x40c00000);
+    const float exp_shift = as_float(0x00800000);
+
+    // clamp
+    // sel (lt)f0.0 t0:f (abs)x:f 0x40c00000:f
+    float intermediate = fmin(fabs(a), f4_e2m1_max);
+    if (isnan(intermediate)) intermediate = f4_e2m1_max;
+
+    // shift high exp bit down
+    // mul t0:f t0:f 0x00800000:f
+    intermediate *= exp_shift;
+
+    // rtne logic
+    // add t0:ud to:ud -0x00200000:ud
+    // and (nz)f0.0 null t0:ud 0x007fffff:ud
+    uint bits = as_uint(intermediate);
+    bits -= 0x00200000;
+    uint round_up = bits & 0x007fffff;
+
+    // shr t0:ud t0:ud 22
+    bits >>= 22;
+
+    // round
+    // (f0.0) add t0:ud t0:ud 1
+    if (round_up) bits += 1;
+
+    // copy sign
+    // shr y:ud x:ud 28
+    // bfn.0xCA y:ud y:ud t0:ud 0x07
+    uint dst = as_uint(a) >> 28;
+    return ((dst & ~0x07) | (bits & 0x07)) & 0xf;
 }
 
 float __attribute__((overloadable)) cvt_f4_e2m1_to_f32(uchar a) {
@@ -706,34 +725,38 @@ float __attribute__((overloadable)) cvt_f4_e2m1_to_f32(uchar a) {
 #if MATH_UTILS_DECLARE_F4_E3M0
 
 // OCL translation of common fp4 methods.
-uchar __attribute__((overloadable)) cvt_f32_to_f4_e3m0(float f) {
-    uint f_raw = as_uint(f);
-    uint sign = f_raw & 0x80000000;
+uchar __attribute__((overloadable)) cvt_f32_to_f4_e3m0(float a) {
+    const float f4_e3m0_max = as_float(0x41800000);
+    const float exp_shift = as_float(0x01800000);
 
-    // There is no NaN or infinity in e3m0, we just return maxval
-    uint naninf_mask = 0x7f800000;
-    if ((f_raw & naninf_mask) == naninf_mask) return 0x7;
+    // clamp
+    // sel (lt)f0.0 t0:f (abs)x:f 0x41800000:f
+    float intermediate = fmin(fabs(a), f4_e3m0_max);
+    if (isnan(intermediate)) intermediate = f4_e3m0_max;
 
-    // we convert with naive closest value computation out of 8
-    float e3m0_val_table[8] = {0.0f, .25f, .5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f};
+    // shift high exp bit down
+    // mul t0:f t0:f 0x01800000:f
+    intermediate *= exp_shift;
 
-    float abs_f = fmin(e3m0_val_table[7], as_float(f_raw ^ sign));
+    // rtne logic
+    // add t0:ud to:ud -0x00400000:ud
+    // and (nz)f0.0 null t0:ud 0x00ffffff:ud
+    uint bits = as_uint(intermediate);
+    bits -= 0x00400000;
+    uint round_up = bits & 0x00ffffff;
 
-    int idx = 0;
-    float min_diff = fabs(e3m0_val_table[idx] - abs_f);
-    uchar raw_bits = idx;
-    for (++idx; idx < 8; ++idx) {
-        float diff = fabs(e3m0_val_table[idx] - abs_f);
-        if (diff < min_diff) {
-            min_diff = diff;
-            raw_bits = idx;
-        }
-        // Special case for midpoint, we round to even (so even index)
-        if ((diff == min_diff) && !(idx & 1)) raw_bits = idx;
-    }
-    // reapply sign
-    if (sign) raw_bits = raw_bits | 0x08;
-    return raw_bits;
+    // shr t0:ud t0:ud 23
+    bits >>= 23;
+
+    // round
+    // (f0.0) add t0:ud t0:ud 1
+    if (round_up) bits += 1;
+
+    // copy sign
+    // shr y:ud x:ud 28
+    // bfn.0xCA y:ud y:ud t0:ud 0x07
+    uint dst = as_uint(a) >> 28;
+    return ((dst & ~0x07) | (bits & 0x07)) & 0xf;
 }
 
 float __attribute__((overloadable)) cvt_f4_e3m0_to_f32(uchar a) {


### PR DESCRIPTION
For very large float values, subtracting from values in fp4 range will alias to the same value. For f4_e3m0, for example:

```c
fabsf(0.25 - 2.41592e+09) = 0x4f100000
fabsf(0.5  - 2.41592e+09) = 0x4f100000
fabsf(1    - 2.41592e+09) = 0x4f100000
fabsf(2    - 2.41592e+09) = 0x4f100000
fabsf(4    - 2.41592e+09) = 0x4f100000
fabsf(8    - 2.41592e+09) = 0x4f100000
fabsf(16   - 2.41592e+09) = 0x4f100000
```

Because the differences are the same, the logic to choose the nearest fp4 value thinks the floating point value is halfway between 0.25 and 0.5, then between 0.5 and 1, ..., ultimately choosing 8 (!) because it is the "nearest even".

This change clamps values to within fp4 range to mitigate aliasing. It also maintains signs for inf/nan values, so -inf/-nan -> -16 in f4_e3m0.

+ @mgouicem @kealan-barbieri 