### PR TITLE
gpu: intel: sycl: workaround failing atomics support

### DIFF
--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -47,15 +47,11 @@ status_t device_info_t::init_arch(impl::engine_t *engine) {
     auto be = xpu::sycl::get_backend(device);
     if (be == xpu::sycl::backend_t::opencl) {
         auto ocl_dev = xpu::sycl::compat::get_native<cl_device_id>(device);
-        auto ocl_dev_wrapper = xpu::ocl::make_wrapper(ocl_dev);
-
         auto ocl_ctx = xpu::sycl::compat::get_native<cl_context>(ctx);
-        auto ocl_ctx_wrapper = xpu::ocl::make_wrapper(ocl_ctx);
 
-        status = gpu::intel::ocl::init_gpu_hw_info(engine, ocl_dev_wrapper,
-                ocl_ctx_wrapper, ip_version_, gpu_arch_, gpu_product_family_,
-                stepping_id_, native_extensions_, mayiuse_systolic_,
-                mayiuse_ngen_kernels_);
+        status = gpu::intel::ocl::init_gpu_hw_info(engine, ocl_dev, ocl_ctx,
+                ip_version_, gpu_arch_, gpu_product_family_, stepping_id_,
+                native_extensions_, mayiuse_systolic_, mayiuse_ngen_kernels_);
     } else if (be == xpu::sycl::backend_t::level0) {
         auto ze_dev = xpu::sycl::compat::get_native<ze_device_handle_t>(device);
         auto ze_ctx = xpu::sycl::compat::get_native<ze_context_handle_t>(ctx);

--- a/src/gpu/intel/sycl/l0/utils.cpp
+++ b/src/gpu/intel/sycl/l0/utils.cpp
@@ -349,21 +349,21 @@ status_t get_l0_device_enabled_native_float_atomics(
         native_extensions |= (uint64_t)native_ext_t::fp16_atomic_load_store;
     if ((fltAtom.fp16Flags & atomic_add) == atomic_add)
         native_extensions |= (uint64_t)native_ext_t::fp16_atomic_add;
-    if ((fltAtom.fp16Flags & atomic_add) == atomic_min_max)
+    if ((fltAtom.fp16Flags & atomic_min_max) == atomic_min_max)
         native_extensions |= (uint64_t)native_ext_t::fp16_atomic_min_max;
 
     if ((fltAtom.fp32Flags & atomic_load_store) == atomic_load_store)
         native_extensions |= (uint64_t)native_ext_t::fp32_atomic_load_store;
     if ((fltAtom.fp32Flags & atomic_add) == atomic_add)
         native_extensions |= (uint64_t)native_ext_t::fp32_atomic_add;
-    if ((fltAtom.fp32Flags & atomic_add) == atomic_min_max)
+    if ((fltAtom.fp32Flags & atomic_min_max) == atomic_min_max)
         native_extensions |= (uint64_t)native_ext_t::fp32_atomic_min_max;
 
     if ((fltAtom.fp64Flags & atomic_load_store) == atomic_load_store)
         native_extensions |= (uint64_t)native_ext_t::fp64_atomic_load_store;
     if ((fltAtom.fp64Flags & atomic_add) == atomic_add)
         native_extensions |= (uint64_t)native_ext_t::fp64_atomic_add;
-    if ((fltAtom.fp64Flags & atomic_add) == atomic_min_max)
+    if ((fltAtom.fp64Flags & atomic_min_max) == atomic_min_max)
         native_extensions |= (uint64_t)native_ext_t::fp64_atomic_min_max;
 
     return status::success;

--- a/src/gpu/intel/sycl/utils.hpp
+++ b/src/gpu/intel/sycl/utils.hpp
@@ -32,6 +32,8 @@ class engine_t;
 ::sycl::nd_range<3> to_sycl_nd_range(
         const gpu::intel::compute::nd_range_t &range);
 
+status_t sycl_dev2ocl_dev(cl_device_id *ocl_dev, const ::sycl::device &dev);
+
 status_t create_ocl_engine(
         std::unique_ptr<gpu::intel::ocl::engine_t, engine_deleter_t>
                 *ocl_engine,


### PR DESCRIPTION
Level Zero query currently returns wrong result wrt support for atomics by the device. This commit reverts to using ocl query until the issue is fixed in level zero.

This commit can be reverted as level zero fixes the query.

Fixes MFDNN-13201