### PR TITLE
ref: sycl: enable zp support in reorder and skip unsupported tests

### DIFF
--- a/src/gpu/generic/sycl/ref_reorder.cpp
+++ b/src/gpu/generic/sycl/ref_reorder.cpp
@@ -27,15 +27,21 @@ namespace sycl {
 status_t ref_reorder_t::pd_t::init_conf() {
     conf_ = sycl_reorder_conf_t();
 
-    conf_.src_md = xpu::sycl::md_t(src_md(0));
-    conf_.dst_md = xpu::sycl::md_t(dst_md());
+    conf_.src_md = xpu::sycl::md_t(arg_md(DNNL_ARG_FROM));
+    conf_.dst_md = xpu::sycl::md_t(arg_md(DNNL_ARG_TO));
 
-    conf_.wk_size = memory_desc_wrapper(src_md(0)).nelems();
+    auto dst_nelems = memory_desc_wrapper(arg_md(DNNL_ARG_TO)).nelems(true);
+    conf_.num_elements = dst_nelems;
 
-    conf_.do_scale_src = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
-    conf_.scale_src_mask = attr()->scales_.get_mask(DNNL_ARG_SRC_0);
-    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
-    conf_.scale_dst_mask = attr()->scales_.get_mask(DNNL_ARG_DST);
+    conf_.apply_src_scale = !attr()->scales_.has_default_values(DNNL_ARG_FROM);
+    conf_.src_scale_mask = attr()->scales_.get_mask(DNNL_ARG_FROM);
+    conf_.apply_dst_scale = !attr()->scales_.has_default_values(DNNL_ARG_TO);
+    conf_.dst_scale_mask = attr()->scales_.get_mask(DNNL_ARG_TO);
+    conf_.apply_src_zp
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_FROM);
+    conf_.src_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_FROM);
+    conf_.apply_dst_zp = !attr()->zero_points_.has_default_values(DNNL_ARG_TO);
+    conf_.dst_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_TO);
     conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     return status::success;
@@ -51,7 +57,8 @@ status_t ref_reorder_t::execute(const exec_ctx_t &ctx) const {
     parallel_for(ctx, kernel_, [&](::sycl::handler &cgh) {
         reorder_kernel_t reorder_kernel(pd()->conf_, cgh, ctx);
 
-        cgh.parallel_for(get_range(ctx, pd()->conf_.wk_size), reorder_kernel);
+        cgh.parallel_for(
+                get_range(ctx, pd()->conf_.num_elements), reorder_kernel);
     });
 
     return status::success;

--- a/src/gpu/generic/sycl/ref_reorder.hpp
+++ b/src/gpu/generic/sycl/ref_reorder.hpp
@@ -54,11 +54,11 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
             VDISPATCH_REORDER(!dst_d.has_runtime_dims_or_strides(),
                     VERBOSE_RUNTIMEDIM_UNSUPPORTED);
             VDISPATCH_REORDER(
-                    check_data_types(src_d, dst_d), VERBOSE_UNSUPPORTED_DT_CFG);
-            VDISPATCH_REORDER(
                     check_formats(src_d, dst_d), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_REORDER(
-                    attr()->has_default_values(sm::scales | sm::post_ops),
+                    check_data_types(src_d, dst_d), VERBOSE_UNSUPPORTED_DT_CFG);
+            VDISPATCH_REORDER(attr()->has_default_values(sm::post_ops
+                                      | sm::scales | sm::zero_points),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_REORDER(IMPLICATION(!attr()->scales_.has_default_values(),
                                       scales_ok()),
@@ -108,6 +108,7 @@ struct ref_reorder_t : public gpu::generic::sycl::primitive_t {
                 const auto dt = scales.get_data_type(arg);
                 if (!is_supported_type(dt)) { return false; }
             }
+
             return true;
         }
     };

--- a/src/gpu/generic/sycl/reorder_kernels.hpp
+++ b/src/gpu/generic/sycl/reorder_kernels.hpp
@@ -37,106 +37,116 @@ struct reorder_kernel_t {
     reorder_kernel_t(const sycl_reorder_conf_t &conf, ::sycl::handler &cgh,
             const exec_ctx_t &ctx)
         : conf_(conf)
-        , src_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_SRC_0))
-        , dst_(CTX_INOUT_SYCL_KERNEL_MEMORY(DNNL_ARG_DST))
+        , src_(CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_FROM))
+        , dst_(CTX_INOUT_SYCL_KERNEL_MEMORY(DNNL_ARG_TO))
         , src_scale_(CTX_IN_SYCL_KERNEL_MEMORY(
-                  DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0))
-        , dst_scale_(CTX_IN_SYCL_KERNEL_MEMORY(
-                  DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST))
-        , scales_src_dt_(conf_.do_scale_src
-                          ? ctx.memory_mdw(
-                                       DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0)
-                                    .data_type()
-                          : data_type_t::dnnl_f32)
-        , scales_dst_dt_(conf_.do_scale_dst
-                          ? ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)
-                                    .data_type()
-                          : data_type_t::dnnl_f32) {}
+                  DNNL_ARG_ATTR_SCALES | DNNL_ARG_FROM))
+        , dst_scale_(
+                  CTX_IN_SYCL_KERNEL_MEMORY(DNNL_ARG_ATTR_SCALES | DNNL_ARG_TO))
+        , src_zero_points(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_FROM))
+        , dst_zero_points(CTX_IN_SYCL_KERNEL_MEMORY(
+                  DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_TO))
+        , scales_src_dt_(ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_FROM)
+                                 .data_type())
+        , scales_dst_dt_(ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_TO)
+                                 .data_type())
+        , src_zp_dt_(ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_FROM)
+                             .data_type())
+        , dst_zp_dt_(ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_TO)
+                             .data_type())
+        , po_args_(cgh, ctx, conf.post_ops) {}
 
     void operator()(::sycl::nd_item<1> item) const {
-        memory_tensor_t src_mem(src_, conf_.src_md);
-        memory_tensor_t dst_mem(dst_, conf_.dst_md);
-        memory_plain_t src_scale_mem(src_scale_, scales_src_dt_);
-        memory_plain_t dst_scale_mem(dst_scale_, scales_dst_dt_);
 
-        float scale_src = conf_.do_scale_src && conf_.scale_src_mask == 0
-                ? src_scale_mem.load(0)
-                : 1.f;
-        float scale_dst = conf_.do_scale_dst && conf_.scale_dst_mask == 0
-                ? dst_scale_mem.load(0)
-                : 1.f;
+        auto from_tensor = memory_tensor_t(src_, conf_.src_md);
+        auto to_tensor = memory_tensor_t(dst_, conf_.dst_md);
+        auto src_scales_tensor
+                = memory_plain_t(src_scale_, scales_src_dt_); // 1D tensor
+        auto dst_scales_tensor = memory_plain_t(dst_scale_, scales_dst_dt_);
+        auto src_zp_tensor = memory_plain_t(src_zero_points, src_zp_dt_);
+        auto dst_zp_tensor = memory_plain_t(dst_zero_points, dst_zp_dt_);
 
-        dims_t dims, off, strides;
-        for (int i = 0; i < max_supported_ndims; i++) {
-            dims[i] = (i < src_md().ndims()) ? src_md().dims()[i] : 1;
-            strides[i]
-                    = (i < src_md().ndims()) ? src_md().strides()[i] : INT_MAX;
-        }
-        dims_t dims_scales_src;
-        if (conf_.scale_src_mask > 0) {
-            for (int i = 0; i < max_supported_ndims; i++) {
-                dims_scales_src[i]
-                        = conf_.scale_src_mask >> i & 1 ? dims[i] : 1;
-            }
-        }
-        dims_t dims_scales_dst;
-        if (conf_.scale_dst_mask > 0) {
-            for (int i = 0; i < max_supported_ndims; i++) {
-                dims_scales_dst[i]
-                        = conf_.scale_dst_mask >> i & 1 ? dims[i] : 1;
-            }
-        }
+        const auto &src_dims = conf_.src_md.dims();
+        const auto &dst_dims = conf_.dst_md.dims();
+        int ndims = conf_.src_md.ndims();
 
-        for (int idx = item.get_global_id(0); idx < conf_.wk_size;
-                idx += item.get_global_range(0)) {
-            for (int i = 0; i < max_supported_ndims; i++) {
-                off[i] = idx / strides[i] % dims[i];
-            }
+        dims_t dst_padded_index;
+        float src_scale = conf_.apply_src_scale ? src_scales_tensor.load(0) : 1;
+        float dst_scale = conf_.apply_dst_scale ? dst_scales_tensor.load(0) : 1;
+        float src_zp = conf_.apply_src_zp ? src_zp_tensor.load(0) : 0;
+        float dst_zp = conf_.apply_dst_zp ? dst_zp_tensor.load(0) : 0;
 
-            int dst_idx = dst_md().off_v(off);
-            auto src = src_mem.load(idx);
+        for (std::size_t flattened_index = item.get_global_id(0);
+                flattened_index < conf_.num_elements;
+                flattened_index += item.get_global_range(0)) {
 
-            if (conf_.do_scale_src) {
-                if (conf_.scale_src_mask > 0) {
-                    int scale_idx = 0;
-                    for (int i = 0; i < max_supported_ndims; i++) {
-                        if (i < src_md().ndims()) {
-                            int off_scales_i = conf_.scale_src_mask >> i & 1
-                                    ? off[i]
-                                    : 0;
-                            scale_idx = scale_idx * dims_scales_src[i]
-                                    + off_scales_i;
-                        }
-                    }
-                    scale_src = src_scale_mem.load(scale_idx);
+            to_tensor.get_logical_index(
+                    flattened_index, dst_padded_index, true);
+
+            float from_value = from_tensor.load_md(dst_padded_index, true);
+            // apply src scale and zero points;
+            // dequantized_x = scale * (quantized_x - zero_point);
+            if (conf_.apply_src_zp) {
+                if (conf_.src_zp_mask > 0) {
+                    dim_t idx = get_quant_param_offset(dst_padded_index,
+                            src_dims, conf_.src_zp_mask, ndims);
+                    src_zp = src_zp_tensor.load(idx);
                 }
-                src *= scale_src;
+                from_value = from_value - src_zp;
             }
-
-            auto acc = src;
-            acc = conf_.post_ops.apply(acc, dst_, dst_idx);
-            if (conf_.do_scale_dst) {
-                if (conf_.scale_dst_mask > 0) {
-                    int scale_idx = 0;
-                    for (int i = 0; i < max_supported_ndims; i++) {
-                        if (i < src_md().ndims()) {
-                            int off_scales_i = conf_.scale_dst_mask >> i & 1
-                                    ? off[i]
-                                    : 0;
-                            scale_idx = scale_idx * dims_scales_dst[i]
-                                    + off_scales_i;
-                        }
-                    }
-
-                    scale_dst = dst_scale_mem.load(scale_idx);
+            if (conf_.apply_src_scale) {
+                if (conf_.src_scale_mask > 0) {
+                    dim_t idx = get_quant_param_offset(dst_padded_index,
+                            src_dims, conf_.src_scale_mask, ndims);
+                    src_scale = src_scales_tensor.load(idx);
                 }
-                acc /= scale_dst;
+                from_value = from_value * src_scale;
             }
-            dst_mem.store(acc, dst_idx);
+
+            auto dst_idx = conf_.dst_md.off_v(dst_padded_index, true);
+            from_value = conf_.post_ops.apply(from_value, dst_, dst_idx);
+            // during quanization, apply scale first
+            // quantized value = dequan_value / scale + zero_point;
+            if (conf_.apply_dst_scale) {
+                if (conf_.dst_scale_mask > 0) {
+                    dim_t idx = get_quant_param_offset(dst_padded_index,
+                            dst_dims, conf_.dst_scale_mask, ndims);
+                    dst_scale = dst_scales_tensor.load(idx);
+                }
+                from_value = from_value / dst_scale;
+            }
+            if (conf_.apply_dst_zp) {
+                if (conf_.dst_zp_mask > 0) {
+                    dim_t idx = get_quant_param_offset(dst_padded_index,
+                            dst_dims, conf_.dst_zp_mask, ndims);
+                    dst_zp = dst_zp_tensor.load(idx);
+                }
+                from_value = from_value + dst_zp;
+            }
+            to_tensor.store_md(from_value, dst_padded_index, true);
         }
     }
 
 private:
+    using sycl_dims_t = int32_t[6];
+
+    inline dim_t get_quant_param_offset(const dims_t &logical_index,
+            const sycl_dims_t &dims, int param_mask, int ndims) const {
+        dim_t idx = 0;
+        for (int32_t i = 0; i < ndims; i++) {
+            bool ith_bit_set = (param_mask >> i) & 1;
+            dim_t dimension_offset = 0;
+            dim_t dimension_stride = 1;
+            if (ith_bit_set) {
+                dimension_offset = logical_index[i];
+                dimension_stride = dims[i];
+            }
+            idx = idx * dimension_stride + dimension_offset;
+        }
+        return idx;
+    }
+
     const xpu::sycl::md_t &src_md() const { return conf_.src_md; }
     const xpu::sycl::md_t &dst_md() const { return conf_.dst_md; }
 
@@ -146,8 +156,13 @@ private:
     xpu::sycl::inout_memory_arg_t dst_;
     xpu::sycl::in_memory_arg_t src_scale_;
     xpu::sycl::in_memory_arg_t dst_scale_;
+    xpu::sycl::in_memory_arg_t src_zero_points;
+    xpu::sycl::in_memory_arg_t dst_zero_points;
     data_type_t scales_src_dt_;
     data_type_t scales_dst_dt_;
+    data_type_t src_zp_dt_;
+    data_type_t dst_zp_dt_;
+    post_op_input_args po_args_;
 };
 
 } // namespace sycl

--- a/src/gpu/generic/sycl/sycl_io_helper.hpp
+++ b/src/gpu/generic/sycl/sycl_io_helper.hpp
@@ -238,8 +238,8 @@ struct memory_tensor_t {
         store_float_vec<width>(md_.data_type(), val, mem_.get_pointer(), idx);
     }
 
-    inline float load_md(dims_t offsets) const {
-        return load(md_.off_v(offsets));
+    inline float load_md(const dims_t &pos, bool padded = false) const {
+        return load(md_.off_v(pos, padded));
     }
 
     inline float load_md_bc(dims_t offsets) const {
@@ -250,8 +250,19 @@ struct memory_tensor_t {
         return load(md_.off_v(offsets_masked));
     }
 
-    inline void store_md(float val, dims_t offsets) {
-        store(val, md_.off_v(offsets));
+    inline void store_md(float val, const dims_t &pos, bool padded = false) {
+        store(val, md_.off_v(pos, padded));
+    }
+
+    // flattened_index must be less than nelems
+    inline void get_logical_index(dim_t flattened_index, dims_t &logical_index,
+            bool use_padded_dims = false) {
+        const auto &dims = use_padded_dims ? md_.padded_dims() : md_.dims();
+        auto ndims = md_.ndims();
+        for (auto i = ndims - 1; i >= 0; i--) {
+            logical_index[i] = flattened_index % dims[i];
+            flattened_index /= dims[i];
+        }
     }
 
     inline void *ptr() const { return mem_.get_pointer(); }

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -198,16 +198,19 @@ struct sycl_shuffle_conf_t {
 struct sycl_reorder_conf_t {
     xpu::sycl::md_t src_md;
     xpu::sycl::md_t dst_md;
-    xpu::sycl::md_t scales;
 
-    bool do_scale_src;
-    int scale_src_mask;
-    bool do_scale_dst;
-    int scale_dst_mask;
+    bool apply_src_scale;
+    int src_scale_mask;
+    bool apply_dst_scale;
+    int dst_scale_mask;
+    bool apply_src_zp;
+    int src_zp_mask;
+    bool apply_dst_zp;
+    int dst_zp_mask;
 
     int ndims;
 
-    int wk_size;
+    std::size_t num_elements;
 
     sycl_post_ops_t post_ops;
 };

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -408,6 +408,31 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             res->reason = skip_reason::case_not_supported;
             return;
         }
+        auto is_blocked_format = [](const std::string &format_tag) {
+            // if the user provided tag has a capital letter,
+            // that indicates it's a blocked format, otherwise it's plain
+
+            for (const auto &c : format_tag) {
+                if (std::isupper(c)) { return true; }
+            }
+            return false;
+        };
+        // Skip blocked format tags and 4 bit formats for Nvidia/AMD/Generic SYCL backends
+        if (is_generic_gpu()) {
+            const bool is_4bit_format
+                    = is_subbyte_type(prb->sdt) || is_subbyte_type(prb->ddt);
+
+            // sycl reorder implementation does not support grouped zero points / scales
+            bool zero_point_has_groups = !prb->attr.scales.is_def();
+            bool scales_has_groups = !prb->attr.zero_points.is_def();
+
+            if (is_blocked_format(prb->stag) || is_blocked_format(prb->dtag)
+                    || is_4bit_format || scales_has_groups
+                    || zero_point_has_groups) {
+                res->state = SKIPPED;
+                res->reason = skip_reason::case_not_supported;
+            }
+        }
     }
 }
 

--- a/tests/benchdnn/utils/numeric.cpp
+++ b/tests/benchdnn/utils/numeric.cpp
@@ -204,3 +204,8 @@ float round_to_nearest_representable(dnnl_data_type_t dt, float value) {
 
     return value;
 }
+
+bool is_subbyte_type(const dnnl_data_type_t &type) {
+    return type == dnnl_f4_e2m1 || type == dnnl_f4_e3m0 || type == dnnl_u4
+            || type == dnnl_s4;
+}

--- a/tests/benchdnn/utils/numeric.hpp
+++ b/tests/benchdnn/utils/numeric.hpp
@@ -36,5 +36,6 @@ float saturate_and_round(dnnl_data_type_t dt, float value);
 bool is_integral_dt(dnnl_data_type_t dt);
 float maybe_saturate(dnnl_data_type_t dt, float value);
 float round_to_nearest_representable(dnnl_data_type_t dt, float value);
+bool is_subbyte_type(const dnnl_data_type_t &type);
 
 #endif


### PR DESCRIPTION
# Description

This PR enables zero point support to the SYCL backend's reorder, and adds skips in benchdnn to skip unsupported cases for the SYCL backend

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
