### PR TITLE
cpu: binary: fix binary add with non-contiguous strides when bs=1

### DIFF
--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -49,7 +49,10 @@ static bool compare_layouts(const memory_desc_wrapper &src0_md,
     if (is_bcast) return true;
 
     bool same_layouts = true;
-    for (int d = 0; d < ndims; ++d)
+    // For batch size == 1, the first dimension is ignored for stride checks,
+    // as non-contiguous strides in this dimension do not affect correctness.
+    int start_dim = (dims0[0] == 1 && dims1[0] == 1) ? 1 : 0;
+    for (int d = start_dim; d < ndims; ++d)
         same_layouts = same_layouts && strides0[d] == strides1[d];
     return same_layouts;
 }

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -47,7 +47,10 @@ static bool compare_layouts(const memory_desc_wrapper &src0_md,
     if (is_bcast) return true;
 
     bool same_layouts = true;
-    for (int d = 0; d < ndims; ++d)
+    // For batch size == 1, the first dimension is ignored for stride checks,
+    // as non-contiguous strides in this dimension do not affect correctness.
+    int start_dim = (dims0[0] == 1 && dims1[0] == 1) ? 1 : 0;
+    for (int d = start_dim; d < ndims; ++d)
         same_layouts = same_layouts && strides0[d] == strides1[d];
     return same_layouts;
 }


### PR DESCRIPTION
[MFDNN-9723](https://jira.devtools.intel.com/browse/MFDNN-9723) Binary add returns incorrect results for non-contiguous strides

Incorrect addition results occur when batch size is 1 and the first dimension has a non-trivial, non-contiguous stride. For any batch size greater than 1, results are correct, even with non-contiguous strides.
When batch size equal to 1, the first stride dimension should not matter, so layouts can be treated as the same. 
