### PR TITLE
[GPU] FP8 Documentation fixup

### DIFF
--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -166,22 +166,22 @@ N/A.
 Convolution primitive supports the following combination of data types for
 source, destination, and weights memory objects:
 
-| Propagation    | Source    | Weights      | Destination                 | Bias                        |
-|:---------------|:----------|:-------------|:----------------------------|:----------------------------|
-| forward        | f32       | f32          | f32, u8, s8                 | f32                         |
-| forward        | f16       | f16          | f16, f32, u8, s8            | f16, f32                    |
-| forward        | u8, s8    | s8           | u8, s8, s32, f32, f16, bf16 | u8, s8, s32, f32, f16, bf16 |
-| forward        | bf16      | bf16         | f32, bf16                   | f32, bf16                   |
-| forward        | f8_e5m2   | f8_e5m2      | f8_e5m2, f32, f16, bf16     | f32                         |
-| forward        | f64       | f64          | f64                         | f64                         |
-| backward       | f32, bf16 | bf16         | bf16                        |                             |
-| backward       | f32, f16  | f16          | f16                         |                             |
-| backward       | f8_e5m2   | f8_e5m2      | f8_e5m2                     |                             |
-| backward       | f32       | f32          | f32                         | f32                         |
-| backward       | f64       | f64          | f64                         | f64                         |
-| weights update | bf16      | f32, bf16    | bf16, s8, u8                | f32, bf16                   |
-| weights update | f16       | f32, f16     | f16                         | f32, f16                    |
-| weights update | f8_e5m2   | f32, f8_e5m2 | f8_e5m2                     | f32                         |
+| Propagation    | Source           | Weights               | Destination                      | Bias                        |
+|:---------------|:-----------------|:----------------------|:---------------------------------|:----------------------------|
+| forward        | f32              | f32                   | f32, u8, s8                      | f32                         |
+| forward        | f16              | f16                   | f16, f32, u8, s8                 | f16, f32                    |
+| forward        | u8, s8           | s8                    | u8, s8, s32, f32, f16, bf16      | u8, s8, s32, f32, f16, bf16 |
+| forward        | bf16             | bf16                  | f32, bf16                        | f32, bf16                   |
+| forward        | f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3      | f8_e5m2, f8_e4m3, f32, f16, bf16 | f32                         |
+| forward        | f64              | f64                   | f64                              | f64                         |
+| backward       | f32, bf16        | bf16                  | bf16                             |                             |
+| backward       | f32, f16         | f16                   | f16                              |                             |
+| backward       | f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3      | f8_e5m2, f8_e4m3                 |                             |
+| backward       | f32              | f32                   | f32                              | f32                         |
+| backward       | f64              | f64                   | f64                              | f64                         |
+| weights update | bf16             | f32, bf16             | bf16, s8, u8                     | f32, bf16                   |
+| weights update | f16              | f32, f16              | f16                              | f32, f16                    |
+| weights update | f8_e5m2, f8_e4m3 | f32, f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3                 | f32                         |
 
 @warning
     There might be hardware and/or implementation specific restrictions.
@@ -438,8 +438,8 @@ of Winograd algorithm implementations.
 
 3. **GPU**
    - Depthwise post-op is not supported
-   - Only reference support is available for f8_e4m3. Optimized implementation
-     is available for f8_e5m2 on Intel(R) Data Center GPU Max Series only.
+   - `f8` iplementation uses Intel XMX cores only on Intel GPUs based on
+     Xe-HPC and Xe2-LPG, and Xe2-HPG uArch.
 
 4. **CPU**
    - Only reference support for fp8 data types (f8_e5m2, f8_e4m3) is

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -181,8 +181,8 @@ memory buffer that shares its shape with the destination buffer).
    - Sum post-op doesn't support data type other than destination data type.
    - Bias of bf16 data type is supported for configuration with bf16 source data
      type and weights bf16 data type, and up to three dimensional matrices.
-   - Only reference support is available for f8_e4m3. Optimized implementation
-     for f8_e5m2 is available only on Intel(R) Data Center GPU Max Series.
+   - Optimized implementations for fp8 data type are available only on Intel(R) 
+     Data Center GPU Max Series and Intel(R) Xe2 Graphics.
    - Configuration with int8 source data type, s8 weight data type and bf16
      destination data type don't support:
      * Destination zero point.
@@ -196,8 +196,6 @@ memory buffer that shares its shape with the destination buffer).
      destination data type isn't supported.
    - Configuration with floating point source data type, integer weights data
      type and floating point destination data type is not optimized.
-   - Only reference support for fp8 data types (f8_e5m2, f8_e4m3) is
-     is available on CPU.
    - The layout of dropout mask has to be exactly the same as that of dst.
  
 ## Performance Tips

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -220,17 +220,23 @@ library:
    * Intel(R) Data Center GPU Flex Series (formerly Arctic Sound)
  * Xe-HPC (accelerated f16, bf16, u8, and s8 support via DPAS and f64 support via MAD)
    * Intel(R) Data Center GPU Max Series (formerly Ponte Vecchio)
+ * Xe2-LPG
+   * Intel(R) Graphics for Intel(R) Core(TM) Ultra processors (Series 2) (formerly Lunar Lake)
+ * Xe2-HPG
+   * Intel(R) Arc(TM) B-Series Graphics (formerly Battlemage)
 
 The following table indicates the data types with performant compute primitives
 for each uArch supported by oneDNN. Unless otherwise noted, all data types have 
 reference support on all architectures.
 
-| uArch  | Supported Data types                                                |
-|:-------|:--------------------------------------------------------------------|
-| Xe-LP  | f32, f16, s8, u8                                                    |
-| Xe-HPG | f32, f16, bf16, s8, u8                                              |
-| Xe-HPC | f64, f32, bf16, f16, s8, u8                                         |
-| TBA    | f64, f32, bf16, f16, s8, u8, f8\_e5m2, f8\_e4m3, f4\_e2m1, f4\_e3m0 |
+| uArch   | Supported Data types                                                |
+|:--------|:--------------------------------------------------------------------|
+| Xe-LP   | f32, f16, s8, u8                                                    |
+| Xe-HPG  | f32, f16, bf16, s8, u8                                              |
+| Xe-HPC  | f64, f32, bf16, f16, s8, u8                                         |
+| Xe2-LPG | f64, f32, bf16, f16, s8, u8                                         |
+| Xe2-HPG | f64, f32, bf16, f16, s8, u8                                         |
+| TBA     | f64, f32, bf16, f16, s8, u8, f8\_e5m2, f8\_e4m3, f4\_e2m1, f4\_e3m0 |
 
 
 @note

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -37,7 +37,7 @@ oneDNN supports training and inference with the following data types:
 | Usage mode | CPU                                                                          | GPU                                           |
 |:-----------|:-----------------------------------------------------------------------------|:----------------------------------------------|
 | Inference  | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f4\_e2m1, f4\_e3m0, s8/u8, s4/u4, boolean | f32, bf16, f16, f8\_e5m2/f8\_e4m3, s8/u8, f64 |
-| Training   | f32, bf16, f16                                                               | f32, bf16, f16, f64                           |
+| Training   | f32, bf16, f16, f8\_e5m2/f8\_e4m3                                            | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f64        |
 
 @note
     Using lower precision arithmetic may require changes in the deep learning
@@ -238,8 +238,8 @@ reference support on all architectures.
   double-precision floating-point.
 
 @note
-  f8\_e5m2 compute operations have limited performance through upconversion on
-  Xe-HPC.
+  f8\_e5m2 and f8\_e4m3 compute operations have limited performance through upconversion on
+  Xe-HPC and Xe2 GPUs.
 
 @note
   f16 operations may be faster with f16 accumulation on GPU architectures older

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -903,8 +903,7 @@ bool data_types_ok(
     auto *device_info = compute_engine->device_info();
     if (prb.is_f64_accumulator() && !device_info->has_native(data_type::f64))
         return false;
-    if (is_fp8
-            && !(utils::one_of(hw, ngen::HW::XeHPC) && hw.systolic_support()))
+    if (is_fp8 && !(hw >= ngen::HW::XeHPC && hw.systolic_support()))
         return false;
     if (prb.is_fwd) return true;
     if (prb.is_bwd_d) return true;


### PR DESCRIPTION
# Description

Update documentation referecnes to fp8 type support on GPU. 

Previously FP8 support only included cases where fp8 was used after upconversion using native routines. Now includes f8_e4m3 which is upconverted using a more involved routine, incurring greater overhead. 

All current architectures use upconversion to f16 internally to support fp8 types. 

Update checks in jit:conv to allow fp8 support on more architectures. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

