### PR TITLE
gpu: intel: ocl: add s32 support for binary

### DIFF
--- a/doc/primitives/binary.md
+++ b/doc/primitives/binary.md
@@ -122,7 +122,6 @@ meaning associated with any of tensors dimensions.
 
 2. **GPU**
    - Only tensors of 6 or fewer dimensions are supported.
-   - s32 data type is not supported.
 
 ## Performance Tips
 

--- a/src/gpu/intel/ocl/gen9_binary.hpp
+++ b/src/gpu/intel/ocl/gen9_binary.hpp
@@ -53,12 +53,12 @@ struct gen9_binary_t : public gpu_primitive_t {
                     ((utils::everyone_is(
                               bf16, src_md(0)->data_type, src_md(1)->data_type)
                              && utils::one_of(dst_md()->data_type, bf16, u8))
-                            || (utils::one_of(
-                                        src_md(0)->data_type, f16, f32, s8, u8)
+                            || (utils::one_of(src_md(0)->data_type, f16, f32,
+                                        s8, u8, s32)
                                     && utils::one_of(src_md(1)->data_type, f16,
-                                            f32, s8, u8)
+                                            f32, s8, u8, s32)
                                     && utils::one_of(dst_md()->data_type, f16,
-                                            f32, s8, u8))),
+                                            f32, s8, u8, s32))),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_BINARY(!is_ternary_op(), VERBOSE_BAD_ALGORITHM);
             VDISPATCH_BINARY(

--- a/src/gpu/intel/ocl/simple_binary.hpp
+++ b/src/gpu/intel/ocl/simple_binary.hpp
@@ -48,12 +48,12 @@ struct simple_binary_t : public gpu_primitive_t {
                               bf16, src_md(0)->data_type, src_md(1)->data_type)
                              && utils::one_of(
                                      dst_md()->data_type, bf16, u8, f32))
-                            || (utils::one_of(
-                                        src_md(0)->data_type, f16, f32, s8, u8)
+                            || (utils::one_of(src_md(0)->data_type, f16, f32,
+                                        s8, u8, s32)
                                     && utils::one_of(src_md(1)->data_type, f16,
-                                            f32, s8, u8)
+                                            f32, s8, u8, s32)
                                     && utils::one_of(dst_md()->data_type, f16,
-                                            f32, s8, u8))
+                                            f32, s8, u8, s32))
                             || (src_md(0)->data_type == f32
                                     && src_md(1)->data_type == bf16
                                     && utils::one_of(

--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -146,14 +146,6 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             res->reason = skip_reason::case_not_supported;
             return;
         }
-
-        // gpu does not support s32
-        for (const auto &dt : dts)
-            if (dt == dnnl_s32) {
-                res->state = SKIPPED;
-                res->reason = skip_reason::data_type_not_supported;
-                return;
-            }
     }
 }
 

--- a/tests/benchdnn/inputs/binary/test_binary_gpu
+++ b/tests/benchdnn/inputs/binary/test_binary_gpu
@@ -36,6 +36,10 @@
 --sdt=f32:f32
 --batch=option_set_minimal
 
+--ddt=s32
+--sdt=s32:s32
+--batch=option_set_minimal
+
 --ddt=s8
 --sdt=s8:s8
 --attr-scales=,src:common:0.25+src1:common:0.5
@@ -85,6 +89,10 @@
 
 --ddt=f32
 --sdt=f32:f32
+--batch=option_set_all
+
+--ddt=s32
+--sdt=s32:s32
 --batch=option_set_all
 
 --batch=harness_binary_different_dt


### PR DESCRIPTION
# Description

Currently the binary primitive doesn't support s32 dtype on GPU, which will affect the reference implementation of SDPA with implicit causal mask

The following change enables support for s32 data types for gpu binary primitive.

Fixes [MFDNN-12984](https://jira.devtools.intel.com/browse/MFDNN-12984)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

