### PR TITLE
xe: ocl: prevent double -> float literal conversion [rnn, softmax, (de)conv]

### DIFF
--- a/src/gpu/intel/ocl/gen9_softmax.cl
+++ b/src/gpu/intel/ocl/gen9_softmax.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ gen9_softmax_fwd(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0 / denom_;
+    denom_ = 1.0f / denom_;
 #endif
 
     for (int i = 0; i < num_buf; i++) {
@@ -267,7 +267,7 @@ gen9_softmax_fwd(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0 / denom_;
+    denom_ = 1.0f / denom_;
 #endif
 
     dst += data_off;
@@ -377,7 +377,7 @@ gen9_softmax_fwd(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0 / denom_;
+    denom_ = 1.0f / denom_;
 #endif
 
     dst += data_off;

--- a/src/gpu/intel/ocl/gen9_wino_conv_fwd_data_fused.cl
+++ b/src/gpu/intel/ocl/gen9_wino_conv_fwd_data_fused.cl
@@ -1,7 +1,7 @@
 /*******************************************************************************
- * Copyright 2020-2024 Intel Corporation
+ * Copyright 2020-2025 Intel Corporation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0f (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -196,16 +196,16 @@ static inline int get_out_oc0(int lx, int ly) {
 static inline void wino_U_transform(
         UTRANS_DATA_T U[WINO_D], UTRANS_DATA_T wei[WINO_R]) {
     U[0] = wei[0];
-    U[1] = TO_TYPE(-2.0 / 9) * (wei[0] + wei[1] + wei[2]);
-    U[2] = TO_TYPE(2.0 / 9) * (-wei[0] + wei[1] - wei[2]);
-    U[3] = TO_TYPE(1.0 / 90) * wei[0] + TO_TYPE(2.0 / 90) * wei[1]
-            + TO_TYPE(4.0 / 90) * wei[2];
-    U[4] = TO_TYPE(1.0 / 90) * wei[0] - TO_TYPE(2.0 / 90) * wei[1]
-            + TO_TYPE(4.0 / 90) * wei[2];
-    U[5] = TO_TYPE(64.0 / 90) * wei[0] + TO_TYPE(32.0 / 90) * wei[1]
-            + TO_TYPE(16.0 / 90) * wei[2];
-    U[6] = TO_TYPE(64.0 / 90) * wei[0] - TO_TYPE(32.0 / 90) * wei[1]
-            + TO_TYPE(16.0 / 90) * wei[2];
+    U[1] = TO_TYPE(-2.0f / 9) * (wei[0] + wei[1] + wei[2]);
+    U[2] = TO_TYPE(2.0f / 9) * (-wei[0] + wei[1] - wei[2]);
+    U[3] = TO_TYPE(1.0f / 90) * wei[0] + TO_TYPE(2.0f / 90) * wei[1]
+            + TO_TYPE(4.0f / 90) * wei[2];
+    U[4] = TO_TYPE(1.0f / 90) * wei[0] - TO_TYPE(2.0f / 90) * wei[1]
+            + TO_TYPE(4.0f / 90) * wei[2];
+    U[5] = TO_TYPE(64.0f / 90) * wei[0] + TO_TYPE(32.0f / 90) * wei[1]
+            + TO_TYPE(16.0f / 90) * wei[2];
+    U[6] = TO_TYPE(64.0f / 90) * wei[0] - TO_TYPE(32.0f / 90) * wei[1]
+            + TO_TYPE(16.0f / 90) * wei[2];
     U[7] = wei[2];
 }
 
@@ -215,33 +215,33 @@ static inline void wino_U_transform(
 static inline void wino_V_transform(
         __local VTRANS_DATA_T *V, const VTRANS_DATA_T src[WINO_D]) {
     // Compute Winograd f6x3 data transform and store components in SLM.
-    V[V_off(0, 0, 0, VTRANS_BLOCK)]
-            = src[0] - TO_TYPE(5.25) * src[2] + TO_TYPE(5.25) * src[4] - src[6];
+    V[V_off(0, 0, 0, VTRANS_BLOCK)] = src[0] - TO_TYPE(5.25f) * src[2]
+            + TO_TYPE(5.25f) * src[4] - src[6];
 
-    VTRANS_DATA_T x0 = src[1] - TO_TYPE(4.25) * src[3] + src[5];
-    VTRANS_DATA_T x1 = src[2] - TO_TYPE(4.25) * src[4] + src[6];
+    VTRANS_DATA_T x0 = src[1] - TO_TYPE(4.25f) * src[3] + src[5];
+    VTRANS_DATA_T x1 = src[2] - TO_TYPE(4.25f) * src[4] + src[6];
 
     V[V_off(0, 1, 0, VTRANS_BLOCK)] = x1 + x0;
     V[V_off(0, 2, 0, VTRANS_BLOCK)] = x1 - x0;
 
     VTRANS_DATA_T x2 = TO_TYPE(-5) * src[3] + src[1];
     VTRANS_DATA_T x3 = TO_TYPE(4) * src[5] + x2;
-    VTRANS_DATA_T x4 = TO_TYPE(0.25) * src[2] + src[6];
-    VTRANS_DATA_T x5 = TO_TYPE(-1.25) * src[4] + x4;
+    VTRANS_DATA_T x4 = TO_TYPE(0.25f) * src[2] + src[6];
+    VTRANS_DATA_T x5 = TO_TYPE(-1.25f) * src[4] + x4;
 
-    V[V_off(0, 3, 0, VTRANS_BLOCK)] = TO_TYPE(0.5) * x3 + x5;
-    V[V_off(0, 4, 0, VTRANS_BLOCK)] = TO_TYPE(-0.5) * x3 + x5;
+    V[V_off(0, 3, 0, VTRANS_BLOCK)] = TO_TYPE(0.5f) * x3 + x5;
+    V[V_off(0, 4, 0, VTRANS_BLOCK)] = TO_TYPE(-0.5f) * x3 + x5;
 
     VTRANS_DATA_T x6 = TO_TYPE(4) * src[1] + src[5];
     VTRANS_DATA_T x7 = TO_TYPE(-5) * src[3] + x6;
     VTRANS_DATA_T x8 = TO_TYPE(4) * src[2] + src[6];
     VTRANS_DATA_T x9 = TO_TYPE(-5) * src[4] + x8;
 
-    V[V_off(0, 5, 0, VTRANS_BLOCK)] = TO_TYPE(+0.5) * x7 + x9;
-    V[V_off(0, 6, 0, VTRANS_BLOCK)] = TO_TYPE(-0.5) * x7 + x9;
+    V[V_off(0, 5, 0, VTRANS_BLOCK)] = TO_TYPE(+0.5f) * x7 + x9;
+    V[V_off(0, 6, 0, VTRANS_BLOCK)] = TO_TYPE(-0.5f) * x7 + x9;
 
-    V[V_off(0, 7, 0, VTRANS_BLOCK)] = -src[1] + TO_TYPE(5.25) * src[3]
-            - TO_TYPE(5.25) * src[5] + src[7];
+    V[V_off(0, 7, 0, VTRANS_BLOCK)] = -src[1] + TO_TYPE(5.25f) * src[3]
+            - TO_TYPE(5.25f) * src[5] + src[7];
 }
 static inline void wino_m_transform(
         OUT_BLOCK_DATA_T C[WINO_M], OUT_BLOCK_DATA_T M[WINO_D]) {

--- a/src/gpu/intel/ocl/gen9_wino_conv_fwd_data_fused.cl
+++ b/src/gpu/intel/ocl/gen9_wino_conv_fwd_data_fused.cl
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright 2020-2025 Intel Corporation
  *
- * Licensed under the Apache License, Version 2.0f (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -38,7 +38,13 @@
 
 #define WINO_D (WINO_M + WINO_R - 1)
 
-#define TO_TYPE(value) ((DATA_T)value)
+#if DT_FP64
+#define F_LIT(value) value
+#else
+#define F_LIT(value) value##f
+#endif
+
+#define TO_TYPE(value) ((DATA_T)(value))
 
 #define UTRANS_BLOCK VECT_DT_N
 #define UTRANS_DATA_T VECT_DATA_T
@@ -196,16 +202,20 @@ static inline int get_out_oc0(int lx, int ly) {
 static inline void wino_U_transform(
         UTRANS_DATA_T U[WINO_D], UTRANS_DATA_T wei[WINO_R]) {
     U[0] = wei[0];
-    U[1] = TO_TYPE(-2.0f / 9) * (wei[0] + wei[1] + wei[2]);
-    U[2] = TO_TYPE(2.0f / 9) * (-wei[0] + wei[1] - wei[2]);
-    U[3] = TO_TYPE(1.0f / 90) * wei[0] + TO_TYPE(2.0f / 90) * wei[1]
-            + TO_TYPE(4.0f / 90) * wei[2];
-    U[4] = TO_TYPE(1.0f / 90) * wei[0] - TO_TYPE(2.0f / 90) * wei[1]
-            + TO_TYPE(4.0f / 90) * wei[2];
-    U[5] = TO_TYPE(64.0f / 90) * wei[0] + TO_TYPE(32.0f / 90) * wei[1]
-            + TO_TYPE(16.0f / 90) * wei[2];
-    U[6] = TO_TYPE(64.0f / 90) * wei[0] - TO_TYPE(32.0f / 90) * wei[1]
-            + TO_TYPE(16.0f / 90) * wei[2];
+    U[1] = TO_TYPE(F_LIT(-2.) / F_LIT(9.)) * (wei[0] + wei[1] + wei[2]);
+    U[2] = TO_TYPE(F_LIT(2.) / F_LIT(9.)) * (-wei[0] + wei[1] - wei[2]);
+    U[3] = TO_TYPE(F_LIT(1.) / F_LIT(90.)) * wei[0]
+            + TO_TYPE(F_LIT(2.) / F_LIT(90.)) * wei[1]
+            + TO_TYPE(F_LIT(4.) / F_LIT(90.)) * wei[2];
+    U[4] = TO_TYPE(F_LIT(1.) / F_LIT(90.)) * wei[0]
+            - TO_TYPE(F_LIT(2.) / F_LIT(90.)) * wei[1]
+            + TO_TYPE(F_LIT(4.) / F_LIT(90.)) * wei[2];
+    U[5] = TO_TYPE(F_LIT(64.) / F_LIT(90.)) * wei[0]
+            + TO_TYPE(F_LIT(32.) / F_LIT(90.)) * wei[1]
+            + TO_TYPE(F_LIT(16.) / F_LIT(90.)) * wei[2];
+    U[6] = TO_TYPE(F_LIT(64.) / F_LIT(90.)) * wei[0]
+            - TO_TYPE(F_LIT(32.) / F_LIT(90.)) * wei[1]
+            + TO_TYPE(F_LIT(16.) / F_LIT(90.)) * wei[2];
     U[7] = wei[2];
 }
 
@@ -215,33 +225,33 @@ static inline void wino_U_transform(
 static inline void wino_V_transform(
         __local VTRANS_DATA_T *V, const VTRANS_DATA_T src[WINO_D]) {
     // Compute Winograd f6x3 data transform and store components in SLM.
-    V[V_off(0, 0, 0, VTRANS_BLOCK)] = src[0] - TO_TYPE(5.25f) * src[2]
-            + TO_TYPE(5.25f) * src[4] - src[6];
+    V[V_off(0, 0, 0, VTRANS_BLOCK)] = src[0] - TO_TYPE(F_LIT(5.25)) * src[2]
+            + TO_TYPE(F_LIT(5.25)) * src[4] - src[6];
 
-    VTRANS_DATA_T x0 = src[1] - TO_TYPE(4.25f) * src[3] + src[5];
-    VTRANS_DATA_T x1 = src[2] - TO_TYPE(4.25f) * src[4] + src[6];
+    VTRANS_DATA_T x0 = src[1] - TO_TYPE(F_LIT(4.25)) * src[3] + src[5];
+    VTRANS_DATA_T x1 = src[2] - TO_TYPE(F_LIT(4.25)) * src[4] + src[6];
 
     V[V_off(0, 1, 0, VTRANS_BLOCK)] = x1 + x0;
     V[V_off(0, 2, 0, VTRANS_BLOCK)] = x1 - x0;
 
-    VTRANS_DATA_T x2 = TO_TYPE(-5) * src[3] + src[1];
-    VTRANS_DATA_T x3 = TO_TYPE(4) * src[5] + x2;
-    VTRANS_DATA_T x4 = TO_TYPE(0.25f) * src[2] + src[6];
-    VTRANS_DATA_T x5 = TO_TYPE(-1.25f) * src[4] + x4;
+    VTRANS_DATA_T x2 = TO_TYPE(F_LIT(-5.)) * src[3] + src[1];
+    VTRANS_DATA_T x3 = TO_TYPE(F_LIT(4.)) * src[5] + x2;
+    VTRANS_DATA_T x4 = TO_TYPE(F_LIT(0.25)) * src[2] + src[6];
+    VTRANS_DATA_T x5 = TO_TYPE(F_LIT(-1.25)) * src[4] + x4;
 
-    V[V_off(0, 3, 0, VTRANS_BLOCK)] = TO_TYPE(0.5f) * x3 + x5;
-    V[V_off(0, 4, 0, VTRANS_BLOCK)] = TO_TYPE(-0.5f) * x3 + x5;
+    V[V_off(0, 3, 0, VTRANS_BLOCK)] = TO_TYPE(F_LIT(0.5)) * x3 + x5;
+    V[V_off(0, 4, 0, VTRANS_BLOCK)] = TO_TYPE(F_LIT(-0.5)) * x3 + x5;
 
-    VTRANS_DATA_T x6 = TO_TYPE(4) * src[1] + src[5];
-    VTRANS_DATA_T x7 = TO_TYPE(-5) * src[3] + x6;
-    VTRANS_DATA_T x8 = TO_TYPE(4) * src[2] + src[6];
-    VTRANS_DATA_T x9 = TO_TYPE(-5) * src[4] + x8;
+    VTRANS_DATA_T x6 = TO_TYPE(F_LIT(4.)) * src[1] + src[5];
+    VTRANS_DATA_T x7 = TO_TYPE(F_LIT(-5.)) * src[3] + x6;
+    VTRANS_DATA_T x8 = TO_TYPE(F_LIT(4.)) * src[2] + src[6];
+    VTRANS_DATA_T x9 = TO_TYPE(F_LIT(-5.)) * src[4] + x8;
 
-    V[V_off(0, 5, 0, VTRANS_BLOCK)] = TO_TYPE(+0.5f) * x7 + x9;
-    V[V_off(0, 6, 0, VTRANS_BLOCK)] = TO_TYPE(-0.5f) * x7 + x9;
+    V[V_off(0, 5, 0, VTRANS_BLOCK)] = TO_TYPE(F_LIT(+0.5)) * x7 + x9;
+    V[V_off(0, 6, 0, VTRANS_BLOCK)] = TO_TYPE(F_LIT(-0.5)) * x7 + x9;
 
-    V[V_off(0, 7, 0, VTRANS_BLOCK)] = -src[1] + TO_TYPE(5.25f) * src[3]
-            - TO_TYPE(5.25f) * src[5] + src[7];
+    V[V_off(0, 7, 0, VTRANS_BLOCK)] = -src[1] + TO_TYPE(F_LIT(5.25)) * src[3]
+            - TO_TYPE(F_LIT(5.25)) * src[5] + src[7];
 }
 static inline void wino_m_transform(
         OUT_BLOCK_DATA_T C[WINO_M], OUT_BLOCK_DATA_T M[WINO_D]) {
@@ -256,11 +266,11 @@ static inline void wino_m_transform(
     OUT_BLOCK_DATA_T x5 = M[5] - M[6];
 
     C[0] = M[0] + x0 + x2 + x4;
-    C[1] = x1 + TO_TYPE(2) * x3 + TO_TYPE(0.5f) * x5;
-    C[2] = x0 + TO_TYPE(4.f) * x2 + TO_TYPE(0.25f) * x4;
-    C[3] = x1 + TO_TYPE(8.f) * x3 + TO_TYPE(0.125f) * x5;
-    C[4] = x0 + TO_TYPE(16.f) * x2 + TO_TYPE(0.0625f) * x4;
-    C[5] = x1 + TO_TYPE(32.f) * x3 + TO_TYPE(0.03125f) * x5 + M[7];
+    C[1] = x1 + TO_TYPE(F_LIT(2.)) * x3 + TO_TYPE(F_LIT(0.5)) * x5;
+    C[2] = x0 + TO_TYPE(F_LIT(4.)) * x2 + TO_TYPE(F_LIT(0.25)) * x4;
+    C[3] = x1 + TO_TYPE(F_LIT(8.)) * x3 + TO_TYPE(F_LIT(0.125)) * x5;
+    C[4] = x0 + TO_TYPE(F_LIT(16.)) * x2 + TO_TYPE(F_LIT(0.0625)) * x4;
+    C[5] = x1 + TO_TYPE(F_LIT(32.)) * x3 + TO_TYPE(F_LIT(0.03125)) * x5 + M[7];
 }
 #elif WINO_M == 4
 static inline void wino_U_transform(
@@ -376,8 +386,8 @@ gen9_wino_conv_fwd(__global DATA_T *dst, const __global DATA_T *src,
             = (WINO_IC_BLOCK * WINO_D * IW_INTERNAL_BLOCK) / VTRANS_BLOCK;
     __local VTRANS_DATA_T V[slm_size]; // 8 KB
 
-    const DATA_T scl = TO_TYPE(16);
-    const DATA_T sc = TO_TYPE(1) / scl;
+    const DATA_T scl = TO_TYPE(F_LIT(16.));
+    const DATA_T sc = TO_TYPE(F_LIT(1.)) / scl;
     const VTRANS_DATA_T scl_vec = (VTRANS_DATA_T)(sc, sc, sc, sc);
 
     const int ow0 = get_group_id(0) * OW_BLOCK;

--- a/src/gpu/intel/ocl/ocl_post_ops.h
+++ b/src/gpu/intel/ocl/ocl_post_ops.h
@@ -188,7 +188,7 @@ float fwd_Xnary(bool is_binary, unsigned algorithm, float x, float y,
 #define APPLY_ALL_PO_STAGES(accumulator, acc_elem_dt, ...) \
     { \
         const int nelems = sizeof(accumulator) / sizeof(acc_elem_dt); \
-        acc_elem_dt *acc = &accumulator; \
+        acc_elem_dt *acc = (acc_elem_dt *)&accumulator; \
         CONCAT2(APPLY_PO_STAGE_, POST_OP_CHAIN_LENGTH) \
         (nelems, acc, acc_elem_dt, __VA_ARGS__) \
     }

--- a/src/gpu/intel/ocl/ref_convolution.cl
+++ b/src/gpu/intel/ocl/ref_convolution.cl
@@ -250,7 +250,7 @@ __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
     const unsigned po_d3 = 0;
     const unsigned po_d4 = 0;
 #endif
-    APPLY_POST_OPS_SERIAL(tmp, POST_OP_DATA_T, sum_src, POST_OP_DATA_T, n, 1,
+    APPLY_POST_OPS_SERIAL(tmp[0], POST_OP_DATA_T, sum_src, POST_OP_DATA_T, n, 1,
             g * IC + ic, 1, po_d2, 1, po_d3, 1, po_d4, 1, 0, 1);
 
 #if WITH_DST_SCALES

--- a/src/gpu/intel/ocl/ref_convolution.cl
+++ b/src/gpu/intel/ocl/ref_convolution.cl
@@ -173,7 +173,7 @@ __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
     const off_t id = GWS_GET_ID();
     const off_t ih = GWS_GET_IH();
     const off_t iw = GWS_GET_IW();
-    ACC_DATA_T d = 0.0;
+    ACC_DATA_T d = 0.0f;
     for_(off_t oc = 0; oc < OC; ++oc)
     for_(off_t kd = 0; kd < KD; ++kd)
     for_(off_t kh = 0; kh < KH; ++kh)
@@ -280,7 +280,7 @@ __kernel void ref_convolution_bwd_weights(const __global SRC_DATA_T *src,
 
 #if WITH_BIAS
     if (ic == 0 && kh == 0 && kw == 0 & kd == 0) {
-        ACC_DATA_T d = 0.0;
+        ACC_DATA_T d = 0.0f;
         for (off_t n = 0; n < MB; ++n)
             for (off_t od = 0; od < OD; ++od)
                 for (off_t oh = 0; oh < OH; ++oh)
@@ -292,7 +292,7 @@ __kernel void ref_convolution_bwd_weights(const __global SRC_DATA_T *src,
     }
 #endif
 
-    ACC_DATA_T dw = 0.0;
+    ACC_DATA_T dw = 0.0f;
     for (off_t n = 0; n < MB; ++n)
         for (off_t od = 0; od < OD; ++od)
             for (off_t oh = 0; oh < OH; ++oh)

--- a/src/gpu/intel/ocl/rnn/rnn_grid.cl
+++ b/src/gpu/intel/ocl/rnn/rnn_grid.cl
@@ -18,11 +18,6 @@
 #include "gpu/intel/ocl/rnn/cell_kind_utility.h"
 #include "gpu/intel/ocl/rnn/rnn_common.h"
 
-#if DT_F64 == 1
-#define POST_OP_LITERAL(x) x
-#else
-#define POST_OP_LITERAL(x) x##f
-#endif
 
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) __kernel void
 simple_rnn_copy_init_layer(__global WS_STATE_DATA_T *dst_base,
@@ -751,13 +746,13 @@ simple_rnn_elemwise_bwd(int dir, int lay, int iter,
                 convert_float(bias[off_ker_bias(dhc, 0, j)]), alpha, tm_scales);
 #endif
 #if IS_TESTMODE
-        float tmp = = dH * activation_bwd(g, tm_scales[0], POST_OP_LITERAL(0.));
+        float tmp = = dH * activation_bwd(g, tm_scales[0], 0.0f);
         scratch_diff_gates[cell_scratch_mem(
                 scratch_diff_gates_ld, dhc, i, 0, j)]
                 = TO_SRC(tmp);
         diff_bias_acc[0] += tmp;
 #else
-        float tmp = dH * activation_bwd(g, alpha, POST_OP_LITERAL(0.));
+        float tmp = dH * activation_bwd(g, alpha, 0.0f);
         scratch_diff_gates[cell_scratch_mem(
                 scratch_diff_gates_ld, dhc, i, 0, j)]
                 = TO_SRC(tmp);

--- a/src/gpu/intel/ocl/rnn/rnn_grid.cl
+++ b/src/gpu/intel/ocl/rnn/rnn_grid.cl
@@ -18,7 +18,6 @@
 #include "gpu/intel/ocl/rnn/cell_kind_utility.h"
 #include "gpu/intel/ocl/rnn/rnn_common.h"
 
-
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) __kernel void
 simple_rnn_copy_init_layer(__global WS_STATE_DATA_T *dst_base,
         __global char *src_base, __global AUX_DATA_T *scratch_diff_states,

--- a/src/gpu/intel/ocl/rnn/rnn_grid.cl
+++ b/src/gpu/intel/ocl/rnn/rnn_grid.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,6 +17,12 @@
 #include "gpu/intel/ocl/rnn/cell_compute.h"
 #include "gpu/intel/ocl/rnn/cell_kind_utility.h"
 #include "gpu/intel/ocl/rnn/rnn_common.h"
+
+#if DT_F64 == 1
+#define POST_OP_LITERAL(x) x
+#else
+#define POST_OP_LITERAL(x) x##f
+#endif
 
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) __kernel void
 simple_rnn_copy_init_layer(__global WS_STATE_DATA_T *dst_base,
@@ -745,13 +751,13 @@ simple_rnn_elemwise_bwd(int dir, int lay, int iter,
                 convert_float(bias[off_ker_bias(dhc, 0, j)]), alpha, tm_scales);
 #endif
 #if IS_TESTMODE
-        float tmp = = dH * activation_bwd(g, tm_scales[0], 0.);
+        float tmp = = dH * activation_bwd(g, tm_scales[0], POST_OP_LITERAL(0.));
         scratch_diff_gates[cell_scratch_mem(
                 scratch_diff_gates_ld, dhc, i, 0, j)]
                 = TO_SRC(tmp);
         diff_bias_acc[0] += tmp;
 #else
-        float tmp = dH * activation_bwd(g, alpha, 0.);
+        float tmp = dH * activation_bwd(g, alpha, POST_OP_LITERAL(0.));
         scratch_diff_gates[cell_scratch_mem(
                 scratch_diff_gates_ld, dhc, i, 0, j)]
                 = TO_SRC(tmp);

--- a/src/gpu/intel/ocl/simple_softmax.cl
+++ b/src/gpu/intel/ocl/simple_softmax.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ simple_softmax_fwd_generic(__global SRC_DATA_T *src, __global DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0 / denom_;
+    denom_ = 1.0f / denom_;
 #endif
 
     for (int i = begin; i < end; ++i) {


### PR DESCRIPTION
# Description

On older arch, if cl_khr_f64 is unsupported, the compiler throws warning about double literals.

Additionally fixes warning in conv:
`incompatible pointer types initializing '__private float *__private' with an expression of type '__private float2 (*)[1][6]' `