### PR TITLE
xe: sdpa: improve performance of quantized sdpa with a head size of 64

### DIFF
--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -32,10 +32,11 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         bool invert_scale, dnnl_dim_t kv_head_number, bool causal_mask,
         const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
         const_dnnl_primitive_attr_t vs_attr) {
-    if (auto err = sdpa_attr_check(query_desc, key_desc, value_desc, engine,
-                attr, kq_attr, vs_attr)) {
-        return err;
-    }
+    CHECK(sdpa_desc_check(query_desc, key_desc, value_desc, dst_desc, mask_desc,
+            engine, attr, kq_attr, vs_attr));
+    CHECK(sdpa_attr_check(
+            query_desc, key_desc, value_desc, engine, attr, kq_attr, vs_attr));
+
     dnnl::impl::sdpa_desc_t sdpa_desc = dnnl::impl::create_sdpa_desc(query_desc,
             key_desc, value_desc, dst_desc, mask_desc,
             (dnnl::impl::data_type_t)scale_dt, invert_scale, kv_head_number,

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -61,8 +61,14 @@ sdpa_config_t xehpg_h64_s128 = {16, 16, 16, 16, 4, 8, 4, 8};
 sdpa_config_t xehpg_h64_s64 = {32, 16, 16, 8, 8, 4, 4, 8};
 sdpa_config_t xehpg_h64_2nd = {8, 16, 16, 8, 8, 1, 4, 2};
 
-sdpa_config_t xehpg_q_h64 = {32, 16, 16, 16, 4, 4, 4, 4};
-sdpa_config_t xehpg_q_h64_2nd = {16, 16, 8, 8, 16, 1, 8, 2};
+sdpa_config_t xehpg_q_h64 = {32, 16, 16, 16, 4, 8, 4, 8};
+sdpa_config_t xehpg_q_h64_s128 = {16, 16, 16, 8, 8, 4, 4, 8};
+sdpa_config_t xehpg_q_h64_s64 = {32, 8, 32, 8, 2, 8, 2, 8};
+sdpa_config_t xehpg_q_h64_s32 = {8, 8, 16, 8, 4, 8, 4, 8};
+
+sdpa_config_t xehpg_q_h64_s64_2nd = {8, 8, 8, 8, 8, 2, 8, 2};
+sdpa_config_t xehpg_q_h64_s128_2nd = {16, 8, 8, 8, 8, 4, 8, 4};
+sdpa_config_t xehpg_q_h64_2nd = {16, 16, 8, 8, 16, 2, 8, 4};
 
 sdpa_config_t xehpg_h128 = {16, 16, 32, 8, 8, 4, 4, 8};
 sdpa_config_t xehpg_h128_s32 = {16, 16, 16, 8, 16, 2, 8, 4};
@@ -90,7 +96,24 @@ sdpa_config_t xehpc_h64_s32 = {16, 16, 16, 16, 4, 2, 4, 2};
 sdpa_config_t xehpc_h64_2nd = {32, 32, 32, 16, 4, 1, 2, 2};
 sdpa_config_t xehpc_h64_s64_2nd = {16, 16, 16, 16, 4, 1, 4, 1};
 
-sdpa_config_t xehpc_q_h64 = {16, 64, 32, 16, 8, 4, 2, 16};
+sdpa_config_t xehpc_q_h64_s64 = {16, 16, 16, 16, 4, 4, 4, 4};
+sdpa_config_t xehpc_q_h64_s384 = {16, 64, 16, 32, 8, 2, 4, 4};
+sdpa_config_t xehpc_q_h64_s1024 = {16, 64, 16, 16, 16, 1, 4, 4};
+sdpa_config_t xehpc_q_h64 = {16, 64, 16, 32, 8, 1, 4, 2};
+
+sdpa_config_t xehpc_q_h64_s128_integrated = {16, 16, 16, 16, 4, 4, 4, 4};
+sdpa_config_t xehpc_q_h64_s384_integrated = {16, 64, 16, 16, 16, 1, 4, 4};
+sdpa_config_t xehpc_q_h64_s1024_integrated = {16, 64, 16, 32, 8, 4, 4, 8};
+sdpa_config_t xehpc_q_h64_integrated = {16, 64, 16, 32, 16, 1, 8, 2};
+
+sdpa_config_t xehpc_q_h64_s96_2nd = {16, 16, 16, 16, 8, 1, 4, 1};
+sdpa_config_t xehpc_q_h64_s256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
+sdpa_config_t xehpc_q_h64_s1152_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
+sdpa_config_t xehpc_q_h64_2nd = {64, 16, 16, 16, 16, 2, 16, 2};
+
+sdpa_config_t xehpc_q_h64_s96_2nd_integrated = {16, 16, 16, 16, 8, 1, 4, 1};
+sdpa_config_t xehpc_q_h64_s384_2nd_integrated = {64, 16, 16, 16, 4, 1, 4, 1};
+sdpa_config_t xehpc_q_h64_2nd_integrated = {16, 16, 16, 16, 8, 1, 8, 1};
 
 sdpa_config_t xehpc_h128 = {16, 64, 32, 16, 16, 2, 4, 8};
 sdpa_config_t xehpc_h128_s64 = {16, 32, 32, 32, 4, 2, 4, 2};
@@ -121,8 +144,16 @@ sdpa_config_t *choose_config_xehpg(
         return &xehpg_h32;
     } else if (head_size <= 64) {
         if (quantized) {
-            if (thin_q) return &xehpg_q_h64_2nd;
-            return &xehpg_q_h64;
+            if (thin_q) {
+                if (seq <= 64) return &xehpg_q_h64_s64_2nd;
+                if (seq <= 128) return &xehpg_q_h64_s128_2nd;
+                return &xehpg_q_h64_2nd;
+            } else {
+                if (seq <= 32) return &xehpg_q_h64_s32;
+                if (seq <= 64) return &xehpg_q_h64_s64;
+                if (seq <= 128) return &xehpg_q_h64_s128;
+                return &xehpg_q_h64;
+            }
         }
         if (thin_q) return &xehpg_h64_2nd;
         if (seq <= 64) return &xehpg_h64_s64;
@@ -164,10 +195,33 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
         return &xehpc_h32;
     } else if (head_size <= 64) {
         if (thin_q) {
+            if (quantized) {
+                if (is_integrated) {
+                    if (seq <= 96) return &xehpc_q_h64_s96_2nd_integrated;
+                    if (seq <= 384) return &xehpc_q_h64_s384_2nd_integrated;
+                    return &xehpc_q_h64_2nd_integrated;
+                }
+                if (seq <= 96) return &xehpc_q_h64_s96_2nd;
+                if (seq <= 256) return &xehpc_q_h64_s256_2nd;
+                if (seq <= 1152) return &xehpc_q_h64_s1152_2nd;
+                return &xehpc_q_h64_2nd;
+            }
+
             if (seq <= 64) return &xehpc_h64_s64_2nd;
             return &xehpc_h64_2nd;
         }
-        if (quantized && seq >= 256) return &xehpc_q_h64;
+        if (quantized) {
+            if (is_integrated) {
+                if (seq <= 128) return &xehpc_q_h64_s128_integrated;
+                if (seq <= 384) return &xehpc_q_h64_s384_integrated;
+                if (seq <= 1024) return &xehpc_q_h64_s1024_integrated;
+                return &xehpc_q_h64_integrated;
+            }
+            if (seq <= 64) return &xehpc_q_h64_s64;
+            if (seq <= 384) return &xehpc_q_h64_s384;
+            if (seq <= 1024) return &xehpc_q_h64_s1024;
+            return &xehpc_q_h64;
+        }
         if (seq <= 32) return &xehpc_h64_s32;
         if (seq <= 64) return &xehpc_h64_s64;
         return &xehpc_h64;


### PR DESCRIPTION
# Description

This PR updates the configurations for the SDPA kernel to optimized for a head size of 64. These updates improve the performance of small head sizes by 1.1-1.5x on LNL. Performance in other platforms will be posted soon.

```
| mb |  N |  D |   KV |    Q | kdt       | vdt       | mask   | quant                 | sdpa(main) | sdpa(PR) | speedup vs. main |
|----+----+----+------+------+-----------+-----------+--------+-----------------------+------------+----------+------------------|
|  1 | 32 | 64 |  385 |    1 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |      80.75 |     62.5 |            1.292 |
|  1 | 32 | 64 |  513 |    1 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |      91.96 |    70.78 |        1.2992371 |
|  1 | 32 | 64 | 1025 |    1 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |     122.32 |   101.19 |        1.2088151 |
|  1 | 32 | 64 | 2049 |    1 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |     216.77 |   154.16 |        1.4061365 |
|  1 | 32 | 64 | 4097 |    1 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |     398.24 |    257.9 |        1.5441644 |
|----+----+----+------+------+-----------+-----------+--------+-----------------------+------------+----------+------------------|
|  1 | 32 | 64 |  384 |  384 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |     402.67 |   299.89 |        1.3427257 |
|  1 | 32 | 64 |  512 |  512 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |     512.16 |   458.93 |        1.1159872 |
|  1 | 32 | 64 | 1024 | 1024 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |    1801.07 |  1616.98 |        1.1138480 |
|  1 | 32 | 64 | 2048 | 2048 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |    9421.45 |  6120.72 |        1.5392715 |
|  1 | 32 | 64 | 4096 | 4096 | s8/f16/na | s8/f16/na | causal | per_token_with_groups |    26456.8 |  23432.6 |        1.1290595 |
#+TBLFM: $12=$10/$11
```

Addresses: [MFDNN-11755](https://jira.devtools.intel.com/browse/MFDNN-11755)

This PR also refactors the checks for the input descriptors so that its uniform between the internal primitive and the Graph API.