### PR TITLE
tests: benchdnn: support --mode-modifer=M for graph driver

### DIFF
--- a/tests/benchdnn/graph/bench_graph.cpp
+++ b/tests/benchdnn/graph/bench_graph.cpp
@@ -64,17 +64,6 @@ void check_correctness(const settings_t &s) {
     }
 }
 
-int verify_input(const settings_t &s) {
-    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
-        // TODO: update graph driver doc page once the limitation is removed.
-        BENCHDNN_PRINT(0, "%s\n",
-                "Error: graph driver doesn't support "
-                "--mode-modifier=M/--mode=F.");
-        return FAIL;
-    }
-    return OK;
-}
-
 int bench(int argc, char **argv) {
     driver_name = "graph";
     using namespace parser;
@@ -94,7 +83,6 @@ int bench(int argc, char **argv) {
         if (!parsed_options) {
             if (!parse_input_file(s.json_file, argv[0]))
                 catch_unknown_options(argv[0]);
-            SAFE(verify_input(s), WARN);
             check_correctness(s);
             flush_temp_memory();
         }

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -202,6 +202,10 @@ int find_logical_tensor(size_t lt_id, const graph::op_ref_list_t &ops,
 int map_unmap_partition_mem(graph::partition_mem_map_t &partition_mem_map,
         const std::vector<dnnl::graph::logical_tensor> &lts,
         const int &map_flag, res_t *res) {
+
+    // Not map or unmap the reference primitive memories for `no_ref_memory`
+    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) return OK;
+
     // In case one logical tensor is used for multiple inputs, record the
     // processed logical tensor ids to avoid duplicate processing
     std::unordered_set<size_t> processed_ids;
@@ -253,7 +257,6 @@ int make_input_tensors(std::vector<dnnl::graph::tensor> &input_ts,
         }
 
         // generate tensor for graph path
-
         const auto iter = partition_mem_map.find(lt_id);
         if (iter != partition_mem_map.end()) {
             const auto &graph_mem = iter->second;
@@ -637,10 +640,12 @@ int doit(const prb_t *prb, res_t *res) {
         std::vector<dnnl::graph::tensor> output_ts(outputs.size());
 
         ref_partition_t ref_partition(dg, partitions[i], inputs, outputs);
+
         // Construct memory for both perf & corr modes
-        SAFE(ref_partition.init_ref(
-                     graph_in_ports, partition_mem_map_v[i], res),
-                WARN);
+        SAFE(ref_partition.init_ref(graph_in_ports, res), WARN);
+        if (res->state == SKIPPED) return OK;
+
+        SAFE(ref_partition.init_graph_mem(partition_mem_map_v[i], res), WARN);
         if (res->state == SKIPPED) return OK;
 
         if (has_bench_mode_bit(mode_bit_t::corr)) {
@@ -657,15 +662,12 @@ int doit(const prb_t *prb, res_t *res) {
         }
 
         // unmap memory from host to device
-        map_unmap_partition_mem(partition_mem_map_v[i], inputs, UNMAP, res);
-        map_unmap_partition_mem(partition_mem_map_v[i], outputs, UNMAP, res);
-        if (res->state == FAIL) {
-            BENCHDNN_PRINT(0,
-                    "FAIL: Fail to unmap memories to host for partition "
-                    "%zu.\n",
-                    i);
-            return FAIL;
-        }
+        SAFE(map_unmap_partition_mem(
+                     partition_mem_map_v[i], inputs, UNMAP, res),
+                WARN);
+        SAFE(map_unmap_partition_mem(
+                     partition_mem_map_v[i], outputs, UNMAP, res),
+                WARN);
 
         const op_ref_list_t &op_list = ref_partition.get_partition_ops();
         const auto &inplace_ports
@@ -705,8 +707,10 @@ int doit(const prb_t *prb, res_t *res) {
         graph_mem_mgr.stop_graph_mem_check();
 
         // map memory from device back to host
-        map_unmap_partition_mem(partition_mem_map_v[i], inputs, MAP, res);
-        map_unmap_partition_mem(partition_mem_map_v[i], outputs, MAP, res);
+        SAFE(map_unmap_partition_mem(partition_mem_map_v[i], inputs, MAP, res),
+                WARN);
+        SAFE(map_unmap_partition_mem(partition_mem_map_v[i], outputs, MAP, res),
+                WARN);
 
         // If the device is out-of-memory due to graph path execution, skip the
         // case.

--- a/tests/benchdnn/graph/graph_memory.hpp
+++ b/tests/benchdnn/graph/graph_memory.hpp
@@ -156,12 +156,13 @@ public:
     //
     // The constructor accepts three boolean parameters:
     // 1. is_op_input: whether the logical tensor is an input of an op
-    // 2. is_fake_output: for fake outputs, the driver cannot create memory
-    // objects based on primitive memory for them, but construct memory
-    // from graph shape. The default value is false.
+    // 2. use_graph_layout: for fake outputs and mode without reference
+    // memories, the driver cannot create memory objects based on primitive
+    // memory for them, but construct memory from graph shape. The default
+    // value is false.
     //
     dnn_graph_mem_t(const dnn_mem_t &mem, const deserialized_lt &lt,
-            const bool is_op_input, const bool is_fake_output = false);
+            const bool is_op_input, const bool use_graph_layout = false);
 
     dnnl::graph::tensor make_graph_tensor(const deserialized_lt &lt) const;
 
@@ -171,6 +172,8 @@ public:
     void unmap_mem() { mem_.unmap(); }
 
 private:
+    int fill_mem_with_data(const dnn_mem_t &mem);
+
     dnn_mem_t mem_;
     std::shared_ptr<void> buffer_;
     dnnl::memory::dims graph_dims_;

--- a/tests/benchdnn/graph/ref_partition.hpp
+++ b/tests/benchdnn/graph/ref_partition.hpp
@@ -40,8 +40,10 @@ public:
             const std::vector<dnnl::graph::logical_tensor> &outs);
 
     // prepare memories in both paths, one by one ref primitive
-    int init_ref(const std::vector<size_t> &graph_ports,
-            partition_mem_map_t &partition_mem_map, res_t *res);
+    int init_ref(const std::vector<size_t> &graph_ports, res_t *res);
+
+    int init_graph_mem(partition_mem_map_t &partition_mem_map, res_t *res);
+
     // run partition in ref path, one by one ref primitive
     void exec_ops(res_t *res);
 

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1627,7 +1627,6 @@ bool get_reduction_prb_vdims(
     }
 
     prb_vdims.vdims = {src_dims, dst_dims};
-    prb_vdims.dst_dims = src_dims;
     prb_vdims.ndims = static_cast<int>(src_dims.size());
     return true;
 }


### PR DESCRIPTION
## General

The PR enables `--mode-modifer=M` for benchdnn graph driver:
1. Avoid creating reference primitives as well as the memories and customized data filling.
2. For customized operations, handle integral inputs specially for indexing values.
3. Otherwise, use fixed value( `0x3F3F3F3F` (0.747059f) ) for data filling.

```
./tests/benchdnn/benchdnn --graph --mode=F --batch=test_graph_all
Output template: perf,%engine%,%prb%,%-time%,%0time%
perf,cpu,--mode=F --graph --case=op/f32/abs.json,0.0561523,0.139608
perf,cpu,--mode=F --graph --case=op/f32/abs_bwd.json,0.0541992,0.064628
perf,cpu,--mode=F --graph --case=op/f32/add.json,0.0571289,0.0702186
perf,cpu,--mode=F --graph --in-shapes=1:- --case=op/f32/add.json,0.0563965,0.0670133
perf,cpu,--mode=F --graph --case=op/f32/avgpool.json,4.81152,10.1638
perf,cpu,--mode=F --graph --op-attrs=0:auto_pad:SAME_UPPER*kernel:2x2 --case=op/f32/avgpool.json,4.58423,6.78208
//....
```

Sanitizer test:
```
        Start 201: test_benchdnn_modeR_graph_ci_cpu
199/220 Test #201: test_benchdnn_modeR_graph_ci_cpu ........................   Passed   21.13 sec

        Start 233: test_benchdnn_modeR_graph_ci_gpu
233/252 Test #233: test_benchdnn_modeR_graph_ci_gpu .........................   Passed   73.62 sec
```