### PR TITLE
cpu: aarch64: default num_threads to max for acl_threadpool

### DIFF
--- a/src/cpu/aarch64/acl_threadpool_scheduler.hpp
+++ b/src/cpu/aarch64/acl_threadpool_scheduler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
 
 #include "arm_compute/runtime/IScheduler.h"
-#include "support/Mutex.h"
+
+#include <mutex>
 
 namespace dnnl {
 namespace impl {
@@ -32,7 +33,7 @@ namespace aarch64 {
 class ThreadpoolScheduler final : public arm_compute::IScheduler {
 public:
     ThreadpoolScheduler();
-    ~ThreadpoolScheduler();
+    ~ThreadpoolScheduler() override;
 
     /// Sets the number of threads the scheduler will use to run the kernels.
     void set_num_threads(unsigned int num_threads) override;
@@ -54,8 +55,8 @@ protected:
     void run_workloads(std::vector<Workload> &workloads) override;
 
 private:
-    uint _num_threads {};
-    arm_compute::Mutex _run_workloads_mutex {};
+    unsigned int _num_threads {};
+    std::mutex _mtx;
 };
 
 } // namespace aarch64


### PR DESCRIPTION
# Description
Default num_threads to max for acl_threadpool. This brings it in line with the other schedulers. This fixes an out-of-bounds crash in upstream frameworks where ops are configured to be single threaded and then are run in parallel.

Also included some cleanup:

- Use `std::mutex` instead of `arm_compute::Mutex` (was a `typedef`)
- Use `std::lock_guard` instead of `arm_compute::lock_guard` (was a minimal wrapper)
- Add missing `thread_local` to the `acl_tp_benchmark_scheduler` (probably accidentally omitted from https://github.com/uxlfoundation/oneDNN/pull/2264)

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?