### PR TITLE
[GPU] Enable e8m0 JIT gemm scaling

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.hpp
@@ -57,7 +57,7 @@ struct gen_gemm_t : public gpu_gemm_t {
 
             // LIMITATIONS:
             // - runtime dims are not supported
-            auto attr_skip_mask = smask_t::scales | smask_t::post_ops
+            auto attr_skip_mask = smask_t::scales_data_type | smask_t::post_ops
                     | smask_t::fpmath_mode | smask_t::accumulation_mode
                     | smask_t::rounding_mode;
             auto &attr_zps = attr()->zero_points_;

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.hpp
@@ -47,6 +47,7 @@ static inline gemmstone::Type convert_dnnl_to_kernel_type(data_type_t type) {
         case data_type::bf16: return Type::bf16;
         case data_type::f8_e5m2: return Type::bf8;
         case data_type::f8_e4m3: return Type::hf8;
+        case data_type::e8m0: return Type::f8_e8m0;
         case data_type::f4_e2m1: return Type::f4_e2m1;
         case data_type::f4_e3m0: return Type::f4_e3m0;
         case data_type::s32: return Type::s32;

--- a/src/gpu/intel/jit/gemm/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/jit/gemm/include/gemmstone/generator.hpp
@@ -328,7 +328,7 @@ protected:
     void gemmAlphaScale(GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state, bool cxCombine = true);
     void gemmBetaScale(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void binaryOp(BinaryOp op, int simd, const ngen::RegData &dst, const ngen::RegData &src0, const ngen::RegData &src1, CommonState &state);
-    void gemmScalarBinaryOpC(BinaryOp op, const ngen::Subregister &offset, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
+    void gemmScalarBinaryOpC(BinaryOp op, const GRFMultirange &offsets, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state, Type Tco = Type::invalid);
     void gemmVectorBinaryOpC(BinaryOp op, bool column, const GRFMultirange &offsets, const ngen::Subregister &scale, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state, Type Tco = Type::invalid, std::vector<RegisterBlock> CO_layout = std::vector<RegisterBlock>(), int y0 = -1, int y1 = -1);
     void gemmRank1UpdateC(const GRFMultirange &r, const GRFMultirange &c, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmCalcABOffsetAddrs(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);

--- a/third_party/ngen/ngen_emulation.hpp
+++ b/third_party/ngen/ngen_emulation.hpp
@@ -277,6 +277,12 @@ struct EmulationImplementation {
             dst.setType(DataType::ud);
             src0.setType(DataType::uw);
             g.shl(mod, dst, src0, 16, loc);
+        } else if (src0.getType() == DataType::bf8
+                && dst.getType() == DataType::f) {
+            RegData hfTmp = src0;
+            hfTmp.setType(DataType::uw);
+            g.shl(mod, hfTmp, src0.setType(DataType::ub), 8, loc);
+            g.mov(mod, dst, hfTmp.setType(DataType::hf), loc);
         } else
             g.mov(mod, dst, src0, loc);
     }


### PR DESCRIPTION
# Description

Initial enabling of e8m0 scales in JIT gemm, baseline for mxfp enabling. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
