### PR TITLE
{src, gtests}: graph: fix clang-tidy warnings

### DIFF
--- a/src/graph/backend/dnnl/fusion_info.hpp
+++ b/src/graph/backend/dnnl/fusion_info.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022-2024 Intel Corporation
+ * Copyright 2022-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -281,7 +281,7 @@ public:
 
     // Initialize an empty fusion info object and return its key
     int64_t init_info() {
-        data_.emplace_back(fusion_info_t());
+        data_.emplace_back();
         return static_cast<int64_t>(data_.size() - 1);
     }
 
@@ -305,7 +305,7 @@ public:
 private:
     std::vector<fusion_info_t> data_;
     // specified floating-point math mode for all fusions
-    fpmath_t fpmath_mode_ {};
+    fpmath_t fpmath_mode_;
     bool can_use_blocked_layout_;
 };
 

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -2490,13 +2490,12 @@ struct genindex_executable_t : public op_executable_t {
 
     genindex_executable_t(std::shared_ptr<op_t> &op,
             const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-
+            pd_cache_t &pd_cache)
+        : axis_(op->get_attr<int64_t>(op_attr::axis)) {
         using ltw = logical_tensor_wrapper_t;
         const auto &input_lt = op->get_input_value(0)->get_logical_tensor();
         nelems_ = ltw(input_lt).nelems();
         ndims_ = ltw(input_lt).ndims();
-        axis_ = op->get_attr<int64_t>(dnnl::impl::graph::op_attr::axis);
         const auto &output_lt = op->get_output_value(0)->get_logical_tensor();
         for (int i = 0; i < ndims_; i++) {
             output_dims_[i] = output_lt.dims[i];
@@ -2530,7 +2529,7 @@ struct genindex_executable_t : public op_executable_t {
 #ifdef DNNL_WITH_SYCL
     ::sycl::event execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<::sycl::event> &deps = {}) const override {
+            const std::vector<::sycl::event> &deps) const override {
         if (stream.get_engine().get_kind() == engine::kind::cpu) {
             auto strm_t = stream.get();
             auto *sycl_stream_impl = dnnl::impl::utils::downcast<
@@ -2581,7 +2580,7 @@ struct genindex_executable_t : public op_executable_t {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     cl_event execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps = {}) const override {
+            const std::vector<cl_event> &deps) const override {
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
         auto compute_stream
                 = dnnl::impl::utils::downcast<compute::compute_stream_t *>(

--- a/src/graph/backend/dnnl/passes/lower.cpp
+++ b/src/graph/backend/dnnl/passes/lower.cpp
@@ -93,7 +93,7 @@ static status_t binary_handler(
     insert_empty_scratchpad(new_op);
     if (op->get_kind() == graph::op_kind::GreaterEqual) {
         auto out_vals = op->get_output_values();
-        auto dst = out_vals[0];
+        const auto &dst = out_vals[0];
         // GreaterEqual output's datatype is boolean. we treated it as u8
         dst->set_data_type(dnnl::impl::data_type::u8);
     }
@@ -657,16 +657,15 @@ static status_t dynamic_dequant_handler(
 
 static status_t select_handler(
         const std::shared_ptr<op_t> &op, subgraph_rewriter_t &rewriter) {
-
     auto in_vals = op->get_input_values();
     auto out_vals = op->get_output_values();
     VCHECK_INVALID_ARGUMENT(in_vals.size() == 3 && out_vals.size() == 1,
             "select should have three input and one output but "
             "got %zu input and %zu output",
             in_vals.size(), out_vals.size());
-    auto cond = in_vals[0];
-    auto src0 = in_vals[1];
-    auto src1 = in_vals[2];
+    const auto &cond = in_vals[0];
+    const auto &src0 = in_vals[1];
+    const auto &src1 = in_vals[2];
     // For the binary select operation, the conditional input tensor can
     // only be of `s8` data type.
     cond->set_data_type(dnnl::impl::data_type::s8);

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -2337,9 +2337,9 @@ status_t decompose_select_to_binary_ops(std::shared_ptr<subgraph_t> &sg) {
         auto in_vals = op->get_input_values();
         auto out_vals = op->get_output_values();
 
-        auto src0 = in_vals[0];
-        auto src1 = in_vals[1];
-        auto cond = in_vals[2];
+        const auto &src0 = in_vals[0];
+        const auto &src1 = in_vals[1];
+        const auto &cond = in_vals[2];
         cond->set_data_type(dnnl::impl::data_type::u8);
 
         //TODO: This reorder can be removed once eltwise_clip support int8 input

--- a/src/graph/backend/dnnl/patterns/data_type_check_pass.hpp
+++ b/src/graph/backend/dnnl/patterns/data_type_check_pass.hpp
@@ -135,11 +135,11 @@ inline bool is_reorder_type(op_kind_t op_kind) {
  * \brief dtype_check_pass_t generates a pass for checking unimplemented data 
  *        type.
  */
-class dtype_check_pass_t : public graph::pass::pass_base {
+class dtype_check_pass_t : public graph::pass::pass_base_t {
 public:
     explicit dtype_check_pass_t(std::string pbackend, std::string pname,
             std::vector<data_type_t> dtypes)
-        : graph::pass::pass_base(std::move(pbackend), std::move(pname))
+        : graph::pass::pass_base_t(std::move(pbackend), std::move(pname))
         , dt_to_check_(std::move(dtypes)) {
         // data type check passes should be executed first, hence should
         // have the highest priority.

--- a/src/graph/backend/dnnl/patterns/pattern_matcher_pass.hpp
+++ b/src/graph/backend/dnnl/patterns/pattern_matcher_pass.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -90,10 +90,10 @@ inline void pattern_utils_t::init_partition(graph_t &backend_graph,
  * \brief pattern_matcher_pass_t generates an optimized graph
  *        when a pre-defined pattern is hit.
  */
-class pattern_matcher_pass_t : public graph::pass::pass_base {
+class pattern_matcher_pass_t : public graph::pass::pass_base_t {
 public:
     explicit pattern_matcher_pass_t(std::string pbackend, std::string pname)
-        : graph::pass::pass_base(std::move(pbackend), std::move(pname)) {}
+        : graph::pass::pass_base_t(std::move(pbackend), std::move(pname)) {}
 
     static graph::pass::pass_base_ptr create(
             std::string pbackend, std::string pname) {

--- a/src/graph/backend/fake/transformation_pass.hpp
+++ b/src/graph/backend/fake/transformation_pass.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@ namespace graph {
 namespace fake_impl {
 namespace pass {
 
-class transformation_pass_t : public graph::pass::pass_base {
+class transformation_pass_t : public graph::pass::pass_base_t {
 public:
     explicit transformation_pass_t(std::string pbackend, std::string pname)
-        : graph::pass::pass_base(std::move(pbackend), std::move(pname)) {}
+        : graph::pass::pass_base_t(std::move(pbackend), std::move(pname)) {}
 
     static graph::pass::pass_base_ptr create(
             std::string pbackend, std::string pname) {

--- a/src/graph/interface/constant_tensor_cache.cpp
+++ b/src/graph/interface/constant_tensor_cache.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2023-2024 Intel Corporation
+ * Copyright 2023-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -352,7 +352,7 @@ private:
             // The first field: engine kind
             impl::engine_kind_t env_eng_kind = impl::engine_kind::any_engine;
             if (!fields.empty() && !fields[0].empty()) {
-                std::string eng_kind = fields[0];
+                const std::string &eng_kind = fields[0];
                 assertm(eng_kind == "cpu" || eng_kind == "gpu",
                         "engine kind must be cpu or gpu");
                 env_eng_kind = eng_kind == "cpu" ? impl::engine_kind::cpu

--- a/src/graph/interface/graph.hpp
+++ b/src/graph/interface/graph.hpp
@@ -68,13 +68,13 @@ struct dnnl_graph_graph : public graph::utils::id_t {
 
 private:
     /*! \brief added ops*/
-    std::vector<op_ptr> ops_ {};
+    std::vector<op_ptr> ops_;
 
     /*! \brief The engine kind on which the operator will be evaluated */
     graph::engine_kind_t engine_kind_ {};
 
     /*! \brief The floating-point math mode */
-    graph::fpmath_t fpmath_ {};
+    graph::fpmath_t fpmath_;
 
     std::vector<std::shared_ptr<graph::partition_impl_t>> partition_impls_;
 

--- a/src/graph/interface/op.hpp
+++ b/src/graph/interface/op.hpp
@@ -500,8 +500,7 @@ public:
         std::for_each(attrs.begin(), attrs.end(),
                 [&copied_attrs](
                         const std::pair<op_attr_t, attribute_value_t> &v) {
-                    copied_attrs.emplace(
-                            std::make_pair(attr2str(v.first), v.second));
+                    copied_attrs.emplace(attr2str(v.first), v.second);
                 });
 
         copied_attrs.erase("op_depth");
@@ -516,9 +515,9 @@ public:
 private:
     size_t id_ {};
     op_kind_t kind_ {};
-    std::string name_ {};
-    std::vector<std::shared_ptr<value_t>> inputs_ {};
-    std::vector<std::shared_ptr<value_t>> outputs_ {};
+    std::string name_;
+    std::vector<std::shared_ptr<value_t>> inputs_;
+    std::vector<std::shared_ptr<value_t>> outputs_;
     std::unordered_map<op_attr_t, attribute_value_t> attributes_;
 
     dnnl::impl::graph::partition_impl_t *partition_ {nullptr};
@@ -527,7 +526,7 @@ private:
     // fused op: we still need to represent a fused op
     // possibly we can remove these once the new backend API and new pattern
     // matcher is done.
-    std::vector<size_t> op_ids_ {};
+    std::vector<size_t> op_ids_;
     // Map from the fused op input index -> (original op id, op input offset)
     std::unordered_map<size_t, pair_t> input_tensor_map_;
     // Map from the fused op output index -> (original op id, op output offset)

--- a/src/graph/interface/op_def_constraint.cpp
+++ b/src/graph/interface/op_def_constraint.cpp
@@ -89,8 +89,8 @@ bool check_bn_data_type(const op_t *n) {
 // only when data is bf16, gamma/beta/mean/var can be bf16.
 // If data is bf16, gamma/beta/mean/var can be f32 or bf16.
 bool check_ln_gn_data_type(const op_t *n) {
-    auto input_values = n->get_input_values();
-    auto output_values = n->get_output_values();
+    const auto &input_values = n->get_input_values();
+    const auto &output_values = n->get_output_values();
 
     const logical_tensor_t &src_lt = input_values[0]->get_logical_tensor();
     logical_tensor_t aux_lt;

--- a/src/graph/interface/op_schema.hpp
+++ b/src/graph/interface/op_schema.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -184,7 +184,7 @@ public:
     /*! @brief Set a particular attribute of the op schema. */
     template <typename T>
     op_schema_t &set_attr(op_attr_t name, bool required,
-            attribute_kind_t attr_kind, T value,
+            attribute_kind_t attr_kind, const T &value,
             const std::vector<T> &candidates = {}) {
         assertm(attributes_.count(name) == 0,
                 "provided attribute has already been set");

--- a/src/graph/interface/partition_impl.hpp
+++ b/src/graph/interface/partition_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -241,10 +241,10 @@ protected:
     std::vector<std::shared_ptr<op_t>> ops_;
 
     /// All the input logical tensors of a partition
-    std::vector<logical_tensor_t> inputs_ {};
+    std::vector<logical_tensor_t> inputs_;
 
     /// All the output logical tensors of a partition
-    std::vector<logical_tensor_t> outputs_ {};
+    std::vector<logical_tensor_t> outputs_;
 
     /// Partition_impl id
     size_t id_ = std::numeric_limits<size_t>::max();
@@ -378,12 +378,12 @@ protected:
     /// The inputs logical tensors which this compiled_partition_impl_t
     /// is specialized for.Should have exact shape/dtype/layout and be
     /// in same order with inputs_ in partition_impl_t
-    std::vector<logical_tensor_t> inputs_ {};
+    std::vector<logical_tensor_t> inputs_;
 
     /// The outputs logical tensors which this compiled_partition_impl_t
     /// is specialized for.Should have exact shape/dtype/layout and be
     /// in same order with outputs_ in partition_impl_t
-    std::vector<logical_tensor_t> outputs_ {};
+    std::vector<logical_tensor_t> outputs_;
 
     /// The inplace_pair_t is used to indicate which input
     /// and output tensor given in execute can share same

--- a/src/graph/utils/json.hpp
+++ b/src/graph/utils/json.hpp
@@ -52,10 +52,10 @@ struct if_else_type;
  * \tparam T the type to be serialized
  */
 template <typename T>
-struct json_handler;
+struct json_handler_t;
 
 template <typename T>
-struct common_json;
+struct common_json_t;
 
 /*!
  * \brief json to write any type.
@@ -228,7 +228,7 @@ struct num_json_t {
 };
 
 template <typename valuetype>
-struct common_json {
+struct common_json_t {
     inline static void write(json_writer_t *writer, const valuetype &value) {
         value.save(writer);
     }
@@ -238,7 +238,7 @@ struct common_json {
 };
 
 template <typename valuetype>
-struct common_json<std::shared_ptr<valuetype>> {
+struct common_json_t<std::shared_ptr<valuetype>> {
     inline static void write(
             json_writer_t *writer, const std::shared_ptr<valuetype> &value) {
         auto *v = value.get();
@@ -270,7 +270,7 @@ struct array_json_t {
         reader->begin_array();
         while (reader->next_array_item()) {
             elemtype value;
-            json_handler<elemtype>::read(reader, &value);
+            json_handler_t<elemtype>::read(reader, &value);
             array->insert(array->end(), value);
         }
     }
@@ -300,7 +300,7 @@ struct map_json_t {
 };
 
 template <>
-struct json_handler<std::string> {
+struct json_handler_t<std::string> {
     inline static void write(json_writer_t *writer, const std::string &value) {
         writer->write_string(value);
     }
@@ -310,31 +310,31 @@ struct json_handler<std::string> {
 };
 
 template <typename T>
-struct json_handler<std::map<std::string, T>>
+struct json_handler_t<std::map<std::string, T>>
     : public map_json_t<std::map<std::string, T>> {};
 
 template <typename T>
-struct json_handler<std::unordered_map<std::string, T>>
+struct json_handler_t<std::unordered_map<std::string, T>>
     : public map_json_t<std::unordered_map<std::string, T>> {};
 
 template <typename T>
-struct json_handler<std::vector<T>> : public array_json_t<std::vector<T>> {};
+struct json_handler_t<std::vector<T>> : public array_json_t<std::vector<T>> {};
 
 template <typename T>
-struct json_handler<std::list<T>> : public array_json_t<std::list<T>> {};
+struct json_handler_t<std::list<T>> : public array_json_t<std::list<T>> {};
 /*!
  * \brief generic serialization json
  */
 template <typename T>
-struct json_handler {
+struct json_handler_t {
     inline static void write(json_writer_t *writer, const T &data) {
         using Tjson = typename if_else_type<std::is_arithmetic<T>::value,
-                num_json_t<T>, common_json<T>>::type;
+                num_json_t<T>, common_json_t<T>>::type;
         Tjson::write(writer, data);
     }
     inline static void read(json_reader_t *reader, T *data) {
         using Tjson = typename if_else_type<std::is_arithmetic<T>::value,
-                num_json_t<T>, common_json<T>>::type;
+                num_json_t<T>, common_json_t<T>>::type;
         Tjson::read(reader, data);
     }
 };
@@ -354,7 +354,7 @@ inline void json_writer_t::write_keyvalue(
     *os_ << key;
     *os_ << "\": ";
     scope_count_.back() += 1;
-    json_handler<valuetype>::write(this, value);
+    json_handler_t<valuetype>::write(this, value);
 }
 
 template <typename valuetype>
@@ -404,7 +404,7 @@ inline void json_writer_t::write_array_seperator() {
 template <typename valuetype>
 inline void json_writer_t::write_array_item(const valuetype &value) {
     this->write_array_seperator();
-    json::json_handler<valuetype>::write(this, value);
+    json::json_handler_t<valuetype>::write(this, value);
 }
 
 inline void json_writer_t::end_object() {
@@ -559,7 +559,7 @@ inline bool json_reader_t::next_array_item() {
 
 template <typename valuetype>
 inline void json_reader_t::read(valuetype *out_value) {
-    json::json_handler<valuetype>::read(this, out_value);
+    json::json_handler_t<valuetype>::read(this, out_value);
 }
 
 inline bool read_helper_t::read_fields(json_reader_t *reader) {
@@ -584,7 +584,7 @@ inline bool read_helper_t::read_fields(json_reader_t *reader) {
 
 template <typename T>
 inline void read_helper_t::reader_function(json_reader_t *reader, void *addr) {
-    json::json_handler<T>::read(reader, static_cast<T *>(addr));
+    json::json_handler_t<T>::read(reader, static_cast<T *>(addr));
 }
 
 } // namespace json

--- a/src/graph/utils/pm/dag_check_pass.hpp
+++ b/src/graph/utils/pm/dag_check_pass.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,10 +34,10 @@ namespace pass {
  * \brief dag_check_pass_t analyzes the graph
  *        to see if it's DAG or not.
  */
-class dag_check_pass_t : public graph::pass::pass_base {
+class dag_check_pass_t : public graph::pass::pass_base_t {
 public:
     explicit dag_check_pass_t(std::string pbackend, std::string pname)
-        : graph::pass::pass_base(std::move(pbackend), std::move(pname)) {}
+        : graph::pass::pass_base_t(std::move(pbackend), std::move(pname)) {}
 
     static graph::pass::pass_base_ptr create(
             std::string pbackend, std::string pname) {

--- a/src/graph/utils/pm/nested_matcher.cpp
+++ b/src/graph/utils/pm/nested_matcher.cpp
@@ -646,11 +646,8 @@ bool resolve_node(const binding_t &bind_arg, match_context_t *ctx,
 std::vector<value_t::consumer_t> sort_op_consumers(
         std::shared_ptr<value_t> &op_out_value) {
     auto &cons = op_out_value->get_consumers();
-    std::vector<value_t::consumer_t> sorted_consumers;
     if (cons.empty()) return cons;
-    for (size_t i = 0; i < cons.size(); i++) {
-        sorted_consumers.push_back(cons[i]);
-    }
+    std::vector<value_t::consumer_t> sorted_consumers = cons;
     std::sort(sorted_consumers.begin(), sorted_consumers.end(),
             [&](value_t::consumer_t con_1, value_t::consumer_t con_2) {
                 return con_1.get_op().get_attr<int64_t>(op_attr::op_depth)

--- a/src/graph/utils/pm/op_depth_check_pass.hpp
+++ b/src/graph/utils/pm/op_depth_check_pass.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@ namespace utils {
 namespace pm {
 
 // Figure out depth of every op in order to find longest path to the root
-class graph_op_depth_check_pass_t : public graph::pass::pass_base {
+class graph_op_depth_check_pass_t : public graph::pass::pass_base_t {
 public:
     explicit graph_op_depth_check_pass_t(
             std::string pbackend, std::string pname)
-        : graph::pass::pass_base(std::move(pbackend), std::move(pname)) {}
+        : graph::pass::pass_base_t(std::move(pbackend), std::move(pname)) {}
 
     static graph::pass::pass_base_ptr create(
             std::string pbackend, std::string pname) {

--- a/src/graph/utils/pm/pass_base.cpp
+++ b/src/graph/utils/pm/pass_base.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ namespace graph {
 namespace pass {
 
 template <>
-pass_base &pass_base::set_attr<FCreatePattern>(
+pass_base_t &pass_base_t::set_attr<FCreatePattern>(
         const std::string &attr_name, // NOLINT(*)
         const FCreatePattern &func) {
     Pattern pgraph = std::make_shared<pb_graph_t>();

--- a/src/graph/utils/pm/pass_base.hpp
+++ b/src/graph/utils/pm/pass_base.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ namespace pass {
 
 using pb_graph_t = utils::pm::pb_graph_t;
 
-class pass_base;
-using pass_base_ptr = std::shared_ptr<pass_base>;
+class pass_base_t;
+using pass_base_ptr = std::shared_ptr<pass_base_t>;
 
 // FCreatePattern: a function for defining pattern.
 // One pass can have several FCreatePattern functions.
@@ -50,16 +50,16 @@ using FCreatePattern
 using Pattern = std::shared_ptr<pb_graph_t>;
 
 /*!
- * \brief pass_base provides a base class for pass creation.
+ * \brief pass_base_t provides a base class for pass creation.
  *        A pass is used to do pattern matching on a given graph,
  *        and reconstruct a new graph based on optimized patterns.
  */
-class pass_base {
+class pass_base_t {
 public:
-    pass_base(std::string pbackend, std::string pname)
+    pass_base_t(std::string pbackend, std::string pname)
         : backend_(std::move(pbackend)), name_(std::move(pname)) {}
 
-    pass_base() = default;
+    pass_base_t() = default;
 
     // the criteria of pass execution
     virtual impl::status_t run(graph_t &agraph) {
@@ -91,7 +91,7 @@ public:
         pkind_ = utils::str2partition_kind(kind);
     }
 
-    virtual ~pass_base() = default;
+    virtual ~pass_base_t() = default;
 
     std::string get_pass_backend() { return backend_; }
 
@@ -99,7 +99,7 @@ public:
 
     // set pass priority, passes with high priority
     // will be executed before passes with low priority
-    pass_base &set_priority(float priority) {
+    pass_base_t &set_priority(float priority) {
         priority_ = priority;
         return *this;
     }
@@ -107,21 +107,21 @@ public:
 
     // set enable status
     // can be used for override default value of enable_
-    pass_base &set_enable(bool enable) {
+    pass_base_t &set_enable(bool enable) {
         enable_ = enable;
         return *this;
     }
 
     bool get_enable() const { return enable_; }
 
-    pass_base &set_kind(partition_kind_t pkind) {
+    pass_base_t &set_kind(partition_kind_t pkind) {
         pkind_ = pkind;
         return *this;
     }
 
     partition_kind_t get_kind() const { return pkind_; }
 
-    pass_base &set_engine_kind(engine_kind_t kind) {
+    pass_base_t &set_engine_kind(engine_kind_t kind) {
         engine_kind_ = kind;
         return *this;
     }
@@ -135,7 +135,7 @@ public:
     * \tparam value_type The type of the value to be set.
     */
     template <typename value_type>
-    pass_base &set_attr(const std::string &attr_name, // NOLINT(*)
+    pass_base_t &set_attr(const std::string &attr_name, // NOLINT(*)
             const value_type &value) {
         attrs_.insert(make_pair(attr_name, value));
         return *this;
@@ -171,8 +171,8 @@ protected:
     std::unordered_multimap<std::string, utils::any_t> attrs_;
 
 private:
-    std::string backend_ {};
-    std::string name_ {};
+    std::string backend_;
+    std::string name_;
     float priority_ {5.0f};
     bool enable_ {true};
     partition_kind_t pkind_ {partition_kind_t::undef};
@@ -180,7 +180,7 @@ private:
 };
 
 template <>
-pass_base &pass_base::set_attr<FCreatePattern>(
+pass_base_t &pass_base_t::set_attr<FCreatePattern>(
         const std::string &attr_name, // NOLINT(*)
         const FCreatePattern &func);
 

--- a/src/graph/utils/pm/pass_manager.cpp
+++ b/src/graph/utils/pm/pass_manager.cpp
@@ -34,7 +34,7 @@ bool default_pass_filter(const pass_base_ptr &pass, partition_policy_t policy) {
 }
 
 // register a pass
-pass_base &pass_registry_t::register_pass(const std::string &backend_name,
+pass_base_t &pass_registry_t::register_pass(const std::string &backend_name,
         const std::string &pass_name, pass_create_fn fn) {
     // create new pass
     auto find = std::find_if(passes_.begin(), passes_.end(),
@@ -51,7 +51,7 @@ pass_base &pass_registry_t::register_pass(const std::string &backend_name,
     }
 }
 
-pass_base &pass_registry_t::register_pass(const pass_base_ptr &pass) {
+pass_base_t &pass_registry_t::register_pass(const pass_base_ptr &pass) {
     passes_.push_back(pass);
     passes_map_[pass->get_pass_name()] = pass;
     return *pass;

--- a/src/graph/utils/pm/pass_manager.hpp
+++ b/src/graph/utils/pm/pass_manager.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -47,9 +47,9 @@ class pass_registry_t {
 
 public:
     // register a pass
-    pass_base &register_pass(const std::string &backend_name,
+    pass_base_t &register_pass(const std::string &backend_name,
             const std::string &pass_name, pass_create_fn fn);
-    pass_base &register_pass(const pass_base_ptr &pass);
+    pass_base_t &register_pass(const pass_base_ptr &pass);
     // get registered passes
     const std::list<pass_base_ptr> &get_passes() const { return passes_; }
 

--- a/tests/gtests/graph/unit/utils/test_pattern_matcher_cpu.cpp
+++ b/tests/gtests/graph/unit/utils/test_pattern_matcher_cpu.cpp
@@ -2785,7 +2785,7 @@ TEST(test_utils_pattern_matcher, GraphNodeName) {
 }
 
 TEST(test_utils_pattern_matcher, GraphRun) {
-    graph::pass::pass_base a;
+    graph::pass::pass_base_t a;
     graph::graph_t agraph;
     ASSERT_EQ(a.run(agraph), graph::status::success);
 }


### PR DESCRIPTION
More fixes for clang-tidy warnings in headers.