### PR TITLE
ngen: fix missing field intializer warning

### DIFF
--- a/cmake/SDL.cmake
+++ b/cmake/SDL.cmake
@@ -44,13 +44,13 @@ endmacro()
 # only. To prevent warnings on users' side who use the library and turn
 # this warning on, let's use it too. Applicable for the library sources
 # and interfaces only (tests currently rely on that fact heavily)
-macro(sdl_gnu_src_ccxx_flags var)
+macro(sdl_unix_src_ccxx_flags var)
     append(${var} "-Wmissing-field-initializers")
 endmacro()
 
-macro(sdl_gnu_example_ccxx_flags var)
+macro(sdl_unix_example_ccxx_flags var)
     # At this point the flags for src and examples are the same
-    sdl_gnu_src_ccxx_flags(${var})
+    sdl_unix_src_ccxx_flags(${var})
 endmacro()
 
 set(ONEDNN_SDL_COMPILER_FLAGS)
@@ -58,14 +58,14 @@ set(ONEDNN_SDL_LINKER_FLAGS)
 
 if(UNIX)
     sdl_unix_common_ccxx_flags(ONEDNN_SDL_COMPILER_FLAGS)
+    sdl_unix_src_ccxx_flags(CMAKE_SRC_CCXX_FLAGS)
+    sdl_unix_example_ccxx_flags(CMAKE_EXAMPLE_CCXX_FLAGS)
     if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "RELEASE")
         append(ONEDNN_SDL_COMPILER_FLAGS "-D_FORTIFY_SOURCE=2")
     endif()
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         sdl_gnu_common_ccxx_flags(ONEDNN_SDL_COMPILER_FLAGS
                                   CMAKE_CXX_COMPILER_VERSION)
-        sdl_gnu_src_ccxx_flags(CMAKE_SRC_CCXX_FLAGS)
-        sdl_gnu_example_ccxx_flags(CMAKE_EXAMPLE_CCXX_FLAGS)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
         get_filename_component(CXX_CMD_NAME ${CMAKE_CXX_COMPILER} NAME)
         # Fujitsu CXX compiler does not support "-fstack-protector-all".

--- a/cmake/host_compiler.cmake
+++ b/cmake/host_compiler.cmake
@@ -35,6 +35,8 @@ if(DPCPP_HOST_COMPILER_KIND MATCHES "^(GNU|CLANG)$")
     platform_unix_and_mingw_common_cxx_flags(DPCPP_HOST_COMPILER_OPTS)
 
     sdl_unix_common_ccxx_flags(DPCPP_HOST_COMPILER_OPTS)
+    sdl_unix_src_ccxx_flags(DPCPP_SRC_COMPILER_OPTS)
+    sdl_unix_example_ccxx_flags(DPCPP_EXAMPLE_COMPILER_OPTS)
 
     # SYCL uses C++17 features in headers hence C++17 support should be enabled
     # for host compiler.
@@ -79,8 +81,6 @@ if(DPCPP_HOST_COMPILER_KIND MATCHES "^(GNU|CLANG)$")
     if(DPCPP_HOST_COMPILER_KIND STREQUAL "GNU")
         platform_gnu_nowarn_ccxx_flags(DPCPP_CXX_NOWARN_FLAGS ${DPCPP_HOST_COMPILER_MAJOR_VER}.${DPCPP_HOST_COMPILER_MINOR_VER})
         sdl_gnu_common_ccxx_flags(DPCPP_HOST_COMPILER_OPTS DPCPP_HOST_COMPILER_VER)
-        sdl_gnu_src_ccxx_flags(DPCPP_SRC_CXX_FLAGS)
-        sdl_gnu_example_ccxx_flags(DPCPP_EXAMPLE_CXX_FLAGS)
 
         # SYCL headers contain some comments that trigger warning with GNU compiler
         append(DPCPP_HOST_COMPILER_OPTS "-Wno-comment")

--- a/third_party/ngen/ngen_level_zero.hpp
+++ b/third_party/ngen/ngen_level_zero.hpp
@@ -152,13 +152,12 @@ Product LevelZeroCodeGenerator<hw>::detectHWInfo(ze_context_handle_t context, ze
 {
     Product product;
 
-    ze_device_properties_t dprop = {ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
+    ze_device_properties_t dprop = {};
+    dprop.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
 
 #ifdef ZE_DEVICE_IP_VERSION_EXT_NAME
     // Try ZE_extension_device_ip_version first if available.
     ze_device_ip_version_ext_t vprop = {ZE_STRUCTURE_TYPE_DEVICE_IP_VERSION_EXT, nullptr, 0};
-
-    dprop.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     dprop.pNext = &vprop;
 
     if (call_zeDeviceGetProperties(device, &dprop) == ZE_RESULT_SUCCESS) {
@@ -191,7 +190,6 @@ Product LevelZeroCodeGenerator<hw>::detectHWInfo(ze_context_handle_t context, ze
         detail::handleL0(call_zeModuleGetNativeBinary(module, &binarySize, binary.data()));
         detail::handleL0(call_zeModuleDestroy(module));
         product = ELFCodeGenerator<hw>::getBinaryHWInfo(binary);
-        dprop.pNext = nullptr;
         detail::handleL0(call_zeDeviceGetProperties(device, &dprop));
     }
 


### PR DESCRIPTION
Address a GCC warning caught when using GCC as a DPC++ host compiler.

Fixes [MFDNN-13429](https://jira.devtools.intel.com/browse/MFDNN-13429l)