### PR TITLE
benchdnn: fix large problem description parsing

### DIFF
--- a/tests/benchdnn/bnorm/bnorm_aux.cpp
+++ b/tests/benchdnn/bnorm/bnorm_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -89,8 +89,8 @@ int str2desc(desc_t *desc, const char *str) {
     const char *s = str;
     assert(s);
 
-    auto mstrtol = [](const char *nptr, char **endptr) {
-        return strtol(nptr, endptr, 10);
+    auto mstrtoll = [](const char *nptr, char **endptr) {
+        return strtoll(nptr, endptr, 10);
     };
 
 #define CASE_NN(prb, c, cvfunc) \
@@ -120,11 +120,11 @@ int str2desc(desc_t *desc, const char *str) {
 #define CASE_N(c, cvfunc) CASE_NN(#c, c, cvfunc)
     while (*s) {
         int ok = 0;
-        CASE_N(mb, mstrtol);
-        CASE_N(ic, mstrtol);
-        CASE_N(id, mstrtol);
-        CASE_N(ih, mstrtol);
-        CASE_N(iw, mstrtol);
+        CASE_N(mb, mstrtoll);
+        CASE_N(ic, mstrtoll);
+        CASE_N(id, mstrtoll);
+        CASE_N(ih, mstrtoll);
+        CASE_N(iw, mstrtoll);
         CASE_N(eps, strtof);
         if (*s == 'n') {
             d.name = s + 1;

--- a/tests/benchdnn/conv/conv_aux.cpp
+++ b/tests/benchdnn/conv/conv_aux.cpp
@@ -82,7 +82,7 @@ int str2desc(desc_t *desc, const char *str) {
             ok = 1; \
             s += strlen(prb); \
             char *end_s; \
-            d.c = strtol(s, &end_s, 10); \
+            d.c = strtoll(s, &end_s, 10); \
             if (end_s == s) { \
                 BENCHDNN_PRINT(0, \
                         "ERROR: No value found for `%s` setting. Full " \

--- a/tests/benchdnn/deconv/deconv_aux.cpp
+++ b/tests/benchdnn/deconv/deconv_aux.cpp
@@ -78,7 +78,7 @@ int str2desc(desc_t *desc, const char *str) {
             ok = 1; \
             s += strlen(prb); \
             char *end_s; \
-            d.c = strtol(s, &end_s, 10); \
+            d.c = strtoll(s, &end_s, 10); \
             if (end_s == s) { \
                 BENCHDNN_PRINT(0, \
                         "ERROR: No value found for `%s` setting. Full " \

--- a/tests/benchdnn/gnorm/gnorm_aux.cpp
+++ b/tests/benchdnn/gnorm/gnorm_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ int str2desc(desc_t *desc, const char *str) {
     const char *s = str;
     assert(s);
 
-    auto mstrtol = [](const char *nptr, char **endptr) {
-        return strtol(nptr, endptr, 10);
+    auto mstrtoll = [](const char *nptr, char **endptr) {
+        return strtoll(nptr, endptr, 10);
     };
 
 #define CASE_NN(prb, c, cvfunc) \
@@ -84,12 +84,12 @@ int str2desc(desc_t *desc, const char *str) {
 #define CASE_N(c, cvfunc) CASE_NN(#c, c, cvfunc)
     while (*s) {
         int ok = 0;
-        CASE_N(g, mstrtol);
-        CASE_N(mb, mstrtol);
-        CASE_N(ic, mstrtol);
-        CASE_N(id, mstrtol);
-        CASE_N(ih, mstrtol);
-        CASE_N(iw, mstrtol);
+        CASE_N(g, mstrtoll);
+        CASE_N(mb, mstrtoll);
+        CASE_N(ic, mstrtoll);
+        CASE_N(id, mstrtoll);
+        CASE_N(ih, mstrtoll);
+        CASE_N(iw, mstrtoll);
         CASE_N(eps, strtof);
         if (*s == 'n') {
             d.name = s + 1;

--- a/tests/benchdnn/ip/ip_aux.cpp
+++ b/tests/benchdnn/ip/ip_aux.cpp
@@ -49,7 +49,7 @@ int str2desc(desc_t *desc, const char *str) {
             ok = 1; \
             s += strlen(prb); \
             char *end_s; \
-            d.c = strtol(s, &end_s, 10); \
+            d.c = strtoll(s, &end_s, 10); \
             if (end_s == s) { \
                 BENCHDNN_PRINT(0, \
                         "ERROR: No value found for `%s` setting. Full " \

--- a/tests/benchdnn/lrn/lrn_aux.cpp
+++ b/tests/benchdnn/lrn/lrn_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,8 +66,8 @@ int str2desc(desc_t *desc, const char *str) {
     const char *s = str;
     assert(s);
 
-    auto mstrtol = [](const char *nptr, char **endptr) {
-        return strtol(nptr, endptr, 10);
+    auto mstrtoll = [](const char *nptr, char **endptr) {
+        return strtoll(nptr, endptr, 10);
     };
 
 #define CASE_NN(prb, c, cvfunc) \
@@ -97,12 +97,12 @@ int str2desc(desc_t *desc, const char *str) {
 #define CASE_N(c, cvfunc) CASE_NN(#c, c, cvfunc)
     while (*s) {
         int ok = 0;
-        CASE_N(mb, mstrtol);
-        CASE_N(ic, mstrtol);
-        CASE_N(id, mstrtol);
-        CASE_N(ih, mstrtol);
-        CASE_N(iw, mstrtol);
-        CASE_N(ls, mstrtol);
+        CASE_N(mb, mstrtoll);
+        CASE_N(ic, mstrtoll);
+        CASE_N(id, mstrtoll);
+        CASE_N(ih, mstrtoll);
+        CASE_N(iw, mstrtoll);
+        CASE_N(ls, mstrtoll);
         CASE_N(alpha, strtof);
         CASE_N(beta, strtof);
         CASE_N(k, strtof);

--- a/tests/benchdnn/pool/pool_aux.cpp
+++ b/tests/benchdnn/pool/pool_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ int str2desc(desc_t *desc, const char *str) {
             ok = 1; \
             s += strlen(prb); \
             char *end_s; \
-            d.c = strtol(s, &end_s, 10); \
+            d.c = strtoll(s, &end_s, 10); \
             if (end_s == s) { \
                 BENCHDNN_PRINT(0, \
                         "ERROR: No value found for `%s` setting. Full " \

--- a/tests/benchdnn/resampling/resampling_aux.cpp
+++ b/tests/benchdnn/resampling/resampling_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ int str2desc(desc_t *desc, const char *str) {
             ok = 1; \
             s += strlen(prb); \
             char *end_s; \
-            d.c = strtol(s, &end_s, 10); \
+            d.c = strtoll(s, &end_s, 10); \
             if (end_s == s) { \
                 BENCHDNN_PRINT(0, \
                         "ERROR: No value found for `%s` setting. Full " \

--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -194,7 +194,7 @@ int str2desc(desc_t *desc, const char *str) {
             ok = 1; \
             s += strlen(prb); \
             char *end_s; \
-            d.c = strtol(s, &end_s, 10); \
+            d.c = strtoll(s, &end_s, 10); \
             if (end_s == s) { \
                 BENCHDNN_PRINT(0, \
                         "ERROR: No value found for `%s` setting. Full " \


### PR DESCRIPTION
This is a minimal fix of parsing a problem description in benchdnn's arguments. The issue was found during analysis of [MFDNN-13286](https://jira.devtools.intel.com/browse/MFDNN-13286) on **Windows**.