### PR TITLE
common: postops: add post-ops support for binary select op

### DIFF
--- a/doc/primitives/binary.md
+++ b/doc/primitives/binary.md
@@ -42,7 +42,8 @@ argument index as specified by the following table.
 | \f$\src_1\f$                | DNNL_ARG_SRC_1                                                            |
 | \f$\src_2\f$                | DNNL_ARG_SRC_2                                                            |
 | \dst                        | DNNL_ARG_DST                                                              |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 | \f$binary scale0\f$         | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC_0                                    |
 | \f$binary scale1\f$         | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC_1                                    |
 

--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -152,7 +152,8 @@ argument index as specified by the following table.
 | \diffbias                   | DNNL_ARG_DIFF_BIAS                                                         |
 | \diffdst                    | DNNL_ARG_DIFF_DST                                                          |
 | \f$depthwise\f$             | DNNL_ARG_ATTR_POST_OP_DW                                                   |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1, |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  |
 | \f$\text{prelu post-op}\f$  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS |
 
 ## Implementation Details

--- a/doc/primitives/eltwise.md
+++ b/doc/primitives/eltwise.md
@@ -84,7 +84,8 @@ argument index as specified by the following table.
 | \dst                        | DNNL_ARG_DST                                                              |
 | \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
 | \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 ## Implementation Details
 

--- a/doc/primitives/group_normalization.md
+++ b/doc/primitives/group_normalization.md
@@ -109,7 +109,8 @@ argument index as specified by the following table.
 | \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
 | \f$\diffgamma\f$            | DNNL_ARG_DIFF_SCALE                                                       |
 | \f$\diffbeta\f$             | DNNL_ARG_DIFF_SHIFT                                                       |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 ## Implementation Details
 

--- a/doc/primitives/inner_product.md
+++ b/doc/primitives/inner_product.md
@@ -59,7 +59,8 @@ argument index as specified by the following table.
 | \diffweights                | DNNL_ARG_DIFF_WEIGHTS                                                      |
 | \diffbias                   | DNNL_ARG_DIFF_BIAS                                                         |
 | \diffdst                    | DNNL_ARG_DIFF_DST                                                          |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1  |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1, |
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  |
 | \f$\text{prelu post-op}\f$  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS |
 
 ## Implementation Details

--- a/doc/primitives/layer_normalization.md
+++ b/doc/primitives/layer_normalization.md
@@ -128,7 +128,8 @@ argument index as specified by the following table.
 | \diffbeta                   | DNNL_ARG_DIFF_SHIFT                                                       |
 | \f$src scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC                                      |
 | \f$dst scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 The variance is marked with an asterisk because, for RMS normalization, the root
 mean square statistic is computed in place of the variance.

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -53,7 +53,8 @@ argument index as specified by the following table.
 | \f$\text{dropout output mask}\f$ | DNNL_ARG_ATTR_DROPOUT_MASK                                                 |
 | \f$\text{dropout probability}\f$ | DNNL_ARG_ATTR_DROPOUT_PROBABILITY                                          |
 | \f$\text{dropout rng seed}\f$    | DNNL_ARG_ATTR_DROPOUT_SEED                                                 |
-| \f$\text{binary post-op}\f$      | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1  |
+| \f$\text{binary post-op}\f$      | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1, |
+|                                  | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2  |
 | \f$\text{prelu post-op}\f$       | DNNL_ARG_ATTR_MULTIPLE_POST_OP(prelu_post_op_position) \| DNNL_ARG_WEIGHTS |
 
 ## Implementation Details

--- a/doc/primitives/pooling.md
+++ b/doc/primitives/pooling.md
@@ -68,7 +68,8 @@ argument index as specified by the following table.
 | workspace                   | DNNL_ARG_WORKSPACE                                                        |
 | \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
 | \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 ## Implementation Details
 

--- a/doc/primitives/reduction.md
+++ b/doc/primitives/reduction.md
@@ -59,7 +59,8 @@ argument index as specified by the following table.
 |-----------------------------|---------------------------------------------------------------------------|
 | \src                        | DNNL_ARG_SRC                                                              |
 | \dst                        | DNNL_ARG_DST                                                              |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 ## Implementation Details
 

--- a/doc/primitives/resampling.md
+++ b/doc/primitives/resampling.md
@@ -90,7 +90,8 @@ argument index as specified by the following table.
 | \dst                        | DNNL_ARG_DST                                                              |
 | \diffsrc                    | DNNL_ARG_DIFF_SRC                                                         |
 | \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 ## Implementation Details
 

--- a/doc/primitives/softmax.md
+++ b/doc/primitives/softmax.md
@@ -82,7 +82,8 @@ argument index as specified by the following table.
 | \diffdst                    | DNNL_ARG_DIFF_DST                                                         |
 | \f$src scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_SRC                                      |
 | \f$dst scale\f$             | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      |
-| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 |
+| \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1,|
+|                             | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 |
 
 ## Implementation Details
 

--- a/doc/programming_model/attributes_post_ops.md
+++ b/doc/programming_model/attributes_post_ops.md
@@ -281,6 +281,29 @@ Currently the following scenarios are optimized:
   post-operation which format may be queried from attributes using
   `dnnl::post_ops::get_params_binary(...)` function call.
 
+For the binary select operation, an additional conditional tensor is required 
+to execute the operation which is implemented using:
+
+~~~cpp
+void dnnl::post_ops::append_binary(
+        algorithm alg, // binary algorithm to apply
+        const memory::desc &src1 // memory descriptor for a second memory operand
+        const memory::desc &src2 // memory descriptor for a third memory operand
+        );
+~~~
+
+The `alg`, `src1`, and `src2` parameters are the same as in 
+@ref dev_guide_binary for the select operation.
+
+The binary post-op thus becomes:
+
+\f[
+    \dst[:] = \operatorname{binary}(\operatorname{Op}(...), Source\_1[:], Source\_2[:])
+\f]
+
+There is no broadcasting support for the conditional tensor. The select op is only 
+supported for CPU implementations.
+
 @anchor dev_guide_attributes_post_ops_prelu
 ### Prelu Post-op
 

--- a/include/oneapi/dnnl/dnnl.h
+++ b/include/oneapi/dnnl/dnnl.h
@@ -718,7 +718,7 @@ dnnl_status_t DNNL_API dnnl_post_ops_get_params_dw(
 
 /// Appends a binary post-op.
 ///
-/// The kind of this post operation is #dnnl_binary.
+/// This post operation is categorized as #dnnl_binary.
 ///
 /// In the simplest case when the binary is the only post operation, the
 /// computations would be:
@@ -736,6 +736,32 @@ dnnl_status_t DNNL_API dnnl_post_ops_get_params_dw(
 dnnl_status_t DNNL_API dnnl_post_ops_append_binary(dnnl_post_ops_t post_ops,
         dnnl_alg_kind_t alg_kind, const_dnnl_memory_desc_t src1_desc);
 
+/// Appends a binary post-op with ternary operators.
+///
+/// This post operation is categorized as #dnnl_binary.
+///
+/// In the simplest case when the binary is the only post operation, the
+/// computations will be:
+///
+///     dst[:] <- binary_op (dst[:], another_input1[:], another_input2[:])
+///
+/// where binary_op is configured with the given parameters. binary_op supports
+/// broadcast semantics only for the second operand and not for the third
+/// operand.
+///
+/// @param post_ops Post-ops.
+/// @param alg_kind Binary algorithm for the post-op.
+/// @param src1_desc Memory descriptor of a second operand.
+/// @param src2_desc Memory descriptor of a third operand. If the specificed
+/// algorithm is not one that requires a ternary input, src2_desc will be
+/// ignored.
+
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_post_ops_append_binary_v2(dnnl_post_ops_t post_ops,
+        dnnl_alg_kind_t alg_kind, const_dnnl_memory_desc_t src1_desc,
+        const_dnnl_memory_desc_t src2_desc);
+
 /// Returns the parameters of a binary post-op.
 ///
 /// @param post_ops Post-ops.
@@ -749,6 +775,25 @@ dnnl_status_t DNNL_API dnnl_post_ops_append_binary(dnnl_post_ops_t post_ops,
 dnnl_status_t DNNL_API dnnl_post_ops_get_params_binary(
         const_dnnl_post_ops_t post_ops, int index, dnnl_alg_kind_t *alg_kind,
         const_dnnl_memory_desc_t *src1_desc);
+
+/// Returns the parameters of a binary post-op with ternary operators.
+///
+/// @param post_ops Post-ops.
+/// @param index Index of the binary post-op.
+/// @param alg_kind Output binary algorithm kind.
+/// @param src1_desc Output memory descriptor of a second operand.
+/// @param src2_desc Output memory descriptor of a third operand. If the
+/// specified algorithm is not one that requires a ternary input, src2_desc
+/// will be ignored.
+
+/// @returns #dnnl_success on success and a status describing the error
+///     otherwise.
+/// @returns #dnnl_invalid_arguments if @p index does not refer to a binary
+///     post-op.
+dnnl_status_t DNNL_API dnnl_post_ops_get_params_binary_v2(
+        const_dnnl_post_ops_t post_ops, int index, dnnl_alg_kind_t *alg_kind,
+        const_dnnl_memory_desc_t *src1_desc,
+        const_dnnl_memory_desc_t *src2_desc);
 
 /// Appends a prelu forward post-op.
 ///

--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -141,6 +141,15 @@ class Converter(metaclass=ConverterMeta):
         return ":".join([po.alg] + args)
 
     def _convert_binary_post_op(self, po: ir.BinaryPostOp):
+        if po.alg == "select":
+            src1_arg = ".".join([po.dt, po.mask])
+            if po.tag != "any":
+                src1_arg = src1_arg + f".{po.tag}"
+            src2_arg = f"{po.src2_mask}"
+            if po.src2_tag != "any":
+                src2_arg = src2_arg + f".{po.tag}"
+            return ":".join([po.alg, src1_arg, src2_arg])
+
         if po.tag != "any":
             return f"{po.alg}:{po.dt}:{po.mask}:{po.tag}"
         return f"{po.alg}:{po.dt}:{po.mask}"

--- a/scripts/verbose_converter/src/ir.py
+++ b/scripts/verbose_converter/src/ir.py
@@ -268,6 +268,9 @@ class BinaryPostOp(PostOp):
     dt: str
     mask: int = 0
     tag: str = "any"
+    src2_dt: str = "s8"
+    src2_mask: int = 0
+    src2_tag: str = "any"
 
 
 @dataclass(eq=False)

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -308,11 +308,12 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
             dnnl::impl::alg_kind_t alg;
             // This is an unmodifiable user copy of attributes which is used in
             // caching mechanism. Not to be used internally.
-            dnnl::impl::memory_desc_t user_src1_desc;
+            dnnl::impl::memory_desc_t user_src1_desc, user_src2_desc;
+
             // This is a modifiable copy of memory desc. It changes format kind
             // and tag of md in case user passed format_kind::any. To be used
             // everywhere internally.
-            dnnl::impl::memory_desc_t src1_desc;
+            dnnl::impl::memory_desc_t src1_desc, src2_desc;
         };
 
         struct prelu_t {
@@ -365,6 +366,11 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
         }
 
         bool is_like_binary() const { return is_binary() || is_prelu(); }
+
+        bool is_binary_with_ternary_op() const {
+            return is_binary()
+                    && (binary.alg == dnnl::impl::alg_kind::binary_select);
+        }
 
         dnnl::impl::status_t validate_binary(
                 dnnl::impl::engine_kind_t engine_kind,
@@ -431,11 +437,13 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
             dnnl::impl::dim_t kernel_size, dnnl::impl::dim_t stride_size,
             dnnl::impl::dim_t padding_l_size);
     dnnl::impl::status_t append_binary(dnnl::impl::alg_kind_t alg,
-            const dnnl::impl::memory_desc_t *user_src1_desc);
+            const dnnl::impl::memory_desc_t *user_src1_desc,
+            const dnnl::impl::memory_desc_t *user_src2_desc = nullptr);
     dnnl::impl::status_t append_prelu(int mask);
 
     dnnl::impl::status_t prepend_binary(dnnl::impl::alg_kind_t alg,
-            const dnnl::impl::memory_desc_t *user_src1_desc);
+            const dnnl::impl::memory_desc_t *user_src1_desc,
+            const dnnl::impl::memory_desc_t *user_src2_desc = nullptr);
 
     int find(dnnl::impl::primitive_kind_t kind, int start = 0,
             int stop = -1) const {
@@ -512,7 +520,8 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
 
 private:
     dnnl::impl::status_t validate_binary(dnnl::impl::alg_kind_t alg,
-            const dnnl::impl::memory_desc_t *user_src1_desc) const;
+            const dnnl::impl::memory_desc_t *user_src1_desc,
+            const dnnl::impl::memory_desc_t *user_src2_desc) const;
 
     bool check_sum_consistent_dt(const dnnl::impl::data_type_t dst_dt,
             const bool diverse_sum_dt_allowed = false) const;

--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -39,7 +39,12 @@ namespace impl {
 static int po_inputs(const post_ops_t &post_ops, const primitive_kind_t kind) {
     int n_inputs = 0;
     for (int idx = 0; idx < post_ops.len(); ++idx) {
-        if (post_ops.contain(kind, idx)) n_inputs++;
+        if (post_ops.contain(kind, idx)) {
+            n_inputs++;
+            if (kind == primitive_kind::binary)
+                n_inputs += static_cast<int>(
+                        post_ops.entry_[idx].is_binary_with_ternary_op());
+        }
     }
     return n_inputs;
 }
@@ -185,6 +190,8 @@ struct primitive_desc_t : public c_compatible {
             if (post_op_has_proper_input(
                         attr(), binary, idx, arg, DNNL_ARG_SRC_1)
                     || post_op_has_proper_input(
+                            attr(), binary, idx, arg, DNNL_ARG_SRC_2)
+                    || post_op_has_proper_input(
                             attr(), prelu, idx, arg, DNNL_ARG_WEIGHTS))
                 return arg_usage_t::input;
         }
@@ -201,12 +208,22 @@ struct primitive_desc_t : public c_compatible {
                            post_ops_t::post_ops_limit)) {
             const auto &po = attr()->post_ops_;
             for (int idx = 0; idx < po.len(); ++idx) {
-                if (arg
-                        != (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
-                                | DNNL_ARG_SRC_1))
+                if (!utils::one_of(arg,
+                            (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
+                                    | DNNL_ARG_SRC_1),
+                            (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
+                                    | DNNL_ARG_SRC_2)))
                     continue;
 
-                return &po.entry_[idx].binary.src1_desc;
+                if (arg
+                        == (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
+                                | DNNL_ARG_SRC_1)) {
+                    return &po.entry_[idx].binary.src1_desc;
+                } else if (arg
+                        == (DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx)
+                                | DNNL_ARG_SRC_2)) {
+                    return &po.entry_[idx].binary.src2_desc;
+                }
             }
         }
 

--- a/src/cpu/binary_injector_utils.cpp
+++ b/src/cpu/binary_injector_utils.cpp
@@ -33,6 +33,11 @@ std::vector<const void *> prepare_binary_args(const post_ops_t &post_ops,
         if (post_op.is_binary()) {
             post_ops_binary_rhs_arg_vec.emplace_back(CTX_IN_MEM(const void *,
                     DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1));
+            if (post_op.is_binary_with_ternary_op()) {
+                post_ops_binary_rhs_arg_vec.emplace_back(CTX_IN_MEM(
+                        const void *,
+                        DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2));
+            }
         } else if (post_op.is_prelu()) {
             auto *arg = CTX_IN_MEM(const void *,
                     DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_WEIGHTS);
@@ -73,6 +78,15 @@ memory_desc_t get_src1_desc(
         memory_desc_t src1_md;
         memory_desc_init_by_tag(src1_md, ndims, src1_dims, data_type::f32, tag);
         return src1_md;
+    }
+}
+
+memory_desc_t get_src2_desc(
+        const post_ops_t::entry_t &post_op, const memory_desc_wrapper &dst_d) {
+    if (post_op.is_binary_with_ternary_op()) {
+        return post_op.binary.src2_desc;
+    } else {
+        return memory_desc_t();
     }
 }
 

--- a/src/cpu/binary_injector_utils.hpp
+++ b/src/cpu/binary_injector_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,6 +50,9 @@ std::vector<broadcasting_strategy_t> extract_bcast_strategies(
         const memory_desc_wrapper &dst_md);
 
 memory_desc_t get_src1_desc(
+        const post_ops_t::entry_t &post_op, const memory_desc_wrapper &dst_d);
+
+memory_desc_t get_src2_desc(
         const post_ops_t::entry_t &post_op, const memory_desc_wrapper &dst_d);
 
 /*

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -799,9 +799,16 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(jcp.isa,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(jcp.isa,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx2 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
     bool args_ok = true && jcp.ngroups == 1 && jcp.src_tag == dat_tag

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -968,10 +968,17 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
-    if (!post_ops_ok_) return status::unimplemented;
+    // temporary workaround that skips avx2 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
+    VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
     jcp.typesize_in = typesize;
     jcp.typesize_out = typesize;

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -1144,9 +1144,16 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const bool sum_at_pos_0_only = (jcp.src_dt == data_type::bf16);
     const bool sum_requires_scale_one = sum_at_pos_0_only;
     const bool sum_requires_zp_zero = sum_at_pos_0_only;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx512 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    p, dst_d));
     if (!post_ops_ok_) return status::unimplemented;
 
     jcp.typesize_in = types::data_type_size(src_d.data_type());

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -2520,9 +2520,16 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const bool sum_at_pos_0_only = (jcp.src_dt == data_type::bf16);
     const bool sum_requires_scale_one = sum_at_pos_0_only;
     const bool sum_requires_zp_zero = sum_at_pos_0_only;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx512 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    p, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
     auto set_or_check_wei_format = [&]() {

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -1277,9 +1277,16 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx512 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     if (!post_ops_ok_) return status::unimplemented;
 
     using namespace format_tag;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -1023,9 +1023,16 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx512 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     if (!post_ops_ok_) return status::unimplemented;
 
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -950,9 +950,16 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     static constexpr bool sum_at_pos_0_only = false;
     static constexpr bool sum_requires_scale_one = false;
     static constexpr bool sum_requires_zp_zero = false;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx512 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     if (!post_ops_ok_) return status::unimplemented;
 
     const int simd_w = (jcp.ic % 16 == 0 && jcp.oc % 16 == 0) ? 16

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1617,9 +1617,16 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = false;
     static constexpr bool sum_requires_scale_one = false;
     static constexpr bool sum_requires_zp_zero = false;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(avx512_core,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips avx512 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     if (!post_ops_ok_) return status::unimplemented;
 
     jcp.typesize_in = types::data_type_size(src_d.data_type());

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -624,9 +624,16 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(sse41,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(sse41,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips sse41 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
     const auto dat_tag_nxc = utils::pick(ndims - 3, nwc, nhwc);

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -468,9 +468,16 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     static constexpr bool sum_at_pos_0_only = true;
     static constexpr bool sum_requires_scale_one = true;
     static constexpr bool sum_requires_zp_zero = true;
-    const bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(sse41,
+    bool post_ops_ok_ = post_ops_ok(post_ops_ok_args_t(sse41,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, sum_at_pos_0_only,
             sum_requires_scale_one, sum_requires_zp_zero));
+    // temporary workaround that skips sse41 implementation for ternary
+    // post-ops with scalar broadcasting to avoid register collisions.
+    post_ops_ok_ = post_ops_ok_
+            && IMPLICATION(jcp.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
     const bool flat = jcp.ic == 3;

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -1257,7 +1257,10 @@ status_t jit_uni_layer_normalization_fwd_t::pd_t::init(engine_t *engine) {
                 accepted_post_ops, attr()->post_ops_, &dst_d, true, true, true,
                 true, get_supported_bcast_strategies(dst_d.ndims()));
 
-        return injector::post_ops_ok(post_ops_args);
+        return injector::post_ops_ok(post_ops_args)
+                && !binary_injector::
+                           any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                   attr()->post_ops_, dst_d);
     };
     VDISPATCH_LNORM(attr_.set_default_formats(dst_md(0)) == status::success,
             VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -166,6 +166,13 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(engine_t *engine) {
     conf_.with_postops
             = conf_.with_eltwise || conf_.with_binary || conf_.with_sum;
 
+    VDISPATCH_RESAMPLING(
+            IMPLICATION(conf_.with_binary,
+                    !binary_injector::
+                            any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                    conf_.post_ops, dst_d)),
+            VERBOSE_UNSUPPORTED_POSTOP);
+
     return status::success;
 }
 

--- a/src/gpu/generic/sycl/sycl_post_ops.hpp
+++ b/src/gpu/generic/sycl/sycl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -280,6 +280,7 @@ struct sycl_post_ops_t {
                     return false;
                 }
             } else if (allow_inputs && attr_po.contain(binary, i)) {
+                if (attr_po.entry_[i].is_binary_with_ternary_op()) return false;
                 if (!ref_binary_op_t::binary_ok(attr_po.entry_[i].binary)) {
                     return false;
                 }

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1022,6 +1022,7 @@ bool post_ops_ok(const conv_problem_t &prb, const hw_t &hw) {
                 // kernel always works correctly in benchdnn.
                 return false;
         }
+        if (po.is_binary_with_ternary_op()) return false;
     }
     return true;
 }

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -54,6 +54,7 @@ status_t gen_reorder_t::pd_t::init(impl::engine_t *engine,
                 if (!dnnl_memory_desc_equal(
                             &dst_md_type, &po.entry_[i].binary.src1_desc))
                     return false;
+                if (po.entry_[i].is_binary_with_ternary_op()) return false;
             }
         return true;
     };

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -324,6 +324,14 @@ struct attr_t {
                 int64_t mask = -1;
                 mask_input_t mask_input = mask_input_t::none;
                 std::string tag = tag::any;
+
+                // For the src2 tensor when the algorithm takes ternary inputs
+                dnnl_data_type_t src2_dt = dnnl_data_type_undef;
+                policy_t src2_policy = policy_t::COMMON;
+                int64_t src2_mask = -1;
+                mask_input_t src2_mask_input = mask_input_t::none;
+                std::string src2_tag = tag::any;
+
             } binary;
             struct {
                 policy_t policy = policy_t::COMMON;
@@ -333,6 +341,7 @@ struct attr_t {
             bool is_convolution_kind() const;
             bool is_eltwise_kind() const;
             bool is_binary_kind() const;
+            bool is_binary_kind_with_ternary_op() const;
             bool is_prelu_kind() const;
         };
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -917,10 +917,18 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
     for (int idx = 0; idx < dnnl_post_ops_len(const_po); ++idx) {
         if (dnnl_post_ops_get_kind(const_po, idx) != dnnl_binary) continue;
 
-        int po_arg = DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1;
-        const auto &po_md = query_md(const_pd, po_arg);
+        int po_arg1 = DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1;
+        const auto &po_md1 = query_md(const_pd, po_arg1);
         mem_map.emplace(
-                po_arg, dnn_mem_t(po_md, test_engine, /* prefill = */ true));
+                po_arg1, dnn_mem_t(po_md1, test_engine, /* prefill = */ true));
+
+        if (!query_post_ops_has_binary_alg_kind(
+                    const_po, idx, dnnl_binary_select))
+            continue;
+        int po_arg2 = DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2;
+        const auto &po_md2 = query_md(const_pd, po_arg2);
+        mem_map.emplace(
+                po_arg2, dnn_mem_t(po_md2, test_engine, /* prefill = */ true));
     }
 
     // Prelu post-op.

--- a/tests/benchdnn/doc/knobs_attr.md
+++ b/tests/benchdnn/doc/knobs_attr.md
@@ -249,6 +249,20 @@ supported, positioned after `MASK_INPUT`, to specify physical memory format.
 - `mul`
 - `ne`
 - `sub`
+- `select`
+
+For the `select` algorithm, the operation also requires a third conditional 
+tensor to be specified. A different format is thus used for providing the 
+arguments for both the tensors:
+
+```
+--attr-post-ops=select:DT[.S1_MASK_INPUT[.S1_TAG]][:S2_MASK_INPUT[.S2_TAG]]
+```
+
+The arguments for each tensor are are delimited using `.`, with the arguments 
+for the third tensor positioned after that of the second and are separated by `:`. 
+The arguments are optional for the third tensor and the data type value for 
+the third tensor is fixed at `s8`. 
 
 ### Prelu
 `PRELU` post operation kind applies forward algorithm to the operations result

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -594,7 +594,7 @@ std::vector<int> supported_exec_args(dir_t dir) {
     return (dir & FLAG_FWD) ? exec_fwd_args : exec_bwd_args;
 };
 
-fill_cfg_t binary_po_fill_cfg(
+void binary_po_fill_cfg(std::unordered_map<int, fill_cfg_t> &fill_cfg_map,
         int exec_arg, const dnn_mem_t &mem, const attr_t &attr) {
     fill_cfg_t cfg;
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
@@ -608,10 +608,16 @@ fill_cfg_t binary_po_fill_cfg(
                 = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE - 1;
         assert(bin_po_idx < attr.post_ops.len());
         const auto alg = attr.post_ops.entry[bin_po_idx].kind;
-        cfg = fill_cfg_t(mem.dt(), 4.f, 16.f, /* int = */ true, alg,
-                "gnorm_binary_post_op");
+        const bool is_src1_arg = !(exec_arg
+                ^ (DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_po_idx)
+                        | DNNL_ARG_SRC_1));
+
+        if (is_src1_arg) {
+            cfg = fill_cfg_t(mem.dt(), 4.f, 16.f, /* int = */ true, alg,
+                    "gnorm_binary_post_op");
+            fill_cfg_map.insert({DNNL_ARG_SRC_1, cfg});
+        }
     }
-    return cfg;
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
@@ -655,10 +661,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
                 break;
             default: {
-                const auto &binary_fill_cfg
-                        = binary_po_fill_cfg(exec_arg, mem, prb->attr);
-                std::unordered_map<int, fill_cfg_t> fill_cfg_map {
-                        {DNNL_ARG_SRC_1, binary_fill_cfg}};
+                std::unordered_map<int, fill_cfg_t> fill_cfg_map;
+                binary_po_fill_cfg(fill_cfg_map, exec_arg, mem, prb->attr);
                 SAFE(init_ref_memory_args_default_case(exec_arg, mem, ref_mem,
                              prb->attr, res, fill_cfg_map),
                         WARN);

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -201,6 +201,15 @@
 --attr-post-ops=mul:f32,relu,sum,prelu,prelu:per_oc
 2x10x3x20:2x10x20x4n"postops+runtime_dims_4d"
 
+# Post-ops with binary select op
+--reset
+--dt=f32,s8:s8:s32,bf16
+--stag=ab --wtag=ab --dtag=ab
+--attr-post-ops=select:f32,\
+                select:f32.per_oc,\
+                select:s8.per_tensor+add:f32
+--batch=shapes_2d
+
 # Rounding Mode
 --reset
 --dt=f8_e5m2,f8_e4m3

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -239,7 +239,7 @@ std::vector<int> supported_exec_args(dir_t dir) {
                                        : exec_bwd_args;
 };
 
-fill_cfg_t binary_po_fill_cfg(
+void binary_po_fill_cfg(std::unordered_map<int, fill_cfg_t> &fill_cfg_map,
         int exec_arg, const dnn_mem_t &mem, const attr_t &attr) {
     fill_cfg_t cfg;
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
@@ -253,10 +253,17 @@ fill_cfg_t binary_po_fill_cfg(
                 = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE - 1;
         assert(bin_po_idx < attr.post_ops.len());
         const auto alg = attr.post_ops.entry[bin_po_idx].kind;
-        cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
-                "pooling_binary_post_op");
+
+        const bool is_src1_arg = !(exec_arg
+                ^ (DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_po_idx)
+                        | DNNL_ARG_SRC_1));
+
+        if (is_src1_arg) {
+            cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
+                    "pooling_binary_post_op");
+            fill_cfg_map.insert({DNNL_ARG_SRC_1, cfg});
+        }
     }
-    return cfg;
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
@@ -311,10 +318,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 SAFE(!check_md_consistency_with_tag(mem.md_, prb->tag), WARN);
                 break;
             default:
-                const auto &binary_fill_cfg
-                        = binary_po_fill_cfg(exec_arg, mem, prb->attr);
-                std::unordered_map<int, fill_cfg_t> fill_cfg_map {
-                        {DNNL_ARG_SRC_1, binary_fill_cfg}};
+                std::unordered_map<int, fill_cfg_t> fill_cfg_map;
+                binary_po_fill_cfg(fill_cfg_map, exec_arg, mem, prb->attr);
                 SAFE(init_ref_memory_args_default_case(exec_arg, mem, ref_mem,
                              prb->attr, res, fill_cfg_map),
                         WARN);

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -242,7 +242,7 @@ std::vector<int> supported_exec_args(dir_t dir) {
     return exec_args;
 };
 
-fill_cfg_t binary_po_fill_cfg(
+void binary_po_fill_cfg(std::unordered_map<int, fill_cfg_t> &fill_cfg_map,
         int exec_arg, const dnn_mem_t &mem, const attr_t &attr) {
     fill_cfg_t cfg;
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
@@ -256,10 +256,16 @@ fill_cfg_t binary_po_fill_cfg(
                 = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE - 1;
         assert(bin_po_idx < attr.post_ops.len());
         const auto alg = attr.post_ops.entry[bin_po_idx].kind;
-        cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
-                "reduction_binary_post_op");
+        const bool is_src1_arg = !(exec_arg
+                ^ (DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_po_idx)
+                        | DNNL_ARG_SRC_1));
+
+        if (is_src1_arg) {
+            cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
+                    "reduction_binary_post_op");
+            fill_cfg_map.insert({DNNL_ARG_SRC_1, cfg});
+        }
     }
-    return cfg;
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
@@ -301,10 +307,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
                 break;
             default: {
-                const auto &binary_fill_cfg
-                        = binary_po_fill_cfg(exec_arg, mem, prb->attr);
-                std::unordered_map<int, fill_cfg_t> fill_cfg_map {
-                        {DNNL_ARG_SRC_1, binary_fill_cfg}};
+                std::unordered_map<int, fill_cfg_t> fill_cfg_map;
+                binary_po_fill_cfg(fill_cfg_map, exec_arg, mem, prb->attr);
                 SAFE(init_ref_memory_args_default_case(exec_arg, mem, ref_mem,
                              prb->attr, res, fill_cfg_map),
                         WARN);

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -151,7 +151,7 @@ std::vector<int> supported_exec_args(dir_t dir) {
     return (dir & FLAG_FWD) ? exec_fwd_args : exec_bwd_args;
 };
 
-fill_cfg_t binary_po_fill_cfg(
+void binary_po_fill_cfg(std::unordered_map<int, fill_cfg_t> &fill_cfg_map,
         int exec_arg, const dnn_mem_t &mem, const attr_t &attr) {
     fill_cfg_t cfg;
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
@@ -164,10 +164,16 @@ fill_cfg_t binary_po_fill_cfg(
                 = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE - 1;
         assert(bin_po_idx < attr.post_ops.len());
         const auto alg = attr.post_ops.entry[bin_po_idx].kind;
-        cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
-                "resampling_binary_post_op");
+        const bool is_src1_arg = !(exec_arg
+                ^ (DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_po_idx)
+                        | DNNL_ARG_SRC_1));
+
+        if (is_src1_arg) {
+            cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
+                    "resampling_binary_post_op");
+            fill_cfg_map.insert({DNNL_ARG_SRC_1, cfg});
+        }
     }
-    return cfg;
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
@@ -213,10 +219,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 SAFE(fill_dst(prb, mem, ref_mem), WARN);
                 break;
             default: {
-                const auto &binary_fill_cfg
-                        = binary_po_fill_cfg(exec_arg, mem, prb->attr);
-                std::unordered_map<int, fill_cfg_t> fill_cfg_map {
-                        {DNNL_ARG_SRC_1, binary_fill_cfg}};
+                std::unordered_map<int, fill_cfg_t> fill_cfg_map;
+                binary_po_fill_cfg(fill_cfg_map, exec_arg, mem, prb->attr);
                 SAFE(init_ref_memory_args_default_case(exec_arg, mem, ref_mem,
                              prb->attr, res, fill_cfg_map),
                         WARN);

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -309,7 +309,7 @@ std::vector<int> supported_exec_args(dir_t dir) {
     return (dir & FLAG_FWD) ? exec_fwd_args : exec_bwd_args;
 };
 
-fill_cfg_t binary_po_fill_cfg(
+void binary_po_fill_cfg(std::unordered_map<int, fill_cfg_t> &fill_cfg_map,
         int exec_arg, const dnn_mem_t &mem, const attr_t &attr) {
     fill_cfg_t cfg;
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
@@ -323,10 +323,16 @@ fill_cfg_t binary_po_fill_cfg(
                 = exec_arg / DNNL_ARG_ATTR_MULTIPLE_POST_OP_BASE - 1;
         assert(bin_po_idx < attr.post_ops.len());
         const auto alg = attr.post_ops.entry[bin_po_idx].kind;
-        cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
-                "softmax_binary_post_op");
+        const bool is_src1_arg = !(exec_arg
+                ^ (DNNL_ARG_ATTR_MULTIPLE_POST_OP(bin_po_idx)
+                        | DNNL_ARG_SRC_1));
+
+        if (is_src1_arg) {
+            cfg = fill_cfg_t(mem.dt(), 0.f, 16.f, /* int = */ true, alg,
+                    "softmax_binary_post_op");
+            fill_cfg_map.insert({DNNL_ARG_SRC_1, cfg});
+        }
     }
-    return cfg;
 }
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
@@ -387,10 +393,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
             } break;
             default: {
-                const auto &binary_fill_cfg
-                        = binary_po_fill_cfg(exec_arg, mem, prb->attr);
-                std::unordered_map<int, fill_cfg_t> fill_cfg_map {
-                        {DNNL_ARG_SRC_1, binary_fill_cfg}};
+                std::unordered_map<int, fill_cfg_t> fill_cfg_map;
+                binary_po_fill_cfg(fill_cfg_map, exec_arg, mem, prb->attr);
                 SAFE(init_ref_memory_args_default_case(exec_arg, mem, ref_mem,
                              prb->attr, res, fill_cfg_map),
                         WARN);

--- a/tests/benchdnn/utils/dnnl_query.cpp
+++ b/tests/benchdnn/utils/dnnl_query.cpp
@@ -99,6 +99,14 @@ bool query_post_ops_has_kind(
     return false;
 }
 
+bool query_post_ops_has_binary_alg_kind(
+        const_dnnl_post_ops_t post_ops, int idx, dnnl_alg_kind_t alg) {
+    dnnl_alg_kind_t po_alg = dnnl_alg_kind_undef;
+    const auto status = dnnl_post_ops_get_params_binary_v2(
+            post_ops, idx, &po_alg, nullptr, nullptr);
+    return (status == dnnl_success && po_alg == alg);
+}
+
 dnnl_scratchpad_mode_t query_scratchpad_mode(const_dnnl_primitive_attr_t attr) {
     dnnl_scratchpad_mode_t mode = dnnl_scratchpad_mode_library;
     dnnl_primitive_attr_get_scratchpad_mode(attr, &mode);

--- a/tests/benchdnn/utils/dnnl_query.hpp
+++ b/tests/benchdnn/utils/dnnl_query.hpp
@@ -48,6 +48,8 @@ int query_n_outputs(const_dnnl_primitive_desc_t pd);
 bool query_post_ops_has_kind(dnnl_primitive_t prim, dnnl_primitive_kind_t kind);
 bool query_post_ops_has_kind(
         const_dnnl_post_ops_t post_ops, dnnl_primitive_kind_t kind);
+bool query_post_ops_has_binary_alg_kind(
+        const_dnnl_post_ops_t post_ops, int idx, dnnl_alg_kind_t alg);
 dnnl_scratchpad_mode_t query_scratchpad_mode(const_dnnl_primitive_attr_t attr);
 const_dnnl_post_ops_t query_post_ops(const_dnnl_primitive_attr_t attr);
 const_dnnl_post_ops_t query_post_ops(const_dnnl_primitive_desc_t pd);


### PR DESCRIPTION
# Description

The PR adds updates post-ops implementations so that they support binary select operation as a post-op:

$dst[i] = cond[i]\quad?\quad src_0[i] \quad:\quad src_1[i]$

The updates account for the third conditional input that the select op requires for computation.

Implements MFDNN-12883.

This also introduces a new benchdnn format for providing arguments to multiple `src` tensors for a single post-op:
```
--attr-post-ops=select:DT[.S1_MASK_INPUT[.S1_TAG]][:S2_MASK_INPUT[.S2_TAG]]
```
#### Testcase:
```
./benchdnn --matmul --attr-post-ops=select:f32.per_tensor.ab:per_tensor.ab 5x10:10x5
```
(Currently, there is no broadcasting support for the conditional `src2` tensor. The data type, mask policy and tag for the `src2` tensor are fixed as `s8`, `common` and `any` respectively).