### PR TITLE
common, xe: sycl: improve logging when OpenCL install is missing

### DIFF
--- a/src/common/verbose_msg.hpp
+++ b/src/common/verbose_msg.hpp
@@ -129,6 +129,7 @@
 #define VERBOSE_INCOMPATIBLE_GEMM_FMT "incompatible gemm format"
 
 #define VERBOSE_DEVICE_CTX_MISMATCH "device not found in the given context"
+#define VERBOSE_MISSING_OCL_DEVICE "%s OpenCL device not found"
 #define VERBOSE_INVALID_PLATFORM "unsupported %s platform (expected %s got %s)"
 #define VERBOSE_ENGINE_CREATION_FAIL "failed to create %s engine with index %zu"
 #define VERBOSE_KERNEL_CREATION_FAIL "failed to create %s kernel"

--- a/src/gpu/intel/sycl/utils.cpp
+++ b/src/gpu/intel/sycl/utils.cpp
@@ -132,13 +132,21 @@ status_t sycl_dev2ocl_dev(cl_device_id *ocl_dev, const ::sycl::device &dev) {
         return uuid2ocl_dev_tmp;
     }();
 
-    if (uuid2ocl_dev.empty()) return status::runtime_error;
+    if (uuid2ocl_dev.empty()) {
+        VERROR(common, runtime, VERBOSE_MISSING_OCL_DEVICE,
+                dev.get_info<::sycl::info::device::name>().c_str());
+        return status::runtime_error;
+    }
 
     const xpu::device_uuid_t l0_dev_uuid
             = gpu::intel::sycl::get_device_uuid(dev);
     auto d = uuid2ocl_dev.get(l0_dev_uuid);
 
-    if (!d) return status::runtime_error;
+    if (!d) {
+        VERROR(common, runtime, VERBOSE_MISSING_OCL_DEVICE,
+                dev.get_info<::sycl::info::device::name>().c_str());
+        return status::runtime_error;
+    }
 
     *ocl_dev = d;
 


### PR DESCRIPTION
This PR is intended to better enable users to determine runtime problems with oneDNN due to a missing or incorrectly installed OpenCL runtime.

Sample behavior:
```
$ OCL_ICD_VENDORS= ~/dnnl/build_dpcpp/tests/benchdnn/benchdnn --engine=gpu --eltwise 1024
onednn_verbose,v1,info,oneDNN v3.8.0 (commit 2f066a7e703d19b77723a5bf8ff5f781fc6586ee)
onednn_verbose,v1,info,cpu,runtime:TBB,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with float16, Intel DL Boost and bfloat16 support
onednn_verbose,v1,info,gpu,runtime:DPC++
onednn_verbose,v1,info,gpu,engine,sycl gpu device count:1
onednn_verbose,v1,common,error,runtime,Intel(R) Data Center GPU Max 1100 OpenCL device not found,src/gpu/intel/sycl/utils.cpp:137
onednn_verbose,v1,info,gpu,engine,0,backend:Level Zero,name:Intel(R) Data Center GPU Max 1100,driver_version:1.6.31294,binary_kernels:disabled
onednn_verbose,v1,info,experimental features are enabled
onednn_verbose,v1,info,use batch_normalization stats one pass is enabled
onednn_verbose,v1,info,GPU convolution v2 is disabled
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,common,error,runtime,Intel(R) Data Center GPU Max 1100 OpenCL device not found,src/gpu/intel/sycl/utils.cpp:137
onednn_verbose,v1,common,error,runtime,Intel(R) Data Center GPU Max 1100 OpenCL device not found,src/gpu/intel/sycl/utils.cpp:137
Error: Function 'create_primitive' at (/nfs/pdx/home/rjoursle/dnnl/tests/benchdnn/dnnl_common.hpp:452) returned 'runtime_error'
Error: Function 'init_prim' at (/nfs/pdx/home/rjoursle/dnnl/tests/benchdnn/dnnl_common.hpp:509) returned '1'
Error: Function 'createit' at (/nfs/pdx/home/rjoursle/dnnl/tests/benchdnn/eltwise/eltwise.cpp:492) returned '1'
Error: Function 'create' at (/nfs/pdx/home/rjoursle/dnnl/tests/benchdnn/utils/task.hpp:57) returned '1'
0:UNTESTED_FAILED (162 ms) __REPRO: --eltwise --engine=gpu --alg=relu --alpha=0 --beta=0 1024
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:UNTESTED_FAILED (162 ms) __REPRO: --eltwise --engine=gpu --alg=relu --alpha=0 --beta=0 1024
============================
```