### PR TITLE
Add LBR_GRU to cell_fusion kernel for MTL dispatch

### DIFF
--- a/src/gpu/intel/ocl/rnn/cell_common.cpp
+++ b/src/gpu/intel/ocl/rnn/cell_common.cpp
@@ -15,8 +15,7 @@
 *******************************************************************************/
 
 // Common for RNN and LSTM cell execution
-
-#include "gpu/intel/ocl/rnn/rnn_grid.hpp"
+#include "gpu/intel/ocl/rnn/simple_cell_fusion.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -26,98 +25,6 @@ namespace ocl {
 
 using namespace dnnl::impl::utils;
 using namespace rnn_utils;
-
-template <size_t out_ndims, size_t in_ndims>
-strides_t<out_ndims> inner(const strides_t<in_ndims> &s) {
-    static_assert(in_ndims >= out_ndims,
-            "The output strides are expected to be smaller than the input "
-            "strides");
-    strides_t<out_ndims> ret;
-    for (size_t i = 0; i < out_ndims; i++) {
-        ret[i] = s[i + in_ndims - out_ndims];
-    }
-    return ret;
-}
-
-status_t compute_cell_fwd(const exec_ctx_t &ctx,
-        const compute::kernel_t &kernel, dim_t lay, dim_t dir, dim_t iter,
-        const workspace_t &workspace, const user_data_t user_data,
-        const sub_buffer_t &weights_layer, const sub_buffer_t &weights_iter,
-        const sub_buffer_t &cell_layer, const strides_t<4> &cell_layer_strides,
-        const sub_buffer_t &cell_iter, const strides_t<4> &cell_iter_strides,
-        const sub_buffer_t &scratch_gates,
-        const strides_t<2> &scratch_gates_strides, float alpha,
-        const memory_storage_t *tm_scales, const conf_t &conf,
-        const ocl_conf_t &ocl_conf, const rnn_offsets_t &offsets) {
-
-    auto &cell_conf = ocl_conf.cell_comp;
-    const size_t dhc = conf.dhc;
-    const size_t dhc_thr = cell_conf.dhc_thr;
-    const size_t dhc_tg = cell_conf.dhc_tg;
-    const size_t dhc_loop = utils::rnd_up(conf.dhc_loop, dhc_thr * dhc_tg);
-
-    gpu_assert(dhc_tg % ocl_conf.subgroup_size == 0);
-
-    const size_t mb = conf.mb;
-    const size_t batch_tg = cell_conf.mb_tg;
-    const size_t batch_thr = cell_conf.mb_thr;
-    const size_t batch_local = batch_thr * batch_tg;
-    compute::nd_range_t nd_range {
-            {utils::div_up(dhc, dhc_loop) * dhc_tg,
-                    utils::div_up(mb, batch_local) * batch_tg},
-            {dhc_tg, batch_tg}};
-
-    auto gates = workspace.gates(lay, dir, iter);
-    auto gates_strides = workspace.gates_strides();
-    auto states = workspace.states(lay, dir, iter);
-    auto states_strides = workspace.states_strides();
-    auto bias = user_data.bias(lay, dir);
-    auto c_states_t_l = ocl_conf.cell_kind == alg_kind::vanilla_lstm
-            ? workspace.c_states(lay, dir, iter)
-            : sub_buffer_t();
-    auto c_states_tm1_l = ocl_conf.cell_kind == alg_kind::vanilla_lstm
-            ? workspace.c_states(lay, dir, iter - 1)
-            : sub_buffer_t();
-
-    arg_list_t arg_list;
-    arg_list.append(weights_layer, ocl_conf.wei_dt);
-    arg_list.append(offsets.weights_layer);
-    arg_list.append(weights_iter, ocl_conf.wei_dt);
-    arg_list.append(offsets.weights_iter);
-    arg_list.append(cell_layer, ocl_conf.ws_state_dt);
-    arg_list.append(inner<2>(cell_layer_strides));
-    arg_list.append(cell_iter, ocl_conf.ws_state_dt);
-    arg_list.append(inner<2>(cell_iter_strides));
-    arg_list.append(gates, ocl_conf.aux_dt);
-    arg_list.append(inner<2>(gates_strides));
-    arg_list.append(states, ocl_conf.ws_state_dt);
-    arg_list.append(inner<2>(states_strides));
-
-    if (ocl_conf.cell_kind == alg_kind::vanilla_lstm) {
-        arg_list.append(c_states_t_l, ocl_conf.aux_dt);
-        arg_list.append(c_states_tm1_l, ocl_conf.aux_dt);
-        arg_list.append(conf.tm_cscale);
-    }
-
-    if (!(cell_conf.compute_gemm_layer && cell_conf.compute_gemm_iter)) {
-        arg_list.append(scratch_gates, ocl_conf.aux_dt);
-        arg_list.append(scratch_gates_strides);
-    }
-
-    if (cell_conf.enable_iter_block) { arg_list.append(conf.iter_loop); }
-
-    arg_list.append(bias, ocl_conf.bia_dt);
-    arg_list.append(alpha);
-    arg_list.append(get_storage(tm_scales));
-    arg_list.append(conf.mb);
-    arg_list.append(conf.dhc);
-    arg_list.append(conf.slc);
-    arg_list.append(conf.sic);
-
-    arg_list.append(into<dim_t>(dhc_loop));
-
-    return gpu_primitive_t::parallel_for(ctx, nd_range, kernel, arg_list.args);
-}
 
 template <prop_kind_t aprop>
 cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution)) {
@@ -146,6 +53,8 @@ cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution)) {
 
     auto wei_layer = user_data.wei_layer(lay, dir);
     auto wei_iter = user_data.wei_iter(lay, dir);
+    // passing empty memory for scratch cell since its not used in lstm and rnn
+    auto &scratch_cell = memory_storage_t::empty_storage();
 
     if ((aprop == prop_kind::forward) || rnn.recompute_gates) {
         if (!rnn.merge_gemm_layer && !rnn.cell_fusion.gemm_layer) {
@@ -170,8 +79,8 @@ cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution)) {
             CHECK(compute_cell_fwd(ctx, kernels_[kernel_id::cell_fwd], lay, dir,
                     iter, workspace, user_data, wei_layer, wei_iter, cell_layer,
                     cell_layer_strides, cell_iter, cell_iter_strides,
-                    scratch_gates, scratch_gates_strides, pd()->desc()->alpha,
-                    tm_scales, rnn, ocl_conf, offsets));
+                    scratch_gates, scratch_gates_strides, scratch_cell,
+                    pd()->desc()->alpha, tm_scales, rnn, ocl_conf, offsets));
         }
 
     } else { // backward

--- a/src/gpu/intel/ocl/rnn/cell_compute.h
+++ b/src/gpu/intel/ocl/rnn/cell_compute.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/rnn/cell_gru_lbr.cpp
+++ b/src/gpu/intel/ocl/rnn/cell_gru_lbr.cpp
@@ -18,7 +18,7 @@
  * Cell execution GRU with linear before reset
  */
 
-#include "gpu/intel/ocl/rnn/rnn_grid.hpp"
+#include "gpu/intel/ocl/rnn/simple_cell_fusion.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -38,18 +38,32 @@ cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution_gru_lbr)) {
     const ocl_conf_t &ocl_conf = this->pd()->ocl_conf;
     const rnn_offsets_t &offsets = this->pd()->off;
 
+    const bool use_cell = ocl_conf.cell_comp.is_enabled;
+
+    strides_t<4> user_layer_strides {[&]() {
+        auto s = user_data.src_layer_strides(dir);
+        return strides_t<4> {0, 0, s[0], s[1]};
+    }()};
+
     auto cell_layer = !rnn.copy_src_layer && lay == 0
             ? user_data.src_layer(dir, iter)
             : workspace.states(lay - 1, dir, iter);
+    auto &cell_layer_strides = !rnn.copy_src_layer && lay == 0
+            ? user_layer_strides
+            : workspace.states_strides();
+    auto cell_iter = workspace.states(lay, dir, iter - 1);
+    auto cell_iter_strides = workspace.states_strides();
+
     auto gemm_cell_layer_fwd = !rnn.copy_src_layer && lay == 0
             ? gemm_layer_fwd_src
             : gemm_layer_fwd;
     auto gemm_diff_wei_cell_layer = !rnn.copy_src_layer && lay == 0
             ? gemm_diff_wei_layer_src
             : gemm_diff_wei_layer;
-    auto cell_iter = workspace.states(lay, dir, iter - 1);
 
     auto scratch_gates = scratch.gates(iter);
+    strides_t<2> scratch_gates_strides
+            = {scratch.calc_off_gates(1), rnn.scratch_gates_ld};
     auto &scratch_cell = scratch.cell() ? *scratch.cell()
                                         : memory_storage_t::empty_storage();
 
@@ -58,17 +72,26 @@ cell_execution_sig((simple_rnn_common_t<aprop>::cell_execution_gru_lbr)) {
 
     if (aprop == prop_kind::forward) {
         // call made when cell execution is enabled
-        if (!rnn.merge_gemm_layer)
+        if (!rnn.merge_gemm_layer && !rnn.cell_fusion.gemm_layer)
             CHECK(gemm_primitive(engine, ctx, wei_layer, cell_layer,
                     scratch_gates, gemm_cell_layer_fwd));
 
-        CHECK(gemm_primitive(
-                engine, ctx, wei_iter, cell_iter, scratch_cell, gemm_iter_fwd));
+        if (!rnn.cell_fusion.gemm_iter)
+            CHECK(gemm_primitive(engine, ctx, wei_iter, cell_iter, scratch_cell,
+                    gemm_iter_fwd));
 
-        CHECK((this->*elemwise_gru_lbr)(ctx, dir, lay, iter, rnn.dhc, rnn.mb, 1,
-                user_data, workspace, scratch_gates, {}, scratch_cell, {}, {},
-                {}, 0, tm_scales, diff_bias));
+        if (!use_cell) {
+            CHECK((this->*elemwise_gru_lbr)(ctx, dir, lay, iter, rnn.dhc,
+                    rnn.mb, 1, user_data, workspace, scratch_gates, {},
+                    scratch_cell, {}, {}, {}, 0, tm_scales, diff_bias));
+        } else {
 
+            CHECK(compute_cell_fwd(ctx, kernels_[kernel_id::cell_fwd], lay, dir,
+                    iter, workspace, user_data, wei_layer, wei_iter, cell_layer,
+                    cell_layer_strides, cell_iter, cell_iter_strides,
+                    scratch_gates, scratch_gates_strides, scratch_cell,
+                    pd()->desc()->alpha, tm_scales, rnn, ocl_conf, offsets));
+        }
     } else {
         auto diff_states_iter = scratch.diff_states(lay, dir, 0, iter + 1);
         auto diff_states_layer

--- a/src/gpu/intel/ocl/rnn/cell_kind_utility.h
+++ b/src/gpu/intel/ocl/rnn/cell_kind_utility.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/rnn/rnn_common.h
+++ b/src/gpu/intel/ocl/rnn/rnn_common.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/rnn/rnn_utils.cpp
+++ b/src/gpu/intel/ocl/rnn/rnn_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/rnn/simple_cell_fusion.cpp
+++ b/src/gpu/intel/ocl/rnn/simple_cell_fusion.cpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/ocl/rnn/simple_cell_fusion.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace ocl {
+
+using namespace rnn_utils;
+using namespace dnnl::impl::utils;
+
+template <size_t out_ndims, size_t in_ndims>
+strides_t<out_ndims> inner(const strides_t<in_ndims> &s) {
+    static_assert(in_ndims >= out_ndims,
+            "The output strides are expected to be smaller than the input "
+            "strides");
+    strides_t<out_ndims> ret;
+    for (size_t i = 0; i < out_ndims; i++) {
+        ret[i] = s[i + in_ndims - out_ndims];
+    }
+    return ret;
+}
+
+status_t compute_cell_fwd(const exec_ctx_t &ctx,
+        const compute::kernel_t &kernel, dim_t lay, dim_t dir, dim_t iter,
+        const workspace_t &workspace, const user_data_t user_data,
+        const sub_buffer_t &weights_layer, const sub_buffer_t &weights_iter,
+        const sub_buffer_t &cell_layer, const strides_t<4> &cell_layer_strides,
+        const sub_buffer_t &cell_iter, const strides_t<4> &cell_iter_strides,
+        const sub_buffer_t &scratch_gates,
+        const strides_t<2> &scratch_gates_strides,
+        const memory_storage_t &scratch_cell, float alpha,
+        const memory_storage_t *tm_scales, const conf_t &conf,
+        const ocl_conf_t &ocl_conf, const rnn_offsets_t &offsets) {
+    auto &cell_conf = ocl_conf.cell_comp;
+    const size_t dhc = conf.dhc;
+    const size_t dhc_thr = cell_conf.dhc_thr;
+    const size_t dhc_tg = cell_conf.dhc_tg;
+    const size_t dhc_loop = utils::rnd_up(conf.dhc_loop, dhc_thr * dhc_tg);
+
+    gpu_assert(dhc_tg % ocl_conf.subgroup_size == 0);
+
+    const size_t mb = conf.mb;
+    const size_t batch_tg = cell_conf.mb_tg;
+    const size_t batch_thr = cell_conf.mb_thr;
+    const size_t batch_local = batch_thr * batch_tg;
+    compute::nd_range_t nd_range {
+            {utils::div_up(dhc, dhc_loop) * dhc_tg,
+                    utils::div_up(mb, batch_local) * batch_tg},
+            {dhc_tg, batch_tg}};
+
+    auto gates = workspace.gates(lay, dir, iter);
+    auto gates_strides = workspace.gates_strides();
+    auto states = workspace.states(lay, dir, iter);
+    auto states_strides = workspace.states_strides();
+    auto bias = user_data.bias(lay, dir);
+    auto c_states_t_l = ocl_conf.cell_kind == alg_kind::vanilla_lstm
+            ? workspace.c_states(lay, dir, iter)
+            : sub_buffer_t();
+    auto c_states_tm1_l = ocl_conf.cell_kind == alg_kind::vanilla_lstm
+            ? workspace.c_states(lay, dir, iter - 1)
+            : sub_buffer_t();
+    auto h_states_tm_l = workspace.states(lay, dir, iter - 1);
+    auto ws_grid = workspace.grid_comp(lay, dir, iter);
+
+    arg_list_t arg_list;
+    arg_list.append(weights_layer, ocl_conf.wei_dt);
+    arg_list.append(offsets.weights_layer);
+    arg_list.append(weights_iter, ocl_conf.wei_dt);
+    arg_list.append(offsets.weights_iter);
+    arg_list.append(cell_layer, ocl_conf.ws_state_dt);
+    arg_list.append(inner<2>(cell_layer_strides));
+    arg_list.append(cell_iter, ocl_conf.ws_state_dt);
+    arg_list.append(inner<2>(cell_iter_strides));
+    arg_list.append(gates, ocl_conf.aux_dt);
+    arg_list.append(inner<2>(gates_strides));
+    arg_list.append(states, ocl_conf.ws_state_dt);
+    arg_list.append(inner<2>(states_strides));
+    arg_list.append(scratch_cell);
+
+    if (ocl_conf.cell_kind == alg_kind::vanilla_lstm) {
+        arg_list.append(c_states_t_l, ocl_conf.aux_dt);
+        arg_list.append(c_states_tm1_l, ocl_conf.aux_dt);
+        arg_list.append(conf.tm_cscale);
+    }
+
+    if (ocl_conf.cell_kind == alg_kind::lbr_gru) {
+        arg_list.append(h_states_tm_l, ocl_conf.ws_state_dt);
+        arg_list.append(ws_grid, ocl_conf.aux_dt);
+    }
+
+    if (!(cell_conf.compute_gemm_layer && cell_conf.compute_gemm_iter)
+            || (ocl_conf.cell_kind == alg_kind::lbr_gru)) {
+        arg_list.append(scratch_gates, ocl_conf.aux_dt);
+        arg_list.append(scratch_gates_strides);
+    }
+
+    if (cell_conf.enable_iter_block) { arg_list.append(conf.iter_loop); }
+
+    arg_list.append(bias, ocl_conf.bia_dt);
+    arg_list.append(alpha);
+    arg_list.append(get_storage(tm_scales));
+    arg_list.append(conf.mb);
+    arg_list.append(conf.dhc);
+    arg_list.append(conf.slc);
+    arg_list.append(conf.sic);
+
+    arg_list.append(into<dim_t>(dhc_loop));
+
+    return gpu_primitive_t::parallel_for(ctx, nd_range, kernel, arg_list.args);
+}
+
+} // namespace ocl
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/ocl/rnn/simple_cell_fusion.hpp
+++ b/src/gpu/intel/ocl/rnn/simple_cell_fusion.hpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_OCL_RNN_SIMPLE_CELL_FUSION_HPP
+#define GPU_INTEL_OCL_RNN_SIMPLE_CELL_FUSION_HPP
+
+#include "gpu/intel/ocl/rnn/rnn_grid.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace ocl {
+
+using namespace rnn_utils;
+
+template <size_t out_ndims, size_t in_ndims>
+strides_t<out_ndims> inner(const strides_t<in_ndims> &s);
+
+status_t compute_cell_fwd(const exec_ctx_t &ctx,
+        const compute::kernel_t &kernel, dim_t lay, dim_t dir, dim_t iter,
+        const workspace_t &workspace, const user_data_t user_data,
+        const sub_buffer_t &weights_layer, const sub_buffer_t &weights_iter,
+        const sub_buffer_t &cell_layer, const strides_t<4> &cell_layer_strides,
+        const sub_buffer_t &cell_iter, const strides_t<4> &cell_iter_strides,
+        const sub_buffer_t &scratch_gates,
+        const strides_t<2> &scratch_gates_strides,
+        const memory_storage_t &scratch_cell, float alpha,
+        const memory_storage_t *tm_scales, const conf_t &conf,
+        const ocl_conf_t &ocl_conf, const rnn_offsets_t &offsets);
+
+} // namespace ocl
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif


### PR DESCRIPTION
# Description
Following is my speedup for the testcase reported in the ticket:
```
[hsadia@sdpmkl170255]$  ../build/tests/benchdnn/benchdnn --rnn --engine=gpu --prop=FWD_I --mode=p --alg=LBR_GRU --direction=left2right --cfg=f32,f16 l1t1000mb1sic256slc256dhc256dic256
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%

perf,gpu,ocl:simple:any,,--mode=P --rnn --engine=gpu --tag=any:any:any --alg=LBR_GRU l1t1000mb1sic256slc256dhc256dic256,0.786432,551.407,87.036,9.03571**,92.8107**,8.66013

perf,gpu,ocl:simple:any,,--mode=P --rnn --engine=gpu --cfg=f16 --tag=any:any:any --alg=LBR_GRU l1t1000mb1sic256slc256dhc256dic256,0.786432,1168.18,128.708,6.11019,**138.647**,5.67221
tests:2 passed:2 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):215.744 avg(ms):229.457
total: 9.00s; create_pd: 0.00s (0%); create_prim: 1.72s (19%); fill: 0.07s (1%); execute: 0.25s (3%);


[hsadia@sdpmkl170255]$  ./tests/benchdnn/benchdnn --rnn --engine=gpu --prop=FWD_I --mode=p --alg=LBR_GRU --direction=left2right --cfg=f32,f16 l1t1000mb1sic256slc256dhc256dic256
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%

perf,gpu,ocl:simple:any,,--mode=P --rnn --engine=gpu --tag=any:any:any --alg=LBR_GRU l1t1000mb1sic256slc256dhc256dic256,0.786432,636.563,18.6973,42.0613,**19.2331,**40.8894

perf,gpu,ocl:simple:any,,--mode=P --rnn --engine=gpu --cfg=f16 --tag=any:any:any --alg=LBR_GRU l1t1000mb1sic256slc256dhc256dic256,0.786432,847.585,13.535,58.1036,**13.8367**,56.8367
tests:2 passed:2 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):32.2323 avg(ms):33.0698
total: 8.51s; create_pd: 0.00s (0%); create_prim: 1.48s (17%); fill: 0.07s (1%); execute: 0.06s (1%);

```
Speed Up for f32 = 93/19 ~5x
Speed Up for f16 = 139/14 ~10x
Fixes # (MFDNN-12712)