### PR TITLE
Another bucket of fixes (and future bugs...)

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -354,21 +354,39 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
             ? utils::get_dims_mask(dst_desc->dims, op_d.bias_desc.dims, ndims)
             : 0;
 
-    // TODO: requirement is for innermost dim to be multiple of 2 for
-    // the memory to be byte aligned.
+    using namespace data_type;
+    if (weights_desc->format_kind == format_kind::blocked
+            && utils::one_of(
+                    weights_desc->data_type, s4, u4, f4_e2m1, f4_e3m0)) {
+        const auto &wei_strides = weights_desc->format_desc.blocking.strides;
 
-    // s4/u4/f4 weights requires n to be multiple of 2 to be byte aligned
-    VCHECK_MATMUL(IMPLICATION(utils::one_of(weights_desc->data_type,
-                                      data_type::s4, data_type::u4,
-                                      data_type::f4_e2m1, data_type::f4_e3m0),
-                          weights_desc->dims[n_idx] % 2 == 0),
-            VERBOSE_BAD_DIM, "weights", n_idx);
-    // s4/u4/f4 src requires k to be multiple of 2 to be byte aligned
-    VCHECK_MATMUL(IMPLICATION(utils::one_of(src_desc->data_type, data_type::s4,
-                                      data_type::u4, data_type::f4_e2m1,
-                                      data_type::f4_e3m0),
-                          src_desc->dims[k_idx_src] % 2 == 0),
-            VERBOSE_BAD_DIM, "src", n_idx);
+        int n_unit_strides = 0;
+        for (int d = 0; d < ndims; d++) {
+            if (wei_strides[d] == 1) {
+                n_unit_strides++;
+                VCHECK_MATMUL(
+                        n_unit_strides <= 1, VERBOSE_BAD_DIM, "weights", d);
+            }
+            VCHECK_MATMUL(
+                    IMPLICATION(wei_strides[d] > 1, wei_strides[d] % 2 == 0),
+                    VERBOSE_BAD_DIM, "weights", d);
+        }
+    }
+    if (src_desc->format_kind == format_kind::blocked
+            && utils::one_of(src_desc->data_type, s4, u4, f4_e2m1, f4_e3m0)) {
+        const auto &src_strides = src_desc->format_desc.blocking.strides;
+
+        int n_unit_strides = 0;
+        for (int d = 0; d < ndims; d++) {
+            if (src_strides[d] == 1) {
+                n_unit_strides++;
+                VCHECK_MATMUL(n_unit_strides <= 1, VERBOSE_BAD_DIM, "src", d);
+            }
+            VCHECK_MATMUL(
+                    IMPLICATION(src_strides[d] > 1, src_strides[d] % 2 == 0),
+                    VERBOSE_BAD_DIM, "src", d);
+        }
+    }
 
     // check if other dims match.
     for (int d = 0; d < ndims - 2; ++d) {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -42,19 +42,18 @@ const float *jit_avx512_core_x8s8s32x_convolution_fwd_t::adjust_oscales(
         const memory_tracking::grantor_t &scratchpad, const float *src_scales,
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
-    const float src_scale = src_scales[0];
+    const bool has_wei_scales
+            = !pd()->attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
     const int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.f;
-    switch (wei_mask) {
-        case 0:
-            utils::array_set(loc_scales, src_scale * wei_scales[0] * factor,
-                    pd()->jcp_.simd_w);
-            break;
-        default:
-            for (dim_t c = 0; c < pd()->OC(); c++)
-                loc_scales[c] = src_scale * wei_scales[c] * factor;
+    if (has_wei_scales && wei_mask > 0) {
+        for (dim_t c = 0; c < pd()->OC(); c++)
+            loc_scales[c] = src_scales[0] * wei_scales[c] * factor;
+    } else {
+        utils::array_set(loc_scales, src_scales[0] * wei_scales[0] * factor,
+                pd()->jcp_.simd_w);
     }
     return loc_scales;
 }

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -1393,16 +1393,18 @@ const float *jit_avx512_core_x8s8s32x_deconvolution_fwd_t::adjust_oscales(
         const memory_tracking::grantor_t &scratchpad, const float *src_scales,
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
+    const bool has_wei_scales
+            = !pd()->attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
     int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.0f;
-    if (wei_mask == 0) {
-        utils::array_set(
-                loc_scales, src_scales[0] * wei_scales[0] * factor, 16);
-    } else {
+    if (has_wei_scales && wei_mask > 0) {
         for (dim_t c = 0; c < pd()->OC(); c++)
             loc_scales[c] = src_scales[0] * wei_scales[c] * factor;
+    } else {
+        utils::array_set(loc_scales, src_scales[0] * wei_scales[0] * factor,
+                /* WHY: pd()->jcp_.simd_w = 0!!! */ 16);
     }
     return loc_scales;
 }

--- a/src/cpu/x64/jit_uni_ncsp_convolution.cpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.cpp
@@ -100,7 +100,7 @@ status_t reduction_helper_t::reshape_weights(
 status_t reduction_helper_t::reshape_for_transpose(
         memory_desc_t &o_md, memory_desc_t &i_md) {
     const int ndims = i_md.ndims;
-    int *perm = new int[ndims];
+    std::vector<int> perm(ndims);
     for (int dim = 0; dim < ndims; dim++) {
         if (dim == ndims - 2)
             perm[dim] = dim + 1;
@@ -109,7 +109,7 @@ status_t reduction_helper_t::reshape_for_transpose(
         else
             perm[dim] = dim;
     }
-    return memory_desc_permute_axes(o_md, i_md, perm);
+    return memory_desc_permute_axes(o_md, i_md, perm.data());
 }
 
 bool reduction_helper_t::is_gemm() {

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -286,7 +286,11 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
                 = dst_mask == 0 ? scale_type_t::COMMON : scale_type_t::MANY;
     }
 
-    if (src_mask != dst_mask) return status::unimplemented;
+    VDISPATCH_REORDER_IC(
+            IMPLICATION(p.src_scale_type != scale_type_t::NONE
+                            && p.dst_scale_type != scale_type_t::NONE,
+                    src_mask == dst_mask),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     p.scale_adjust = (om_d.extra().flags & memory_extra_flags::scale_adjust)
             ? om_d.extra().scale_adjust

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -1451,15 +1451,18 @@ const float *jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::adjust_oscales(
         const memory_tracking::grantor_t &scratchpad, const float *src_scales,
         const float *wei_scales) const {
     auto loc_scales = scratchpad.template get<float>(key_conv_adjusted_scales);
+    const bool has_wei_scales
+            = !pd()->attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
     int wei_mask = pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS);
     float factor = (pd()->jcp_.signed_input && (!pd()->jcp_.has_vnni))
             ? 1.f / pd()->jcp_.wei_adj_scale
             : 1.0f;
-    if (wei_mask == 0) {
-        utils::array_set(loc_scales, src_scales[0] * wei_scales[0] * factor, 8);
-    } else {
+    if (has_wei_scales && wei_mask > 0) {
         for (dim_t c = 0; c < pd()->OC(); c++)
             loc_scales[c] = src_scales[0] * wei_scales[c] * factor;
+    } else {
+        utils::array_set(loc_scales, src_scales[0] * wei_scales[0] * factor,
+                /* WHY: pd()->jcp_.simd_w = 0!!! */ 8);
     }
     return loc_scales;
 }

--- a/tests/benchdnn/reorder/cfg.cpp
+++ b/tests/benchdnn/reorder/cfg.cpp
@@ -42,10 +42,11 @@ REG(f8_e5m2, -f16_max_exact, f16_max_exact);
 REG(f8_e4m3, -f16_max_exact, f16_max_exact);
 REG(f4_e2m1, -f16_max_exact, f16_max_exact);
 REG(f4_e3m0, -f4_max_exact, f4_max_exact);
-// Do not exceed max float value representable in integer. Otherwise, we get
-// a correctness issue caused by different computations in reference and the
-// library.
-REG(s32, INT_MIN, BENCHDNN_S32_TO_F32_SAT_CONST);
+// Do not exceed min/max float value representable in integer. Otherwise, we get
+// a correctness issue caused by different computations or roudings in the naive
+// reference and the library. One of those can be zero-point subtracting which
+// leads to underflow or overflow.
+REG(s32, -BENCHDNN_S32_TO_F32_SAT_CONST, BENCHDNN_S32_TO_F32_SAT_CONST);
 REG(s8, INT8_MIN, INT8_MAX);
 REG(u8, 0, UINT8_MAX);
 REG(s4, -7, 8);

--- a/tests/benchdnn/reorder/reorder_aux.cpp
+++ b/tests/benchdnn/reorder/reorder_aux.cpp
@@ -103,7 +103,8 @@ void prb_t::get_compensation_parameters(
         dims_t &comp_dims, int &mask, flag_bit_t flag) const {
     if (is_reorder_with_compensation(flag)) {
         for (const auto &i_oflag : oflag) {
-            if (i_oflag.first != flag) continue;
+            const bool has_flag_bit = (i_oflag.first & flag);
+            if (!has_flag_bit) continue;
 
             mask = i_oflag.second;
             for (int d = 0; d < ndims; ++d)

--- a/tests/benchdnn/self/common.cpp
+++ b/tests/benchdnn/self/common.cpp
@@ -118,10 +118,10 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::zero_points_t> &zp = s.zero_points;
-        SELF_CHECK_EQ(parse_attributes(s, def,
-                              "--attr-zero-points=src:common:0+wei:per_oc+dst:"
-                              "common:-2,src:per_dim_1"),
-                true);
+        std::string content_to_parse(
+                "--attr-zero-points=src:common:0+wei:per_oc+dst:common:-2,src:"
+                "per_dim_1");
+        SELF_CHECK_EQ(parse_attributes(s, def, content_to_parse.c_str()), true);
         SELF_CHECK_EQ(zp.size(), 2);
         const std::vector<dnnl_dim_t> def_g {};
         SELF_CHECK_ATTR_ZP(
@@ -138,11 +138,10 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::arg_scales_t> &sc = s.scales;
+        std::string content_to_parse(
+                "--attr-scales=src:common:1.5+wei:per_oc+src:common:0.5");
         // `src` scale is overridden with the latter value.
-        SELF_CHECK_EQ(parse_attributes(s, def,
-                              "--attr-scales=src:common:1.5+wei:per_oc+src:"
-                              "common:0.5"),
-                true);
+        SELF_CHECK_EQ(parse_attributes(s, def, content_to_parse.c_str()), true);
         SELF_CHECK_EQ(sc.size(), 1);
         SELF_CHECK_EQ(sc[0].get(DNNL_ARG_SRC).policy, policy_t::COMMON);
         SELF_CHECK_EQ(sc[0].get(DNNL_ARG_SRC).scale, 0.5f);
@@ -153,9 +152,9 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::arg_scales_t> &sc = s.scales;
-        SELF_CHECK_EQ(parse_attributes(s, def,
-                              "--attr-scales=src:common:2.5+src1:common:1.5"),
-                true);
+        std::string content_to_parse(
+                "--attr-scales=src:common:2.5+src1:common:1.5");
+        SELF_CHECK_EQ(parse_attributes(s, def, content_to_parse.c_str()), true);
         SELF_CHECK_EQ(sc.size(), 1);
         SELF_CHECK_EQ(sc[0].get(DNNL_ARG_SRC_0).policy, policy_t::COMMON);
         SELF_CHECK_EQ(sc[0].get(DNNL_ARG_SRC_0).scale, 2.5);
@@ -166,9 +165,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::zero_points_t> &zp = s.zero_points;
-        SELF_CHECK_EQ(parse_attributes(
-                              s, def, "--attr-zero-points=wei:per_ocic:s8:2x1"),
-                true);
+        std::string content_to_parse("--attr-zero-points=wei:per_ocic:s8:2x1");
+        SELF_CHECK_EQ(parse_attributes(s, def, content_to_parse.c_str()), true);
         SELF_CHECK_EQ(zp.size(), 1);
         std::vector<dnnl_dim_t> groups = {2, 1};
         SELF_CHECK_ATTR_ZP(zp[0], DNNL_ARG_WEIGHTS, policy_t::PER_OCIC, 0,
@@ -178,9 +176,9 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::arg_scales_t> &sc = s.scales;
-        SELF_CHECK_EQ(parse_attributes(s, def,
-                              "--attr-scales=attr_post_op_dw_wei:common:2"),
-                true);
+        std::string content_to_parse(
+                "--attr-scales=attr_post_op_dw_wei:common:2");
+        SELF_CHECK_EQ(parse_attributes(s, def, content_to_parse.c_str()), true);
         SELF_CHECK_EQ(sc.size(), 1);
         const auto arg = DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS;
         SELF_CHECK_EQ(sc[0].get(arg).policy, policy_t::COMMON);
@@ -191,7 +189,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::post_ops_t> &po = s.post_ops;
-        auto st = parse_attributes(s, def, "--attr-post-ops=dw:k3s1p1");
+        std::string content_to_parse("--attr-post-ops=dw:k3s1p1");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(po[0].len(), 1);
         const auto &e = po[0].entry[0];
@@ -206,8 +205,9 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::post_ops_t> &po = s.post_ops;
-        auto st = parse_attributes(
-                s, def, "--attr-post-ops=relu:0.5+dw:k3s2p1:s8+linear:2:1");
+        std::string content_to_parse(
+                "--attr-post-ops=relu:0.5+dw:k3s2p1:s8+linear:2:1");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(po[0].len(), 3);
         auto &e = po[0].entry[0];
@@ -236,7 +236,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::fpmath_mode_t> &fm = s.fpmath_mode;
-        auto st = parse_attributes(s, def, "--attr-fpmath=strict:true");
+        std::string content_to_parse("--attr-fpmath=strict:true");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(fm[0].mode, dnnl_fpmath_mode_strict);
         SELF_CHECK_EQ(fm[0].apply_to_int, true);
@@ -245,7 +246,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::fpmath_mode_t> &fm = s.fpmath_mode;
-        auto st = parse_attributes(s, def, "--attr-fpmath=bf16");
+        std::string content_to_parse("--attr-fpmath=bf16");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(fm[0].mode, dnnl_fpmath_mode_bf16);
         SELF_CHECK_EQ(fm[0].apply_to_int, false);
@@ -257,7 +259,8 @@ static int check_attr() {
         std::vector<attr_t::fpmath_mode_t> &fm = s.fpmath_mode;
         def.fpmath_mode.emplace_back();
         def.fpmath_mode[0].set(dnnl_fpmath_mode_bf16, true);
-        auto st = parse_attributes(s, def, "--attr-fpmath=");
+        std::string content_to_parse("--attr-fpmath=");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(fm[0].mode, dnnl_fpmath_mode_bf16);
         SELF_CHECK_EQ(fm[0].apply_to_int, true);
@@ -268,7 +271,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::dropout_t> &d = s.dropout;
-        auto st = parse_attributes(s, def, "--attr-dropout=0.5:12345:axb");
+        std::string content_to_parse("--attr-dropout=0.5:12345:axb");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(d[0].p, 0.5f);
         SELF_CHECK_EQ(d[0].seed, 12345);
@@ -278,7 +282,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::dropout_t> &d = s.dropout;
-        auto st = parse_attributes(s, def, "--attr-dropout=0.75");
+        std::string content_to_parse("--attr-dropout=0.75");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(d[0].p, 0.75f);
         SELF_CHECK_EQ(d[0].seed, 0);
@@ -288,7 +293,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::dropout_t> &d = s.dropout;
-        auto st = parse_attributes(s, def, "--attr-dropout=");
+        std::string content_to_parse("--attr-dropout=");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(d[0].p, 0.f);
         SELF_CHECK_EQ(d[0].seed, 0);
@@ -298,8 +304,8 @@ static int check_attr() {
     {
         base_settings_t s;
         std::vector<attr_t::rounding_mode_t> &rm = s.rounding_mode;
-        auto st = parse_attributes(
-                s, def, "--attr-rounding-mode=dst:stochastic");
+        std::string content_to_parse("--attr-rounding-mode=dst:stochastic");
+        auto st = parse_attributes(s, def, content_to_parse.c_str());
         SELF_CHECK_EQ(st, true);
         SELF_CHECK_EQ(rm[0].get(DNNL_ARG_DST), dnnl_rounding_mode_stochastic);
         SELF_CHECK_EQ(rm[0].get(DNNL_ARG_SRC), dnnl_rounding_mode_environment);


### PR DESCRIPTION
MFDNN-13351 - improve filling for matmul so that benchdnn doesn't report false-positives with relatively big zero-point values.
MFDNN-13377 - Update benchdnn and the library to restrict int4 buffers for byte-alignment only on the most dense dimension.
MFDNN-13360 - Fixup of previous change reducing the scratchpad space - the execute part was misaligned with the updated logic.
MFDNN-13368 - Updated benchdnn filling for reorder to avoid underflow in case of s32 validation with zero-points.
MFDNN-13376 - The product of refactor + a victim of a bug in benchdnn which didn't report cases becoming unimplemented properly. Reporting was fixed, case started returning unimplemented as expected. Unimplemented case was fixed in jit_uni_reorder, and also verbose messages were added.
MFDNN-11868 - Use a string object to carry the content for parsing as it sometimes somehow can be destroyed.