### PR TITLE
x64: matmul: amx blocking heuristics

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -813,6 +813,9 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
             && brg->LDB % brg->ld_block > 0)
         return status::unimplemented;
 
+    if (!IMPLICATION(brg->brgattr.LDB2 == 0, brg->load_dim <= brg->LDB))
+        return status::invalid_arguments;
+
     brg->LDA2 = (brg->brgattr.LDA2 != 0) ? brg->brgattr.LDA2 : brg->LDA;
     brg->LDB2 = (brg->brgattr.LDB2 != 0) ? brg->brgattr.LDB2 : brg->LDB;
     brg->LDC2_M = (brg->brgattr.LDC2_M != 0) ? brg->brgattr.LDC2_M : brg->LDC;

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -724,11 +724,12 @@ size_t jit_brgemm_amx_uker_base_t::B_offset(
 
     const auto rdb_B_offset = bi.rdi->pos(0) * brg.rd_block * LDB_size_;
 
-    const auto ldb_B_offset = bi.ldi->pos(0) * ld_block_B_size_ * brg.ld_step;
+    const auto ldb_offs = bi.ldi->pos(ldb) * brg.ld_block;
+    const auto ldb_B_offset = brg.typesize_B
+            * ((ldb_offs / brg.LDB) * brg.brgattr.LDB2
+                    + (ldb_offs % brg.LDB) * brg.rd_step);
 
-    return rdb_B_offset + ldb_B_offset
-            + (brg.is_blocked ? 1 : brg.rd_step) * ldb * ld_block_B_size_
-            + bs_offs;
+    return rdb_B_offset + ldb_B_offset + bs_offs;
 }
 
 size_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
@@ -736,7 +737,12 @@ size_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
-    return (size_t)bd_shift * LDC2_size_M_ + (size_t)ldb * LDC2_size_N_;
+    size_t ldc_elem = (size_t)ldb * bi.ldi->block(0);
+    size_t bloc_idx = ldc_elem / brg.LDC;
+    size_t in_block = ldc_elem % brg.LDC;
+
+    return (size_t)bd_shift * LDC2_size_M_ + (size_t)bloc_idx * LDC2_size_N_
+            + in_block * brg.typesize_C;
 }
 
 size_t jit_brgemm_amx_uker_base_t::D_offset(const brgemm_iteration_t &bi,
@@ -2655,10 +2661,8 @@ void jit_brgemm_amx_uker_base_t::generate() {
             = (brg.beta != 0.f && !may_load_accumulators_) || brg.alpha != 1.f;
     are_post_ops_applicable_ = brg.are_post_ops_applicable();
 
-    // second level blocking eligible only if we don't use store by vectors for now
-    assert(IMPLICATION(are_post_ops_applicable_ || need_to_apply_alpha_beta_
-                    || brg.brgattr.bd_mask_level,
-            !brg.is_blocked && !brg.brgattr.var_bs));
+    assert(IMPLICATION(brg.brgattr.LDB2 == 0, brg.load_dim <= brg.LDB));
+
     assert(IMPLICATION(brg.brgattr.var_bs,
             IMPLICATION(brg.is_input_convert(), brg.is_fp8_via_convert())));
     read_params();

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1124,9 +1124,14 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
             auto ptr_D = EVEX_compress_addr(reg_D, d_offset);
             uni_prefetch(ptr_D, pft, true);
         } else if (are_post_ops_applicable_) {
-            const auto c_offset = C_offset(bi, bdb, bd, ldb_pos);
-            auto ptr_C = EVEX_compress_addr(reg_C, c_offset);
-            uni_prefetch(ptr_C, pft, true);
+            //            TODO: split hints C and D hints
+            //              Using prefetchw for the C matrix is generally harmful
+            //              because the C matrix is frequently reused and remains in the cache.
+            //              However, it is very necessary for the D matrix
+
+            //            const auto c_offset = C_offset(bi, bdb, bd, ldb_pos);
+            //            auto ptr_C = EVEX_compress_addr(reg_C, c_offset);
+            //            uni_prefetch(ptr_C, pft, true);
         } else {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
             auto ptr_D = EVEX_compress_addr(reg_D, d_offset);

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1,0 +1,1085 @@
+/*******************************************************************************
+* Copyright 2021-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/x64/matmul/amx_blocking_heuristics.hpp"
+#include "cpu/matmul/gemm_based_common.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace matmul {
+
+using namespace dnnl::impl::cpu::matmul;
+
+using namespace dnnl::impl::memory_tracking::names;
+using namespace dnnl::impl::utils;
+
+using namespace data_type;
+using namespace format_tag;
+void matmul_amx_blocking_params_t::update_configuration(
+        brgemm_matmul_conf_t &bgmmc) const {
+    bgmmc.nthr_k = nthr_k_;
+    bgmmc.nthr_m = nthr_m_;
+    bgmmc.nthr_n = nthr_n_;
+    bgmmc.nthr_b = nthr_b_;
+    bgmmc.nthr = nthr_;
+    bgmmc.M_blk = m_blk_;
+    bgmmc.M_chunk_size = m_chunk_size_;
+    bgmmc.N_blk = n_blk_;
+    bgmmc.N_chunk_size = n_chunk_size_;
+
+    bgmmc.K_blk = k_blk_;
+    bgmmc.K_chunk_size = k_chunk_size_;
+    bgmmc.brgemm_batch_size = brgemm_batch_size_;
+
+    bgmmc.use_buffer_c = need_buf_c_;
+    bgmmc.use_buffer_a = need_buf_a_;
+    bgmmc.extendable_k = extendable_k_;
+    bgmmc.LDA = current_lda_;
+
+    bgmmc.is_a_nt = is_a_nt_;
+    bgmmc.is_b_nt = is_b_nt_;
+    bgmmc.set_nt = set_nt_;
+    bgmmc.is_macro_heuristics
+            = dynamic_cast<const matmul_amx_blocking_params_macro_t *>(this)
+            != nullptr;
+}
+
+dim_t matmul_amx_blocking_params_t::get_actual_lda() const {
+    if (!need_buf_a_)
+        return treat_A_as_plain ? K : A_strides[1 - transposed_A] / a_dt_sz;
+
+    constexpr int bytes_in_cacheline = 64;
+    const int elems_in_cacheline = bytes_in_cacheline / a_dt_sz;
+    dim_t lda = rnd_up(k_blk_, elems_in_cacheline);
+    const bool is_big_2_pow = lda >= 512 && math::is_pow2(lda);
+    if (is_big_2_pow) lda += elems_in_cacheline;
+    return lda;
+}
+
+bool matmul_amx_blocking_params_t::is_buffer_c_required() const {
+    if (nthr_k_ > 1 && K > k_chunk_elems_) return true;
+
+    return ((acc_dt != dst_dt || with_sum)
+            && (K > k_chunk_elems_ || K % k_blk_ > 0));
+}
+
+size_t matmul_amx_blocking_params_t::L2_threshold() {
+    return 3 * platform::get_per_core_cache_size(2) / 4;
+}
+
+size_t matmul_amx_blocking_params_t::L1_threshold() {
+    return 5 * platform::get_per_core_cache_size(1) / 6;
+}
+
+bool matmul_amx_blocking_params_macro_t::is_supported(
+        const brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils) {
+    // TODO: enable extendable_k optimization
+    if (bgmmc.K < bgmmc.wei_k_blk
+            || bgmmc.K % data_type_vnni_granularity(bgmmc.wei_dt) != 0) {
+        return false;
+    }
+
+    bool a_dt_ok
+            = one_of(bgmmc.orig_src_dt, dnnl_s8, dnnl_u8, dnnl_bf16, dnnl_f16);
+    bool b_dt_ok
+            = one_of(bgmmc.orig_wei_dt, dnnl_s8, dnnl_u8, dnnl_bf16, dnnl_f16);
+
+    bool a_tag_ok = bgmmc.src_tag == dnnl_format_tag_any
+            || bm_conf_utils.check_is_plain(bgmmc.src_tag);
+    bool b_tag_ok = bm_conf_utils.is_any_B_layout()
+            || bm_conf_utils.check_b_layout_blocked_32_by_n(bgmmc.wei_tag);
+
+    bool has_zp = bgmmc.src_zp_type != brgemm_broadcast_t::none
+            || bgmmc.wei_zp_type != brgemm_broadcast_t::none
+            || bgmmc.dst_zp_type != brgemm_broadcast_t::none;
+
+    return bgmmc.orig_src_dt == bgmmc.src_dt
+            && bgmmc.orig_wei_dt == bgmmc.wei_dt && bgmmc.is_amx
+            && !bgmmc.is_runtime_N && !bgmmc.is_runtime_M && a_dt_ok && a_tag_ok
+            && (bgmmc.reduce_kind == matmul_reduce_kind::undef) && b_tag_ok
+            && b_dt_ok && !has_zp;
+}
+
+bool matmul_amx_blocking_params_macro_t::divs_are_acceptable() const {
+    bool unacceptable_m_div = m_per_thread < min_m_dim && nthr_m_ > 1;
+    bool unacceptable_k_div = k_per_thread < min_k_dim && nthr_k_ > 1;
+    bool unacceptable_n_div;
+    if (nthr_k_ == 1 && k_per_thread < k_threshold_write_bound_layer) {
+        // The layer is write-bound (small K) and no reduction (C becomes non-consecutive)
+        unacceptable_n_div
+                = n_per_thread < min_n_dim_write_bound_layer && nthr_n_ > 1;
+    } else {
+        unacceptable_n_div = n_per_thread < min_n_dim && nthr_n_ > 1;
+    }
+
+    bool unacceptable_b_div = nthr_b_ > (size_t)batch;
+
+    return !unacceptable_m_div && !unacceptable_k_div && !unacceptable_n_div
+            && !unacceptable_b_div;
+}
+
+size_t determine_tmul_size(size_t num_elements, int full_tile_size) {
+    size_t tmul_tiles = div_up(num_elements, full_tile_size);
+    size_t tmul_size = div_up(num_elements, tmul_tiles);
+    return tmul_size;
+}
+
+bool matmul_amx_blocking_params_macro_t::find_best_blocking(
+        const brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils,
+        matmul_amx_blocking_params_macro_t &best_blocking) {
+
+    if (!matmul_amx_blocking_params_macro_t::is_supported(
+                bgmmc, bm_conf_utils)) {
+        return false;
+    }
+
+    best_blocking = matmul_amx_blocking_params_micro_t(bgmmc);
+
+    matmul_amx_blocking_params_macro_t current_blocking(bgmmc);
+    assert(bgmmc.tr_a_dt_sz == bgmmc.tr_b_dt_sz);
+    current_blocking.gemm_dt_sz = bgmmc.tr_a_dt_sz;
+
+    for (size_t nthr_to_check = bgmmc.nthr; nthr_to_check > 0;
+            nthr_to_check--) {
+        current_blocking.nthr_ = nthr_to_check;
+
+        for (int b_div = 1; b_div <= current_blocking.nthr_; ++b_div) {
+            if (current_blocking.nthr_ % b_div != 0) continue;
+            for (int m_div = 1; m_div <= current_blocking.nthr_ / b_div;
+                    ++m_div) {
+                if ((current_blocking.nthr_ / b_div) % m_div != 0) continue;
+                for (int k_div = 1;
+                        k_div <= (current_blocking.nthr_ / b_div) / m_div;
+                        ++k_div) {
+                    if (((current_blocking.nthr_ / b_div) / m_div) % k_div != 0)
+                        continue;
+                    int n_div = ((current_blocking.nthr_ / b_div) / m_div)
+                            / k_div;
+                    current_blocking.set_core_divs(b_div, m_div, k_div, n_div);
+                    if (current_blocking.divs_are_acceptable()
+                            && current_blocking.set_blocking_parameters()) {
+                        if (current_blocking > best_blocking) {
+                            best_blocking = current_blocking;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
+
+    size_t a_size = m_per_thread * k_per_thread * gemm_dt_sz;
+    size_t b_size = n_per_thread * k_per_thread * gemm_dt_sz;
+    size_t d_size = m_per_thread * n_per_thread * c_dt_sz;
+
+    bw_map_t bw_interpulator;
+
+    int macs_per_cycle_base = 1024;
+    int max_k_tmul = 64;
+    int max_n_tmul = 16;
+    // Reducing k-tmul or n-tmul does not shorten the cycles.
+    // However, reducing mtmul reduces the number of cycles required to execute a single tmul instruction.
+    int num_cycles_per_tmul
+            = m_tmul * max_k_tmul * max_n_tmul / macs_per_cycle_base;
+
+    // Calculate reduction cycles
+    float strip_1_size_shared, strip_1_size_private, strip_1_share_coef;
+    float strip_mid_size_shared, strip_mid_size_private;
+    float num_tmuls_per_strip, strip_mid_share_coef, num_strip, nt_mat_l1_miss;
+    float l1_reuse;
+
+    if (is_horizontal) {
+        // Amount of C/D bytes that are written per core
+        size_t strip_dst_size = m_decomposition * n_per_thread
+                * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
+        // Amount of compute
+        num_tmuls_per_strip = m_decomposition * k_per_thread * n_per_thread
+                / (m_tmul * k_tmul * n_tmul);
+        // Amount of strips in the execution
+        num_strip = div_up(m_per_thread, m_decomposition);
+        // B is blocked to the L2 in horizontal traversal, its loads are NT
+        nt_mat_l1_miss = b_size;
+        // Number of times A is reused from L1 in a strip
+        l1_reuse = div_up(n_blk_, n_decomposition);
+
+        // In horizontal multiple cores load the same B to L2
+        strip_1_size_shared = b_size;
+        // In strip 1 there is no sharing of A since there are no prefetches
+        size_t strip_1_size_private_a
+                = m_decomposition * k_per_thread * gemm_dt_sz;
+        strip_1_size_private = strip_1_size_private_a + strip_dst_size;
+        // The cores that share B
+        strip_1_share_coef = nthr_m_;
+
+        // In the mid strips B is reused from L2 and
+        // A is prefetched by multiple cores.
+        strip_mid_size_shared = m_decomposition * k_per_thread
+                * gemm_dt_sz; // A size per strip
+        // C is private to a core, since each core writes to a distinct buffer
+        strip_mid_size_private = strip_dst_size;
+        // share_coeff - the cores that share A
+        strip_mid_share_coef = std::max((size_t)1, nthr_n_);
+
+    } else {
+        // Amount of C/D bytes that are written per core
+        size_t strip_dst_size = n_decomposition * m_per_thread
+                * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
+        // Amount of compute
+        num_tmuls_per_strip = n_decomposition * k_per_thread * m_per_thread
+                / (m_tmul * k_tmul * n_tmul);
+        // Amount of strips in the execution
+        num_strip = div_up(n_per_thread, n_decomposition);
+        // A is blocked to the L2 in vertical traversal, its loads are NT
+        nt_mat_l1_miss = a_size;
+        // Number of times B is reused from L1 in a strip
+        l1_reuse = div_up(m_blk_, m_decomposition);
+
+        // In vertical multiple cores load the same A to L2
+        strip_1_size_shared = a_size;
+        // In strip 1 there is no sharing of B since there are no prefetches
+        size_t strip_1_size_private_b
+                = n_decomposition * k_per_thread * gemm_dt_sz;
+        strip_1_size_private = strip_1_size_private_b + strip_dst_size;
+        // The cores that share A
+        strip_1_share_coef = nthr_n_;
+
+        // In the mid strips A is reused from L2 and
+        // B is prefetched by multiple cores.
+        strip_mid_size_shared = n_decomposition * k_per_thread
+                * gemm_dt_sz; // B size per strip
+        // C is private to a core, since each core writes to a distinct buffer
+        strip_mid_size_private = strip_dst_size;
+        // share_coeff - the cores that share B
+        strip_mid_share_coef = std::max((size_t)1, nthr_m_);
+    }
+    // There are 2 L1 misses for the L1 matrix:
+    //   1. For the prefetch to the L2 (==L1 miss)
+    //   2. For the read from L2
+    float temporal_matrix_l1_miss = strip_mid_size_shared * 2;
+    float temporal_matrix_l1_hit = strip_mid_size_shared * (l1_reuse - 1);
+
+    float c_elem_per_strip = m_blk_ * n_blk_;
+
+    // C post write miss in bytes = m_blk_ * (#n_decompositions in BRGEMM) * (#cache lines per n_decomposition) * 64
+    float c_post_write_miss = m_blk_ * div_up(n_blk_, n_decomposition)
+            * rnd_up(n_decomposition * c_dt_sz, 64);
+    // C post write total in bytes = m_blk_ * (#n_decompositions in BRGEMM) * (#writes per n_decomposition) * 64
+    float c_post_write_total = m_blk_ * div_up(n_blk_, n_decomposition)
+            * div_up(n_decomposition, 16) * 64;
+    float c_post_write_hit = c_post_write_total - c_post_write_miss;
+
+    float c_post_read_c_tmp = c_elem_per_strip * acc_dt_sz;
+
+    float c_tmp_l1_cycles;
+    if (k_blk_ == K) {
+        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+                / bw_interpulator.l1_load_hit_bw;
+    } else {
+        // TODO: modify wrt wsp
+        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+                / bw_interpulator.l1_store_miss_bw;
+    }
+
+    float c_l1_cycles = c_post_write_miss / bw_interpulator.l1_store_miss_bw
+            + c_post_write_hit / bw_interpulator.l1_store_hit_bw
+            + c_post_read_c_tmp / bw_interpulator.l1_store_hit_bw
+            + c_tmp_l1_cycles;
+    float l1_cycles = temporal_matrix_l1_miss / bw_interpulator.l1_load_miss_bw
+            + temporal_matrix_l1_hit / bw_interpulator.l1_load_hit_bw
+            + nt_mat_l1_miss / bw_interpulator.l1_load_miss_bw + c_l1_cycles;
+
+    float strip_1_cycles
+            = strip_1_size_shared / bw_interpulator.get_bw(strip_1_share_coef)
+            + strip_1_size_private / bw_interpulator.get_bw(1);
+
+    float strip_mid_dram = strip_mid_size_shared
+                    / bw_interpulator.get_bw(strip_mid_share_coef)
+            + strip_mid_size_private / bw_interpulator.get_bw(1);
+    float strip_mid_llc = (strip_mid_size_private + strip_mid_size_shared)
+            / bw_interpulator.llc_bw;
+    float strip_tmul = num_tmuls_per_strip * num_cycles_per_tmul;
+    float strip_mid_cycles
+            = std::max({strip_mid_dram, strip_mid_llc, l1_cycles, strip_tmul});
+
+    float gemm_cycles = strip_1_cycles + (num_strip - 1) * strip_mid_cycles;
+
+    // Calculate reduction cycles
+    float reduction_cycles;
+    size_t c_size_per_core = m_per_thread * n_per_thread * acc_dt_sz;
+
+    if (nthr_k_ != 1) {
+        if (c_size_per_core * 2 < L2_threshold() && batch == 1) {
+            float reduction_read_bytes = (M * N * acc_dt_sz) * ((nthr_k_ - 1))
+                    / (nthr_m_ * nthr_n_);
+            float reduction_read_cycles;
+            if (a_size + b_size + d_size < L2_threshold()) {
+                reduction_read_cycles
+                        = reduction_read_bytes / bw_interpulator.get_bw(2);
+            } else {
+                reduction_read_cycles
+                        = reduction_read_bytes / bw_interpulator.llc_bw;
+            }
+
+            float reduction_write_bytes
+                    = (M * N * c_dt_sz) / (nthr_m_ * nthr_n_);
+            float reduction_write_cycles
+                    = reduction_write_bytes / bw_interpulator.get_bw(1);
+            // Add reduction const overhead - measured
+            reduction_cycles
+                    = reduction_read_cycles + reduction_write_cycles + 25000;
+        } else {
+            // Don't do reduction if c tmp doesn't fit
+            // Also parallel reduction is not supported for large batch
+            return 0;
+        }
+    } else {
+        reduction_cycles = 0;
+    }
+
+    float total_macs = M * K * N * batch;
+    float total_cycles = (gemm_cycles + reduction_cycles) * b_per_thread;
+    float peak_macs_per_cycle = (macs_per_cycle_base / gemm_dt_sz) * nthr;
+    float peak_cycles = total_macs / peak_macs_per_cycle;
+    return peak_cycles / total_cycles;
+}
+
+bool matmul_amx_blocking_params_macro_t::operator==(
+        const matmul_amx_blocking_params_macro_t &other) const {
+    bool same_score = other.efficiency_score_ == this->efficiency_score_;
+    bool same_direction = this->is_horizontal == other.is_horizontal;
+    bool same_l2_reuse = this->m_chunk_size_ * this->n_chunk_size_
+            == other.m_chunk_size_ * other.n_chunk_size_;
+    return same_score && same_direction && same_l2_reuse;
+}
+
+bool matmul_amx_blocking_params_macro_t::operator>(
+        const matmul_amx_blocking_params_macro_t &other) const {
+    if (other.efficiency_score_ > this->efficiency_score_) { return false; }
+    if (other.efficiency_score_ < this->efficiency_score_) { return true; }
+    // Both efficiency scores are equal
+    if (!this->is_horizontal && other.is_horizontal) {
+        if (this->m_per_thread * K + (size_t)(this->m_per_thread * N)
+                < L2_threshold()) {
+            // Vertical is an option. No l2 set issues for A
+            if (other.is_a_nt_) {
+                // Horizontal doesn't use the L1
+                return true;
+            }
+        }
+        return false;
+    } else if (this->is_horizontal && !other.is_horizontal) {
+        if (other.m_per_thread * K + (size_t)(other.m_per_thread * N)
+                < L2_threshold()) {
+            // Vertical is an option. No L2 set issues for A
+            if (this->is_a_nt_) {
+                // Horizontal doesn't use the L1
+                return false;
+            }
+        }
+        return true;
+    } else {
+        // Both are vertical or both are horizontal
+        // Pick by L2 reuse - the one with the largest m/n_chunk
+        // One of m_chunk_size_ and n_chunk_size is always 1
+        return this->m_chunk_size_ * this->n_chunk_size_
+                > other.m_chunk_size_ * other.n_chunk_size_;
+    }
+}
+
+bool matmul_amx_blocking_params_macro_t::operator!=(
+        const matmul_amx_blocking_params_macro_t &other) const {
+    return !(*this == other);
+}
+
+bool matmul_amx_blocking_params_macro_t::operator<(
+        const matmul_amx_blocking_params_macro_t &other) const {
+    return *this != other && !(*this > other);
+}
+
+dim_t matmul_amx_blocking_params_macro_t::calc_k_blk(size_t l1_dim) const {
+    // Assuming 2x2 decomposition
+    const size_t c_tiles = m_decomposition * n_decomposition * acc_dt_sz;
+    const size_t d_tiles = m_decomposition
+            * rnd_up(n_decomposition * c_dt_sz,
+                    64); // Rounded up to cache line size
+    const size_t available_space_in_l1
+            = L1_threshold() - (c_tiles * 2 + d_tiles);
+
+    const dim_t largest_k = available_space_in_l1 / (l1_dim * gemm_dt_sz);
+    const dim_t largest_k_tiles = largest_k / this->k_tmul;
+    const dim_t k_tiles = div_up(K, this->k_tmul);
+    const dim_t k_per_thread_tiles = div_up(k_tiles, nthr_k_);
+    const dim_t num_K_blocks = div_up(k_per_thread_tiles, largest_k_tiles);
+    return nstl::min(
+            (dim_t)(div_up(k_per_thread_tiles, num_K_blocks) * this->k_tmul),
+            K);
+}
+
+std::set<dim_t> matmul_amx_blocking_params_macro_t::blk_candidates(
+        dim_t dim_per_thread, dim_t decomposition) const {
+    dim_t num_inner_blocks = div_up(dim_per_thread, decomposition);
+    std::set<dim_t> dim_set;
+    for (int num_groups = 1; num_groups <= num_inner_blocks; ++num_groups) {
+        dim_t group_size = div_up(num_inner_blocks, num_groups);
+        dim_set.insert(group_size);
+    }
+
+    return dim_set;
+}
+
+size_t matmul_amx_blocking_params_macro_t::l2_matrix_usage(size_t k_chunk_size,
+        size_t m_or_n_blk, size_t k_blk, bool is_horizontal) const {
+    int decomposition = is_horizontal ? m_decomposition : n_decomposition;
+    int l1_matrix_size = 2 * decomposition
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz; // 2 for prefetch
+    int l2_matrix_size = m_or_n_blk
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz;
+    int c_size = 2 * decomposition * m_or_n_blk
+            * acc_dt_sz; // Keep 2 C strips just to avoid evicting A
+    return l1_matrix_size + l2_matrix_size + c_size;
+}
+
+size_t matmul_amx_blocking_params_macro_t::l2_matrix_and_c_usage(
+        size_t k_chunk_size, size_t m_or_n_blk, size_t k_blk,
+        bool is_horizontal) const {
+    size_t per_thread_for_l1_matrix
+            = is_horizontal ? m_per_thread : n_per_thread;
+    int l1_matrix_size = 2 * per_thread_for_l1_matrix
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz; // 2x factor to make sure C is fresher than A,B in LRU
+    int l2_matrix_size = 2 * m_or_n_blk
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz; // 2x factor to make sure C is fresher than A,B in LRU
+    int c_size
+            = per_thread_for_l1_matrix * m_or_n_blk * acc_dt_sz; // Keep C in L2
+    return l1_matrix_size + l2_matrix_size + c_size;
+}
+
+int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
+        size_t k_blk, size_t n_blk, bool is_horizontal) const {
+    int a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz;
+    int b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz;
+    int c_bw;
+
+    if ((l2_matrix_and_c_usage(k_chunk_size, is_horizontal ? n_blk : m_blk,
+                 k_blk, is_horizontal)
+                        < L2_threshold()
+                || (dim_t)nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+                        == K)
+            && nthr_k_ == 1) {
+        c_bw = 0;
+    } else {
+        c_bw = m_blk * n_blk * acc_dt_sz;
+    }
+    return a_bw + b_bw + c_bw;
+}
+
+int matmul_amx_blocking_params_macro_t::compute(
+        size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk) const {
+    return m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * n_blk;
+}
+
+float matmul_amx_blocking_params_macro_t::ratio(size_t m_blk,
+        size_t k_chunk_size, size_t k_blk, size_t n_blk,
+        bool is_horizontal) const {
+    return static_cast<float>(compute(m_blk, k_chunk_size, k_blk, n_blk))
+            / bw(m_blk, k_chunk_size, k_blk, n_blk, is_horizontal);
+}
+
+float matmul_amx_blocking_params_macro_t::evaluate_single_core_blocking(
+        size_t k_chunk_size, size_t m_or_n_blk, size_t k_blk,
+        bool is_horizontal) const {
+    if (l2_matrix_usage(k_chunk_size, m_or_n_blk, k_blk, is_horizontal)
+            <= L2_threshold()) {
+        size_t m_blk, n_blk;
+        if (is_horizontal) {
+            m_blk = m_decomposition;
+            n_blk = m_or_n_blk;
+        } else {
+            m_blk = m_or_n_blk;
+            n_blk = n_decomposition;
+        }
+        float ratio_score
+                = ratio(m_blk, k_chunk_size, k_blk, n_blk, is_horizontal);
+        return ratio_score;
+    }
+    return 0;
+}
+
+void matmul_amx_blocking_params_macro_t::set_tmul_sizes() {
+    this->m_tmul = determine_tmul_size(this->m_per_thread, 16);
+    this->n_tmul = 16; // B blocked layout is a multiply of 16
+    this->k_tmul = nstl::min((size_t)wei_k_blk, (size_t)K);
+}
+
+void matmul_amx_blocking_params_macro_t::set_decomposition() {
+    m_decomposition = nstl::min((size_t)m_per_thread, 2 * m_tmul);
+    n_decomposition = nstl::min((size_t)n_per_thread, 2 * n_tmul);
+}
+
+bool matmul_amx_blocking_params_macro_t::is_horizontal_selected(
+        bool horizontal_not_possible, bool vertical_not_possible,
+        size_t best_m_v, size_t best_k_v, size_t k_blk_v) const {
+    // Choose between horizontal and vertical
+
+    bool is_horizontal_local;
+
+    if (horizontal_not_possible) {
+        is_horizontal_local = false;
+    } else if (vertical_not_possible) {
+        is_horizontal_local = true;
+    } else if ((size_t)m_per_thread < m_tmul * 2) {
+        // There are not enough tiles in M direction to go vertical
+        is_horizontal_local = true;
+    } else if ((size_t)n_per_thread < n_tmul * 2) {
+        // There are not enough tiles in N direction to go horizontal
+        is_horizontal_local = false;
+    } else if (m_per_thread >= n_per_thread) {
+        // Choose horizontal
+        is_horizontal_local = true;
+    } else {
+        // Choose vertical
+        is_horizontal_local = false;
+    }
+    return is_horizontal_local;
+}
+
+bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
+    set_tmul_sizes();
+    set_decomposition();
+
+    std::set<dim_t> m_candidates
+            = blk_candidates(m_per_thread, m_decomposition);
+    std::set<dim_t> n_candidates
+            = blk_candidates(n_per_thread, n_decomposition);
+    dim_t best_k_h, best_n_h;
+    dim_t best_m_v, best_k_v;
+    float best_score_h = 0, best_score_v = 0;
+    bool horizontal_not_possible = false;
+    bool vertical_not_possible = false;
+
+    auto calc_horizontal = [&](size_t k_blk_h, dim_t min_k_chunk_size = 0) {
+        if (rnd_up(m_per_thread, m_decomposition) * (nthr_m_ - 1) > (size_t)M) {
+            horizontal_not_possible = true;
+        } else if (rnd_up(k_per_thread, k_blk_h) * (nthr_k_ - 1) > (size_t)K) {
+            // Early exit: There is no possible division of work for nthr_k threads
+            horizontal_not_possible = true;
+        } else {
+            std::set<dim_t> k_candidates_h
+                    = blk_candidates(k_per_thread, k_blk_h);
+            best_n_h = 0;
+            for (std::set<dim_t>::reverse_iterator it_n = n_candidates.rbegin();
+                    it_n != n_candidates.rend(); it_n++) {
+                for (std::set<dim_t>::reverse_iterator it_k
+                        = k_candidates_h.rbegin();
+                        it_k != k_candidates_h.rend(); it_k++) {
+                    float cur_score = evaluate_single_core_blocking(
+                            *it_k, *it_n * n_decomposition, k_blk_h, true);
+                    if (cur_score > best_score_h && *it_k >= min_k_chunk_size) {
+                        best_score_h = cur_score;
+                        best_k_h = *it_k;
+                        best_n_h = *it_n;
+                    }
+                }
+            }
+
+            if (rnd_up(n_per_thread, best_n_h * n_decomposition) * (nthr_n_ - 1)
+                    > (size_t)N) {
+                horizontal_not_possible = true;
+            }
+            if (rnd_up(k_per_thread, best_k_h * k_blk_h) * (nthr_k_ - 1)
+                    > (size_t)K) {
+                // There is not enough work for nthr_k threads
+                horizontal_not_possible = true;
+            }
+        }
+    };
+    // Calculate best score for horizontal traversal
+    dim_t k_blk_h = calc_k_blk(m_decomposition);
+    calc_horizontal(k_blk_h);
+
+    auto calc_vertical = [&](size_t k_blk_v) {
+        if (rnd_up(n_per_thread, n_decomposition) * (nthr_n_ - 1) > (size_t)N) {
+            vertical_not_possible = true;
+        } else if (rnd_up(k_per_thread, k_blk_v) * (nthr_k_ - 1) > (size_t)K) {
+            // Early exit: There is no possible division of work for nthr_k threads
+            vertical_not_possible = true;
+        } else {
+            // Calculate best score for vertical traversal
+            std::set<dim_t> k_candidates_v
+                    = blk_candidates(k_per_thread, k_blk_v);
+            for (std::set<dim_t>::reverse_iterator it_m = m_candidates.rbegin();
+                    it_m != m_candidates.rend(); it_m++) {
+                for (std::set<dim_t>::reverse_iterator it_k
+                        = k_candidates_v.rbegin();
+                        it_k != k_candidates_v.rend(); it_k++) {
+                    float cur_score = evaluate_single_core_blocking(
+                            *it_k, *it_m * m_decomposition, k_blk_v, false);
+                    if (cur_score > best_score_v) {
+                        best_score_v = cur_score;
+                        best_k_v = *it_k;
+                        best_m_v = *it_m;
+                    }
+                }
+            }
+
+            if (rnd_up(m_per_thread, best_m_v * m_decomposition) * (nthr_m_ - 1)
+                    > (size_t)M) {
+                vertical_not_possible = true;
+            }
+            if (rnd_up(k_per_thread, best_k_v * k_blk_v) * (nthr_k_ - 1)
+                    > (size_t)K) {
+                // There is not enough work for nthr_k threads
+                vertical_not_possible = true;
+            }
+            size_t l2_util_v;
+
+            if (!vertical_not_possible) {
+                // Figure out if vertical is an option wrt L2 usage
+                l2_util_v = l2_matrix_and_c_usage(
+                        best_k_v, best_m_v, k_blk_v, false);
+                if (l2_util_v > L2_threshold()) {
+                    l2_util_v = l2_matrix_usage(
+                            best_k_v, best_m_v, k_blk_v, false);
+                }
+            }
+            bool repeat_loop_over_k = div_up(K, k_blk_v * best_k_v) != 1;
+            bool critical_l2_set_issues_a
+                    = div_up((size_t)K, k_blk_v * best_k_v) != nthr_k_
+                    || (size_t)((l2_util_v * nthr_k_)) >= L2_threshold();
+
+            if (repeat_loop_over_k && critical_l2_set_issues_a)
+                vertical_not_possible = true;
+        }
+    };
+
+    dim_t k_blk_v = calc_k_blk(n_decomposition);
+    calc_vertical(k_blk_v);
+
+    if (vertical_not_possible && horizontal_not_possible) { return false; }
+
+    is_horizontal = is_horizontal_selected(horizontal_not_possible,
+            vertical_not_possible, best_m_v, best_k_v, k_blk_v);
+
+    if (is_horizontal) {
+        size_t l1_eff_factor = div_up(K, k_blk_h);
+        // This works for M > 32 in this case k_blk_h << 4096 =~ 512
+        // For M <= the problem is heavily memory bound ==> don't care about the L1 and work completely from the L2
+
+        size_t a_l1 = k_blk_h * m_decomposition * gemm_dt_sz;
+        size_t c_l1 = n_decomposition * m_decomposition * acc_dt_sz;
+        size_t d_post = m_decomposition * rnd_up(n_decomposition * c_dt_sz, 64);
+        is_a_nt_ = false;
+        is_b_nt_ = true;
+
+        if (k_blk_h < K
+                && l1_eff_factor * a_l1 + 2 * c_l1 + d_post > L1_threshold()) {
+            best_score_h = 0;
+            // Calculate k_blk_h and n_blk_h that can fit in the L2 when k_blk is wei_k_blk
+            calc_horizontal(wei_k_blk, k_blk_h / wei_k_blk);
+            // Give up on the L1.
+            k_blk_h = nstl::min(wei_k_blk * best_k_h, K);
+            best_k_h = 1;
+            is_a_nt_ = true;
+            // TODO: revive after precopy implementation
+            //            need_buf_a_ = false;
+            need_prefetch = false;
+        } else {
+            // TODO: revive after precopy implementation
+            //            need_buf_a_ = false;
+            need_prefetch = true;
+        }
+
+        k_blk_ = k_blk_h;
+        k_chunk_size_ = best_k_h;
+        n_blk_ = nstl::min(best_n_h * n_decomposition, N);
+        n_chunk_size_ = 1;
+        m_blk_ = m_decomposition;
+        m_chunk_size_ = div_up(m_per_thread, m_blk_);
+    } else {
+        k_blk_ = k_blk_v;
+        k_chunk_size_ = best_k_v;
+        n_blk_ = n_decomposition;
+        n_chunk_size_ = div_up(n_per_thread, n_blk_);
+        m_blk_ = nstl::min(best_m_v * m_decomposition, M);
+        m_chunk_size_ = 1;
+        is_a_nt_ = true;
+        is_b_nt_ = false;
+        need_prefetch = true;
+    }
+
+    extendable_k_ = K % data_type_vnni_granularity(wei_dt) != 0;
+
+    brgemm_batch_size_ = 1;
+
+    n_chunk_elems_ = nstl::min(n_per_thread, n_blk_ * n_chunk_size_);
+    m_chunk_elems_ = nstl::min(m_per_thread, m_blk_ * m_chunk_size_);
+    k_chunk_elems_ = nstl::min(k_per_thread, k_blk_ * k_chunk_size_);
+
+    set_nt_ = true;
+
+    current_lda_ = get_actual_lda();
+
+    // Need a temp C buffer if a BRGEMM creates partial results
+    need_buf_c_ = (nthr_k_ != 1) || (k_blk_ != K);
+
+    efficiency_score_ = calculate_blocking_scores();
+
+    return true;
+}
+
+void matmul_amx_blocking_params_macro_t::set_core_divs(
+        int nthr_b, int nthr_m, int nthr_k, int nthr_n) {
+    nthr_b_ = nthr_b;
+    nthr_m_ = nthr_m;
+    nthr_k_ = nthr_k;
+    nthr_n_ = nthr_n;
+    m_per_thread = div_up(M, nthr_m_);
+    k_per_thread = div_up(K, nthr_k_);
+    n_per_thread = div_up(N, nthr_n_);
+    b_per_thread = div_up(this->batch, nthr_b_);
+
+    nthr_mnb_ = nthr_ / nthr_k_;
+}
+
+void matmul_amx_blocking_params_micro_t::find_best_blocking(
+        const brgemm_matmul_conf_t &bgmmc,
+        const brgemm_matmul_conf_utils_t &bm_conf_utils,
+        matmul_amx_blocking_params_t &best_blocking) {
+
+    matmul_amx_blocking_params_micro_t current_blocking(bgmmc);
+
+    const int min_k_per_thread = 1024;
+    const int max_k_parallel_work
+            = div_up(static_cast<int>(bgmmc.K), min_k_per_thread);
+    const bool is_amx_xf16 = bgmmc.is_amx
+            && (bm_conf_utils.is_bf16() || bm_conf_utils.is_f16()
+                    || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
+                    || bm_conf_utils.is_bf32()
+                    || bm_conf_utils.is_bf16_with_int_wei()
+                    || bm_conf_utils.is_f16_with_int_wei());
+    const bool is_amx_int8 = bgmmc.is_amx && bm_conf_utils.is_int8();
+
+    const bool runtime_dims
+            = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;
+    const int max_nthr_k = !runtime_dims && is_amx_xf16 && bgmmc.batch == 1
+            ? nstl::min(saturate(1, 7, bgmmc.nthr / 8), max_k_parallel_work)
+            : 1;
+    int iter = 0;
+    const int runtime_M_chunk = bgmmc.lda_big_pow2() ? 2 : 4;
+    const int runtime_N_chunk = 2;
+
+    // Disable skip configuration due to regressions for some cases.
+    const bool disable_skip_config = bgmmc.M == 4
+            && utils::one_of(true, bgmmc.N == 4096 && bgmmc.K == 4096,
+                    bgmmc.N == 11008 && bgmmc.K == 4096,
+                    bgmmc.N == 4096 && bgmmc.K == 11008);
+
+    for (int nthr_k = 1; nthr_k <= max_nthr_k; nthr_k++) {
+        int nthr_bmn = bgmmc.nthr / nthr_k;
+
+        int num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
+        int num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
+        int k_parallel_work = nstl::min(max_k_parallel_work, nthr_k);
+        int num_parallel_work
+                = bgmmc.batch * num_M_blk * num_N_blk * k_parallel_work;
+        const bool a_lot_of_parallel_work_lvl2
+                = num_parallel_work > 16 * bgmmc.nthr;
+        const bool low_parallelism
+                = static_cast<float>(num_parallel_work) < 1.5f * bgmmc.nthr;
+        const bool maybe_low_blocking
+                = is_amx_int8 && bm_conf_utils.maybe_low_brg_blocking();
+        const int min_M_blk = !bgmmc.is_runtime_M
+                        && (maybe_low_blocking || low_parallelism)
+                        && bgmmc.M_blk > 32
+                ? div_up(bgmmc.M_blk, 2)
+                : bgmmc.M_blk;
+        const int min_N_blk = !bgmmc.is_runtime_N && low_parallelism
+                        && is_amx_xf16 && !bm_conf_utils.check_n_blk_fixed()
+                        && bgmmc.N_blk > 32 && !runtime_dims
+                ? 32
+                : bgmmc.N_blk;
+        const int desired_M_chunk = bgmmc.is_runtime_M
+                ? runtime_M_chunk
+                : nstl::min(4, num_M_blk);
+        const int desired_N_chunk = bgmmc.is_runtime_N
+                ? runtime_N_chunk
+                : nstl::min(a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
+
+        std::unordered_set<int> mblk_candidates;
+        for (int m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
+                m_blk = m_blk > 1 ? div_up(m_blk, 2) : m_blk - 1) {
+            if (IMPLICATION(maybe_low_blocking, m_blk != bgmmc.M_blk))
+                mblk_candidates.insert(m_blk);
+        }
+
+        if (!bgmmc.is_runtime_M && bgmmc.M > 16) {
+            // Add multiple of 16 M block sizes for consideration
+            const int mul16_m_blk_max
+                    = nstl::min(rnd_dn(static_cast<int>(bgmmc.M), 16), 64);
+            const int mul16_m_blk_min = rnd_up(min_M_blk, 16);
+            for (int m_blk = mul16_m_blk_max; m_blk >= mul16_m_blk_min;
+                    m_blk -= 16) {
+                mblk_candidates.insert(m_blk);
+            }
+        }
+
+        bool found_best_blocking = false;
+        for_(int n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
+        for_(int m_blk : mblk_candidates)
+        for_(int n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
+        for (int m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
+            current_blocking.set_blocking_parameters(
+                    nthr_k, n_blk, n_ch_sz, m_blk, m_ch_sz);
+
+            float cur_score = current_blocking.get_blocking_scores();
+            float bst_score = best_blocking.get_blocking_scores();
+
+            int m_chunks = div_up(bgmmc.M, m_blk * m_ch_sz);
+            int n_chunks = div_up(bgmmc.N, n_blk * n_ch_sz);
+            int work_amount = bgmmc.batch * m_chunks * n_chunks;
+
+            bool skip_config = work_amount < nthr_bmn * 3
+                    && work_amount % nthr_bmn != 0 && max_nthr_k == 1;
+            if (skip_config && !disable_skip_config) continue;
+
+            if (cur_score > bst_score) {
+                best_blocking = current_blocking;
+                found_best_blocking = true;
+            }
+        }
+
+        if (!found_best_blocking) {
+            current_blocking.set_blocking_parameters(
+                    nthr_k, min_N_blk, 1, min_M_blk, 1);
+
+            float cur_score = current_blocking.get_blocking_scores();
+            float bst_score = best_blocking.get_blocking_scores();
+            if (cur_score > bst_score) best_blocking = current_blocking;
+        }
+    }
+}
+
+void matmul_amx_blocking_params_micro_t::update_k_blocking_dependent_params() {
+    k_chunk_elems_ = k_blk_ * k_chunk_size_ * brgemm_batch_size_;
+    current_lda_ = get_actual_lda();
+    need_buf_c_ = is_buffer_c_required();
+}
+
+void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
+        int nthr_k, int n_blk, int n_chunk_size, int m_blk, int m_chunk_size) {
+    nthr_k_ = nstl::max(1, nthr_k);
+    nthr_mnb_ = nthr / nthr_k_;
+    nthr_ = nthr_mnb_ * nthr_k_;
+    n_blk_ = n_blk;
+    n_chunk_size_ = n_chunk_size;
+    m_blk_ = m_blk;
+    m_chunk_size_ = m_chunk_size;
+
+    if (one_of(0, n_blk_, n_chunk_size_, m_blk_, m_chunk_size_)) {
+        k_blk_ = k_chunk_size_ = k_chunk_elems_ = brgemm_batch_size_ = 0;
+        efficiency_score_ = 0.0f;
+        return;
+    }
+
+    n_chunk_elems_ = n_blk_ * n_chunk_size_;
+    m_chunk_elems_ = m_blk_ * m_chunk_size_;
+
+    if (K < wei_k_blk) {
+        k_blk_ = is_amx ? rnd_up(K, required_k_granularity) : K;
+        brgemm_batch_size_ = 1;
+    } else {
+        dim_t k_per_thr = div_up(K, nthr_k_);
+        k_blk_ = nstl::min(rnd_up(k_per_thr, required_k_granularity),
+                static_cast<dim_t>(wei_k_blk));
+        const dim_t num_k_blk = div_up(K, k_blk_);
+        const dim_t num_k_blk_per_thread = div_up(num_k_blk, nthr_k_);
+        brgemm_batch_size_ = num_k_blk_per_thread;
+
+        auto chunk_sz = calculate_chunk_memory_size();
+        const dim_t div_min = chunk_sz / L2_threshold();
+        const dim_t div_max = div_up(chunk_sz, L2_threshold());
+        // For big pow2 lda prefer to increase area of linear memory access
+        const dim_t adjust_k_divisor_threshold = lda_big_pow2() ? 2 : 0;
+        // Adjust K blocking values to fit into L2 cache
+        if (div_min > adjust_k_divisor_threshold && brgemm_batch_size_ > 1) {
+            const auto kc1 = nstl::max(
+                    brgemm_batch_size_ / div_min, static_cast<dim_t>(1));
+            const auto kc2 = div_up(brgemm_batch_size_, div_max);
+            const auto tail1 = num_k_blk_per_thread % kc1;
+            const auto tail2 = num_k_blk_per_thread % kc2;
+            // Prefer adjusted chunk size with more equal work distribution
+            // Across iterations
+            brgemm_batch_size_
+                    = IMPLICATION(tail1 == 0 || tail2 < tail1, tail2 == 0)
+                    ? kc2
+                    : kc1;
+        }
+
+        k_chunk_elems_ = k_blk_ * brgemm_batch_size_ * k_chunk_size_;
+        dim_t brgemm_k_elems = k_blk_ * brgemm_batch_size_;
+        const dim_t current_k_tail = K % k_blk_;
+
+        // TODO: review extendable_k_ condition to cover more cases
+        extendable_k_ = (K % wei_k_blk != 0) && (brgemm_k_elems > wei_k_blk)
+                && wei_zp_type == none && !use_buffer_a
+                && !packed_sparse_weights;
+
+        if (extendable_k_) {
+            if (brgemm_k_elems >= K) {
+                k_blk_ = K;
+                k_chunk_size_ = 1;
+            } else {
+                k_blk_ = brgemm_k_elems;
+                k_chunk_size_ = 1;
+            }
+        } else if (current_k_tail == 0
+                && K % (k_blk_ * brgemm_batch_size_) == 0) {
+            k_blk_ = brgemm_k_elems;
+            brgemm_batch_size_ = 1;
+        } else if (nthr_k_ == 1
+                && K == k_blk_ * brgemm_batch_size_ + current_k_tail) {
+            k_blk_ = brgemm_k_elems;
+            brgemm_batch_size_ = 2;
+        }
+    }
+    need_buf_a_
+            = use_buffer_a || (!extendable_k_ && K % required_k_granularity);
+
+    blocking_chunk_mem_size_ = calculate_chunk_memory_size();
+
+    efficiency_score_ = calculate_blocking_scores();
+}
+
+// Returns score for current blocking parameters' values in range [0, 1]
+// for parallel work over threads distribution score. Maximum scores - when
+// all threads have the same work amount w/o tails
+float matmul_amx_blocking_params_micro_t::get_thread_balance_scores() const {
+    assert(!(is_runtime_M && is_runtime_N)
+            && "single runtime dim is supported");
+    // Ignore M sizes in thread balance computation as actual M size is unknown
+    if (is_runtime_M) return (float)N / rnd_up(N, n_chunk_elems_);
+    // Ignore N sizes in thread balance computation as actual N size is unknown
+    if (is_runtime_N) return (float)M / rnd_up(M, m_chunk_elems_);
+
+    const dim_t num_M_chunks = div_up(M, m_chunk_elems_);
+    const dim_t num_N_chunks = div_up(N, n_chunk_elems_);
+    float mnb_parallel_score = batch * ((float)M / m_chunk_elems_)
+            * ((float)N / n_chunk_elems_)
+            / rnd_up(batch * num_M_chunks * num_N_chunks, nthr_mnb_)
+            * nthr_mnb_;
+    float k_parallel_score = 1.0f;
+    if (nthr_k_ > 1) {
+        const dim_t num_K_chunks = div_up(K, k_chunk_elems_);
+        const float parallel_reduction_penalty = 0.8f;
+        k_parallel_score = parallel_reduction_penalty
+                * ((float)K / k_chunk_elems_) / rnd_up(num_K_chunks, nthr_k_)
+                * nthr_k_;
+    }
+
+    return mnb_parallel_score * k_parallel_score / nthr;
+}
+
+// Returns score for current blocking parameters' values in range [0, 1]
+// for copied data reusage
+float matmul_amx_blocking_params_micro_t::get_copied_data_reusage_scores()
+        const {
+    const dim_t effective_m_chunk_sz = 64 * 4;
+    const dim_t desired_M_chunk_size = is_runtime_M
+            ? effective_m_chunk_sz
+            : nstl::min(M, effective_m_chunk_sz);
+    const dim_t effective_n_chunk_sz = 64 * (need_buf_a_ ? 4 : 1);
+    const dim_t desired_N_chunk_size = is_runtime_N
+            ? effective_n_chunk_sz
+            : nstl::min(N, effective_n_chunk_sz);
+    const float coef_M = nstl::min(
+            static_cast<float>(m_chunk_elems_) / desired_M_chunk_size, 1.0f);
+    const float coef_N = nstl::min(
+            static_cast<float>(n_chunk_elems_) / desired_N_chunk_size, 1.0f);
+    return 0.5f * (coef_M + coef_N);
+}
+
+// Returns score for current blocking parameters' values in range [0, 1]
+// for L2 utilization
+float matmul_amx_blocking_params_micro_t::get_L2_utilization_scores() const {
+    const float relative_difference_with_L2
+            = fabsf((float)L2_threshold() - blocking_chunk_mem_size_)
+            / nstl::max(L2_threshold(), blocking_chunk_mem_size_);
+    return 1.0f - relative_difference_with_L2;
+}
+
+// Returns score for current blocking parameters' values in range [0, 1]
+// consists of 3 parts with its own weights:
+// 	1) parallel work over threads distribution score
+// 	2) L2 utilization score
+// 	3) copied data re-usage score
+float matmul_amx_blocking_params_micro_t::calculate_blocking_scores() const {
+    if (one_of(0, n_blk_, n_chunk_size_, m_blk_, m_chunk_size_, k_blk_,
+                brgemm_batch_size_))
+        return 0.0f;
+
+    const float nthr_coeff = nstl::min(nthr, 100);
+    const float reusage_factor = 1.0f;
+    // For runtume M the actual size is unknown, use independent on num_threads
+    // balance factors
+    const float balance_factor
+            = is_runtime_M ? 1.0f : (nthr_coeff - 1.0f) / nthr_coeff;
+    const float cache_utilization_factor
+            = is_runtime_M ? 1.0f : 1.0f / nthr_coeff;
+
+    float scores = cache_utilization_factor * get_L2_utilization_scores()
+            + reusage_factor * get_copied_data_reusage_scores();
+    if (balance_factor > 0.0f)
+        scores += balance_factor * get_thread_balance_scores();
+    return scores
+            / (reusage_factor + balance_factor + cache_utilization_factor);
+}
+
+size_t matmul_amx_blocking_params_micro_t::calculate_chunk_memory_size() {
+    update_k_blocking_dependent_params();
+
+    const size_t A_chunk_sz = a_dt_sz * k_chunk_elems_ * m_chunk_elems_;
+    const size_t A_buf_sz = need_buf_a_
+            ? tr_a_dt_sz * current_lda_ * brgemm_batch_size_ * m_chunk_elems_
+            : 0;
+    const size_t B_chunk_sz = b_dt_sz * k_chunk_elems_ * n_chunk_elems_;
+    const size_t B_buf_sz
+            = use_buffer_b ? tr_b_dt_sz * n_blk_ * k_chunk_elems_ : 0;
+    const size_t C_chunk_sz = c_dt_sz * m_chunk_elems_ * n_chunk_elems_;
+    const size_t C_buf_sz
+            = need_buf_c_ ? acc_dt_sz * m_chunk_elems_ * n_chunk_elems_ : 0;
+    return A_chunk_sz + A_buf_sz + B_chunk_sz + B_buf_sz + C_chunk_sz
+            + C_buf_sz;
+}
+
+} // namespace matmul
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -1,0 +1,227 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_MATMUL_AMX_BLOCKING_HEURISTICS_HPP
+#define CPU_X64_MATMUL_AMX_BLOCKING_HEURISTICS_HPP
+
+#include "common/math_utils.hpp"
+#include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace matmul {
+
+class matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
+public:
+    matmul_amx_blocking_params_t(const brgemm_matmul_conf_t &bgmmc)
+        : brgemm_matmul_conf_t(bgmmc)
+        , nthr_m_(nstl::max(nthr_m, 1))
+        , nthr_n_(nstl::max(nthr_n, 1))
+        , nthr_k_(nstl::max(nthr_k, 1))
+        , nthr_b_(nstl::max(nthr_b, 1))
+        , nthr_mnb_(nthr / nthr_k_)
+        , nthr_(nthr_mnb_ * nthr_k_)
+        , n_blk_(N_blk)
+        , n_chunk_size_(N_chunk_size)
+        , n_chunk_elems_(n_blk_ * n_chunk_size_)
+        , m_blk_(M_blk)
+        , m_chunk_size_(M_chunk_size)
+        , m_chunk_elems_(m_blk_ * m_chunk_size_)
+        , k_blk_(K_blk)
+        , k_chunk_size_(K_chunk_size)
+        , k_chunk_elems_(k_blk_ * k_chunk_size_ * brgemm_batch_size)
+        , is_a_nt_(is_a_nt)
+        , is_b_nt_(is_b_nt)
+        , set_nt_(set_nt)
+        , brgemm_batch_size_(brgemm_batch_size)
+        , current_lda_(LDA)
+        , need_buf_c_(use_buffer_c)
+        , need_buf_a_(use_buffer_a)
+        , extendable_k_(extendable_k)
+        , blocking_chunk_mem_size_(0)
+        , efficiency_score_(0.0f) {}
+
+    void update_configuration(brgemm_matmul_conf_t &bgmmc) const;
+    float get_blocking_scores() const { return efficiency_score_; }
+
+    static size_t L1_threshold();
+    static size_t L2_threshold();
+
+protected:
+    virtual float calculate_blocking_scores() const = 0;
+    virtual dim_t get_actual_lda() const;
+
+    // Num threads for parallelism wrt K dimension
+    size_t nthr_m_ {0}, nthr_n_ {0}, nthr_k_ {0}, nthr_b_ {0};
+    // Num threads for parallelism wrt M, N and batch dimensions
+    int nthr_mnb_ {0};
+    int nthr_ {0};
+    dim_t n_blk_ {0}, n_chunk_size_ {0}, n_chunk_elems_ {0};
+    dim_t m_blk_ {0}, m_chunk_size_ {0}, m_chunk_elems_ {0};
+    dim_t k_blk_ {0}, k_chunk_size_ {0}, k_chunk_elems_ {0};
+
+    bool is_a_nt_ {true}, is_b_nt_ {true};
+    bool set_nt_ {false};
+
+    dim_t brgemm_batch_size_ {0};
+    dim_t current_lda_ {0};
+    bool need_buf_c_ {false}, need_buf_a_ {false};
+    bool extendable_k_ {false};
+    size_t blocking_chunk_mem_size_ {0};
+    float efficiency_score_ {0.0};
+
+    bool is_buffer_c_required() const;
+};
+
+class matmul_amx_blocking_params_macro_t : public matmul_amx_blocking_params_t {
+public:
+    matmul_amx_blocking_params_macro_t(const brgemm_matmul_conf_t &bgmmc)
+        : matmul_amx_blocking_params_t(bgmmc) {}
+    static bool is_supported(const brgemm_matmul_conf_t &bgmmc,
+            const brgemm_matmul_conf_utils_t &bm_conf_utils);
+    static bool find_best_blocking(const brgemm_matmul_conf_t &bgmmc,
+            const brgemm_matmul_conf_utils_t &bm_conf_utils,
+            matmul_amx_blocking_params_macro_t &best_blocking);
+
+protected:
+    float calculate_blocking_scores() const override;
+
+private:
+    static const dim_t min_m_dim = 64;
+    static const dim_t min_k_dim = 256;
+    static const dim_t min_n_dim = 64;
+    static const dim_t k_threshold_write_bound_layer = 256;
+    static const dim_t min_n_dim_write_bound_layer = 256;
+    dim_t n_decomposition = 32;
+    dim_t m_decomposition = 32;
+    size_t gemm_dt_sz;
+    dim_t m_per_thread, k_per_thread, n_per_thread, b_per_thread;
+    bool need_prefetch;
+    bool is_horizontal;
+
+    size_t m_tmul, n_tmul, k_tmul;
+    bool set_blocking_parameters();
+    bool is_horizontal_selected(bool horizontal_not_possible,
+            bool vertical_not_possible, size_t best_m_v, size_t best_k_v,
+            size_t k_blk_v) const;
+    void set_tmul_sizes();
+    void set_decomposition();
+    size_t l2_matrix_usage(size_t k_chunk_size, size_t m_or_n_blk, size_t k_blk,
+            bool is_horizontal) const;
+    size_t l2_matrix_and_c_usage(size_t k_chunk_size, size_t m_or_n_blk,
+            size_t k_blk, bool is_horizontal) const;
+    void set_core_divs(int nthr_b, int nthr_m, int nthr_k, int nthr_n);
+    int bw(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
+            bool is_horizontal) const;
+    int compute(size_t m_blk, size_t k_chunk_size, size_t k_blk,
+            size_t n_blk) const;
+    float ratio(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
+            bool is_horizontal) const;
+    std::set<dim_t> blk_candidates(
+            dim_t dim_per_thread, dim_t decomposition) const;
+    float evaluate_single_core_blocking(size_t k_chunk_size, size_t m_or_n_blk,
+            size_t k_blk, bool is_horizontal) const;
+    dim_t calc_k_blk(size_t l1_dim) const;
+    bool divs_are_acceptable() const;
+    bool operator==(const matmul_amx_blocking_params_macro_t &other) const;
+    bool operator>(const matmul_amx_blocking_params_macro_t &other) const;
+    bool operator!=(const matmul_amx_blocking_params_macro_t &other) const;
+    bool operator<(const matmul_amx_blocking_params_macro_t &other) const;
+};
+
+class matmul_amx_blocking_params_micro_t : public matmul_amx_blocking_params_t {
+public:
+    matmul_amx_blocking_params_micro_t(const brgemm_matmul_conf_t &bgmmc)
+        : matmul_amx_blocking_params_t(bgmmc) {}
+
+    void set_blocking_parameters(int nthr_k, int n_blk, int n_chunk_size,
+            int m_blk, int m_chunk_size);
+
+    static void find_best_blocking(const brgemm_matmul_conf_t &bgmmc,
+            const brgemm_matmul_conf_utils_t &bm_conf_utils,
+            matmul_amx_blocking_params_t &best_blocking);
+
+protected:
+    float calculate_blocking_scores() const override;
+
+private:
+    float get_thread_balance_scores() const;
+    void update_k_blocking_dependent_params();
+    size_t calculate_chunk_memory_size();
+    float get_copied_data_reusage_scores() const;
+    float get_L2_utilization_scores() const;
+};
+
+class bw_map_t {
+public:
+    bw_map_t() {}
+
+    float get_bw(int x) const { return linear_interpolation(multicore_bw, x); }
+
+    // All the following bandwidth measurements were taken on an
+    // EMR machine with two NUMA domains, each containing 32 cores.
+
+    // This BW is the BW for read/store when hitting the L1
+    const float l1_load_hit_bw = (float)106.41;
+    const float l1_store_hit_bw = l1_load_hit_bw;
+
+    // This l1 BW is the BW for read when missing the L1
+    const float l1_load_miss_bw = (float)(106.41 / 2.28);
+    // This l1 BW is the BW for store when missing the L1
+    const float l1_store_miss_bw = (float)(106.41 / 2.85);
+    // LLC BW
+    const float llc_bw = (float)6.0;
+
+private:
+    // This dictionary includes DRAM bandwidth for cores that share data.
+    // The key represents the number of cores sharing, and the value is the bandwidth.
+    const std::map<int, float> multicore_bw = {
+            {32, 4.06}, {16, 3.31}, {8, 2.98}, {4, 2.39}, {2, 0.9}, {1, 2.28}};
+
+    float linear_interpolation(
+            const std::map<int, float> &points, float x) const {
+        // Find the interval [x0, x1] where x0 <= x <= x1
+        auto it = points.lower_bound(x);
+        if (it == points.end()) {
+            return points.rbegin()
+                    ->second; // x is greater than the largest x in the map
+        }
+        if (it == points.begin()) {
+            return it->second; // x is less than the smallest x in the map
+        }
+
+        auto it1 = it;
+        auto it0 = std::prev(it);
+
+        int x0 = it0->first;
+        float y0 = it0->second;
+        int x1 = it1->first;
+        float y1 = it1->second;
+
+        // Perform linear interpolation
+        return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
+    }
+};
+
+} // namespace matmul
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -439,11 +439,11 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
     const int N_chunks = brgmm_ctx.get_N_chunks();
     const int N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
     parallel(num_threads, [&](const int ithr, const int nthr) {
-        const int ithr_bmn = brgmm_ctx.get_thread_idx_for_bmn(ithr);
+        const int ithr_bmn = brgmm_ctx.get_thread_idx_for_bmn_gemm(ithr);
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
         int start {0}, end {0};
-        balance211(brgmm_ctx.get_parallel_work_amount(),
+        balance211(brgmm_ctx.get_parallel_work_amount_gemm(),
                 brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn, start, end);
         int kc_start {0}, kc_end {bgmmc.K_chunks};
         if (brgmm_ctx.parallel_reduction_is_used())
@@ -454,14 +454,39 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         brgemm_palettes_.maybe_tile_configure(
                 is_amx, prev_ker_idx, brgmm_ctx.get_base_brgemm_kernel_idx());
 
-        int b {0}, mc {0}, nc {0};
-        nd_iterator_init(start, b, bgmmc.batch, mc, M_chunks, nc, N_chunks);
+        int b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
+                bt {0}, mt {0}, nt {0};
+        int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
+        int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
+        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
+                bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
+                m_chunks_per_thread, nc_per_t, n_chunks_per_thread);
+        mc = mt * m_chunks_per_thread + mc_per_t;
+        nc = nt * n_chunks_per_thread + nc_per_t;
+        b = bt * batch_per_thread + b_per_t;
+
+        auto advance_func = [&]() {
+            ++start;
+            nd_iterator_step(bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
+                    bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
+                    m_chunks_per_thread, nc_per_t, n_chunks_per_thread);
+            mc = mt * m_chunks_per_thread + mc_per_t;
+            nc = nt * n_chunks_per_thread + nc_per_t;
+            b = bt * batch_per_thread + b_per_t;
+        };
+
         int mc_prev = -1;
         int nb_prev = -1;
         int b_prev = -1;
         const char *a_batch_ptr = nullptr;
         const char *b_batch_ptr = nullptr;
         while (start < end) {
+            if (mc >= M_chunks || nc >= N_chunks || b >= bgmmc.batch) {
+                advance_func();
+                continue;
+            }
+
             auto m_start = mc * M_chunk_size;
             const bool m_chunk_tail = mc == M_chunks - 1 && M_chunk_tail > 0;
             auto m_end = m_start + (m_chunk_tail ? M_chunk_tail : M_chunk_size);
@@ -519,8 +544,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             }
             mc_prev = mc;
             b_prev = b;
-            ++start;
-            nd_iterator_step(b, bgmmc.batch, mc, M_chunks, nc, N_chunks);
+            advance_func();
         }
         if (is_amx) { amx_tile_release(); }
     });
@@ -1400,6 +1424,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         }
         C_ptr_shift_b_ = bgmmc_.C_ptr_shift_b;
 
+        // create parallel work of amount that is divisible by nthr_m and nthr_n,
+        // the chunks that do not exist will be ignored in gemm execution
+        // In case of micro heuristics, nthr_m==nthr_n==nthr_b==1 (round up has no effect)
+        int m_chunks_per_thread = rnd_up(M_chunks_, bgmmc.nthr_m);
+        int n_chunks_per_thread = rnd_up(N_chunks_, bgmmc.nthr_n);
+        int b_per_thread = rnd_up(bgmmc.batch, bgmmc.nthr_b);
+        parallel_work_amount_gemm_
+                = b_per_thread * m_chunks_per_thread * n_chunks_per_thread;
+
         // parallelization
         parallel_work_amount_ = bgmmc.batch * M_chunks_ * N_chunks_;
 
@@ -1892,6 +1925,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     int get_parallel_work_amount() const { return parallel_work_amount_; }
+    int get_parallel_work_amount_gemm() const {
+        return parallel_work_amount_gemm_;
+    }
     int get_num_threads_for_k() const { return nthr_k_; }
     bool parallel_reduction_is_used() const {
         return nthr_k_ > 1 && bgmmc_.K_chunks > 1;
@@ -1903,11 +1939,19 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         const int ithr_k = ithr / nthr_bmn_;
         return ithr_k < bgmmc_.K_chunks ? ithr_k : -1;
     }
+
+    int get_thread_idx_for_bmn_gemm(int ithr) const {
+        if (ithr >= num_threads_used_) return -1;
+        const int ithr_bmn = ithr % nthr_bmn_;
+        return ithr_bmn < parallel_work_amount_gemm_ ? ithr_bmn : -1;
+    }
+
     int get_thread_idx_for_bmn(int ithr) const {
         if (ithr >= num_threads_used_) return -1;
         const int ithr_bmn = ithr % nthr_bmn_;
         return ithr_bmn < parallel_work_amount_ ? ithr_bmn : -1;
     }
+
     int get_num_threads_for_parallelization() const {
         return num_threads_used_;
     }
@@ -2149,6 +2193,7 @@ private:
 
     // parallelization parameters
     int parallel_work_amount_;
+    int parallel_work_amount_gemm_;
     int nthr_, nthr_k_, nthr_bmn_, num_threads_used_;
     int last_brgemm_batch_size_;
     dim_t M_;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -281,6 +281,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brgattr.hint_expected_C_size = vM * vN * bs;
             if (bgmmc_.LDB2 != 0) brgattr.LDB2 = bgmmc_.LDB2;
 
+            brgattr.LDC2_N = bgmmc_.M_blk * bgmmc_.LDC;
+
             brgattr.hint_innermost_loop = brgemm_innermost_undef;
             brgattr.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
         }
@@ -1645,8 +1647,16 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         }
         char *buf_C_ptr_local
                 = buf_C_ptr_ + ithr * bgmmc_.buffer_c_per_thread_sz;
-        const int n_blk_local = n_blk_idx % bgmmc_.N_chunk_size;
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+
+        int n_blk_local = 0;
+        int m_blk_local = 0;
+
+        if (bgmmc_.is_runtime_N || bgmmc_.is_runtime_M
+                || bgmmc_.K_chunk_elems < bgmmc_.K) {
+            n_blk_local = n_blk_idx % bgmmc_.N_chunk_size;
+            m_blk_local = m_blk_idx % get_M_chunk_size();
+        }
+
         const bool runtime_M_tail = is_runtime_M_tail_chunk(m_blk_idx);
         const bool runtime_N_tail = is_runtime_N_tail_chunk(n_blk_idx);
 

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -45,6 +45,14 @@ using namespace nstl;
 using namespace data_type;
 
 template <cpu_isa_t isa>
+void brgemm_matmul_t<isa>::pd_t::maybe_set_LDB2() {
+    if (bgmmc_.LDB < bgmmc_.N_blk
+            && (bgmmc_.N_blk % bgmmc_.LDB == 0 || bgmmc_.N_blk == bgmmc_.N)) {
+        bgmmc_.LDB2 = rnd_up(bgmmc_.K, bgmmc_.wei_k_blk) * bgmmc_.LDB;
+    }
+}
+
+template <cpu_isa_t isa>
 status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     const auto src_dt = src_md_.data_type;
     const auto wei_dt = weights_md_.data_type;
@@ -218,6 +226,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                                                        : avx512_core)))
             : isa;
 
+    maybe_set_LDB2();
+
     const int i_bs_end = bgmmc_.brgemm_batch_tail_size ? 2 : 1;
     const int i_init_start = bgmmc_.K_blk != bgmmc_.K ? 0 : 1;
     const int i_K_end = bgmmc_.K_tail ? 2 : 1;
@@ -269,6 +279,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brgattr.hint_expected_A_size = vM * vK * bs;
             brgattr.hint_expected_B_size = vN * vK * bs;
             brgattr.hint_expected_C_size = vM * vN * bs;
+            if (bgmmc_.LDB2 != 0) brgattr.LDB2 = bgmmc_.LDB2;
+
             brgattr.hint_innermost_loop = brgemm_innermost_undef;
             brgattr.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
         }
@@ -417,6 +429,11 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
     const int M_chunks = brgmm_ctx.get_M_chunks();
     const int M_chunk_size = brgmm_ctx.get_M_chunk_size();
     const int M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
+
+    const int K_chunks = brgmm_ctx.get_K_chunks();
+    const int K_chunk_size = brgmm_ctx.get_K_chunk_size();
+    const int K_chunk_tail = brgmm_ctx.get_K_chunk_tail();
+
     const int N_chunks = brgmm_ctx.get_N_chunks();
     const int N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
     parallel(num_threads, [&](const int ithr, const int nthr) {
@@ -456,30 +473,47 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                 b_batch_ptr = brgmm_ctx.get_data_B_batch_ptr(b);
             }
             for_(int kc = kc_start; kc < kc_end; kc++)
-            for (int nb = n_start; nb < n_end; nb++) {
-                const bool bcast_across_all_batch_dims
-                        = bgmmc.bcast_B_desc.bcast_across_all_batch_dims;
-                const bool skip_copy_b
-                        = (nb_prev == nb && kc_prev == kc
-                                  && (b_prev == b
-                                          || bcast_across_all_batch_dims))
-                        && !bgmmc.packed_sparse_weights;
-                if (bgmmc.use_buffer_b && !skip_copy_b)
-                    copy_b_chunk_in_buffer(
-                            brgmm_ctx, b_batch_ptr, ithr, b, nb, kc);
-                for (int mb = m_start; mb < m_end; mb++) {
-                    const bool skip_copy_a = mc_prev == mc && kc_prev == kc
-                            && (b_prev == b
-                                    || bgmmc.bcast_A_desc
-                                               .bcast_across_all_batch_dims);
-                    if (use_buffer_a && nb == n_start && !skip_copy_a)
-                        copy_a_chunk_in_buffer(
-                                brgmm_ctx, a_batch_ptr, ithr, mb, kc);
-                    compute_kernel(brgmm_ctx, a_batch_ptr, b_batch_ptr, ithr, b,
-                            mb, nb, kc, kc == kc_start, prev_ker_idx);
+            {
+                const bool k_chunk_tail
+                        = kc == K_chunks - 1 && K_chunk_tail > 0;
+                auto kb_start = kc * K_chunk_size;
+                auto kb_end = kb_start
+                        + (k_chunk_tail ? K_chunk_tail : K_chunk_size);
+
+                for (int nb = n_start; nb < n_end; nb++) {
+                    const bool bcast_across_all_batch_dims
+                            = bgmmc.bcast_B_desc.bcast_across_all_batch_dims;
+                    const bool skip_copy_b
+                            = (nb_prev == nb && kc_prev == kc
+                                      && (b_prev == b
+                                              || bcast_across_all_batch_dims))
+                            && !bgmmc.packed_sparse_weights;
+
+                    for (int mb = m_start; mb < m_end; mb++) {
+                        const bool skip_copy_a = mc_prev == mc && kc_prev == kc
+                                && (b_prev == b
+                                        || bgmmc.bcast_A_desc
+                                                   .bcast_across_all_batch_dims);
+                        for (int kb = kb_start; kb < kb_end; kb++) {
+
+                            if (bgmmc.use_buffer_b && mb == m_start
+                                    && !skip_copy_b)
+                                copy_b_chunk_in_buffer(brgmm_ctx, b_batch_ptr,
+                                        ithr, b, nb, kb);
+
+                            if (use_buffer_a && nb == n_start && !skip_copy_a)
+                                copy_a_chunk_in_buffer(
+                                        brgmm_ctx, a_batch_ptr, ithr, mb, kb);
+
+                            compute_kernel(brgmm_ctx, a_batch_ptr, b_batch_ptr,
+                                    ithr, b, mb, nb, kb,
+                                    kc == kc_start && kb == kb_start,
+                                    prev_ker_idx);
+                        }
+                    }
+                    kc_prev = kc;
+                    nb_prev = nb;
                 }
-                kc_prev = kc;
-                nb_prev = nb;
             }
             mc_prev = mc;
             b_prev = b;
@@ -499,28 +533,28 @@ template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::compute_kernel(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
         const char *B_data_batch_ptr, int ithr, int b_idx, int m_blk_idx,
-        int n_blk_idx, int k_chunk_idx, bool do_init, int &prev_ker_idx) const {
+        int n_blk_idx, int k_blk_idx, bool do_init, int &prev_ker_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
     const auto addr_batch = brgmm_ctx.get_batch_elem_ptr(ithr);
 
     const auto wsp_tile = brgmm_ctx.get_tile_workspace(ithr);
 
     const dim_t n = brgmm_ctx.get_N_idx(n_blk_idx, true);
-    const int k_blk_idx = k_chunk_idx * bgmmc.brgemm_batch_size;
 
     const dim_t M = brgmm_ctx.get_M();
     const dim_t N = brgmm_ctx.get_N();
     const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(m_blk_idx);
     const int n_ker_idx = brgmm_ctx.get_N_kernel_idx(n_blk_idx);
-    const bool is_last_K_chunk = brgmm_ctx.is_last_K_chunk(k_chunk_idx);
+    const bool is_last_K_blk = brgmm_ctx.is_last_K_blk(k_blk_idx);
 
+    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
     const int remaining_k_blks
             = (bgmmc.use_buffer_a ? utils::rnd_up(bgmmc.K, bgmmc.K_blk)
                                   : bgmmc.K)
-            - k_chunk_idx * bgmmc.K_chunk_elems;
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_chunk_idx);
+            - k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
     const bool is_K_tail
-            = is_last_K_chunk && (gemm_batch * bgmmc.K_blk) != remaining_k_blks;
+            = is_last_K_blk && (gemm_batch * bgmmc.K_blk) != remaining_k_blks;
+
     auto is_bs_tail = (gemm_batch != bgmmc.brgemm_batch_size);
     const int brg_ker_idx = pd()->get_brg_kernel_idx(
             is_bs_tail, do_init, m_ker_idx, n_ker_idx, false);
@@ -558,8 +592,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
         brgmm_ctx.init_brgemm_batch_elements_values(ithr, 0, gemm_batch,
                 A_data_batch_ptr, B_data_batch_ptr, b_idx, m_blk_idx, k_blk_idx,
                 n_blk_idx);
-
-        if (post_ops_applicable && is_last_K_chunk && !is_K_tail) {
+        if (post_ops_applicable && is_last_K_blk && !is_K_tail) {
             void *scratch = is_amx
                     ? static_cast<void *>(wsp_tile)
                     : static_cast<void *>(brgmm_ctx.get_s8s8_comp_ptr(
@@ -594,7 +627,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
         }
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
-                k_chunk_idx, do_init, is_K_tail, /* do_K_tail */ false);
+                k_blk_idx, do_init, is_K_tail, /* do_K_tail */ false);
     }
     if (is_K_tail) {
         brgmm_ctx.init_brgemm_batch_elements_values(ithr, gemm_batch, 1,
@@ -650,7 +683,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
         }
 
         maybe_reduce_A(brgmm_ctx, ithr, gemm_batch, m_blk_idx, n_blk_idx,
-                k_chunk_idx, do_init, is_K_tail,
+                k_blk_idx, do_init, is_K_tail,
                 /* do_K_tail */ true);
     }
 
@@ -665,7 +698,6 @@ void brgemm_matmul_t<isa>::maybe_reduce_A(
         bool has_K_tail, bool do_K_tail) const {
 
     if (!pd()->with_reduce()) return;
-
     const bool reduce_a = pd()->reduce_kind() == matmul_reduce_kind::src;
     // Only `matmul_reduce_kind::src` is supported for now.
     assert(reduce_a);
@@ -962,14 +994,15 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
-        int ithr, int m_blk_idx, int k_chunk_idx) const {
+        int ithr, int m_blk_idx, int k_blk_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
 
     auto ctx = jit_brgemm_matmul_copy_a_t::ctx_t();
-    const int k_start = k_chunk_idx * bgmmc.K_chunk_elems;
+    const int k_start = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
     const bool is_K_tail
-            = brgmm_ctx.is_last_K_chunk(k_chunk_idx) && bgmmc.K_tail > 0;
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_chunk_idx);
+            = brgmm_ctx.is_last_K_blk(k_blk_idx) && bgmmc.K_tail > 0;
+
+    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
     const int gemm_batch_iters = bgmmc.use_buffer_a_tail_only ? 0 : gemm_batch;
 
     const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
@@ -988,7 +1021,8 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     for (int gb = 0; gb < gemm_batch_iters; gb++) {
         const int k = k_start + gb * bgmmc.K_blk;
         ctx.src = (void *)brgmm_ctx.get_data_A_mk_ptr(A_data_batch_ptr, m, k);
-        ctx.tr_src = (void *)brgmm_ctx.get_buf_A_ptr(ithr, m_blk_idx, gb);
+        ctx.tr_src = (void *)brgmm_ctx.get_buf_A_ptr(
+                ithr, m_blk_idx, k_blk_idx, gb);
         ctx.current_K_blk = nstl::min(bgmmc.K_blk, bgmmc.K);
         ctx.current_K_start = k;
 
@@ -999,7 +1033,7 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
         const int k = k_start + gemm_batch * bgmmc.K_blk;
         ctx.src = (void *)brgmm_ctx.get_data_A_mk_ptr(A_data_batch_ptr, m, k);
         ctx.tr_src = (void *)brgmm_ctx.get_buf_A_ptr(
-                ithr, m_blk_idx, gemm_batch_iters);
+                ithr, m_blk_idx, k_blk_idx, gemm_batch_iters);
         ctx.current_K_blk = K_tail;
         ctx.current_K_start = k;
 
@@ -1010,13 +1044,13 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *B_data_batch_ptr,
-        int ithr, int b_idx, int n_blk_idx, int k_chunk_idx) const {
+        int ithr, int b_idx, int n_blk_idx, int k_blk_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
 
-    const int k_start = k_chunk_idx * bgmmc.K_chunk_elems;
+    const int k_start = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
     const bool is_K_tail
-            = brgmm_ctx.is_last_K_chunk(k_chunk_idx) && bgmmc.K_tail > 0;
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_chunk_idx);
+            = brgmm_ctx.is_last_K_blk(k_blk_idx) && bgmmc.K_tail > 0;
+    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
 
     const dim_t n = brgmm_ctx.get_N_idx(n_blk_idx, true);
 
@@ -1029,7 +1063,8 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
             p.src_ptr = (void *)B_data_ptr;
             p.bitmask_ptr
                     = (void *)brgmm_ctx.get_data_B_bitmask_ptr(b_idx, k, n);
-            p.dst_ptr = (void *)brgmm_ctx.get_buf_B_ptr(ithr, gb, n_blk_idx);
+            p.dst_ptr = (void *)brgmm_ctx.get_buf_B_ptr(
+                    ithr, k_blk_idx, n_blk_idx, gb);
             (*sparse_decompress_kernel_)(&p);
         }
         return;
@@ -1044,11 +1079,11 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
     ctx.zp_b_value_ptr = (void *)brgmm_ctx.get_zp_b_val_ptr();
     ctx.dynamic_src_stride = brgmm_ctx.copy_B_wei_stride();
 
-    int gb = 0;
-    for (; gb < gemm_batch; gb++) {
+    for (int gb = 0; gb < gemm_batch; gb++) {
         const int k = k_start + gb * bgmmc.K_blk;
         ctx.src = (void *)brgmm_ctx.get_data_B_kn_ptr(B_data_batch_ptr, k, n);
-        ctx.tr_src = (void *)brgmm_ctx.get_buf_B_ptr(ithr, gb, n_blk_idx);
+        ctx.tr_src = (void *)brgmm_ctx.get_buf_B_ptr(
+                ithr, k_blk_idx, n_blk_idx, gb);
         ctx.compensation_ptr
                 = (void *)brgmm_ctx.get_s8s8_comp_ptr(ithr, b_idx, n_blk_idx);
         ctx.current_K_start = k;
@@ -1066,9 +1101,10 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
     }
 
     if (is_K_tail) {
-        const int k = k_start + gb * bgmmc.K_blk;
+        const int k = k_start + gemm_batch * bgmmc.K_blk;
         ctx.src = (void *)brgmm_ctx.get_data_B_kn_ptr(B_data_batch_ptr, k, n);
-        ctx.tr_src = (void *)brgmm_ctx.get_buf_B_ptr(ithr, gb, n_blk_idx);
+        ctx.tr_src = (void *)brgmm_ctx.get_buf_B_ptr(
+                ithr, k_blk_idx, n_blk_idx, gemm_batch);
         ctx.compensation_ptr
                 = (void *)brgmm_ctx.get_s8s8_comp_ptr(ithr, b_idx, n_blk_idx);
         ctx.current_K_start = k;
@@ -1214,11 +1250,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                                     + s8s8_buffer_sz]));
         }
 
-        // Set last_chunk_brgemm_batch_size_ to brgemm_batch_size
+        // Set last_brgemm_batch_size_ to brgemm_batch_size
         // when K_tail = 0 and brgemm_batch_tail_size = 0
-        last_chunk_brgemm_batch_size_ = bgmmc.brgemm_batch_tail_size;
-        if (bgmmc.K_tail == 0 && last_chunk_brgemm_batch_size_ == 0)
-            last_chunk_brgemm_batch_size_ = bgmmc.brgemm_batch_size;
+        last_brgemm_batch_size_ = bgmmc.brgemm_batch_tail_size;
+        if (bgmmc.K_tail == 0 && last_brgemm_batch_size_ == 0)
+            last_brgemm_batch_size_ = bgmmc.brgemm_batch_size;
 
         LDD_ = is_runtime_value(bgmmc_.LDD) ? helper.ldc() : bgmmc_.LDD;
         LDC_ = is_runtime_value(bgmmc_.LDC) ? LDD_ : bgmmc_.LDC;
@@ -1226,6 +1262,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         is_A_batch_layout_trivial_ = bgmmc_.is_src_batch_layout_trivial;
         is_B_batch_layout_trivial_ = bgmmc_.is_wei_batch_layout_trivial;
         is_C_batch_layout_trivial_ = bgmmc_.is_dst_batch_layout_trivial;
+
+        K_ = bgmmc.K;
+        K_chunks_ = bgmmc.K_chunks;
+        K_chunk_tail_ = bgmmc.num_K_blocks % get_K_chunk_size();
+        K_chunk_tail_elements_ = K_ % bgmmc.K_chunk_elems;
+
         if (bgmmc.is_runtime_M) {
             M_ = helper.M();
             M_chunks_ = M_ / bgmmc.M_chunk_elems;
@@ -1542,21 +1584,23 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         for (int b_iter = 0; b_iter < brg_batch_iters; b_iter++) {
             const int brg_batch_idx = brg_batch_start + b_iter;
-            const int k = (k_blk_idx + brg_batch_idx) * bgmmc_.K_blk;
+            const int k = k_blk_idx * bgmmc_.K_blk * bgmmc_.brgemm_batch_size
+                    + brg_batch_idx * bgmmc_.K_blk;
             addr_batch[b_iter].ptr.A = bgmmc_.use_buffer_a
-                    ? get_buf_A_ptr(ithr, m_blk_idx, brg_batch_idx)
+                    ? get_buf_A_ptr(ithr, m_blk_idx, k_blk_idx, brg_batch_idx)
                     : get_data_A_mk_ptr(A_data_batch_ptr, m, k);
             addr_batch[b_iter].ptr.B = (bgmmc_.use_buffer_b)
-                    ? get_buf_B_ptr(ithr, brg_batch_idx, n_blk_idx)
+                    ? get_buf_B_ptr(ithr, k_blk_idx, n_blk_idx, brg_batch_idx)
                     : get_data_B_kn_ptr(B_data_batch_ptr, k, n);
         }
     }
 
-    char *get_buf_A_ptr(int ithr, int m_blk_idx, int k_blk_idx) const {
+    char *get_buf_A_ptr(int ithr, int m_blk_idx, int k_blk_idx, int gb) const {
         if (!bgmmc_.use_buffer_a && !bgmmc_.use_buffer_a_tail_only)
             return nullptr;
 
-        const int k_blk_local = bgmmc_.use_buffer_a_tail_only ? 0 : k_blk_idx;
+        int k_blk_local = bgmmc_.use_buffer_a_tail_only ? 0 : k_blk_idx;
+        k_blk_local = k_blk_local % get_K_chunk_size();
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
             const int tail_idx = get_M_tail_block_idx(m_blk_idx);
             const int curr_m_block_size
@@ -1569,23 +1613,27 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             const int batch = bgmmc_.use_buffer_a_tail_only
                     ? 1
                     : bgmmc_.brgemm_batch_size;
-            const dim_t offset = curr_m_buf_shift * ld * batch
-                    + k_blk_local * ld * curr_m_block_size;
-            return buf_A_ptr_ + ithr * bgmmc_.buffer_a_per_thread_sz + offset;
+            const dim_t offset = ithr * bgmmc_.buffer_a_per_thread_sz
+                    + curr_m_buf_shift * ld * batch * bgmmc_.K_chunk_size
+                    + k_blk_local * batch * ld * curr_m_block_size
+                    + gb * ld * curr_m_block_size;
+            return buf_A_ptr_ + offset;
         }
 
         const int m_blk_local = m_blk_idx % get_M_chunk_size();
         return buf_A_ptr_ + ithr * bgmmc_.buffer_a_per_thread_sz
-                + m_blk_local * bgmmc_.buffer_a_chunk_shift_along_m
-                + k_blk_local * bgmmc_.buffer_a_chunk_sz;
+                + m_blk_local * bgmmc_.buffer_a_m_stride
+                + k_blk_local * bgmmc_.buffer_a_k_stride
+                + gb * bgmmc_.buffer_a_gb_stride;
     }
 
-    char *get_buf_B_ptr(int ithr, int k_blk_idx, int n_blk_idx) const {
+    char *get_buf_B_ptr(int ithr, int k_blk_idx, int n_blk_idx, int gb) const {
         UNUSED(n_blk_idx);
         if (!bgmmc_.use_buffer_b) return nullptr;
-
+        int k_blk_local = k_blk_idx % get_K_chunk_size();
         return buf_B_ptr_ + ithr * bgmmc_.buffer_b_per_thread_sz
-                + k_blk_idx * bgmmc_.buffer_b_chunk_sz;
+                + k_blk_local * bgmmc_.buffer_b_k_brg_stride
+                + gb * bgmmc_.buffer_b_gb_stride;
     }
 
     char *get_buf_C_ptr(int ithr, int m_blk_idx, int n_blk_idx) const {
@@ -1601,6 +1649,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         const int m_blk_local = m_blk_idx % get_M_chunk_size();
         const bool runtime_M_tail = is_runtime_M_tail_chunk(m_blk_idx);
         const bool runtime_N_tail = is_runtime_N_tail_chunk(n_blk_idx);
+
         if (runtime_M_tail || runtime_N_tail) {
             const int curr_m_block_size = get_M_kernel_size(m_blk_idx);
             const dim_t curr_m_buf_shift = runtime_M_tail
@@ -1823,13 +1872,13 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     int get_base_brgemm_kernel_idx() const { return base_brg_ker_idx_; }
 
-    bool is_last_K_chunk(int k_chunk_idx) const {
-        return k_chunk_idx == bgmmc_.K_chunks - 1;
+    bool is_last_K_blk(int k_blk_idx) const {
+        return k_blk_idx == bgmmc_.num_K_blocks - 1;
     }
 
     int get_brgemm_batch_size(int k_chunk_idx) const {
-        return is_last_K_chunk(k_chunk_idx) ? last_chunk_brgemm_batch_size_
-                                            : bgmmc_.brgemm_batch_size;
+        return is_last_K_blk(k_chunk_idx) ? last_brgemm_batch_size_
+                                          : bgmmc_.brgemm_batch_size;
     }
 
     int get_parallel_work_amount() const { return parallel_work_amount_; }
@@ -1856,6 +1905,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     int get_M_chunks() const { return M_chunks_; }
     int get_M_chunk_size() const { return bgmmc_.M_chunk_size; }
     int get_M_chunk_tail() const { return M_chunk_tail_; }
+
+    int get_K_chunks() const { return K_chunks_; }
+    int get_K_chunk_size() const { return bgmmc_.K_chunk_size; }
+    int get_K_chunk_tail() const { return K_chunk_tail_; }
 
     int get_M_kernel_idx(int m_block_idx) const {
         if (!is_M_tail_processing(m_block_idx))
@@ -2087,12 +2140,17 @@ private:
     // parallelization parameters
     int parallel_work_amount_;
     int nthr_, nthr_k_, nthr_bmn_, num_threads_used_;
-    int last_chunk_brgemm_batch_size_;
+    int last_brgemm_batch_size_;
     dim_t M_;
     int M_chunks_;
     int M_chunk_tail_;
     int M_chunk_tail_elements_;
     int M_tail_block_start_;
+
+    dim_t K_;
+    int K_chunks_;
+    int K_chunk_tail_;
+    int K_chunk_tail_elements_;
 
     dim_t N_;
     int N_chunks_;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -285,6 +285,13 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
             brgattr.hint_innermost_loop = brgemm_innermost_undef;
             brgattr.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
+
+            if (bgmmc_.set_nt) {
+                brgattr.hint_load_nt_A = bgmmc_.is_a_nt ? brgemm_hint_nt_true
+                                                        : brgemm_hint_nt_false;
+                brgattr.hint_load_nt_B = bgmmc_.is_b_nt ? brgemm_hint_nt_true
+                                                        : brgemm_hint_nt_false;
+            }
         }
 
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
@@ -724,6 +731,8 @@ void brgemm_matmul_t<isa>::maybe_reduce_A(
         bool has_K_tail, bool do_K_tail) const {
 
     if (!pd()->with_reduce()) return;
+    //current state macro heuristics don't support reduce_A -> kb =1 -> kb == kc
+    assert(!pd()->get_brgemm_matmul_conf().is_macro_heuristics);
     const bool reduce_a = pd()->reduce_kind() == matmul_reduce_kind::src;
     // Only `matmul_reduce_kind::src` is supported for now.
     assert(reduce_a);

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -71,8 +71,9 @@ inline int get_brg_kernel_index(const brgemm_matmul_conf_t &bgmmc,
             : bgmmc.N_blk;
     auto vK = (is_K_tail) ? bgmmc.K_tail : bgmmc.K_blk;
     if (vM == 0 || vN == 0 || vK == 0 || bs == 0 || bgmmc.LDA < vK
-            || bgmmc.LDB < vN
-            || (bgmmc.LDC < vN && !is_runtime_value(bgmmc.LDC)))
+            || (bgmmc.LDB < vN && !bgmmc.is_amx)
+            || ((bgmmc.LDC < vN && !bgmmc.is_amx)
+                    && !is_runtime_value(bgmmc.LDC)))
         return -1;
 
     int idx = 2 * max_n_ker_idx
@@ -113,6 +114,8 @@ struct brgemm_matmul_t : public primitive_t {
         const brgemm_matmul_conf_t &get_brgemm_matmul_conf() const {
             return bgmmc_;
         }
+
+        void maybe_set_LDB2();
 
     private:
         brgemm_desc_t brg_descs_[max_num_brg_kernels_matmul];

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -676,7 +676,6 @@ struct matmul_avx512_blocking_params_t {
     }
 };
 
-
 float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
@@ -1907,10 +1906,6 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
                 bgmmc.M_blk * bgmmc.N_blk * bgmmc.c_dt_sz * bgmmc.nthr,
                 default_data_align);
 }
-
-
-
-
 
 } // namespace matmul
 } // namespace x64

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1148,9 +1148,28 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
     bgmmc.N_blk = bgmmc.wei_n_blk;
     if (!bgmmc.is_runtime_N) bgmmc.N_blk = nstl::min(bgmmc.N_blk, bgmmc.N);
 
-    bgmmc.M_chunk_size = bgmmc.N_chunk_size = 1;
+    bgmmc.M_chunk_size = bgmmc.N_chunk_size = bgmmc.K_chunk_size = 1;
+
+    bool prefer_copy_a
+            = one_of(true, bm_conf_utils.is_f32() && bgmmc.isa == avx2,
+                      bm_conf_utils.is_bf16(),
+                      bm_conf_utils.is_bf16_with_int_wei(),
+                      (bgmmc.is_amx
+                              && (bm_conf_utils.is_f16()
+                                      || bm_conf_utils.is_f16_with_int_wei())))
+            && (bgmmc.isa != avx2_vnni_2) // no perf study yet.
+            && bgmmc.lda_big_pow2() && bgmmc.M >= 1024;
+
+    // Avoid copying A for small N gives better performance.
+    // TODO: Expand for other precisions and cases.
+
+    if (bgmmc.is_amx && bm_conf_utils.is_int8())
+        prefer_copy_a &= bgmmc.N >= 256;
 
     if (bgmmc.is_amx) {
+
+        bgmmc.use_buffer_a |= prefer_copy_a;
+
         // Configure matrix sizes
         if (bgmmc.is_runtime_M) {
             bgmmc.M_blk = 64; // use fixed block size for runtime M case
@@ -1234,7 +1253,7 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
         //
         // Batch_Size:
         // - unused.
-
+        bgmmc.use_buffer_a |= prefer_copy_a;
         const matmul_avx512_blocking_params_t::matmul_params_t matmul(
                 bgmmc.M, bgmmc.N, bgmmc.K, bgmmc.batch);
 
@@ -1247,6 +1266,7 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
 
         best_blocking.update_configuration(bgmmc);
     } else {
+        bgmmc.use_buffer_a |= prefer_copy_a;
         VCONDCHECK_BG(is_superset(bm_conf_utils.get_isa(), avx2),
                 VERBOSE_UNSUPPORTED_ISA)
         const bool is_f32 = bm_conf_utils.is_f32() && bgmmc.isa == avx2;
@@ -1574,27 +1594,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                 VERBOSE_UNSUPPORTED_MEM_STRIDE);
     }
 
-    bool prefer_copy_a
-            = one_of(true, bm_conf_utils.is_f32() && bgmmc.isa == avx2,
-                      bm_conf_utils.is_bf16(),
-                      bm_conf_utils.is_bf16_with_int_wei(),
-                      (bgmmc.is_amx
-                              && (bm_conf_utils.is_f16()
-                                      || bm_conf_utils.is_f16_with_int_wei())))
-            && (bgmmc.isa != avx2_vnni_2) // no perf study yet.
-            && bgmmc.lda_big_pow2() && bgmmc.M >= 1024;
-
-    // Avoid copying A for small N gives better performance.
-    // TODO: Expand for other precisions and cases.
-    if (bgmmc.is_amx && bm_conf_utils.is_int8())
-        prefer_copy_a &= bgmmc.N >= 256;
-
     const bool is_copy_a_required = (bgmmc.is_amx && bm_conf_utils.is_bf32())
             || ((bm_conf_utils.is_f16() || bm_conf_utils.is_f16_with_int_wei())
                     && isa == avx512_core_fp16)
             || (bgmmc.wei_zp_type != brgemm_broadcast_t::none
                     && !bm_conf_utils.with_weights_decompression())
-            || bgmmc.transposed_A || prefer_copy_a;
+            || bgmmc.transposed_A;
+
     bgmmc.use_buffer_a = is_copy_a_required;
 
     // Supported computation with copy only part of A related to K_tail if
@@ -1665,6 +1671,11 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             : 0;
 
     bgmmc.LDB = bm_conf_utils.get_actual_LDB();
+    VCONDCHECK_BG(!(bgmmc.LDB < bgmmc.N_blk && bgmmc.N_blk % bgmmc.LDB != 0
+                          && bgmmc.N_blk != bgmmc.N),
+            "The first coordinate of every N_blk that is larger than LDB "
+            "needs to be divisible by LDB");
+
     bgmmc.LDD = dst_d.ndims() == 2 && dst_d.count_non_unit_dims(1)
             ? bgmmc.N
             : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
@@ -1731,7 +1742,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         // bf16/f16
         const dim_t buffer_a_chunk_sz_limit = 126;
         is_small_shapes = is_small_shapes
-                && bgmmc.buffer_a_chunk_sz <= buffer_a_chunk_sz_limit;
+                && bgmmc.buffer_a_gb_stride <= buffer_a_chunk_sz_limit;
     } else {
         is_small_shapes = is_small_shapes && bgmmc.ndims < 3
                 && ((bgmmc.M == 1 && bgmmc.K == 256)
@@ -1842,16 +1853,20 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
         const memory_desc_wrapper &dst_d) {
     bgmmc.M_chunk_elems = bgmmc.M_blk * bgmmc.M_chunk_size;
     bgmmc.N_chunk_elems = bgmmc.N_blk * bgmmc.N_chunk_size;
-    bgmmc.K_chunk_elems = bgmmc.K_blk * bgmmc.brgemm_batch_size;
+    bgmmc.K_chunk_elems
+            = bgmmc.K_blk * bgmmc.K_chunk_size * bgmmc.brgemm_batch_size;
     bgmmc.M_chunks = div_up(bgmmc.M, bgmmc.M_chunk_elems);
     bgmmc.N_chunks = div_up(bgmmc.N, bgmmc.N_chunk_elems);
     bgmmc.K_chunks = div_up(bgmmc.K, bgmmc.K_chunk_elems);
     bgmmc.num_M_blocks = div_up(bgmmc.M, bgmmc.M_blk);
     bgmmc.num_N_blocks = div_up(bgmmc.N, bgmmc.N_blk);
+    bgmmc.num_K_blocks = div_up(bgmmc.K, bgmmc.K_blk * bgmmc.brgemm_batch_size);
+
     const int last_chunck_batch_size
             = (nstl::max(bgmmc.K, bgmmc.K_blk)
                       - (bgmmc.K_chunks - 1) * bgmmc.K_chunk_elems)
             / bgmmc.K_blk;
+
     bgmmc.brgemm_batch_tail_size
             = last_chunck_batch_size % bgmmc.brgemm_batch_size;
 
@@ -1861,15 +1876,28 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.buffer_c_per_thread_sz = bgmmc.buffer_c_chunk_sz
             * (bgmmc.nthr_k > 1 ? 1 : bgmmc.M_chunk_size * bgmmc.N_chunk_size);
 
-    bgmmc.buffer_a_chunk_sz = bgmmc.tr_a_dt_sz * bgmmc.M_blk
+    bgmmc.buffer_a_gb_stride = bgmmc.tr_a_dt_sz * bgmmc.M_blk
             * (bgmmc.use_buffer_a_tail_only ? bgmmc.wei_k_blk : bgmmc.LDA);
-    bgmmc.buffer_a_chunk_shift_along_m = bgmmc.buffer_a_chunk_sz
-            * (bgmmc.use_buffer_a_tail_only ? 1 : bgmmc.brgemm_batch_size);
-    bgmmc.buffer_a_per_thread_sz
-            = bgmmc.buffer_a_chunk_shift_along_m * bgmmc.M_chunk_size;
 
-    bgmmc.buffer_b_chunk_sz = bgmmc.tr_b_dt_sz * bgmmc.LDB
-            * rnd_up(bgmmc.K_blk, bgmmc.wei_k_blk);
+    bgmmc.buffer_a_k_stride
+            = bgmmc.buffer_a_gb_stride * bgmmc.brgemm_batch_size;
+
+    bgmmc.buffer_a_m_stride = bgmmc.buffer_a_k_stride * bgmmc.K_chunk_size;
+
+    bgmmc.buffer_a_per_thread_sz = bgmmc.buffer_a_m_stride * bgmmc.M_chunk_size;
+
+    bgmmc.buffer_b_gb_stride = bgmmc.tr_b_dt_sz * bgmmc.LDB * bgmmc.K_blk;
+    bgmmc.buffer_b_k_brg_stride
+            = bgmmc.buffer_b_gb_stride * bgmmc.brgemm_batch_size;
+
+    bgmmc.buffer_b_n_blk_stride = bgmmc.tr_b_dt_sz
+            * ((bgmmc.N_blk / bgmmc.LDB) * bgmmc.LDB2
+                    + (bgmmc.N_blk % bgmmc.LDB)
+                            * data_type_vnni_granularity(bgmmc.wei_dt));
+
+    bgmmc.buffer_b_chunk_sz = bgmmc.tr_b_dt_sz * rnd_up(bgmmc.N_blk, bgmmc.LDB)
+            * rnd_up(bgmmc.K_chunk_elems, bgmmc.wei_k_blk);
+
     bgmmc.buffer_b_per_thread_sz
             = bgmmc.buffer_b_chunk_sz * bgmmc.brgemm_batch_size;
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1680,7 +1680,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             ? bgmmc.N
             : dst_d.blocking_desc().strides[bgmmc.ndims - 2];
     bgmmc.LDC = bgmmc.use_buffer_c && bgmmc.nthr_k <= 1
-            ? bgmmc.N_blk * (bgmmc.is_runtime_N ? bgmmc.N_chunk_size : 1)
+            ? (bgmmc.is_amx ? nstl::min((dim_t)32, bgmmc.N_blk) : bgmmc.N_blk)
+                    * (bgmmc.is_runtime_N ? bgmmc.N_chunk_size : 1)
             : bgmmc.LDD;
 
     bgmmc.is_src_batch_layout_trivial
@@ -1870,11 +1871,29 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.brgemm_batch_tail_size
             = last_chunck_batch_size % bgmmc.brgemm_batch_size;
 
-    bgmmc.buffer_c_chunk_sz = bgmmc.acc_dt_sz
-            * (bgmmc.is_runtime_N ? bgmmc.N_blk : bgmmc.LDC)
-            * (bgmmc.nthr_k > 1 ? bgmmc.M : bgmmc.M_blk);
-    bgmmc.buffer_c_per_thread_sz = bgmmc.buffer_c_chunk_sz
-            * (bgmmc.nthr_k > 1 ? 1 : bgmmc.M_chunk_size * bgmmc.N_chunk_size);
+    if (!bgmmc.is_runtime_N && bgmmc.is_amx && bgmmc.nthr_k == 1) {
+        bgmmc.buffer_c_chunk_sz = rnd_up(bgmmc.N_blk, bgmmc.LDC) * bgmmc.M_blk
+                * bgmmc.acc_dt_sz;
+    } else {
+        bgmmc.buffer_c_chunk_sz = bgmmc.acc_dt_sz
+                * (bgmmc.is_runtime_N ? bgmmc.N_blk : bgmmc.LDC)
+                * (bgmmc.nthr_k > 1 ? bgmmc.M : bgmmc.M_blk);
+    }
+
+    if (bgmmc.nthr_k > 1) {
+        // c size == M * N (for reduction)
+        bgmmc.buffer_c_per_thread_sz = bgmmc.buffer_c_chunk_sz;
+
+    } else if (!bgmmc.is_runtime_N && !bgmmc.is_runtime_M
+            && bgmmc.K_chunk_elems >= bgmmc.K) {
+        // c size == BRGEMM size
+        bgmmc.buffer_c_per_thread_sz = bgmmc.buffer_c_chunk_sz;
+
+    } else {
+        // c size == chunk size
+        bgmmc.buffer_c_per_thread_sz = bgmmc.buffer_c_chunk_sz
+                * bgmmc.M_chunk_size * bgmmc.N_chunk_size;
+    }
 
     bgmmc.buffer_a_gb_stride = bgmmc.tr_a_dt_sz * bgmmc.M_blk
             * (bgmmc.use_buffer_a_tail_only ? bgmmc.wei_k_blk : bgmmc.LDA);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -22,6 +22,7 @@
 #include "cpu/matmul/matmul_utils.hpp"
 #include "cpu/platform.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/x64/matmul/amx_blocking_heuristics.hpp"
 #include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
 #include "oneapi/dnnl/dnnl_debug.h"
 
@@ -302,6 +303,11 @@ int brgemm_matmul_conf_utils_t::get_default_n_block(
     if (n_blk > 0) return n_blk;
 
     const int simd_w = isa_max_vlen(isa_) / sizeof(float);
+
+    if (matmul_amx_blocking_params_macro_t::is_supported(bgmmc, *this)) {
+        return 32;
+    }
+
     return is_superset(isa_, avx512_core) || !f32_dt
             ? 64
             : nstl::min<int>(24, rnd_up(bgmmc.N, simd_w));
@@ -521,87 +527,6 @@ brgemm_broadcast_t get_zp_type(const primitive_attr_t &attr, int arg) {
             : brgemm_broadcast_t::per_tensor;
 }
 
-struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
-    matmul_amx_blocking_params_t()
-        : nthr_m_(0)
-        , nthr_n_(0)
-        , nthr_k_(0)
-        , nthr_mnb_(0)
-        , nthr_(0)
-        , n_blk_(0)
-        , n_chunk_size_(0)
-        , n_chunk_elems_(0)
-        , m_blk_(0)
-        , m_chunk_size_(0)
-        , m_chunk_elems_(0)
-        , k_blk_(0)
-        , k_chunk_size_(0)
-        , k_chunk_elems_(0)
-        , use_buffer_a_(false)
-        , extendable_k_(false)
-        , current_lda_(0)
-        , need_buf_c_(false)
-        , blocking_chunk_mem_size_(0)
-        , efficiency_score_(0.0f) {}
-
-    matmul_amx_blocking_params_t(const brgemm_matmul_conf_t &bgmmc)
-        : brgemm_matmul_conf_t(bgmmc)
-        , nthr_m_(nstl::max(nthr_m, 1))
-        , nthr_n_(nstl::max(nthr_n, 1))
-        , nthr_k_(nstl::max(nthr_k, 1))
-        , nthr_mnb_(nthr / nthr_k_)
-        , nthr_(nthr_mnb_ * nthr_k_)
-        , n_blk_(N_blk)
-        , n_chunk_size_(N_chunk_size)
-        , n_chunk_elems_(n_blk_ * n_chunk_size_)
-        , m_blk_(M_blk)
-        , m_chunk_size_(M_chunk_size)
-        , m_chunk_elems_(m_blk_ * m_chunk_size_)
-        , k_blk_(K_blk)
-        , k_chunk_size_(brgemm_batch_size)
-        , k_chunk_elems_(k_blk_ * k_chunk_size_)
-        , use_buffer_a_(use_buffer_a)
-        , extendable_k_(extendable_k)
-        , current_lda_(LDA)
-        , need_buf_c_(use_buffer_c)
-        , blocking_chunk_mem_size_(0)
-        , efficiency_score_(0.0f) {}
-
-    void set_blocking_parameters(int nthr_k, int n_blk, int n_chunk_size,
-            int m_blk, int m_chunk_size);
-    void update_configuration(brgemm_matmul_conf_t &bgmmc) const;
-    float get_blocking_scores() const { return efficiency_score_; }
-
-    static size_t L2_threshold();
-
-private:
-    // num threads for parallelism
-    int nthr_m_, nthr_n_, nthr_k_;
-    // num threads for parallelism wrt m, n and batch dimensions
-    int nthr_mnb_;
-    int nthr_;
-    dim_t n_blk_, n_chunk_size_, n_chunk_elems_;
-    dim_t m_blk_, m_chunk_size_, m_chunk_elems_;
-    dim_t k_blk_, k_chunk_size_, k_chunk_elems_;
-
-    bool use_buffer_a_;
-    bool extendable_k_;
-
-    dim_t current_lda_;
-    bool need_buf_c_;
-    size_t blocking_chunk_mem_size_;
-    float efficiency_score_;
-
-    void update_k_blocking_dependent_params();
-    dim_t get_actual_lda();
-    bool is_buffer_c_required();
-    size_t calculate_chunk_memory_size();
-    float get_thread_balance_scores();
-    float get_copied_data_reusage_scores();
-    float get_L2_utilization_scores() const;
-    float calculate_blocking_scores();
-};
-
 struct matmul_avx512_blocking_params_t {
     struct matmul_params_t {
         matmul_params_t(int m, int n, int k, int od)
@@ -751,125 +676,6 @@ struct matmul_avx512_blocking_params_t {
     }
 };
 
-size_t matmul_amx_blocking_params_t::L2_threshold() {
-    return 3 * platform::get_per_core_cache_size(2) / 4;
-}
-
-void compute_blocking_heuristic_amx(const brgemm_matmul_conf_t &bgmmc,
-        const brgemm_matmul_conf_utils_t &bm_conf_utils,
-        matmul_amx_blocking_params_t &best_blocking) {
-    matmul_amx_blocking_params_t current_blocking(bgmmc);
-
-    const int min_k_per_thread = 1024;
-    const int max_k_parallel_work
-            = div_up(static_cast<int>(bgmmc.K), min_k_per_thread);
-    const bool is_amx_xf16 = bgmmc.is_amx
-            && (bm_conf_utils.is_bf16() || bm_conf_utils.is_f16()
-                    || bm_conf_utils.is_f32_f16() || bm_conf_utils.is_f32_bf16()
-                    || bm_conf_utils.is_bf32()
-                    || bm_conf_utils.is_bf16_with_int_wei()
-                    || bm_conf_utils.is_f16_with_int_wei());
-    const bool is_amx_int8 = bgmmc.is_amx && bm_conf_utils.is_int8();
-
-    const bool runtime_dims
-            = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;
-    const int max_nthr_k = !runtime_dims && is_amx_xf16 && bgmmc.batch == 1
-            ? nstl::min(saturate(1, 7, bgmmc.nthr / 8), max_k_parallel_work)
-            : 1;
-    int iter = 0;
-    const int runtime_M_chunk = bgmmc.lda_big_pow2() ? 2 : 4;
-    const int runtime_N_chunk = 2;
-
-    // Disable skip configuration due to regressions for some cases.
-    const bool disable_skip_config = bgmmc.M == 4
-            && utils::one_of(true, bgmmc.N == 4096 && bgmmc.K == 4096,
-                    bgmmc.N == 11008 && bgmmc.K == 4096,
-                    bgmmc.N == 4096 && bgmmc.K == 11008);
-
-    for (int nthr_k = 1; nthr_k <= max_nthr_k; nthr_k++) {
-        int nthr_bmn = bgmmc.nthr / nthr_k;
-
-        int num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
-        int num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
-        int k_parallel_work = nstl::min(max_k_parallel_work, nthr_k);
-        int num_parallel_work
-                = bgmmc.batch * num_M_blk * num_N_blk * k_parallel_work;
-        const bool a_lot_of_parallel_work_lvl2
-                = num_parallel_work > 16 * bgmmc.nthr;
-        const bool low_parallelism
-                = static_cast<float>(num_parallel_work) < 1.5f * bgmmc.nthr;
-        const bool maybe_low_blocking
-                = is_amx_int8 && bm_conf_utils.maybe_low_brg_blocking();
-        const int min_M_blk = !bgmmc.is_runtime_M
-                        && (maybe_low_blocking || low_parallelism)
-                        && bgmmc.M_blk > 32
-                ? div_up(bgmmc.M_blk, 2)
-                : bgmmc.M_blk;
-        const int min_N_blk = !bgmmc.is_runtime_N && low_parallelism
-                        && is_amx_xf16 && !bm_conf_utils.check_n_blk_fixed()
-                        && bgmmc.N_blk > 32 && !runtime_dims
-                ? 32
-                : bgmmc.N_blk;
-        const int desired_M_chunk = bgmmc.is_runtime_M
-                ? runtime_M_chunk
-                : nstl::min(4, num_M_blk);
-        const int desired_N_chunk = bgmmc.is_runtime_N
-                ? runtime_N_chunk
-                : nstl::min(a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
-
-        std::unordered_set<int> mblk_candidates;
-        for (int m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
-                m_blk = m_blk > 1 ? div_up(m_blk, 2) : m_blk - 1) {
-            if (IMPLICATION(maybe_low_blocking, m_blk != bgmmc.M_blk))
-                mblk_candidates.insert(m_blk);
-        }
-
-        if (!bgmmc.is_runtime_M && bgmmc.M > 16) {
-            // Add multiple of 16 M block sizes for consideration
-            const int mul16_m_blk_max
-                    = nstl::min(rnd_dn(static_cast<int>(bgmmc.M), 16), 64);
-            const int mul16_m_blk_min = rnd_up(min_M_blk, 16);
-            for (int m_blk = mul16_m_blk_max; m_blk >= mul16_m_blk_min;
-                    m_blk -= 16) {
-                mblk_candidates.insert(m_blk);
-            }
-        }
-
-        bool found_best_blocking = false;
-        for_(int n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
-        for_(int m_blk : mblk_candidates)
-        for_(int n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
-        for (int m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
-            current_blocking.set_blocking_parameters(
-                    nthr_k, n_blk, n_ch_sz, m_blk, m_ch_sz);
-
-            float cur_score = current_blocking.get_blocking_scores();
-            float bst_score = best_blocking.get_blocking_scores();
-
-            int m_chunks = div_up(bgmmc.M, m_blk * m_ch_sz);
-            int n_chunks = div_up(bgmmc.N, n_blk * n_ch_sz);
-            int work_amount = bgmmc.batch * m_chunks * n_chunks;
-
-            bool skip_config = work_amount < nthr_bmn * 3
-                    && work_amount % nthr_bmn != 0 && max_nthr_k == 1;
-            if (skip_config && !disable_skip_config) continue;
-
-            if (cur_score > bst_score) {
-                best_blocking = current_blocking;
-                found_best_blocking = true;
-            }
-        }
-
-        if (!found_best_blocking) {
-            current_blocking.set_blocking_parameters(
-                    nthr_k, min_N_blk, 1, min_M_blk, 1);
-
-            float cur_score = current_blocking.get_blocking_scores();
-            float bst_score = best_blocking.get_blocking_scores();
-            if (cur_score > bst_score) best_blocking = current_blocking;
-        }
-    }
-}
 
 float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
@@ -1171,7 +977,18 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
         prefer_copy_a &= bgmmc.N >= 256;
 
     if (bgmmc.is_amx) {
+        if (matmul_amx_blocking_params_macro_t::is_supported(
+                    bgmmc, bm_conf_utils)) {
+            //grid heuristic is possible best blocking is set
+            matmul_amx_blocking_params_macro_t best_blocking(bgmmc);
+            matmul_amx_blocking_params_macro_t::find_best_blocking(
+                    bgmmc, bm_conf_utils, best_blocking);
 
+            if (best_blocking.get_blocking_scores() != 0.0f) {
+                best_blocking.update_configuration(bgmmc);
+                return status::success;
+            }
+        }
         bgmmc.use_buffer_a |= prefer_copy_a;
 
         // Configure matrix sizes
@@ -1211,9 +1028,10 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
         bgmmc.brgemm_batch_size
                 = nstl::max(bgmmc.K / bgmmc.K_blk, static_cast<dim_t>(1));
 
-        matmul_amx_blocking_params_t best_blocking(bgmmc);
+        matmul_amx_blocking_params_micro_t best_blocking(bgmmc);
 
-        compute_blocking_heuristic_amx(bgmmc, bm_conf_utils, best_blocking);
+        matmul_amx_blocking_params_micro_t::find_best_blocking(
+                bgmmc, bm_conf_utils, best_blocking);
 
         VCONDCHECK_BG(best_blocking.get_blocking_scores() != 0.0f,
                 VERBOSE_BLOCKING_FAIL, "");
@@ -2090,230 +1908,9 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
                 default_data_align);
 }
 
-void matmul_amx_blocking_params_t::update_k_blocking_dependent_params() {
-    k_chunk_elems_ = k_blk_ * k_chunk_size_;
-    current_lda_ = get_actual_lda();
-    need_buf_c_ = is_buffer_c_required();
-}
 
-void matmul_amx_blocking_params_t::set_blocking_parameters(
-        int nthr_k, int n_blk, int n_chunk_size, int m_blk, int m_chunk_size) {
-    nthr_k_ = nstl::max(1, nthr_k);
-    nthr_mnb_ = nthr / nthr_k_;
-    nthr_ = nthr_mnb_ * nthr_k_;
-    n_blk_ = n_blk;
-    n_chunk_size_ = n_chunk_size;
-    m_blk_ = m_blk;
-    m_chunk_size_ = m_chunk_size;
-    if (one_of(0, n_blk_, n_chunk_size_, m_blk_, m_chunk_size_)) {
-        k_blk_ = k_chunk_size_ = k_chunk_elems_ = 0;
-        efficiency_score_ = 0.0f;
-        return;
-    }
 
-    n_chunk_elems_ = n_blk_ * n_chunk_size_;
-    m_chunk_elems_ = m_blk_ * m_chunk_size_;
 
-    if (K < wei_k_blk) {
-        k_blk_ = is_amx ? rnd_up(K, required_k_granularity) : K;
-        k_chunk_size_ = 1;
-    } else {
-        dim_t k_per_thr = div_up(K, nthr_k_);
-        k_blk_ = nstl::min(rnd_up(k_per_thr, required_k_granularity),
-                static_cast<dim_t>(wei_k_blk));
-        const dim_t num_k_blk = div_up(K, k_blk_);
-        const dim_t num_k_blk_per_thread = div_up(num_k_blk, nthr_k_);
-        k_chunk_size_ = num_k_blk_per_thread;
-
-        auto chunk_sz = calculate_chunk_memory_size();
-        const dim_t div_min = chunk_sz / L2_threshold();
-        const dim_t div_max = div_up(chunk_sz, L2_threshold());
-        // for big pow2 lda prefer to increase area of linear memory access
-        const dim_t adjust_k_divisor_threshold = lda_big_pow2() ? 2 : 0;
-        // adjust k blocking values to fit into L2 cache
-        if (div_min > adjust_k_divisor_threshold && k_chunk_size_ > 1) {
-            const auto kc1
-                    = nstl::max(k_chunk_size_ / div_min, static_cast<dim_t>(1));
-            const auto kc2 = div_up(k_chunk_size_, div_max);
-            const auto tail1 = num_k_blk_per_thread % kc1;
-            const auto tail2 = num_k_blk_per_thread % kc2;
-            // prefer adjusted chunk size with more equal work distribution
-            // across iterations
-            k_chunk_size_ = IMPLICATION(tail1 == 0 || tail2 < tail1, tail2 == 0)
-                    ? kc2
-                    : kc1;
-        }
-
-        k_chunk_elems_ = k_blk_ * k_chunk_size_;
-
-        const dim_t current_k_tail = K % k_blk_;
-
-        // TODO: review extendable_k_ condition to cover more cases
-        extendable_k_ = (K % wei_k_blk != 0) && (k_chunk_elems_ > wei_k_blk)
-                && wei_zp_type == none && !use_buffer_a
-                && !packed_sparse_weights;
-
-        if (extendable_k_) {
-            if (k_chunk_elems_ >= K) {
-                k_blk_ = K;
-                k_chunk_size_ = 1;
-            } else {
-                k_blk_ = k_chunk_elems_;
-                k_chunk_size_ = 1;
-            }
-        } else if (current_k_tail == 0 && K % (k_blk_ * k_chunk_size_) == 0) {
-            k_blk_ = k_chunk_elems_;
-            k_chunk_size_ = 1;
-        } else if (nthr_k_ == 1
-                && K == k_blk_ * k_chunk_size_ + current_k_tail) {
-            k_blk_ = k_chunk_elems_;
-            k_chunk_size_ = 2;
-        }
-    }
-    use_buffer_a_
-            = use_buffer_a || (!extendable_k_ && K % required_k_granularity);
-
-    blocking_chunk_mem_size_ = calculate_chunk_memory_size();
-
-    efficiency_score_ = calculate_blocking_scores();
-}
-
-// returns score for current blocking parameters' values in range [0, 1]
-// for parallel work over threads distribution score. Maximum scores - when
-// all threads have the same work amount w/o tails
-float matmul_amx_blocking_params_t::get_thread_balance_scores() {
-    assert(!(is_runtime_M && is_runtime_N)
-            && "single runtime dim is supported");
-    // Ignore M sizes in thread balance computation as actual M size is unknown
-    if (is_runtime_M) return (float)N / rnd_up(N, n_chunk_elems_);
-    // Ignore N sizes in thread balance computation as actual N size is unknown
-    if (is_runtime_N) return (float)M / rnd_up(M, m_chunk_elems_);
-
-    dim_t num_M_chunks = div_up(M, m_chunk_elems_);
-    dim_t num_N_chunks = div_up(N, n_chunk_elems_);
-    float mnb_parallel_score = batch * ((float)M / m_chunk_elems_)
-            * ((float)N / n_chunk_elems_)
-            / rnd_up(batch * num_M_chunks * num_N_chunks, nthr_mnb_)
-            * nthr_mnb_;
-    float k_parallel_score = 1.0f;
-    if (nthr_k_ > 1) {
-        dim_t num_K_chunks = div_up(K, k_chunk_elems_);
-        const float parallel_reduction_penalty = 0.8f;
-        k_parallel_score = parallel_reduction_penalty
-                * ((float)K / k_chunk_elems_) / rnd_up(num_K_chunks, nthr_k_)
-                * nthr_k_;
-    }
-
-    return mnb_parallel_score * k_parallel_score / nthr;
-}
-
-// returns score for current blocking parameters' values in range [0, 1]
-// for copied data reusage
-float matmul_amx_blocking_params_t::get_copied_data_reusage_scores() {
-    const dim_t effective_m_chunk_sz = 64 * 4;
-    const dim_t desired_M_chunk_size = is_runtime_M
-            ? effective_m_chunk_sz
-            : nstl::min(M, effective_m_chunk_sz);
-    const dim_t effective_n_chunk_sz = 64 * (use_buffer_a_ ? 4 : 1);
-    const dim_t desired_N_chunk_size = is_runtime_N
-            ? effective_n_chunk_sz
-            : nstl::min(N, effective_n_chunk_sz);
-    const float coef_M = nstl::min(
-            static_cast<float>(m_chunk_elems_) / desired_M_chunk_size, 1.0f);
-    const float coef_N = nstl::min(
-            static_cast<float>(n_chunk_elems_) / desired_N_chunk_size, 1.0f);
-    return 0.5f * (coef_M + coef_N);
-}
-
-// returns score for current blocking parameters' values in range [0, 1]
-// for L2 utilization
-float matmul_amx_blocking_params_t::get_L2_utilization_scores() const {
-    const float relative_difference_with_L2
-            = fabsf((float)L2_threshold() - blocking_chunk_mem_size_)
-            / nstl::max(L2_threshold(), blocking_chunk_mem_size_);
-    return 1.0f - relative_difference_with_L2;
-}
-
-// returns score for current blocking parameters' values in range [0, 1]
-// consists of 3 parts with its own weights:
-// 	1) parallel work over threads distribution score
-// 	2) L2 utilization score
-// 	3) copied data re-usage score
-float matmul_amx_blocking_params_t::calculate_blocking_scores() {
-    if (one_of(0, n_blk_, n_chunk_size_, m_blk_, m_chunk_size_, k_blk_,
-                k_chunk_size_))
-        return 0.0f;
-
-    const float nthr_coeff = nstl::min(nthr, 100);
-    const float reusage_factor = 1.0f;
-    // for runtume M the actual size is unknown, use independent on num_threads
-    // balance factors
-    const float balance_factor
-            = is_runtime_M ? 1.0f : (nthr_coeff - 1.0f) / nthr_coeff;
-    const float cache_utilization_factor
-            = is_runtime_M ? 1.0f : 1.0f / nthr_coeff;
-
-    float scores = cache_utilization_factor * get_L2_utilization_scores()
-            + reusage_factor * get_copied_data_reusage_scores();
-    if (balance_factor > 0.0f)
-        scores += balance_factor * get_thread_balance_scores();
-    return scores
-            / (reusage_factor + balance_factor + cache_utilization_factor);
-}
-
-void matmul_amx_blocking_params_t::update_configuration(
-        brgemm_matmul_conf_t &bgmmc) const {
-    bgmmc.nthr_k = nthr_k_;
-    bgmmc.nthr_m = nthr_m_;
-    bgmmc.nthr_n = nthr_n_;
-    bgmmc.M_blk = m_blk_;
-    bgmmc.M_chunk_size = m_chunk_size_;
-    bgmmc.N_blk = n_blk_;
-    bgmmc.N_chunk_size = n_chunk_size_;
-
-    bgmmc.K_blk = k_blk_;
-    bgmmc.brgemm_batch_size = k_chunk_size_;
-
-    bgmmc.use_buffer_c = need_buf_c_;
-    bgmmc.LDA = current_lda_;
-    bgmmc.use_buffer_a = use_buffer_a_;
-    bgmmc.extendable_k = extendable_k_;
-}
-
-dim_t matmul_amx_blocking_params_t::get_actual_lda() {
-    if (!use_buffer_a_)
-        return treat_A_as_plain ? K : A_strides[1 - transposed_A] / a_dt_sz;
-
-    constexpr int bytes_in_cacheline = 64;
-    const int elems_in_cacheline = bytes_in_cacheline / a_dt_sz;
-    dim_t lda = rnd_up(k_blk_, elems_in_cacheline);
-    const bool is_big_2_pow = lda >= 512 && math::is_pow2(lda);
-    if (is_big_2_pow) lda += elems_in_cacheline;
-    return lda;
-}
-
-bool matmul_amx_blocking_params_t::is_buffer_c_required() {
-    if (nthr_k_ > 1 && K > k_chunk_elems_) return true;
-
-    return ((acc_dt != dst_dt || with_sum)
-            && (K > k_chunk_elems_ || K % k_blk_ > 0));
-}
-
-size_t matmul_amx_blocking_params_t::calculate_chunk_memory_size() {
-    update_k_blocking_dependent_params();
-
-    size_t A_chunk_sz = a_dt_sz * k_chunk_elems_ * m_chunk_elems_;
-    size_t A_buf_sz = use_buffer_a_
-            ? tr_a_dt_sz * current_lda_ * k_chunk_size_ * m_chunk_elems_
-            : 0;
-    size_t B_chunk_sz = b_dt_sz * k_chunk_elems_ * n_chunk_elems_;
-    size_t B_buf_sz = use_buffer_b ? tr_b_dt_sz * n_blk_ * k_chunk_elems_ : 0;
-    size_t C_chunk_sz = c_dt_sz * m_chunk_elems_ * n_chunk_elems_;
-    size_t C_buf_sz
-            = need_buf_c_ ? acc_dt_sz * m_chunk_elems_ * n_chunk_elems_ : 0;
-    return A_chunk_sz + A_buf_sz + B_chunk_sz + B_buf_sz + C_chunk_sz
-            + C_buf_sz;
-}
 
 } // namespace matmul
 } // namespace x64

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -523,7 +523,9 @@ brgemm_broadcast_t get_zp_type(const primitive_attr_t &attr, int arg) {
 
 struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
     matmul_amx_blocking_params_t()
-        : nthr_k_(0)
+        : nthr_m_(0)
+        , nthr_n_(0)
+        , nthr_k_(0)
         , nthr_mnb_(0)
         , nthr_(0)
         , n_blk_(0)
@@ -544,6 +546,8 @@ struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
 
     matmul_amx_blocking_params_t(const brgemm_matmul_conf_t &bgmmc)
         : brgemm_matmul_conf_t(bgmmc)
+        , nthr_m_(nstl::max(nthr_m, 1))
+        , nthr_n_(nstl::max(nthr_n, 1))
         , nthr_k_(nstl::max(nthr_k, 1))
         , nthr_mnb_(nthr / nthr_k_)
         , nthr_(nthr_mnb_ * nthr_k_)
@@ -571,8 +575,8 @@ struct matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
     static size_t L2_threshold();
 
 private:
-    // num threads for parallelism wrt k dimension
-    int nthr_k_;
+    // num threads for parallelism
+    int nthr_m_, nthr_n_, nthr_k_;
     // num threads for parallelism wrt m, n and batch dimensions
     int nthr_mnb_;
     int nthr_;
@@ -2260,6 +2264,8 @@ float matmul_amx_blocking_params_t::calculate_blocking_scores() {
 void matmul_amx_blocking_params_t::update_configuration(
         brgemm_matmul_conf_t &bgmmc) const {
     bgmmc.nthr_k = nthr_k_;
+    bgmmc.nthr_m = nthr_m_;
+    bgmmc.nthr_n = nthr_n_;
     bgmmc.M_blk = m_blk_;
     bgmmc.M_chunk_size = m_chunk_size_;
     bgmmc.N_blk = n_blk_;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -87,8 +87,10 @@ struct brgemm_matmul_conf_t {
     int ndims, batch_ndims;
     dim_t M, N, K, batch, batch_without_first_dim;
     dim_t M_blk, N_blk, K_blk, M_tail, N_tail, K_tail;
-    int M_chunk_size, N_chunk_size;
+    int M_chunk_size, N_chunk_size, K_chunk_size;
+    bool is_a_nt, is_b_nt, set_nt;
     dim_t LDA, LDB, LDC, LDD;
+    dim_t LDB2;
     int brgemm_batch_size, brgemm_batch_tail_size;
     int wei_n_blk, wei_k_blk;
     brgemm_batch_kind_t brg_type;
@@ -146,6 +148,7 @@ struct brgemm_matmul_conf_t {
     int K_chunks;
     int num_M_blocks;
     int num_N_blocks;
+    int num_K_blocks;
     dim_t M_chunk_elems;
     dim_t N_chunk_elems;
     dim_t K_chunk_elems;
@@ -163,9 +166,14 @@ struct brgemm_matmul_conf_t {
     dim_t copy_A_src_stride;
     dim_t copy_B_wei_stride;
 
-    dim_t buffer_a_chunk_sz;
-    dim_t buffer_a_chunk_shift_along_m;
+    dim_t buffer_a_gb_stride;
+    dim_t buffer_a_k_stride;
+    dim_t buffer_a_m_stride;
     dim_t buffer_a_per_thread_sz;
+
+    dim_t buffer_b_gb_stride;
+    dim_t buffer_b_k_brg_stride;
+    dim_t buffer_b_n_blk_stride;
 
     dim_t buffer_b_chunk_sz;
     dim_t buffer_b_per_thread_sz;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -94,6 +94,7 @@ struct brgemm_matmul_conf_t {
     int brgemm_batch_size, brgemm_batch_tail_size;
     int wei_n_blk, wei_k_blk;
     brgemm_batch_kind_t brg_type;
+    bool is_macro_heuristics;
 
     cpu_isa_t isa;
 
@@ -246,6 +247,12 @@ struct brgemm_matmul_conf_utils_t {
                         blocked_48n_B_layout_tag, blocked_32n_B_layout_tag,
                         blocked_24n_B_layout_tag, blocked_16n_B_layout_tag,
                         blocked_8n_B_layout_tag);
+    }
+
+    inline bool check_b_layout_blocked_32_by_n(
+            format_tag_t matrix_b_tag) const {
+        return blocked_B_layouts_allowed && !bgmmc.is_runtime_N
+                && utils::one_of(matrix_b_tag, blocked_32n_B_layout_tag);
     }
 
     inline bool get_blocked_B() const {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -133,7 +133,7 @@ struct brgemm_matmul_conf_t {
     data_type_t orig_src_dt;
     data_type_t orig_wei_dt;
     int nthr;
-    int nthr_k;
+    int nthr_k = 1, nthr_m = 1, nthr_n = 1, nthr_b = 1;
 
     // Auxiliary values for init_config() and execute()
     dim_t a_dt_sz, b_dt_sz, c_dt_sz, acc_dt_sz, bias_dt_sz, reduce_dt_sz;


### PR DESCRIPTION
New blocking heuristics for matrix multiplication using AMX include a new k-loop, utilize blocked C, and employ larger N dimensions in BRGEM with LDB2
