### PR TITLE
cpu: skip f64 inputs

### DIFF
--- a/src/cpu/ref_binary.hpp
+++ b/src/cpu/ref_binary.hpp
@@ -43,6 +43,11 @@ struct ref_binary_t : public primitive_t {
             using namespace data_type;
             using sm = primitive_attr_t::skip_mask_t;
 
+            const bool is_f64 = utils::one_of(f64, src_md(0)->data_type,
+                    src_md(1)->data_type, src_md(2)->data_type,
+                    dst_md()->data_type);
+            VDISPATCH_BINARY(!is_f64, VERBOSE_UNSUPPORTED_DT);
+
             VDISPATCH_BINARY(
                     platform::has_data_type_support(src_md(0)->data_type),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/cpu/ref_deconvolution.hpp
+++ b/src/cpu/ref_deconvolution.hpp
@@ -140,7 +140,8 @@ struct ref_deconvolution_fwd_t : public primitive_t {
             }
 
             // Intermediate f32 buffer is supported only for given condition.
-            if (!attr()->has_default_values() || with_bias()) {
+            if ((!attr()->has_default_values() || with_bias())
+                    && dst_md()->data_type != f64) {
                 // Enforce f32 dt for diff src and work with f32 output for bias
                 // update or post ops after conv execution.
                 CHECK(conv_descr_create(desc(), &cd, nullptr, data_type::f32));

--- a/src/cpu/ref_prelu.hpp
+++ b/src/cpu/ref_prelu.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -55,6 +55,9 @@ struct ref_prelu_fwd_t : public primitive_t {
             VDISPATCH_PRELU(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_PRELU(src_md(0)->data_type == dst_md(0)->data_type,
                     VERBOSE_INCONSISTENT_DT, "src", "dst");
+            VDISPATCH_PRELU(!utils::one_of(data_type::f64, src_md(0)->data_type,
+                                    weights_md(0)->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(
                     platform::has_data_type_support(src_md(0)->data_type),
                     VERBOSE_UNSUPPORTED_DT);
@@ -100,6 +103,9 @@ struct ref_prelu_bwd_t : public primitive_t {
             VDISPATCH_PRELU(
                     diff_dst_md(0)->data_type == diff_src_md(0)->data_type,
                     VERBOSE_INCONSISTENT_DT, "diff_src", "diff_dst");
+            VDISPATCH_PRELU(!utils::one_of(data_type::f64, src_md(0)->data_type,
+                                    weights_md(0)->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_PRELU(
                     platform::has_data_type_support(src_md(0)->data_type),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/cpu/ref_resampling.hpp
+++ b/src/cpu/ref_resampling.hpp
@@ -45,6 +45,10 @@ struct ref_resampling_fwd_t : public primitive_t {
 
             VDISPATCH_RESAMPLING(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_RESAMPLING(
+                    !utils::one_of(data_type::f64, src_md()->data_type,
+                            dst_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_RESAMPLING(
                     platform::has_data_type_support(src_md()->data_type),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_RESAMPLING(
@@ -99,6 +103,10 @@ struct ref_resampling_bwd_t : public primitive_t {
         status_t init(engine_t *engine) {
             using namespace data_type;
             VDISPATCH_RESAMPLING(!is_fwd(), VERBOSE_BAD_PROPKIND);
+            VDISPATCH_RESAMPLING(
+                    !utils::one_of(data_type::f64, diff_src_md()->data_type,
+                            diff_dst_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_RESAMPLING(
                     platform::has_data_type_support(diff_src_md()->data_type),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/cpu/ref_shuffle.hpp
+++ b/src/cpu/ref_shuffle.hpp
@@ -50,6 +50,10 @@ struct ref_shuffle_t : public primitive_t {
             VDISPATCH_SHUFFLE(src_d.data_type() == dst_d.data_type(),
                     VERBOSE_INCONSISTENT_DT, "src", "dst");
             VDISPATCH_SHUFFLE(
+                    utils::one_of(types::data_type_size(src_d.data_type()),
+                            sizeof(float), sizeof(bfloat16_t), sizeof(int8_t)),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_SHUFFLE(
                     platform::has_data_type_support(src_d.data_type()),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_SHUFFLE(

--- a/src/cpu/simple_resampling.hpp
+++ b/src/cpu/simple_resampling.hpp
@@ -67,6 +67,12 @@ struct simple_resampling_fwd_t : public primitive_t {
             VDISPATCH_RESAMPLING(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_RESAMPLING(
                     !has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+            VDISPATCH_RESAMPLING(utils::one_of(src_md()->data_type, f32, s32,
+                                         bf16, f16, s8, u8),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_RESAMPLING(utils::one_of(dst_md()->data_type, f32, s32,
+                                         bf16, f16, s8, u8),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_RESAMPLING(
                     platform::has_data_type_support(src_md()->data_type),
                     VERBOSE_UNSUPPORTED_DT);
@@ -126,6 +132,12 @@ struct simple_resampling_bwd_t : public primitive_t {
             VDISPATCH_RESAMPLING(!is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_RESAMPLING(
                     !has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+            VDISPATCH_RESAMPLING(utils::one_of(diff_dst_md()->data_type, f32,
+                                         s32, bf16, f16, s8, u8),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_RESAMPLING(utils::one_of(diff_src_md()->data_type, f32,
+                                         s32, bf16, f16, s8, u8),
+                    VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_RESAMPLING(
                     platform::has_data_type_support(diff_dst_md()->data_type),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/cpu/x64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.hpp
@@ -28,7 +28,7 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-void init_kernel_datatype(
+status_t init_kernel_datatype(
         brgemm_desc_t *brg, data_type_t dt_a, data_type_t dt_b);
 
 namespace brgemm_utils {
@@ -48,7 +48,7 @@ status_t brdgmm_blocking(brgemm_desc_t *brg);
  * having to depend on BRGeMM's API. An additional feature is that this
  * function can be modified depending on needs without requiring changes
  * at the API level. */
-void init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
+status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_b, brgemm_layout_t layout, float alpha, float beta,
         dim_t LDA, dim_t LDB, dim_t LDC, dim_t M, dim_t N, dim_t K,
@@ -59,7 +59,7 @@ void init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
  * having to depend on BRDGeMM's API. An additional feature is that this
  * function can be modified depending on needs without requiring changes
  * at the API level. */
-void init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
+status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_b, brgemm_layout_t layout, float alpha, float beta,
         dim_t LDA, dim_t LDC, dim_t M, dim_t N,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -58,7 +58,15 @@ bool is_data_supported(cpu_isa_t isa, data_type_t data_type) {
                     || is_superset(isa, avx2_vnni_2);
         case data_type::f8_e5m2:
         case data_type::f8_e4m3: return is_superset(isa, avx512_core_fp16);
-        default: return true;
+        case data_type::f4_e3m0:
+        case data_type::f4_e2m1:
+        case data_type::e8m0:
+        case data_type::f64:
+        case data_type::s4:
+        case data_type::u4:
+        case data_type::boolean: return false;
+        case data_type::undef:
+        default: assert(!"unknown data_type"); return false;
     }
 }
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -126,6 +126,9 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
             one_of(true, is_f32_supported, is_xf16_supported, is_int8_supported,
                     is_fp8_supported, is_f32_xf16_supported),
             VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_CONV(!one_of(f64, diff_src_type, wei_type, diff_dst_type)
+                    && IMPLICATION(with_bias(), f64 != bias_md_.data_type),
+            VERBOSE_UNSUPPORTED_DT);
     VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
             VERBOSE_BAD_ALGORITHM);
     VDISPATCH_CONV(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -589,18 +589,18 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     const float alpha = 1.0;
     const float beta = 0.0;
     brgemm_desc_t brg;
-    brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
+    CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
-            is_bf32);
+            is_bf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     ur = brg.bd_block * (is_amx(isa) ? brg.bd_block2 : 1);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
-        brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr, src_dt,
-                wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC, M_tail,
-                vN, vK, nullptr, is_bf32);
+        CHECK(brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr,
+                src_dt, wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC,
+                M_tail, vN, vK, nullptr, is_bf32));
         CHECK(brgemm_utils::brgemm_blocking(&brg_sp_tail));
         ur_block_tail = brg_sp_tail.bd_block;
     } else {
@@ -645,9 +645,9 @@ status_t brg_blocking_t::get_brgemm_ur(
                     const auto strides_ptr = (brg_type == brgemm_strd)
                             ? &brg_strides
                             : nullptr;
-                    brgemm_utils::init_brgemm_conf(&brg, isa, brg_type, src_dt,
-                            wei_dt, brgemm_row_major, alpha, vbeta, LDA, LDB,
-                            LDC, vM, vN, vK, strides_ptr, is_bf32);
+                    CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brg_type,
+                            src_dt, wei_dt, brgemm_row_major, alpha, vbeta, LDA,
+                            LDB, LDC, vM, vN, vK, strides_ptr, is_bf32));
                     CHECK(brgemm_utils::brgemm_blocking(&brg));
 
                     brgemm_attr_t brgattr;

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -616,9 +616,9 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     const float alpha = 1.0;
     const float beta = 0.0;
     brgemm_desc_t brg;
-    brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
+    CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
-            is_bf32);
+            is_bf32));
     if (exec_type == exec_vpad) {
         brg.zp_type_a = src_zero_point ? brgemm_broadcast_t::per_tensor
                                        : brgemm_broadcast_t::none;
@@ -635,9 +635,9 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
-        brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr, src_dt,
-                wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC, M_tail,
-                vN, vK, nullptr, is_bf32);
+        CHECK(brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr,
+                src_dt, wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC,
+                M_tail, vN, vK, nullptr, is_bf32));
         if (exec_type == exec_vpad) {
             brg_sp_tail.zp_type_a = src_zero_point
                     ? brgemm_broadcast_t::per_tensor
@@ -717,9 +717,9 @@ status_t brg_blocking_t::get_brgemm_ur(
                 = rnd_up(ic, vnni_block) * rnd_up(oc, oc_block) * wei_dsz;
         const auto strides_ptr
                 = (brg_type == brgemm_strd) ? &brg_strides : nullptr;
-        brgemm_utils::init_brgemm_conf(&brg, isa, brg_type, src_dt, wei_dt,
-                brgemm_row_major, alpha, vbeta, LDA, LDB, LDC, vM, vN, vK,
-                strides_ptr, is_bf32);
+        CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brg_type, src_dt,
+                wei_dt, brgemm_row_major, alpha, vbeta, LDA, LDB, LDC, vM, vN,
+                vK, strides_ptr, is_bf32));
 
         brgemm_attr_t brgattr;
         brgattr.max_bs = max_batch;

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
@@ -283,6 +283,9 @@ status_t jit_uni_reorder_direct_copy_t::pd_t::init(
     const bool is_s32 = utils::everyone_is(s32, src_dt, dst_dt);
     VDISPATCH_REORDER(!is_s32, VERBOSE_UNSUPPORTED_DT);
 
+    const bool is_f64 = utils::one_of(f64, src_dt, dst_dt);
+    VDISPATCH_REORDER(!is_f64, VERBOSE_UNSUPPORTED_DT);
+
     VDISPATCH_REORDER(IMPLICATION(utils::one_of(bf16, src_dt, dst_dt),
                               mayiuse(avx512_core) || mayiuse(avx2_vnni_2)),
             VERBOSE_ISA_DT_MISMATCH);

--- a/src/cpu/x64/ukernel/brgemm.cpp
+++ b/src/cpu/x64/ukernel/brgemm.cpp
@@ -137,7 +137,10 @@ status_t brgemm_t::get_B_pack_type(
     brgemm_desc_t brg {};
     brg.dt_a = dt_a;
     brg.dt_b = dt_b;
-    init_kernel_datatype(&brg, dt_a, dt_b);
+    auto status = init_kernel_datatype(&brg, dt_a, dt_b);
+    if (status != status::success) {
+        VCHECK_BRGEMM_STATUS(status, false, "get_B_pack_type failed");
+    }
     brgemm_utils::set_isa_impl(&brg);
     if (brg.isa_impl == cpu_isa_t::isa_undef) {
         VCHECK_BRGEMM_STATUS(


### PR DESCRIPTION
It was found during analysis of logs attached to [MFDNN-13286](https://jira.devtools.intel.com/browse/MFDNN-13286) that a test for concat failed because a concat primitive did not recognized that an input contained f64 data. A reorder created by ref_concat_t did nothing (only generate a message in a log) in a release binary; there is only an assert in a debug version.
I also found several other such places. This PR fixes them.
