### PR TITLE
graph: interface: several fixes and code improves

### DIFF
--- a/src/graph/interface/backend.hpp
+++ b/src/graph/interface/backend.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2024 Intel Corporation
+ * Copyright 2020-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,7 +162,6 @@ public:
     // of vector
     std::vector<const backend_t *> &get_registered_backends() {
         invoke_backend_registration();
-        std::lock_guard<std::mutex> lock(m_);
         return sorted_backends_;
     }
 
@@ -175,7 +174,6 @@ public:
     const backend_t *get_registered_backend(size_t layout_id) {
         invoke_backend_registration();
         size_t backend_id = extract_backend_id(layout_id);
-        std::lock_guard<std::mutex> lock(m_);
         return backends_[backend_id];
     }
 

--- a/src/graph/interface/graph.hpp
+++ b/src/graph/interface/graph.hpp
@@ -445,6 +445,7 @@ public:
         writer.write_keyvalue("output_ports", outputs_id);
         writer.write_keyvalue("graph", get_ops());
         writer.end_object();
+        writer.write_newline();
 
         return graph::status::success;
     }

--- a/src/graph/interface/graph.hpp
+++ b/src/graph/interface/graph.hpp
@@ -41,7 +41,6 @@
 
 #include "graph/utils/debug.hpp"
 #include "graph/utils/id.hpp"
-#include "graph/utils/json.hpp"
 #include "graph/utils/utils.hpp"
 
 namespace graph = dnnl::impl::graph;
@@ -409,46 +408,7 @@ public:
     }
 
     // This function is used to serialize graph to a JSON file
-    graph::status_t serialize(const std::string &filename) const {
-        const auto &fpmath = get_fpmath_mode();
-        dnnl::impl::verbose_printf(
-                "graph,info,serialize graph to a json file %s\n",
-                filename.c_str());
-        std::ofstream of(filename);
-        graph::utils::json::json_writer_t writer(&of);
-        writer.begin_object();
-        std::string version = std::to_string(dnnl_version()->major) + "."
-                + std::to_string(dnnl_version()->minor) + "."
-                + std::to_string(dnnl_version()->patch);
-        writer.write_keyvalue("version", version);
-        writer.write_keyvalue("engine_kind",
-                std::string(graph::utils::engine_kind2str(get_engine_kind())));
-        writer.write_keyvalue("fpmath_mode",
-                std::string(graph::utils::fpmath_mode2str(fpmath.mode_)));
-        writer.write_keyvalue("fpmath_mode_apply_to_int",
-                std::string(fpmath.apply_to_int_ ? "true" : "false"));
-        std::vector<size_t> inputs_id;
-        inputs_id.reserve(get_input_values().size());
-        for (const auto &val : get_input_values()) {
-            auto lt = val->get_logical_tensor();
-            auto ltw = logical_tensor_wrapper_t(lt);
-            inputs_id.push_back(ltw.id());
-        }
-        writer.write_keyvalue("input_ports", inputs_id);
-        std::vector<size_t> outputs_id;
-        outputs_id.reserve(get_output_values().size());
-        for (const auto &val : get_output_values()) {
-            auto lt = val->get_logical_tensor();
-            auto ltw = logical_tensor_wrapper_t(lt);
-            outputs_id.push_back(ltw.id());
-        }
-        writer.write_keyvalue("output_ports", outputs_id);
-        writer.write_keyvalue("graph", get_ops());
-        writer.end_object();
-        writer.write_newline();
-
-        return graph::status::success;
-    }
+    graph::status_t serialize(const std::string &filename) const;
 
     static std::vector<op_ptr> deep_copy(const std::vector<op_ptr> &ops);
 };

--- a/src/graph/interface/graph_attr.hpp
+++ b/src/graph/interface/graph_attr.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,16 +24,16 @@ namespace impl {
 namespace graph {
 
 struct fpmath_t {
+    fpmath_t() = default;
 
-    fpmath_t(dnnl_fpmath_mode_t mode = fpmath_mode::strict,
-            bool apply_to_int = false)
+    fpmath_t(fpmath_mode_t mode, bool apply_to_int)
         : mode_(mode), apply_to_int_(apply_to_int) {}
 
     bool operator==(const fpmath_t &rhs) const {
         return mode_ == rhs.mode_ && apply_to_int_ == rhs.apply_to_int_;
     }
 
-    graph::fpmath_mode_t mode_;
+    fpmath_mode_t mode_ = fpmath_mode::strict;
     bool apply_to_int_ = false;
 };
 

--- a/src/graph/utils/json.hpp
+++ b/src/graph/utils/json.hpp
@@ -101,6 +101,8 @@ public:
     template <typename valuetype>
     inline void write_array_item(const valuetype &value);
 
+    inline void write_newline();
+
 private:
     std::ostream *os_;
     /*!
@@ -394,7 +396,7 @@ inline void json_writer_t::end_array() {
 }
 
 inline void json_writer_t::write_array_seperator() {
-    if (scope_count_.back() != 0) { *os_ << ", "; }
+    if (scope_count_.back() != 0) { *os_ << ","; }
     scope_count_.back() += 1;
     write_seperator();
 }
@@ -421,6 +423,10 @@ inline void json_writer_t::write_seperator() {
         *os_ << '\n';
         *os_ << std::string(scope_multi_line_.size() * 2, ' ');
     }
+}
+
+inline void json_writer_t::write_newline() {
+    *os_ << '\n';
 }
 
 inline int json_reader_t::next_char() {

--- a/tests/gtests/graph/unit/backend/dnnl/test_compiled_partition.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_compiled_partition.cpp
@@ -309,9 +309,9 @@ TEST(test_compiled_partition, GetAndInfoMethod) {
             graph::dnnl_impl::dnnl_compiled_partition_impl_t>(
             engine, inputs, outputs, kernel);
     graph::partition_t par;
+    const graph::fpmath_t fpm {graph::fpmath_mode::strict, false};
     auto par_impl = std::make_shared<graph::dnnl_impl::dnnl_partition_impl_t>(
-            engine.kind(), graph::fpmath_mode::strict,
-            graph::partition_kind_t::undef);
+            engine.kind(), fpm, graph::partition_kind_t::undef);
     par.init(par_impl);
     graph::compiled_partition_t cp(par);
     cp.init(cp_impl);

--- a/tests/gtests/graph/unit/backend/dnnl/test_layout_propagator_cpu.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_layout_propagator_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,9 +45,10 @@ TEST(test_layout_propagator, LayoutPropagatorForPermute) {
     dnnl::engine p_engine = dnnl_impl::make_dnnl_engine(eng);
     dnnl_impl::fusion_info_mgr_t mgr;
     dnnl_impl::pd_cache_t pd_cache;
+    const graph::fpmath_t fpm {graph::fpmath_mode::any, false};
     auto sg = std::make_shared<dnnl_impl::subgraph_t>(
-            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine,
-            graph::fpmath_mode::any, false, false);
+            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine, fpm,
+            false, false);
     dnnl_impl::subgraph_rewriter_t rewriter {sg};
     ASSERT_EQ(dnnl_impl::layout_propagator_for_permute(
                       op, p_engine, mgr, pd_cache, rewriter),
@@ -69,9 +70,10 @@ TEST(test_layout_propagator, LayoutPropagatorForReorder) {
     dnnl::engine p_engine = dnnl_impl::make_dnnl_engine(eng);
     dnnl_impl::fusion_info_mgr_t mgr;
     dnnl_impl::pd_cache_t pd_cache;
+    const graph::fpmath_t fpm {graph::fpmath_mode::any, false};
     auto sg = std::make_shared<dnnl_impl::subgraph_t>(
-            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine,
-            graph::fpmath_mode::any, false, false);
+            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine, fpm,
+            false, false);
     dnnl_impl::subgraph_rewriter_t rewriter {sg};
     ASSERT_EQ(layout_propagator_for_reorder(
                       op, p_engine, mgr, pd_cache, rewriter),
@@ -91,9 +93,10 @@ TEST(test_layout_propagator, LayoutPropagatorForSumDeathTest) {
 
     op->add_input(lt_in);
     op->add_output(lt_out);
+    const graph::fpmath_t fpm {graph::fpmath_mode::any, false};
     auto sg = std::make_shared<dnnl_impl::subgraph_t>(
-            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine,
-            graph::fpmath_mode::any, false, false);
+            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine, fpm,
+            false, false);
     dnnl_impl::subgraph_rewriter_t rewriter {sg};
     ASSERT_EQ(layout_propagator_for_sum(op, p_engine, mgr, pd_cache, rewriter),
             graph::status::success);
@@ -126,9 +129,10 @@ TEST(test_layout_propagator, LayoutPropagatorForSubZpsDeathTest) {
     dnnl_impl::fusion_info_mgr_t mgr;
     dnnl_impl::pd_cache_t pd_cache;
     auto op = std::make_shared<graph::op_t>(0, graph::op_kind::Wildcard, "op");
+    const graph::fpmath_t fpm {graph::fpmath_mode::any, false};
     auto sg = std::make_shared<dnnl_impl::subgraph_t>(
-            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine,
-            graph::fpmath_mode::any, false, false);
+            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine, fpm,
+            false, false);
     dnnl_impl::subgraph_rewriter_t rewriter {sg};
 #ifndef NDEBUG
     EXPECT_DEATH(dnnl_impl::layout_propagator_for_sub_zps(
@@ -147,9 +151,10 @@ TEST(test_layout_propagator, LayoutPropagatorForAddZpsDeathTest) {
     dnnl_impl::fusion_info_mgr_t mgr;
     dnnl_impl::pd_cache_t pd_cache;
     auto op = std::make_shared<graph::op_t>(0, graph::op_kind::Wildcard, "op");
+    const graph::fpmath_t fpm {graph::fpmath_mode::any, false};
     auto sg = std::make_shared<dnnl_impl::subgraph_t>(
-            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine,
-            graph::fpmath_mode::any, false, false);
+            std::vector<std::shared_ptr<graph::op_t>> {op}, p_engine, fpm,
+            false, false);
     dnnl_impl::subgraph_rewriter_t rewriter {sg};
 #ifndef NDEBUG
     EXPECT_DEATH(dnnl_impl::layout_propagator_for_add_zps(

--- a/tests/gtests/graph/unit/backend/dnnl/test_partition_cpu.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_partition_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,19 +30,21 @@ using namespace dnnl::impl::graph;
 using namespace dnnl::graph::tests::unit::utils;
 
 TEST(test_partition, CreateSimple) {
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(
-            engine_kind::cpu, fpmath_mode::strict, partition_kind_t::undef);
+            engine_kind::cpu, fpm, partition_kind_t::undef);
     ASSERT_EQ(p.get_ops().size(), 0U);
-    ASSERT_EQ(p.get_fpmath_mode(), fpmath_mode::strict);
+    ASSERT_EQ(p.get_fpmath_mode().mode_, fpmath_mode::strict);
     ASSERT_EQ(p.get_kind(), partition_kind_t::undef);
 }
 
 TEST(test_partition, AddOps) {
     std::vector<engine_kind_t> engine_kinds
             = {engine_kind::cpu, engine_kind::gpu};
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     for (const auto &engine_kind : engine_kinds) {
         dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(
-                engine_kind, fpmath_mode::strict, partition_kind_t::undef);
+                engine_kind, fpm, partition_kind_t::undef);
         size_t id = 100;
         std::shared_ptr<op_t> n(new op_t(id, op_kind::Wildcard, "Wildcard"));
         p.add_op(n);
@@ -60,8 +62,9 @@ TEST(test_partition, AddOps) {
 }
 
 TEST(test_partition, GetOps) {
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(
-            engine_kind::cpu, fpmath_mode::strict, partition_kind_t::undef);
+            engine_kind::cpu, fpm, partition_kind_t::undef);
     size_t id = 100;
     std::shared_ptr<op_t> n(new op_t(id, op_kind::Wildcard, "Wildcard"));
     p.add_op(n);
@@ -73,9 +76,10 @@ TEST(test_partition, GetOps) {
 TEST(test_partition, Init) {
     std::vector<engine_kind_t> engine_kinds
             = {engine_kind::cpu, engine_kind::gpu};
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     for (const auto &engine_kind : engine_kinds) {
         dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(
-                engine_kind, fpmath_mode::strict, partition_kind_t::undef);
+                engine_kind, fpm, partition_kind_t::undef);
         std::shared_ptr<op_t> n(new op_t(0, op_kind::Convolution, "Conv"));
         n->set_attr<int64_t>(op_attr::groups, 0);
         p.add_op(n);
@@ -87,9 +91,10 @@ TEST(test_partition, Init) {
 TEST(test_partition, Clone) {
     std::vector<engine_kind_t> engine_kinds
             = {engine_kind::cpu, engine_kind::gpu};
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     for (const auto &engine_kind : engine_kinds) {
-        dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(engine_kind,
-                fpmath_mode::strict, partition_kind_t::convolution_post_ops);
+        dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(
+                engine_kind, fpm, partition_kind_t::convolution_post_ops);
         auto n = std::make_shared<op_t>(op_kind::Convolution);
         n->set_attr<int64_t>(op_attr::groups, 1);
 
@@ -120,11 +125,10 @@ TEST(test_partition_op, AssignedPartition) {
     op_t conv {0, op_kind::Convolution, std::string("convolution")};
 
     ASSERT_EQ(conv.get_partition(), nullptr);
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto part = std::make_shared<
             dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t>(
-            engine_kind::cpu, fpmath_mode::strict,
-            partition_kind_t::convolution_post_ops);
+            engine_kind::cpu, fpm, partition_kind_t::convolution_post_ops);
     conv.set_partition(part.get());
     ASSERT_EQ(conv.get_partition(), part.get());
 }
@@ -133,9 +137,10 @@ TEST(test_partition, SetFpmathMode) {
     engine_t *eng = get_engine();
     for (auto m : {fpmath_mode::strict, fpmath_mode::bf16, fpmath_mode::f16,
                  fpmath_mode::any}) {
+        const graph::fpmath_t fpm {m, false};
         dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t p(
-                eng->kind(), m, partition_kind_t::undef);
-        ASSERT_EQ(p.get_fpmath_mode(), m);
+                eng->kind(), fpm, partition_kind_t::undef);
+        ASSERT_EQ(p.get_fpmath_mode().mode_, m);
     }
 }
 
@@ -154,11 +159,10 @@ TEST(test_partition, InferShape) {
 
         std::vector<const graph::logical_tensor_t *> inputs {&lt1, &lt2};
         std::vector<graph::logical_tensor_t *> outputs {&lt3};
-
+        const graph::fpmath_t fpm {fpmath_mode::strict, false};
         auto par = std::make_shared<
                 dnnl::impl::graph::dnnl_impl::dnnl_partition_impl_t>(
-                engine_kind, graph::fpmath_mode::strict,
-                graph::partition_kind_t::undef);
+                engine_kind, fpm, graph::partition_kind_t::undef);
         ASSERT_EQ(par->infer_shape(inputs, outputs), graph::status::success);
     }
 }

--- a/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -408,10 +408,9 @@ TEST(test_subgraph_pass, Conv2dNxcPlainDst) {
 
     std::vector<graph::logical_tensor_t> lt_ins {src_u8, weight_s8};
     std::vector<graph::logical_tensor_t> lt_outs {dst_u8};
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            agraph.get_partitions()[0]->get_ops(), p_eng, fpmath_mode::strict,
-            true, true);
+            agraph.get_partitions()[0]->get_ops(), p_eng, fpm, true, true);
     ASSERT_EQ(subgraph->get_ops().size(), 4U);
 
     ASSERT_EQ(dnnl_impl::set_given_inputs_outputs(subgraph, lt_ins, lt_outs),
@@ -619,9 +618,9 @@ TEST(test_subgraph_pass, Int8ConvSumRelu) {
 
     weight_f32.property = graph::property_type::constant;
     bias_f32.property = graph::property_type::constant;
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            part->get_ops(), p_eng, fpmath_mode::strict, false, true);
+            part->get_ops(), p_eng, fpm, false, true);
 
     std::vector<logical_tensor_t> inputs
             = {src_u8, weight_f32, bias_f32, other_s8};
@@ -871,10 +870,9 @@ TEST_P(int8_matmul_with_diff_inputs_t, Int8MatmulPasses) {
             graph::partition_kind_t::quantized_matmul_post_ops);
     ASSERT_EQ(agraph.get_partitions()[0]->get_outputs().size(), 1U);
     ASSERT_EQ(agraph.get_partitions()[0]->get_inputs().size(), 3U);
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            agraph.get_partitions()[0]->get_ops(), p_eng, fpmath_mode::strict,
-            true, true);
+            agraph.get_partitions()[0]->get_ops(), p_eng, fpm, true, true);
     ASSERT_EQ(subgraph->get_ops().size(), 5U);
 
     dnnl_impl::check_with_bias(subgraph);
@@ -992,10 +990,9 @@ TEST_P(matmul_with_diff_inputs_t, MatmulPasses) {
             graph::partition_kind_t::matmul_post_ops);
     ASSERT_EQ(agraph.get_partitions()[0]->get_outputs().size(), 1U);
     ASSERT_EQ(agraph.get_partitions()[0]->get_inputs().size(), 3U);
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            agraph.get_partitions()[0]->get_ops(), p_eng, fpmath_mode::strict,
-            true, true);
+            agraph.get_partitions()[0]->get_ops(), p_eng, fpm, true, true);
     ASSERT_EQ(subgraph->get_ops().size(), 2U);
 
     dnnl_impl::check_with_bias(subgraph);
@@ -1278,9 +1275,9 @@ TEST(test_subgraph_pass, MemoryPlanning) {
     g.add_op(&op8);
     g.add_op(&op9);
     g.finalize();
-
-    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(g.get_ops(), p_eng,
-            fpmath_mode::strict, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
+    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
+            g.get_ops(), p_eng, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(subgraph->get_ops().size(), 9U);
 
     std::vector<logical_tensor_t> inputs = {val0};
@@ -1354,9 +1351,9 @@ TEST(test_subgraph_pass, FusePostOpsForConvDepthwise_CPU) {
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            part->get_ops(), p_eng, fpmath_mode::strict, false, true);
+            part->get_ops(), p_eng, fpm, false, true);
     dnnl_impl::subgraph_visualizer_t vis(part->id(), [](const value_t *val) {
         (void)val;
         return std::string();
@@ -1465,9 +1462,9 @@ TEST(test_subgraph_pass, FuseSigmoidMultiplyToSwish) {
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            part->get_ops(), p_eng, fpmath_mode::strict, false, true);
+            part->get_ops(), p_eng, fpm, false, true);
     dnnl_impl::pass_pipeline_t pipeline(
             dnnl_impl::subgraph_visualizer_t(), true, false);
     dnnl_impl::larger_partition_kernel_t::setup_pipeline_stage1(pipeline);
@@ -1572,10 +1569,9 @@ TEST(test_subgraph_pass_int8_matmul_passes_with_diff_inputs,
                 graph::partition_kind_t::quantized_matmul_post_ops);
         ASSERT_EQ(agraph.get_partitions()[0]->get_outputs().size(), 1U);
         ASSERT_EQ(agraph.get_partitions()[0]->get_inputs().size(), 4U);
-
+        const graph::fpmath_t fpm {fpmath_mode::strict, false};
         auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-                agraph.get_partitions()[0]->get_ops(), p_eng,
-                fpmath_mode::strict, false, true);
+                agraph.get_partitions()[0]->get_ops(), p_eng, fpm, false, true);
         // dequant, dequant, tc, tc, matmul, scale, add
         ASSERT_EQ(subgraph->get_ops().size(), 7U);
 
@@ -1659,10 +1655,9 @@ TEST(test_subgraph_pass, FuseTypecastToQuantize) {
     pass::pass_base_ptr apass = get_pass("typecast_quantize_fusion");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
-
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            agraph.get_partitions()[0]->get_ops(), p_eng, fpmath_mode::strict,
-            false, true);
+            agraph.get_partitions()[0]->get_ops(), p_eng, fpm, false, true);
     // tc, quant
     ASSERT_EQ(subgraph->get_ops().size(), 2U);
 
@@ -1695,9 +1690,9 @@ TEST(test_subgraph_pass_layout_propagation, ReshapeWithSpecifiedOutputLayout) {
     graph::graph_t g;
     g.add_op(&op1);
     g.finalize();
-
-    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(g.get_ops(), p_eng,
-            fpmath_mode::strict, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
+    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
+            g.get_ops(), p_eng, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(subgraph->get_ops().size(), 1U);
 
     ASSERT_EQ(dnnl_impl::lower_down(subgraph), graph::status::success);
@@ -1737,9 +1732,9 @@ TEST(test_subgraph_pass_layout_propagation,
     graph::graph_t g;
     g.add_op(&op1);
     g.finalize();
-
-    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(g.get_ops(), p_eng,
-            fpmath_mode::strict, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
+    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
+            g.get_ops(), p_eng, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(subgraph->get_ops().size(), 1U);
 
     ASSERT_EQ(dnnl_impl::lower_down(subgraph), graph::status::success);
@@ -1775,9 +1770,9 @@ TEST(test_subgraph_pass_layout_propagation, ReshapeWithReshapableInputLayout) {
     graph::graph_t g;
     g.add_op(&op1);
     g.finalize();
-
-    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(g.get_ops(), p_eng,
-            fpmath_mode::strict, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
+    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
+            g.get_ops(), p_eng, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(subgraph->get_ops().size(), 1U);
 
     ASSERT_EQ(dnnl_impl::lower_down(subgraph), graph::status::success);
@@ -1808,9 +1803,9 @@ TEST(test_subgraph_pass_layout_propagation, Transpose) {
     graph::graph_t g;
     g.add_op(&op1);
     g.finalize();
-
-    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(g.get_ops(), p_eng,
-            fpmath_mode::strict, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
+    auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
+            g.get_ops(), p_eng, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(subgraph->get_ops().size(), 1U);
 
     ASSERT_EQ(dnnl_impl::lower_down(subgraph), graph::status::success);
@@ -1944,9 +1939,9 @@ TEST(test_subgraph_pass, FuseTypecastBeforeFusePostops) {
 
     graph::engine_t *g_eng = get_engine();
     dnnl::engine p_eng = dnnl::impl::graph::dnnl_impl::make_dnnl_engine(*g_eng);
+    const graph::fpmath_t fpm {fpmath_mode::strict, false};
     auto subgraph = std::make_shared<dnnl_impl::subgraph_t>(
-            g.get_partitions()[0]->get_ops(), p_eng, fpmath_mode::strict, false,
-            true);
+            g.get_partitions()[0]->get_ops(), p_eng, fpm, false, true);
     ASSERT_EQ(subgraph->get_ops().size(), 8U);
 
     dnnl_impl::subgraph_visualizer_t vis(0, [](const value_t *val) {
@@ -2050,8 +2045,9 @@ TEST(test_subgraph_pass, CommonReorderElimination) {
     g.add_op(&reorder_op2);
     g.add_op(&op1);
     g.finalize();
-    auto subgraph = std::make_shared<graph::dnnl_impl::subgraph_t>(g.get_ops(),
-            p_eng, graph::fpmath_mode::any, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::any, false};
+    auto subgraph = std::make_shared<graph::dnnl_impl::subgraph_t>(
+            g.get_ops(), p_eng, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(graph::dnnl_impl::common_reorder_elimination(subgraph),
             graph::status::success);
     ASSERT_EQ(subgraph->get_ops().size(), 3U);
@@ -2156,9 +2152,9 @@ TEST(test_subgraph_pass, CombineBinaryPostOpScales) {
     g.add_op(&mul_op);
     g.add_op(&qout_op);
     g.finalize();
-
-    auto subgraph = std::make_shared<graph::dnnl_impl::subgraph_t>(g.get_ops(),
-            p_engine, graph::fpmath_mode::any, false, /* reset_layout */ false);
+    const graph::fpmath_t fpm {fpmath_mode::any, false};
+    auto subgraph = std::make_shared<graph::dnnl_impl::subgraph_t>(
+            g.get_ops(), p_engine, fpm, false, /* reset_layout */ false);
     ASSERT_EQ(graph::dnnl_impl::lower_down(subgraph), graph::status::success);
     ASSERT_EQ(graph::dnnl_impl::fuse_to_int8_pool(subgraph),
             graph::status::success);
@@ -2294,9 +2290,9 @@ TEST(test_subgraph_pass, FuseNCXConvolutionBinaryAddNC11PostSrc) {
     ASSERT_EQ(g.add_op(&conv_op), graph::status::success);
     ASSERT_EQ(g.add_op(&add_op), graph::status::success);
     g.finalize();
-
+    const graph::fpmath_t fpm {fpmath_mode::any, false};
     auto subgraph = std::make_shared<graph::dnnl_impl::subgraph_t>(g.get_ops(),
-            p_engine, graph::fpmath_mode::any, false,
+            p_engine, fpm, false,
             /* reset_layout */ false);
     ASSERT_EQ(graph::dnnl_impl::lower_down(subgraph), graph::status::success);
     ASSERT_EQ(
@@ -2450,9 +2446,9 @@ TEST(test_subgraph_pass, FuseNXCConvolutionBinaryAddNC11PostSrc) {
     ASSERT_EQ(g.add_op(&conv_op), graph::status::success);
     ASSERT_EQ(g.add_op(&add_op), graph::status::success);
     g.finalize();
-
+    const graph::fpmath_t fpm {fpmath_mode::any, false};
     auto subgraph = std::make_shared<graph::dnnl_impl::subgraph_t>(g.get_ops(),
-            p_engine, graph::fpmath_mode::any, false,
+            p_engine, fpm, false,
             /* reset_layout */ false);
     ASSERT_EQ(graph::dnnl_impl::lower_down(subgraph), graph::status::success);
     ASSERT_EQ(

--- a/tests/gtests/graph/unit/interface/test_graph_cpu.cpp
+++ b/tests/gtests/graph/unit/interface/test_graph_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -414,12 +414,12 @@ TEST(test_interface_graph, SetFpmathMode) {
     ASSERT_EQ(dnnl::impl::get_fpmath_mode(), fpmath_mode::strict);
 
     graph_t graph;
-    ASSERT_EQ(graph.get_fpmath_mode(), fpmath_mode::strict);
+    ASSERT_EQ(graph.get_fpmath_mode().mode_, fpmath_mode::strict);
 
     for (auto m : {fpmath_mode::strict, fpmath_mode::bf16, fpmath_mode::f16,
                  fpmath_mode::any}) {
         graph_t graph2 {engine_kind::cpu, m};
-        ASSERT_EQ(graph2.get_fpmath_mode(), m);
+        ASSERT_EQ(graph2.get_fpmath_mode().mode_, m);
     }
 }
 


### PR DESCRIPTION
1. JSON file serialization: removed the trailing whitespaces which may cause unintended edits when a JSON file is opened and closed with an editor (eg. vscode) configured with removing trailing whitespaces. Also added a newline at the end of the JSON file.
2. Moved the graph::serialize() method to cpp file so changing it or the JSON utility will not cause the whole graph component recompile (due to graph.hpp is almost included everywhere).
3. Backend interface: removed two lock guards which seem unnecessary.
4. fpmath_t: make the constructor explicit so we don't confuse it with fpmath_mode_t. At some places, we passed fpmath_mode_t to functions which requires fpmath_t as an argument.