### PR TITLE
[rls-v3.7] backport xe: sdpa: add block 2d load store definition for bf16

### DIFF
--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -66,25 +66,32 @@ static inline status_t sdpa_attr_check(const memory_desc_t *q_desc,
     if (kq_attr && !kq_attr->has_default_values()) {
         const auto &sc = kq_attr->scales_;
         const auto &zp = kq_attr->zero_points_;
-        const auto &scale_dt = sc.get_data_type(DNNL_ARG_WEIGHTS);
-        const auto &zp_dt = zp.get_data_type(DNNL_ARG_WEIGHTS);
-
-        VCHECK_SDPA_ATTR_TYPE(utils::one_of(scale_dt, f16, f32), kq_attr,
-                "scales", "f16 or f32");
-        VCHECK_SDPA_ATTR_TYPE(utils::one_of(zp_dt, s4, u4, u8, s8, s32),
-                kq_attr, "zero_points", "u4, s4, u8, s8, or s32");
+        if (!sc.has_default_values()) {
+            const auto &scale_dt = sc.get_data_type(DNNL_ARG_WEIGHTS);
+            VCHECK_SDPA_ATTR_TYPE(utils::one_of(scale_dt, f16, f32), kq_attr,
+                    "scales", "f16 or f32");
+        }
+        if (!zp.has_default_values()) {
+            const auto &zp_dt = zp.get_data_type(DNNL_ARG_WEIGHTS);
+            VCHECK_SDPA_ATTR_TYPE(utils::one_of(zp_dt, s4, u4, u8, s8, s32),
+                    kq_attr, "zero_points", "u4, s4, u8, s8, or s32");
+        }
     }
 
     if (vs_attr && !vs_attr->has_default_values()) {
         const auto &sc = vs_attr->scales_;
         const auto &zp = vs_attr->zero_points_;
-        const auto &scale_dt = sc.get_data_type(DNNL_ARG_WEIGHTS);
-        const auto &zp_dt = zp.get_data_type(DNNL_ARG_WEIGHTS);
 
-        VCHECK_SDPA_ATTR_TYPE(utils::one_of(scale_dt, f16, f32), vs_attr,
-                "scales", "f16 or f32");
-        VCHECK_SDPA_ATTR_TYPE(utils::one_of(zp_dt, s4, u4, u8, s8, s32),
-                vs_attr, "zero_points", "u4, s4, u8, s8, or s32");
+        if (!sc.has_default_values()) {
+            const auto &scale_dt = sc.get_data_type(DNNL_ARG_WEIGHTS);
+            VCHECK_SDPA_ATTR_TYPE(utils::one_of(scale_dt, f16, f32), vs_attr,
+                    "scales", "f16 or f32");
+        }
+        if (!zp.has_default_values()) {
+            const auto &zp_dt = zp.get_data_type(DNNL_ARG_WEIGHTS);
+            VCHECK_SDPA_ATTR_TYPE(utils::one_of(zp_dt, s4, u4, u8, s8, s32),
+                    vs_attr, "zero_points", "u4, s4, u8, s8, or s32");
+        }
     }
 
     if (attr) {

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -100,14 +100,16 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         "kq scales mask(%d) must equal kq zero point(%d) "
                         "mask",
                         kq_scales_mask, kq_zp_mask);
-            VDISPATCH_SDPA(utils::one_of(kq_scales_mask, 0, 1, 3, 11, 15),
-                    "unsupported mask for kq matmul(%d). must be 0, 1, 3, 11, "
-                    "or 15",
-                    kq_scales_mask);
-            VDISPATCH_SDPA(utils::one_of(kq_zp_mask, 0, 1, 3, 11, 15),
-                    "unsupported mask for kq matmul(%d). must be 0, 1, 3, 11, "
-                    "or 15",
-                    kq_zp_mask);
+            if (!desc()->kq_scales.has_default_values())
+                VDISPATCH_SDPA(utils::one_of(kq_scales_mask, 0, 1, 3, 11, 15),
+                        "unsupported mask for kq matmul(%d). must be 0, 1, 3, "
+                        "11, or 15",
+                        kq_scales_mask);
+            if (!desc()->kq_zero_points.has_default_values())
+                VDISPATCH_SDPA(utils::one_of(kq_zp_mask, 0, 1, 3, 11, 15),
+                        "unsupported mask for kq matmul(%d). must be 0, 1, 3, "
+                        "11, or 15",
+                        kq_zp_mask);
 
             /// NOTE: Limitation of microkernels
             if (utils::one_of(
@@ -127,14 +129,16 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         "vs scales mask(%d) must equal vs zero point(%d) "
                         "mask",
                         vs_scales_mask, vs_zp_mask);
-            VDISPATCH_SDPA(utils::one_of(vs_scales_mask, 0, 1, 3, 7, 15),
-                    "unsupported mask for vs matmul(%d). must be 0, 1, 3, 7, "
-                    "or 15",
-                    vs_scales_mask);
-            VDISPATCH_SDPA(utils::one_of(vs_zp_mask, 0, 1, 3, 7, 15),
-                    "unsupported mask for vs matmul(%d). must be 0, 1, 3, 7, "
-                    "or 15",
-                    vs_zp_mask);
+            if (!desc()->vs_scales.has_default_values())
+                VDISPATCH_SDPA(utils::one_of(vs_scales_mask, 0, 1, 3, 7, 15),
+                        "unsupported mask for vs matmul(%d). must be 0, 1, 3, "
+                        "7, or 15",
+                        vs_scales_mask);
+            if (!desc()->vs_zero_points.has_default_values())
+                VDISPATCH_SDPA(utils::one_of(vs_zp_mask, 0, 1, 3, 7, 15),
+                        "unsupported mask for vs matmul(%d). must be 0, 1, 3, "
+                        "7, or 15",
+                        vs_zp_mask);
 
             /// NOTE: Limitation of microkernels
             if (utils::one_of(

--- a/src/gpu/intel/ocl/tile_ops.h
+++ b/src/gpu/intel/ocl/tile_ops.h
@@ -152,6 +152,7 @@ DEF_BLOCK2D_LOAD_STORE(half, ushort, 8, 16, u16_m8k16v1, 16, 8)
 DEF_BLOCK2D_LOAD_STORE(half, ushort, 8, 16, u16_m4k32v1, 32, 4)
 DEF_BLOCK2D_LOAD_STORE(half, ushort, 16, 16, u16_m8k32v1, 32, 8)
 
+DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 8, 16, u16_m8k16v1, 16, 8)
 DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 8, 16, u16_m4k32v1, 32, 4)
 DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 16, 16, u16_m8k32v1, 32, 8)
 


### PR DESCRIPTION
# Description

This PR backports an error that appeared in SDPA for very small tensors. 

Fixes: https://jira.devtools.intel.com/browse/MFDNN-13392

Backport commits pull from: https://github.com/uxlfoundation/oneDNN/pull/2854 and https://github.com/uxlfoundation/oneDNN/pull/2633
