### PR TITLE
graph: refine and support GQA pattern with ukernel

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -286,10 +286,15 @@ status_t sdp_primitive_config_t::initial_check(
 
     VCHECK_SDP_PRIMITIVE(q_id != -1 && k_id != -1 && v_id != -1,
             status::unimplemented, "Q, K, V are not found");
-    VCHECK_SDP_PRIMITIVE(ltw(inputs[q_id]).vdims().size() == 4
-                    && ltw(inputs[k_id]).vdims().size() == 4
-                    && ltw(inputs[v_id]).vdims().size() == 4,
-            status::unimplemented, "Q, K, V should be 4-dims");
+
+    // Note: sdpa_primitive_v1 kernel accept 5D GQA pattern, and will reshape to
+    // 4D in later compilation pass.
+    if (!v1_kernel) {
+        VCHECK_SDP_PRIMITIVE(ltw(inputs[q_id]).vdims().size() == 4
+                        && ltw(inputs[k_id]).vdims().size() == 4
+                        && ltw(inputs[v_id]).vdims().size() == 4,
+                status::unimplemented, "Q, K, V should be 4-dims");
+    }
 
     // sdp_primitive only supports single scale value.
     if (scale) {

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_v1.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_v1.cpp
@@ -76,6 +76,7 @@ status_t sdp_primitive_v1_kernel_t::compile_impl(
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_src_transpose_to_matmul);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_sdpa);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_predecessor);
+    BACKEND_DNNL_ADD_PASS(pipeline, insert_reshape_for_sdpa);
     BACKEND_DNNL_ADD_PASS(pipeline, layout_propagation);
 
     // bind the memory for each op`

--- a/src/graph/backend/dnnl/passes/insert_ops.hpp
+++ b/src/graph/backend/dnnl/passes/insert_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2024 Intel Corporation
+ * Copyright 2021-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,11 @@ status_t insert_permute_for_matmul(std::shared_ptr<subgraph_t> &sg);
 /// 1) reshape src0 to 2d(keep last dimension and flatten others)
 /// 2) reshape dst back to nd after compilation
 status_t insert_reshape_for_ndx2d_matmul(std::shared_ptr<subgraph_t> &sg);
+
+/// Insert reshape for 5D sdpa. sdpa only support 4D input/output
+/// 1) reshape Q/K/V/scale/mask from 5D to 4D
+/// 2) reshape output from 4D to 5D
+status_t insert_reshape_for_sdpa(std::shared_ptr<subgraph_t> &sg);
 
 // Insert an unsqueeze-squeeze pair for matmul
 //

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -12,6 +12,7 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/GQA-fp16.json
+--reset --dt=f32,bf16,f16 --case=complex_fusion/mha/GQA-fp16-v2.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -10,6 +10,7 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/GQA-fp16.json
+--reset --dt=f32,bf16,f16 --case=complex_fusion/mha/GQA-fp16-v2.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16-v2.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16-v2.json
@@ -1,0 +1,373 @@
+{
+  "version": "3.8.0",
+  "engine_kind": "gpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    1,
+    3,
+    8,
+    11,
+    19
+  ],
+  "output_ports": [
+    20
+  ],
+  "graph": [
+    {
+      "id": 7,
+      "name": "bmm1",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 1
+        }
+      },
+      "inputs": [
+        {
+          "id": 1,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            64
+          ],
+          "stride": [
+            393216,
+            196608,
+            24576,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 3,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            1,
+            384,
+            64
+          ],
+          "stride": [
+            49152,
+            24576,
+            24576,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 4,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "name": "scale_div",
+      "kind": "Divide",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 4,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 8,
+          "dtype": "f16",
+          "shape": [
+            1
+          ],
+          "stride": [
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 9,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "name": "mask_add",
+      "kind": "Add",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 9,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 11,
+          "dtype": "f16",
+          "shape": [
+            32,
+            1,
+            1,
+            1,
+            384
+          ],
+          "stride": [
+            384,
+            384,
+            384,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 14,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "name": "softmax",
+      "kind": "SoftMax",
+      "attrs": {
+        "axis": {
+          "type": "s64",
+          "value": -1
+        }
+      },
+      "inputs": [
+        {
+          "id": 14,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 16,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "name": "bmm2",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        }
+      },
+      "inputs": [
+        {
+          "id": 16,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            384
+          ],
+          "stride": [
+            2359296,
+            1179648,
+            147456,
+            384,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 19,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            1,
+            384,
+            64
+          ],
+          "stride": [
+            49152,
+            24576,
+            24576,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 20,
+          "dtype": "f16",
+          "shape": [
+            32,
+            2,
+            8,
+            384,
+            64
+          ],
+          "stride": [
+            393216,
+            196608,
+            24576,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Follow up PR based on #2930. Part 2 for addressing MFDNN-12871 which is requested by PyTorch upstream. This PR refined the legacy GQA pattern and added a pass to handle new pattern. Now, the GQA pattern and graph compilation fusion processed pattern as follows.
GQA pattern that graph API support. 
Q[batch size, group num, group size, seq len, head size]
K[batch size, group num, 1, seq len, head size]
V[batch size, group num, 1, seq len, head size]
![image](https://github.com/user-attachments/assets/1db29000-4a58-4688-8973-be9f2b3b5af3)

The processed GQA pattern after graph compilation.
![image](https://github.com/user-attachments/assets/539b9cd9-f691-47bc-9eb6-7e49a08de6ee)


## Works
- Added a pass to transform 5D GQA into 4D so that the ukernel can support it.
- Added some check and layout propagation to avoid unnecessary reorder.

## Validation
```
onednn_verbose,v1,graph,exec,gpu,100002,sdp,bmm1;scale_div;mask_add;softmax;bmm2,,in0_f16:1:strided:undef:32x2x8x384x64:393216s196608s24576s64s1 in1_f16:3:strided:undef:32x2x1x384x64:49152s24576s24576s64s1 in2_f16:8:strided:undef:1:1 in3_f16:11:strided:undef:32x1x1x1x384:384s384s384s384s1 in4_f16:19:strided:undef:32x2x1x384x64:49152s24576s24576s64s1 out0_f16:20:strided:undef:32x2x8x384x64:393216s196608s24576s64s1,fpm:strict,sdp_primitive_v1_kernel_t,dnnl_backend,1.71313
0:PASSED __REPRO: --graph --engine=gpu --dt=f16 --case=/home/gta/xiangguo/oneDNN/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16-v2.json
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 7.64s; fill: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```

PyTorch upstream team also helped to verified the new design that the new solution works fine. 
