### PR TITLE
xe: fix post-op runtime dimension handling

### DIFF
--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -60,9 +60,19 @@ public:
         }
 
         for (auto &int_var : int_var_map_) {
-            oss << " -D" << int_var.first << "=" << int_var.second;
-            if (int_var.second > INT_MAX || int_var.second < INT_MIN)
-                oss << "L";
+            // C tokens are parsed as (-)(integer_literal). As abs(INT_MIN) >
+            // INT_MAX, some compilers will promote the integer literal to a
+            // larger type. To avoid this promotion, and because the INT_MIN
+            // defines results in type promotion, we use a custom calculation.
+            if (int_var.second == std::numeric_limits<int32_t>::min())
+                oss << " -D" << int_var.first << "=(-2147483647-1)";
+            else if (int_var.second == std::numeric_limits<int64_t>::min())
+                oss << " -D" << int_var.first << "=(-9223372036854775807L-1)";
+            else {
+                oss << " -D" << int_var.first << "=" << int_var.second;
+                if (int_var.second > INT_MAX || int_var.second < INT_MIN)
+                    oss << "L";
+            }
         }
 
         for (auto &float_var : float_var_map_) {

--- a/src/gpu/intel/ocl/convolution_inner_product.hpp
+++ b/src/gpu/intel/ocl/convolution_inner_product.hpp
@@ -65,7 +65,7 @@ struct convolution_inner_product_fwd_t : public gpu_primitive_t {
             VDISPATCH_INNER_PRODUCT(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_INNER_PRODUCT(
-                    post_ops_with_binary_ok(attr(), desc()->dst_desc.data_type),
+                    post_ops_with_binary_ok(attr(), desc()->dst_desc),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_INNER_PRODUCT_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/ocl/gemm_inner_product.hpp
+++ b/src/gpu/intel/ocl/gemm_inner_product.hpp
@@ -69,7 +69,7 @@ struct gemm_inner_product_fwd_t : public gpu_primitive_t {
             VDISPATCH_INNER_PRODUCT(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_INNER_PRODUCT(
-                    post_ops_with_binary_ok(attr(), desc()->dst_desc.data_type),
+                    post_ops_with_binary_ok(attr(), desc()->dst_desc),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_INNER_PRODUCT_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/ocl/gen9_binary.hpp
+++ b/src/gpu/intel/ocl/gen9_binary.hpp
@@ -92,8 +92,8 @@ struct gen9_binary_t : public gpu_primitive_t {
                                             compute::device_ext_t::
                                                     intel_subgroups_short)),
                     VERBOSE_UNSUPPORTED_DT_CFG);
-            VDISPATCH_BINARY(post_ops_with_binary_ok(
-                                     attr(), dst_md()->data_type, MAX_NDIMS),
+            VDISPATCH_BINARY(
+                    post_ops_with_binary_ok(attr(), *dst_md(), MAX_NDIMS),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_BINARY_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/ocl/gen9_pooling.hpp
+++ b/src/gpu/intel/ocl/gen9_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,8 +66,7 @@ struct gen9_pooling_fwd_t : public gpu_primitive_t {
                     IMPLICATION(utils::one_of(src_data_t, f16, s8, u8),
                             desc()->prop_kind == forward_inference),
                     VERBOSE_UNSUPPORTED_DT_CFG);
-            VDISPATCH_POOLING(
-                    post_ops_with_binary_ok(attr(), dst_md()->data_type),
+            VDISPATCH_POOLING(post_ops_with_binary_ok(attr(), *dst_md()),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_POOLING_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/intel/ocl/gen9_wino_convolution.hpp
+++ b/src/gpu/intel/ocl/gen9_wino_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ struct gen9_wino_convolution_fwd_t : public gpu_primitive_t {
             VDISPATCH_CONV(
                     attr()->has_default_values(attr_skip_mask, dst_data_t),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_CONV(post_ops_with_binary_ok(attr(), dst_data_t),
+            VDISPATCH_CONV(post_ops_with_binary_ok(attr(), desc()->dst_desc),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             VDISPATCH_CONV_SC(init_conf(compute_engine),

--- a/src/gpu/intel/ocl/ocl_post_ops.h
+++ b/src/gpu/intel/ocl/ocl_post_ops.h
@@ -91,6 +91,12 @@ float fwd_Xnary(bool is_binary, unsigned algorithm, float x, float y,
 
 #define FILL_BIN_ARG_SERIAL(idx, dest_ptr, x0, x0_s, x1, x1_s, x2, x2_s, x3, \
         x3_s, x4, x4_s, x5, x5_s) \
+    bool bcast0 = CONCAT3(PO_, idx, _BIN_ARG_D0) == 1; \
+    bool bcast1 = CONCAT3(PO_, idx, _BIN_ARG_D1) == 1; \
+    bool bcast2 = CONCAT3(PO_, idx, _BIN_ARG_D2) == 1; \
+    bool bcast3 = CONCAT3(PO_, idx, _BIN_ARG_D3) == 1; \
+    bool bcast4 = CONCAT3(PO_, idx, _BIN_ARG_D4) == 1; \
+    bool bcast5 = CONCAT3(PO_, idx, _BIN_ARG_D5) == 1; \
     unroll_for(typeof(x0 + x0_s) x0_idx = x0, bin_arg_offset = 0; \
                x0_idx < x0 + x0_s; ++x0_idx) { \
         unroll_for(typeof(x1 + x1_s) x1_idx = x1; x1_idx < x1 + x1_s; \
@@ -106,12 +112,9 @@ float fwd_Xnary(bool is_binary, unsigned algorithm, float x, float y,
                                    ++x5_idx, ++bin_arg_offset) { \
                             const auto bin_arg_glob_off = OFF_MD( \
                                     CONCAT3(PO_, idx, _BIN_ARG), \
-                                    x0_idx % CONCAT3(PO_, idx, _BIN_ARG_D0), \
-                                    x1_idx % CONCAT3(PO_, idx, _BIN_ARG_D1), \
-                                    x2_idx % CONCAT3(PO_, idx, _BIN_ARG_D2), \
-                                    x3_idx % CONCAT3(PO_, idx, _BIN_ARG_D3), \
-                                    x4_idx % CONCAT3(PO_, idx, _BIN_ARG_D4), \
-                                    x5_idx % CONCAT3(PO_, idx, _BIN_ARG_D5)); \
+                                    bcast0 ? 0 : x0_idx, bcast1 ? 0 : x1_idx, \
+                                    bcast2 ? 0 : x2_idx, bcast3 ? 0 : x3_idx, \
+                                    bcast4 ? 0 : x4_idx, bcast5 ? 0 : x5_idx); \
                             dest_ptr[bin_arg_offset] = into_float( \
                                     po_buf(idx)[bin_arg_glob_off]); \
                         } \

--- a/src/gpu/intel/ocl/reduction/combined_reduction.hpp
+++ b/src/gpu/intel/ocl/reduction/combined_reduction.hpp
@@ -60,8 +60,7 @@ struct combined_reduction_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_REDUCTION(!memory_desc_ndims_ok(src_md(), dst_md()),
                     VERBOSE_INCONSISTENT_NDIMS, "src", "dst");
-            VDISPATCH_REDUCTION(
-                    post_ops_with_binary_ok(attr(), dst_md()->data_type, 5),
+            VDISPATCH_REDUCTION(post_ops_with_binary_ok(attr(), *dst_md(), 5),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_REDUCTION_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/intel/ocl/reduction/ref_reduction.hpp
+++ b/src/gpu/intel/ocl/reduction/ref_reduction.hpp
@@ -47,8 +47,7 @@ struct ref_reduction_t : public gpu_primitive_t {
                     VERBOSE_INCONSISTENT_NDIMS, "src", "dst");
             VDISPATCH_REDUCTION(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_REDUCTION(
-                    post_ops_with_binary_ok(attr(), dst_md()->data_type, 5),
+            VDISPATCH_REDUCTION(post_ops_with_binary_ok(attr(), *dst_md(), 5),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_REDUCTION_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/intel/ocl/ref_convolution.hpp
+++ b/src/gpu/intel/ocl/ref_convolution.hpp
@@ -91,8 +91,7 @@ struct ref_convolution_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_CONV_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(
-                    post_ops_with_binary_ok(attr(), dst_md_.data_type, 5),
+            VDISPATCH_CONV(post_ops_with_binary_ok(attr(), *dst_md(), 5),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
@@ -203,8 +202,7 @@ struct ref_convolution_bwd_data_t : public gpu_primitive_t {
             VDISPATCH_CONV(
                     this->set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
 
-            VDISPATCH_CONV(post_ops_with_binary_ok(
-                                   attr(), dst_md()->data_type, ndims()),
+            VDISPATCH_CONV(post_ops_with_binary_ok(attr(), *dst_md(), ndims()),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_CONV_SC(attr_.set_default_formats(diff_src_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/ocl/ref_eltwise.hpp
+++ b/src/gpu/intel/ocl/ref_eltwise.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,8 +73,8 @@ struct ref_eltwise_fwd_t : public gpu_primitive_t {
             VDISPATCH_ELTWISE(memory_desc_wrapper(src_md())
                             == memory_desc_wrapper(dst_md()),
                     VERBOSE_INCONSISTENT_MDS, "src", "dst");
-            VDISPATCH_ELTWISE(post_ops_with_binary_ok(
-                                      attr(), dst_md()->data_type, MAX_NDIMS),
+            VDISPATCH_ELTWISE(
+                    post_ops_with_binary_ok(attr(), *dst_md(), MAX_NDIMS),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_ELTWISE_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/ocl/ref_group_normalization.cpp
+++ b/src/gpu/intel/ocl/ref_group_normalization.cpp
@@ -85,8 +85,7 @@ status_t ref_group_normalization_fwd_t::pd_t::init(impl::engine_t *engine) {
 
     // post-op related checks and adjustments
     VDISPATCH_GNORM(set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-    VDISPATCH_GNORM(
-            post_ops_with_binary_ok(attr(), dst_md()->data_type, MAX_NDIMS),
+    VDISPATCH_GNORM(post_ops_with_binary_ok(attr(), *dst_md(), MAX_NDIMS),
             VERBOSE_UNSUPPORTED_TAG);
     CHECK(attr_.set_default_formats(
             dst_md(0))); // can't use attr() due to it is const

--- a/src/gpu/intel/ocl/ref_inner_product.hpp
+++ b/src/gpu/intel/ocl/ref_inner_product.hpp
@@ -84,7 +84,7 @@ struct ref_inner_product_fwd_t : public gpu_primitive_t {
             VDISPATCH_INNER_PRODUCT(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_INNER_PRODUCT(
-                    post_ops_with_binary_ok(attr(), desc()->dst_desc.data_type),
+                    post_ops_with_binary_ok(attr(), desc()->dst_desc),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_INNER_PRODUCT_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);

--- a/src/gpu/intel/ocl/ref_matmul.hpp
+++ b/src/gpu/intel/ocl/ref_matmul.hpp
@@ -106,7 +106,7 @@ struct ref_matmul_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_DT_CFG);
             VDISPATCH_MATMUL_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_MATMUL(post_ops_with_binary_ok(attr(), dst_dt_, 6),
+            VDISPATCH_MATMUL(post_ops_with_binary_ok(attr(), *dst_md(), 6),
                     VERBOSE_UNSUPPORTED_POSTOP);
             const memory_desc_wrapper dropout_md(attr_.dropout_.dropout_desc_);
             VDISPATCH_MATMUL(

--- a/src/gpu/intel/ocl/ref_pooling.hpp
+++ b/src/gpu/intel/ocl/ref_pooling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -97,8 +97,7 @@ struct ref_pooling_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_DT_CFG);
             VDISPATCH_POOLING(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_POOLING(
-                    post_ops_with_binary_ok(attr(), dst_md()->data_type, 5),
+            VDISPATCH_POOLING(post_ops_with_binary_ok(attr(), *dst_md(), 5),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_POOLING_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/intel/ocl/ref_resampling.hpp
+++ b/src/gpu/intel/ocl/ref_resampling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ struct ref_resampling_fwd_t : public gpu_primitive_t {
                     set_default_params(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_RESAMPLING(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_RESAMPLING(
-                    post_ops_with_binary_ok(attr(), dst_md()->data_type, 5),
+            VDISPATCH_RESAMPLING(post_ops_with_binary_ok(attr(), *dst_md(), 5),
                     VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_RESAMPLING_SC(attr_.set_default_formats(dst_md(0)),
                     VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/intel/ocl/simple_binary.hpp
+++ b/src/gpu/intel/ocl/simple_binary.hpp
@@ -76,8 +76,8 @@ struct simple_binary_t : public gpu_primitive_t {
             VDISPATCH_BINARY(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
 
-            VDISPATCH_BINARY(post_ops_with_binary_ok(
-                                     attr(), dst_md()->data_type, MAX_NDIMS),
+            VDISPATCH_BINARY(
+                    post_ops_with_binary_ok(attr(), *dst_md(), MAX_NDIMS),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             VDISPATCH_BINARY_SC(attr_.set_default_formats(dst_md(0)),

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -690,7 +690,7 @@ void def_binary_alg_kinds(compute::kernel_ctx_t &kernel_ctx);
 void def_eltwise_alg_kinds(compute::kernel_ctx_t &kernel_ctx);
 
 bool post_ops_with_binary_ok(const primitive_attr_t *attr,
-        const data_type_t dst_dt, const int max_ndims_supported = 2);
+        const memory_desc_t &dst_md, const int max_ndims_supported = 2);
 
 constexpr int prelu_max_ndims = 5;
 status_t get_prelu_md(int prelu_mask, const dim_t *dst_dims,


### PR DESCRIPTION
Fixes the invalid use of DNNL_RUNTIME_DIM_VAL for offset calculations in post-ops that by pure chance is functionally correct. This circumvents a compiler issues exposed by [this iGC change](https://github.com/intel/intel-graphics-compiler/commit/c7b3bb58542d7d91e34271e5c15fa442a0d2fa58) on the workload
```
--matmul --engine=gpu --stag=ab --wtag=ab --dtag=ab --runtime_dims_masks=0:2 --attr-post-ops=prelu:per_oc 3x20:20x4_n"postops+runtime_dims_2d"
```
The constant -9223372036854775808L (DNNL_RUNTIM_DIM_VAL) is parsed as two tokens (-) and (9223372036854775808L). The token 9223372036854775808L is in some sense invalid as it does not fit in the long type, so clang promotes it to long-long which is an i128 by the OpenCL specification. IGC then attempts to perform calculations with this i128 and fails due to it being unsupported in IGC.