### PR TITLE
cpu: x64: cpu_reducer: fix unaligned access [WIP]

### DIFF
--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -195,9 +195,11 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
         for (int i = 0; i < nloads; ++i) {
             size_t off = base_off + i * load_len;
 
-            if (load_len == typesize)
-                this->uni_add(Xmm(i), this->ptr[reg_src + off]);
-            else if (load_len == vlen)
+            if (load_len == typesize) {
+                assert(nloads == 1);
+                this->movd(Xmm(nloads + i), this->ptr[reg_src + off]);
+                this->uni_add(Xmm(i), Xmm(nloads + i));
+            } else if (load_len == vlen)
                 this->uni_vadd(Vmm(i), Vmm(i), vmmword[reg_src + off]);
             else
                 assert(!"unsupported");


### PR DESCRIPTION
In the reduction flow, using an unaligned PADDD instruction causes a segmentation fault.
Fix for issue : MFDNN-13401: [QA][CPU] IP primitive Failed with SegFault