### PR TITLE
removed waits around enqueue_primitive in verbose mode

### DIFF
--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -97,10 +97,10 @@ status_t primitive_execute(
 
     if (get_verbose(verbose_t::exec_profile,
                 prim_kind2_comp_kind(primitive_iface->pd()->impl()->kind()))) {
-        stream->wait();
         double start_ms = get_msec();
         status = stream->enqueue_primitive(primitive_iface, ctx);
-        stream->wait();
+        // Do not enclose enqueue_primitive with waits, as calling waits is
+        // illegal when DNN code is called during SYCL graph recording.
         double duration_ms = get_msec() - start_ms;
         if (primitive_iface->pd()->impl()->has_runtime_dims_or_strides()) {
             // Take out mds from `ctx` here to avoid primitive_desc dependency


### PR DESCRIPTION
# Description

When running [llama.cpp](https://github.com/ggml-org/llama.cpp) with [SYCL Graph feature](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc) enabled by [GGML_SYCL_GRAPH](https://github.com/ggml-org/llama.cpp/blob/master/docs/backend/SYCL.md#environment-variable) variable and with [verbose logging on oneDNN](https://uxlfoundation.github.io/oneDNN/dev_guide_verbose.html), the `wait` call is executed on the sycl stream. This is illegal when recording graph, and _wait cannot be called for a queue which is recording to a command graph_ exception is thrown by [this line in llvm compiler](https://github.com/intel/llvm/blob/sycl/sycl/source/detail/queue_impl.cpp#L589).

I'd like to solve this `wait` problem in order to allow testing llama.cpp with SYCL and with oneDNN verbose logs, as active work on enabling fast graphs in llama.cpp is currently in progress.

# What is the best solution

The simplest solution is just remove wait calls, as proposed in this PR, but in this case measurement of kernel execution time will be wrongly calculated.

Other solutions that I see are:

1. Use "before" and "after" [host tasks](https://github.khronos.org/SYCL_Reference/iface/host-task-basic.html) and log time from the "after" task.
2. Use "before" and "after" regular tasks and print time directly from kernel code in the "after" task using [SYCL stream](https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2023-0/doing-io-in-the-kernel.html).
3. Use [SYCL timers](https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-0/using-the-timers.html) with its `get_profiling_info` function. This measures just kernel execution time, not data transfers and kernel launch time.
4. Remove time measurements, as this can be observed by calculated by profiling tools

Is there a perfect solution to this problem already designed, or is there any other solution possible, that avoids waits but still computes and logs kernel execution time correctly?