### PR TITLE
oneDNN v3.7.2 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.7.1")
+set(PROJECT_VERSION "3.7.2")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.7.1:
* Fixed hang in matmul with odd shapes on Intel Arc GPUs (46e7499d8576ac036346f23c9f6d746823dd56b0)
* Fixed out-of-registers error in matmul on Intel Arc GPUs (599c8390610bbd9e8c8afdfeba582726ad3af0e1)
* Fixed incorrect results in SDPA pattern on Intel GPUs (6343c73143a6185d440bbd61e4089ed07196e9ec)
* Fixed integer overflow in convolution with large shapes on x64 CPUs (c541100d5b7678cf042c698aca5cddcbac1426a2)
* Fixed acccess violation issue in experimental Graph Compiler (8b0e6265648a95f3fdb8f3e734b8eb3075538de2)
* Fixed access violation in pooling on Intel GPUs (cd2cd5d654078608b9f0de3a1a847708dc3d8e15)
* Improved performance of int8 matmul with int4 weights on Intel GPUs (d6c98ec835f449c71fe359f9da68cf48ed68fad1)
