### PR TITLE
benchdnn: matmul: resolve the regression introduced by grouped scales and zero-points support

### DIFF
--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -68,6 +68,18 @@ dnn_mem_t::dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
     }
 }
 
+dnn_mem_t::dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
+        const dnnl_dims_t strides, dnnl_engine_t engine) {
+    const int ndims = query_md_ndims(md);
+    if (ndims > 0) {
+        auto status = dnnl_memory_desc_create_with_strides(
+                &md_, ndims, query_md_dims(md), dt, strides);
+        (void)status;
+        assert(status == dnnl_success);
+        active_ = (initialize(engine) == OK);
+    }
+}
+
 dnn_mem_t::dnn_mem_t(int ndims, const dnnl_dims_t dims, dnnl_data_type_t dt,
         const std::string &tag, dnnl_engine_t engine) {
     if (ndims > 0) {

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -47,8 +47,11 @@ struct dnn_mem_t {
     dnn_mem_t() { map(); }
     dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_engine_t engine,
             const handle_info_t &handle_info = handle_info_t::allocate());
+
     dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
             const std::string &tag, dnnl_engine_t engine);
+    dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
+            const dnnl_dims_t strides, dnnl_engine_t engine);
 
     dnn_mem_t(int ndims, const dnnl_dims_t dims, dnnl_data_type_t dt,
             const std::string &tag, dnnl_engine_t engine);

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -280,10 +280,6 @@ inline int64_t src_off_f(const prb_t *prb, int64_t mb, int64_t m, int64_t k) {
     return (mb * prb->m + m) * prb->k + k;
 }
 
-inline int64_t wei_off_f(const prb_t *prb, int64_t mb, int64_t k, int64_t n) {
-    return (mb * prb->k + k) * prb->n + n;
-}
-
 inline int64_t dst_off_f(const prb_t *prb, int64_t mb, int64_t m, int64_t n) {
     return (mb * prb->m + m) * prb->n + n;
 }


### PR DESCRIPTION
MFDNN-13114

Couple changes to improve the situation reported in the tracker above:
* Avoid unnecessary get_idx calls for each K while it should be done once per a group of K.
* Use `ba` format for weights in ref kernel to avoid bad leading dimensions and have memory dense in K-loop.

Seems to give a significant boost compared to what it was before.