### PR TITLE
xe: jit: codegen: prevent IR -> nGEN assembly functional changes

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -1609,8 +1609,12 @@ void convert_ir_to_ngen_impl(const stmt_t &body, ngen_generator_t *host,
 std::string get_ngen_str(const stmt_t &body, ir_asm_kernel_t host,
         const walk_order_t *kernel_grid_walk_order) {
 #ifdef NGEN_ASM
-    convert_ir_to_ngen_impl(body, &host, kernel_grid_walk_order);
-    return host.str();
+    try {
+        convert_ir_to_ngen_impl(body, &host, kernel_grid_walk_order);
+        return host.str();
+    } catch (std::runtime_error &e) {
+        return "IR to nGEN Exception: " + std::string(e.what());
+    }
 #else
     return "";
 #endif

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -236,7 +236,7 @@ public:
         or_(1, ngen_generator_t::cr0, ngen_generator_t::cr0, uint16_t(0x14C0));
 
         // Allocate and initialize signal header for future use.
-        if (require_signal_header_) {
+        if (exec_cfg_.require_signal_header()) {
             signal_header_ = ra_.alloc();
             ngen_generator_t::barrierheader(signal_header_);
         }
@@ -1144,7 +1144,6 @@ protected:
 
     kernel_iface_t kernel_iface_;
     exec_config_t exec_cfg_;
-    bool require_signal_header_ = false;
     reg_allocator_t ra_;
     ngen::GRF signal_header_;
 

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1183,6 +1183,7 @@ status_t init_pd_time_cfg(const conv_problem_t &prb, conv_config_t &cfg,
     cfg.set_exec_cfg(exec_config_t(hw));
     cfg.maybe_override_from_env();
 
+    cfg.set_require_signal_header(true);
     CHECK(init_fma_kind(cfg, pd, engine));
     CHECK(init_simd(cfg));
     CHECK(init_vec_size(cfg));

--- a/src/gpu/intel/jit/conv/config.hpp
+++ b/src/gpu/intel/jit/conv/config.hpp
@@ -599,6 +599,12 @@ public:
         set_exec_cfg(tmp);
     }
 
+    void set_require_signal_header(bool r) {
+        auto tmp = exec_cfg();
+        tmp.set_require_signal_header(r);
+        set_exec_cfg(tmp);
+    }
+
     void set_tiler(const std::shared_ptr<conv_tiler_t> &tiler);
     const conv_tiler_t &tiler() const;
     conv_tiler_t &tiler();

--- a/src/gpu/intel/jit/conv/conv_kernel.hpp
+++ b/src/gpu/intel/jit/conv/conv_kernel.hpp
@@ -78,7 +78,6 @@ conv_kernel_t<hw>::conv_kernel_t(const conv_config_t &cfg,
     profile.stamp("Alloc_Mgr Construct");
 
     setup_interface(body);
-    this->require_signal_header_ = true;
 #ifdef DNNL_DEV_MODE
     profile.stop();
     verify_grf_usage(cfg, body, ra_.get_alloced_regs());

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -146,17 +146,23 @@ class exec_config_t {
 public:
     exec_config_t() = default;
     exec_config_t(const hw_t &hw) : hw_(hw) {}
-    exec_config_t(const hw_t &hw, int regs, int simd)
-        : hw_(hw), regs_(regs), simd_(simd) {}
+    exec_config_t(const hw_t &hw, int regs, int simd,
+            bool require_signal_header = false)
+        : hw_(hw)
+        , regs_(regs)
+        , simd_(simd)
+        , require_signal_header_(require_signal_header) {}
 
     const hw_t &hw() const { return hw_; }
     int regs() const { return regs_; }
     int simd() const { return simd_; }
     int vec_size() const { return vec_size_; }
     int grf_size() const { return hw_.grf_size(); }
+    bool require_signal_header() const { return require_signal_header_; }
     void set_regs(int regs) { regs_ = regs; }
     void set_simd(int simd) { simd_ = simd; }
     void set_vec_size(int vec_size) { vec_size_ = vec_size; }
+    void set_require_signal_header(bool r) { require_signal_header_ = r; }
 
     std::string str() const {
         std::ostringstream oss;
@@ -172,6 +178,7 @@ private:
     int regs_ = 0;
     int simd_ = 0;
     int vec_size_ = 0;
+    bool require_signal_header_ = false;
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/v2/conv/kernel.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel.hpp
@@ -50,8 +50,6 @@ kernel_t<hw>::kernel_t(
 
     auto &desc = static_cast<const kernel_desc_t &>(_desc);
 
-    this->require_signal_header_ = true;
-
     // Build IR for the kernel.
     var_manager_t var_mgr(kernel_iface());
     stmt_t body = build_ir(exec_cfg(), desc, var_mgr);

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -344,7 +344,7 @@ public:
     std::string kernel_name() const override { return "gen_conv_v2"; }
 
     exec_config_t exec_cfg(const impl::engine_t *engine) const override {
-        return exec_config_t(hw_t(engine), regs, simd);
+        return exec_config_t(hw_t(engine), regs, simd, true);
     }
 
     compute::range_t local_range() const override;


### PR DESCRIPTION
It appears that there are scenarios where ngen_asm will throw unexpectedly fail, even though kernel generation succeeds. This patch prevents functional changes from occurring due to this failure.

Fix for [MFDNN-13424](https://jira.devtools.intel.com/browse/MFDNN-13424)