### PR TITLE
cpu: aarch64: Add BF16 support for eltwise JIT via reordering to FP32

### DIFF
--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -119,14 +119,13 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
             // - unpack BF16 to FP32 by zero-extending
             // - compute eltwise alg in FP32
             // - down convert back to BF16 using bfcvt, and pack result
-            mov(ZReg(tmp0).s, P_ALL_ONE, ZReg(vmm_src).s);
-            lsl(ZReg(vmm_src.getIdx()).s, ZReg(vmm_src).s, 16);
-            and_(ZReg(tmp0).s, 0xFFFF0000); // 0xFFFF0000
+            mov(tmp0.s, P_ALL_ONE, vmm_src.s);
+            lsl(vmm_src.s, vmm_src.s, 16);
+            and_(tmp0.s, 0xFFFF0000);
             eltwise_injector_->compute_vector_range(
                     {vmm_src.getIdx(), tmp0.getIdx()});
-            bfcvt(ZReg(vmm_src.getIdx()).h, P_ALL_ONE,
-                    ZReg(vmm_src.getIdx()).s);
-            bfcvtnt(ZReg(vmm_src.getIdx()).h, P_ALL_ONE, ZReg(tmp0.getIdx()).s);
+            bfcvt(vmm_src.h, P_ALL_ONE, vmm_src.s);
+            bfcvtnt(vmm_src.h, P_ALL_ONE, tmp0.s);
         } else {
             eltwise_injector_->compute_vector(vmm_src.getIdx());
         }

--- a/src/cpu/cpu_eltwise_list.cpp
+++ b/src/cpu/cpu_eltwise_list.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2024 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2022, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_eltwise_int_fwd_t<sse41, u8>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_512, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, bf16>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_128, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s8>)

--- a/src/cpu/cpu_eltwise_list.cpp
+++ b/src/cpu/cpu_eltwise_list.cpp
@@ -68,6 +68,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, bf16>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_128, f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_128, bf16>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s8>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, u8>)


### PR DESCRIPTION
Currently, PyTorch’s mapping to eltwise algorithms for `BF16` introduces multiple reorder operations:
reorder(BF16 → FP32) → Eltwise → reorder(FP32 → BF16). 
Relevant iDeep PR: https://github.com/intel/ideep/pull/350

This PR proposes moving the BF16-to-FP32 conversion directly into the JIT-generated code. By doing so, we eliminate the need for explicit reorder operations, resulting in performance improvements for these ops.


Benchdnn perf for Gelu ~ similar times for fp32 and bf16 equivalent. 

`OMP_NUM_THREADS=1 ./benchdnn --eltwise   --alg=gelu_erf --alpha=0 --beta=0 --mode=p --dt=bf16  1024x4096` 

Ref implementation: `total perf: min(ms):74.1855 avg(ms):74.2793` 
Current implementation:  `total perf: min(ms):6.7478 avg(ms):6.78948` **~12x speedup** 
FP32 run: `total perf: min(ms):6.71167 avg(ms): 6.7328` 


Speedup when benchmarked with PyTorch : 
<img width="448" alt="Screenshot 2025-03-31 at 07 53 35" src="https://github.com/user-attachments/assets/bb766c48-465a-44f1-9178-2f24e2f2dd3c" />

Tests: `./test/benchdnn/benchdnn --eltwise --batch=inputs/eltwise/test_eltwise_bfloat16` 

cc: @jondea @theComputeKid  @Sqvid
