### PR TITLE
xe: jit: gemm: virtual flag allocator fixes

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -962,10 +962,9 @@ status_t gen_gemm_kernel_t::get_kernel(
     } catch (const std::runtime_error &err) {
         VERROR(primitive, gpu, "%s,%s", "jit::gemm", err.what());
     }
-
-    return {};
-
 #undef ARCH_DISPATCH
+
+    return status::runtime_error;
 }
 
 void gen_gemm_kernel_t::maybe_print_verbose() {

--- a/src/gpu/intel/jit/gemm/generator/pieces/allocators.hpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/allocators.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -83,14 +83,16 @@ public:
     bool isLocked(VirtualFlag vflag)          const { return !(~locked & mask(vflag)); }
     bool canLock(int n = 1) const;
     void freeUnlocked();
+    void freeVFlagTempAllocs()                      { free |= vtemps; vtemps = 0; }
 
     ngen::FlagRegister assignPhysical(VirtualFlag vflag);
 
 protected:
-    uint64_t free;
-    uint8_t locked = 0;
-    uint8_t nextPhys = 0;
-    uint8_t nflag;
+    uint64_t free;                  // Bitmask: free virtual flags
+    uint8_t locked = 0;             // Bitmask: locked physical flags (= unavailable for vflag usage)
+    uint8_t vtemps = 0;             // Bitmask: temporary allocations for physical assignments of virtual flags */
+    uint8_t nextPhys = 0;           // Next physical flag to try for physical flag assignment.
+    uint8_t nflag;                  // # of physical flags in HW.
 
     static uint64_t mask(VirtualFlag vflag)         { return mask(vflag.idx, vflag.n); }
     static uint64_t mask(int idx, int n)            { return (uint64_t(1) << (idx + n)) - (uint64_t(1) << idx); }

--- a/src/gpu/intel/jit/gemm/generator/pieces/state.cpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/state.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ void CommonState::wipeActiveVFlags()
     for (int i = 0; i < int(activeVFlags.size()); i++)
         if (!raVFlag.isLocked(VirtualFlag(i)))
             activeVFlags[i].clear();
+    raVFlag.freeVFlagTempAllocs();
 }
 
 void CommonState::allocEmulate64Temp(const EmulationStrategy &estrategy)


### PR DESCRIPTION
Fixes two bugs in the virtual flag allocator, one silly one, and one subtle one which seems to be the root cause of several x8x8bf16 failures (e.g. MFDNN-13358).