### PR TITLE
ci: clang-tidy: no repo ref

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install clang
         run: |


### PR DESCRIPTION
This PR provides fix for fork repositories check.