### PR TITLE
cpu: x64: fix invalid immediate encoding in cpu_reducer and conv

### DIFF
--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -197,10 +197,23 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
 
             if (load_len == typesize) {
                 assert(nloads == 1);
-                this->movd(Xmm(nloads + i), this->ptr[reg_src + off]);
-                this->uni_add(Xmm(i), Xmm(nloads + i));
+                if (off > static_cast<size_t>(INT_MAX)) {
+                    this->mov(reg_long_offt, off);
+                    this->movd(Xmm(nloads + i),
+                            this->ptr[reg_src + reg_long_offt]);
+                    this->uni_add(Xmm(i), Xmm(nloads + i));
+                } else {
+                    this->movd(Xmm(nloads + i), this->ptr[reg_src + off]);
+                    this->uni_add(Xmm(i), Xmm(nloads + i));
+                }
             } else if (load_len == vlen)
-                this->uni_vadd(Vmm(i), Vmm(i), vmmword[reg_src + off]);
+                if (off > static_cast<size_t>(INT_MAX)) {
+                    this->mov(reg_long_offt, off);
+                    this->uni_vadd(
+                            Vmm(i), Vmm(i), vmmword[reg_src + reg_long_offt]);
+                } else {
+                    this->uni_vadd(Vmm(i), Vmm(i), vmmword[reg_src + off]);
+                }
             else
                 assert(!"unsupported");
         }

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -262,8 +262,9 @@ void jit_avx2_1x1_conv_kernel_f32::generate_reduce_loop(
             default:
                 offt = (i * rnd_up(jcp.ic, jcp.ic_block) + u0) * jcp.oc_block;
         }
-        return ptr[aux_reg_load_data + u1 * jcp.reduce_loop_load_step
-                + sizeof(float) * offt];
+        return make_safe_addr(aux_reg_load_data,
+                u1 * jcp.reduce_loop_load_step + sizeof(float) * offt,
+                reg_long_offt);
     };
 
     auto get_output_offset = [this](int i, int j) {


### PR DESCRIPTION
Fixes the following failure:
```
442: run: --conv --engine=gpu --dir=BWD_W ic7688iw3oc135342ow3kw1pw0
442: Error: Function 'execute_reorder' at (sources\tests\benchdnn\dnnl_memory.cpp:182) returned 'runtime_error'
```
and
```
$ ~/dnnl/build_clang/tests/benchdnn/benchdnn --conv --engine=gpu -v1 --batch=test_conv_large_gpu
create: --conv --engine=gpu --dir=BWD_W --dt=f64:f64:f64 --stag=axb --dtag=axb ic2iw86368893oc2ow86368893kw1pw0
run: --conv --engine=gpu --dir=BWD_W --dt=f64:f64:f64 --stag=axb --dtag=axb ic2iw86368893oc2ow86368893kw1pw0
0:PASSED (6273 ms) __REPRO: --conv --engine=gpu --dir=BWD_W --dt=f64:f64:f64 --stag=axb --dtag=axb ic2iw86368893oc2ow86368893kw1pw0
create: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
run: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
Error: Function 'execute_reorder' at (/nfs/pdx/home/rjoursle/dnnl/tests/benchdnn/dnnl_memory.cpp:182) returned 'runtime_error'
```
Partial fix for [MFDNN13428](https://jira.devtools.intel.com/browse/MFDNN-13428).