### PR TITLE
cpu: pooling: fix crashes of large tensor processing

### DIFF
--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -66,7 +66,7 @@ status_t nchw_pooling_fwd_t<data_type::f32>::execute_forward(
     const dim_t padT = pd()->padT();
     const dim_t padL = pd()->padL();
 
-    const auto apply_offset = [](int index, int offset) {
+    const auto apply_offset = [](dim_t index, dim_t offset) {
         return (index > offset) ? index - offset : 0;
     };
 
@@ -270,7 +270,7 @@ status_t nchw_pooling_fwd_t<d_type>::execute_forward(
     const size_t blocked_size = src_size / simd_w;
     const size_t tail_size = src_size % simd_w;
 
-    auto apply_offset = [=](int index, int offset) {
+    auto apply_offset = [=](dim_t index, dim_t offset) {
         return (index > offset) ? index - offset : 0;
     };
 
@@ -469,7 +469,7 @@ status_t nchw_pooling_bwd_t<data_type::f32>::execute_backward(
     const dim_t padT = pd()->padT();
     const dim_t padL = pd()->padL();
 
-    auto apply_offset = [=](int index, int offset) {
+    auto apply_offset = [=](dim_t index, dim_t offset) {
         return (index > offset) ? index - offset : 0;
     };
 
@@ -622,7 +622,7 @@ status_t nchw_pooling_bwd_t<d_type>::execute_backward(
     const size_t dst_sp_size = pd()->OD() * pd()->OH() * pd()->OW();
     const size_t src_sp_size = pd()->ID() * pd()->IH() * pd()->IW();
 
-    auto apply_offset = [=](int index, int offset) {
+    auto apply_offset = [=](dim_t index, dim_t offset) {
         return (index > offset) ? index - offset : 0;
     };
 
@@ -704,6 +704,7 @@ status_t nchw_pooling_bwd_t<d_type>::execute_backward(
     if (alg == alg_kind::pooling_max) {
         parallel_nd_ext(nthr, MB, utils::div_up(C, c_blk),
                 [&](int ithr, int, dim_t mb, dim_t cb) {
+                    assert(ithr < pd()->nbuf_);
                     bool is_last_c_block
                             = c_blk_tail > 0 && (cb + 1) * c_blk > C;
                     dim_t curr_c_block = is_last_c_block ? c_blk_tail : c_blk;
@@ -740,6 +741,7 @@ status_t nchw_pooling_bwd_t<d_type>::execute_backward(
     } else {
         parallel_nd_ext(nthr, MB, utils::div_up(C, c_blk),
                 [&](int ithr, int, dim_t mb, dim_t cb) {
+                    assert(ithr < pd()->nbuf_);
                     bool is_last_c_block
                             = c_blk_tail > 0 && (cb + 1) * c_blk > C;
                     dim_t curr_c_block = is_last_c_block ? c_blk_tail : c_blk;

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -35,8 +35,8 @@ namespace impl {
 namespace cpu {
 
 namespace nhwc_pooling {
-size_t strided_offset(const int _n, const size_t _sn, const int _d,
-        const size_t _sd, const int _h, const size_t _sh, const int _w,
+size_t strided_offset(const dim_t _n, const size_t _sn, const dim_t _d,
+        const size_t _sd, const dim_t _h, const size_t _sh, const dim_t _w,
         const size_t _sw);
 }
 
@@ -130,14 +130,15 @@ struct nhwc_pooling_fwd_t : public primitive_t {
 
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
-    void array_div_by_const(const int n, const ker_data_t *src,
+    void array_div_by_const(const dim_t n, const ker_data_t *src,
             const size_t num, ker_data_t *dst) const;
-    void array_add(const int n, const ker_data_t *src, ker_data_t *dst) const;
-    void array_nhwc_max(const int n, ker_data_t *dst, const ker_data_t *src,
+    void array_add(const dim_t n, const ker_data_t *src, ker_data_t *dst) const;
+    void array_nhwc_max(const dim_t n, ker_data_t *dst, const ker_data_t *src,
             unsigned char *ws, const size_t ws_offset, const data_type_t ws_dt,
             const int index) const;
-    void array_nhwc_initialize(const int n, ker_data_t *dst, unsigned char *ws,
-            const size_t ws_offset, const data_type_t ws_dt) const;
+    void array_nhwc_initialize(const dim_t n, ker_data_t *dst,
+            unsigned char *ws, const size_t ws_offset,
+            const data_type_t ws_dt) const;
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     std::unique_ptr<ref_post_ops_t> ref_post_ops_;


### PR DESCRIPTION
This PR fixes crashes of simple_nchw and simple_nhwc in some cases that were found in [MFDNN-13286](https://jira.devtools.intel.com/browse/MFDNN-13286).
It also reduces memory allocation in simple_nchw in case of back propagation for non-f32 data types: simple_nchw requested scratchpad memory for every available thread even if the number of work items was smaller (e.g. it requested more than 4TB for mb1ic1iw4294967311ow858993461kw7sw5pw0 according to logs in MFDNN-13286; the size depends on the number of available threads). This helps in some cases (particularly, in the cases from MFDNN-13286).
