### PR TITLE
xe: jit: gemm: fix corner cases in descriptor-based remainders

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/layout_utils.cpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/layout_utils.cpp
@@ -572,6 +572,8 @@ void assignUniformMask(vector<RegisterBlock> &layout, FlagRegister flag, int idx
 bool assignAllDescs(vector<RegisterBlock> &layout)
 {
     for (auto &block : layout) {
+        if (!block.descRemR && !block.descRemC)
+            continue;
         if (block.simdSize != layout[0].simdSize)
             return false;
         block.descAssigned = true;


### PR DESCRIPTION
Fixes MFDNN-13350. There was a corner case where a particular XeHPG strategy was asking to use variable send descriptors for k remainder handling, but they weren't necessary. This case wasn't being handled correctly (it used indirect descriptors but didn't initialize them), leading to hangs.