### PR TITLE
xe: sdpa: Update additional tile configurations for quantized kernels

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -75,16 +75,26 @@ sdpa_config_t xehpg_h128_s32 = {16, 16, 16, 8, 16, 2, 8, 4};
 sdpa_config_t xehpg_h128_2nd = {8, 16, 16, 8, 16, 1, 8, 2};
 sdpa_config_t xehpg_h128_s256_2nd = {8, 16, 32, 8, 8, 1, 4, 2};
 
-sdpa_config_t xehpg_q_h128 = {32, 16, 16, 16, 8, 2, 8, 2};
-sdpa_config_t xehpg_q_h128_2nd = {16, 8, 16, 8, 8, 2, 8, 2};
-sdpa_config_t xehpg_q_h128_s64_2nd = {16, 16, 16, 8, 16, 1, 8, 2};
+sdpa_config_t xehpg_q_h128 = {8, 32, 16, 32, 8, 2, 8, 2};
+sdpa_config_t xehpg_q_h128_s64 = {8, 8, 16, 8, 8, 4, 8, 4};
+sdpa_config_t xehpg_q_h128_s512 = {16, 16, 16, 16, 8, 4, 8, 4};
+sdpa_config_t xehpg_q_h128_2nd = {16, 16, 16, 8, 16, 2, 8, 4};
+sdpa_config_t xehpg_q_h128_s96_2nd = {8, 8, 8, 8, 16, 2, 16, 2};
 
 sdpa_config_t xehpg_h256 = {16, 16, 32, 8, 16, 2, 8, 4};
 sdpa_config_t xehpg_h256_s128 = {8, 16, 32, 16, 8, 4, 8, 4};
 sdpa_config_t xehpg_h256_s32 = {8, 16, 32, 8, 16, 2, 8, 4};
+
+sdpa_config_t xehpg_q_h256 = {16, 16, 64, 8, 8, 4, 4, 8};
+sdpa_config_t xehpg_q_h256_s512 = {16, 16, 32, 16, 8, 4, 8, 4};
+sdpa_config_t xehpg_q_h256_s64 = {8, 8, 32, 8, 8, 4, 8, 4};
+
 sdpa_config_t xehpg_h256_2nd = {8, 8, 16, 8, 16, 1, 16, 1};
 sdpa_config_t xehpg_h256_s64_2nd = {16, 8, 16, 8, 16, 1, 16, 1};
 sdpa_config_t xehpg_h256_s32_2nd = {16, 16, 32, 8, 16, 1, 8, 2};
+
+sdpa_config_t xehpg_q_h256_2nd = {32, 8, 32, 8, 8, 4, 8, 4};
+sdpa_config_t xehpg_q_h256_s96_2nd = {8, 8, 16, 8, 16, 2, 16, 2};
 
 sdpa_config_t xehpc_h32 = {16, 64, 32, 16, 4, 2, 1, 8};
 sdpa_config_t xehpc_h32_s32 = {16, 16, 16, 16, 2, 4, 2, 4};
@@ -120,15 +130,25 @@ sdpa_config_t xehpc_h128_s64 = {16, 32, 32, 32, 4, 2, 4, 2};
 sdpa_config_t xehpc_h128_s32 = {16, 16, 16, 16, 8, 2, 8, 2};
 sdpa_config_t xehpc_h128_2nd = {32, 32, 32, 16, 8, 1, 4, 2};
 
-sdpa_config_t xehpc_q_h128 = {32, 32, 16, 32, 8, 2, 8, 2};
-sdpa_config_t xehpc_q_h128_s512 = {32, 32, 16, 32, 8, 4, 8, 4};
+sdpa_config_t xehpc_q_h128 = {16, 64, 16, 32, 16, 1, 8, 2};
+sdpa_config_t xehpc_q_h128_s32 = {16, 16, 16, 16, 8, 2, 8, 2};
+sdpa_config_t xehpc_q_h128_s128 = {16, 16, 16, 16, 8, 4, 8, 4};
+sdpa_config_t xehpc_q_h128_s128_integrated = {16, 16, 16, 16, 8, 2, 8, 2};
+
 sdpa_config_t xehpc_q_h128_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 sdpa_config_t xehpc_q_h128_2nd_integrated = {16, 16, 16, 16, 8, 1, 8, 1};
-sdpa_config_t xehpc_q_h128_s32_2nd = {16, 32, 32, 16, 8, 1, 4, 2};
+sdpa_config_t xehpc_q_h128_s96_2nd = {16, 16, 16, 16, 8, 1, 8, 1};
+sdpa_config_t xehpc_q_h128_s512_2nd = {16, 16, 16, 16, 16, 2, 8, 2};
 
 sdpa_config_t xehpc_h256 = {16, 32, 32, 32, 8, 4, 8, 4};
 sdpa_config_t xehpc_h256_s64 = {16, 32, 32, 32, 8, 1, 8, 1};
 sdpa_config_t xehpc_h256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
+
+sdpa_config_t xe2_q_h64 = {16, 64, 16, 32, 16, 1, 8, 2};
+sdpa_config_t xe2_q_h64_s384 = {16, 64, 16, 16, 16, 1, 4, 4};
+sdpa_config_t xe2_q_h64_s128 = {16, 64, 16, 32, 8, 1, 4, 2};
+sdpa_config_t xe2_q_h64_s128_integrated = {16, 16, 16, 16, 4, 4, 4, 4};
+sdpa_config_t xe2_q_h64_s32 = {16, 16, 16, 16, 4, 4, 4, 4};
 
 sdpa_config_t *choose_config_xehpg(
         dim_t head_size, dim_t seq, bool thin_q, bool quantized) {
@@ -162,10 +182,11 @@ sdpa_config_t *choose_config_xehpg(
     } else if (head_size <= 128) {
         if (quantized) {
             if (thin_q) {
-                if (seq <= 64) return &xehpg_q_h128_s64_2nd;
+                if (seq <= 96) return &xehpg_q_h128_s96_2nd;
                 return &xehpg_q_h128_2nd;
             }
-            if (seq <= 32) return &xehpg_h128_s32;
+            if (seq <= 64) return &xehpg_q_h128_s64;
+            if (seq <= 512) return &xehpg_q_h128_s512;
             return &xehpg_q_h128;
         }
         if (thin_q) {
@@ -176,9 +197,18 @@ sdpa_config_t *choose_config_xehpg(
         return &xehpg_h128;
     } else if (head_size <= 256) {
         if (thin_q) {
+            if (quantized) {
+                if (seq <= 96) return &xehpg_q_h256_s96_2nd;
+                return &xehpg_q_h256_2nd;
+            }
             if (seq <= 32) return &xehpg_h256_s32_2nd;
             if (seq <= 64) return &xehpg_h256_s64_2nd;
             return &xehpg_h256_2nd;
+        }
+        if (quantized) {
+            if (seq <= 64) return &xehpg_q_h256_s64;
+            if (seq <= 512) return &xehpg_q_h256_s512;
+            return &xehpg_q_h256;
         }
         if (seq <= 32) return &xehpg_h256_s32;
         if (seq <= 128) return &xehpg_h256_s128;
@@ -228,11 +258,16 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
     } else if (head_size <= 128) {
         if (quantized) {
             if (thin_q) {
-                if (seq <= 32) return &xehpc_q_h128_s32_2nd;
                 if (is_integrated) { return &xehpc_q_h128_2nd_integrated; }
+                if (seq <= 96) return &xehpc_q_h128_s96_2nd;
+                if (seq <= 512) return &xehpc_q_h128_s512_2nd;
                 return &xehpc_q_h128_2nd;
             }
-            if (seq <= 512) return &xehpc_q_h128_s512;
+            if (is_integrated) {
+                if (seq <= 128) { return &xehpc_q_h128_s128_integrated; }
+            }
+            if (seq <= 32) return &xehpc_q_h128_s32;
+            if (seq <= 128) return &xehpc_q_h128_s128;
             return &xehpc_q_h128;
         }
         if (thin_q) return &xehpc_h128_2nd;
@@ -245,6 +280,25 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
         return &xehpc_h256;
     }
     return nullptr;
+}
+
+sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
+        bool quantized, bool is_integrated) {
+
+    if (head_size <= 64) {
+        if (quantized) {
+            if (is_integrated) {
+                if (seq <= 128) return &xe2_q_h64_s128_integrated;
+            }
+            if (seq <= 32) return &xe2_q_h64_s32;
+            if (seq <= 128) return &xe2_q_h64_s128;
+            if (seq <= 384) return &xe2_q_h64_s384;
+            return &xe2_q_h64;
+        }
+    }
+
+    return choose_config_xehpc(
+            head_size, seq, thin_q, quantized, is_integrated);
 }
 
 /// Returns true if a common scale value is used for each slice of the tensor
@@ -338,9 +392,11 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
                     d->head_size(), d->keys(), thin_q, quantized);
             break;
         case arch_t::xe_hpc:
+            config = choose_config_xehpc(d->head_size(), d->keys(), thin_q,
+                    quantized, is_integrated);
         case arch_t::xe2:
         case arch_t::xe3:
-            config = choose_config_xehpc(d->head_size(), d->keys(), thin_q,
+            config = choose_config_xe2(d->head_size(), d->keys(), thin_q,
                     quantized, is_integrated);
         default: break;
     }

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -111,19 +111,10 @@ sdpa_config_t xehpc_q_h64_s384 = {16, 64, 16, 32, 8, 2, 4, 4};
 sdpa_config_t xehpc_q_h64_s1024 = {16, 64, 16, 16, 16, 1, 4, 4};
 sdpa_config_t xehpc_q_h64 = {16, 64, 16, 32, 8, 1, 4, 2};
 
-sdpa_config_t xehpc_q_h64_s128_integrated = {16, 16, 16, 16, 4, 4, 4, 4};
-sdpa_config_t xehpc_q_h64_s384_integrated = {16, 64, 16, 16, 16, 1, 4, 4};
-sdpa_config_t xehpc_q_h64_s1024_integrated = {16, 64, 16, 32, 8, 4, 4, 8};
-sdpa_config_t xehpc_q_h64_integrated = {16, 64, 16, 32, 16, 1, 8, 2};
-
 sdpa_config_t xehpc_q_h64_s96_2nd = {16, 16, 16, 16, 8, 1, 4, 1};
 sdpa_config_t xehpc_q_h64_s256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 sdpa_config_t xehpc_q_h64_s1152_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 sdpa_config_t xehpc_q_h64_2nd = {64, 16, 16, 16, 16, 2, 16, 2};
-
-sdpa_config_t xehpc_q_h64_s96_2nd_integrated = {16, 16, 16, 16, 8, 1, 4, 1};
-sdpa_config_t xehpc_q_h64_s384_2nd_integrated = {64, 16, 16, 16, 4, 1, 4, 1};
-sdpa_config_t xehpc_q_h64_2nd_integrated = {16, 16, 16, 16, 8, 1, 8, 1};
 
 sdpa_config_t xehpc_h128 = {16, 64, 32, 16, 16, 2, 4, 8};
 sdpa_config_t xehpc_h128_s64 = {16, 32, 32, 32, 4, 2, 4, 2};
@@ -145,11 +136,22 @@ sdpa_config_t xehpc_h256_s64 = {16, 32, 32, 32, 8, 1, 8, 1};
 sdpa_config_t xehpc_h256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 
 sdpa_config_t xe2_q_h64 = {16, 64, 16, 32, 16, 1, 8, 2};
+sdpa_config_t xe2_q_h64_s1024_integrated = {16, 64, 16, 32, 8, 4, 4, 8};
+sdpa_config_t xe2_q_h64_s512 = {16, 64, 16, 32, 8, 4, 4, 8};
 sdpa_config_t xe2_q_h64_s384 = {16, 64, 16, 16, 16, 1, 4, 4};
 sdpa_config_t xe2_q_h64_s128 = {16, 64, 16, 32, 8, 1, 4, 2};
 sdpa_config_t xe2_q_h64_s128_integrated = {16, 16, 16, 16, 4, 4, 4, 4};
 sdpa_config_t xe2_q_h64_s32 = {16, 16, 16, 16, 4, 4, 4, 4};
 
+sdpa_config_t xe2_q_h64_2nd = {16, 16, 16, 16, 16, 1, 8, 1};
+sdpa_config_t xe2_q_h64_2nd_integrated = {16, 16, 16, 16, 8, 1, 8, 1};
+sdpa_config_t xe2_q_h64_s96_2nd_integrated = {16, 16, 16, 16, 8, 1, 4, 1};
+sdpa_config_t xe2_q_h64_s384_2nd_integrated = {64, 16, 16, 16, 4, 1, 4, 1};
+sdpa_config_t xe2_q_h64_s64_2nd = {16, 16, 16, 16, 4, 2, 4, 2};
+sdpa_config_t xe2_q_h64_s128_2nd = {16, 16, 16, 16, 8, 2, 8, 2};
+sdpa_config_t xe2_q_h64_s384_2nd = {16, 16, 16, 16, 16, 1, 4, 1};
+sdpa_config_t xe2_q_h64_s512_2nd = {64, 16, 16, 16, 8, 1, 8, 1};
+sdpa_config_t xe2_q_h64_s768_2nd = {64, 16, 16, 16, 16, 1, 8, 1};
 sdpa_config_t *choose_config_xehpg(
         dim_t head_size, dim_t seq, bool thin_q, bool quantized) {
     if (head_size <= 32) {
@@ -226,11 +228,6 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
     } else if (head_size <= 64) {
         if (thin_q) {
             if (quantized) {
-                if (is_integrated) {
-                    if (seq <= 96) return &xehpc_q_h64_s96_2nd_integrated;
-                    if (seq <= 384) return &xehpc_q_h64_s384_2nd_integrated;
-                    return &xehpc_q_h64_2nd_integrated;
-                }
                 if (seq <= 96) return &xehpc_q_h64_s96_2nd;
                 if (seq <= 256) return &xehpc_q_h64_s256_2nd;
                 if (seq <= 1152) return &xehpc_q_h64_s1152_2nd;
@@ -241,12 +238,6 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
             return &xehpc_h64_2nd;
         }
         if (quantized) {
-            if (is_integrated) {
-                if (seq <= 128) return &xehpc_q_h64_s128_integrated;
-                if (seq <= 384) return &xehpc_q_h64_s384_integrated;
-                if (seq <= 1024) return &xehpc_q_h64_s1024_integrated;
-                return &xehpc_q_h64_integrated;
-            }
             if (seq <= 64) return &xehpc_q_h64_s64;
             if (seq <= 384) return &xehpc_q_h64_s384;
             if (seq <= 1024) return &xehpc_q_h64_s1024;
@@ -287,12 +278,29 @@ sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
 
     if (head_size <= 64) {
         if (quantized) {
+            if (thin_q) {
+                if (is_integrated) {
+                    if (seq <= 96) return &xe2_q_h64_s96_2nd_integrated;
+                    if (seq <= 384) return &xe2_q_h64_s384_2nd_integrated;
+                    return &xe2_q_h64_2nd_integrated;
+                }
+                if (seq <= 64) return &xe2_q_h64_s64_2nd;
+                if (seq <= 128) return &xe2_q_h64_s128_2nd;
+                if (seq <= 384) return &xe2_q_h64_s384_2nd;
+                if (seq <= 512) return &xe2_q_h64_s512_2nd;
+                if (seq <= 768) return &xe2_q_h64_s768_2nd;
+                return &xe2_q_h64_2nd;
+            }
+            if (seq <= 32) return &xe2_q_h64_s32;
             if (is_integrated) {
                 if (seq <= 128) return &xe2_q_h64_s128_integrated;
             }
-            if (seq <= 32) return &xe2_q_h64_s32;
             if (seq <= 128) return &xe2_q_h64_s128;
             if (seq <= 384) return &xe2_q_h64_s384;
+            if (seq <= 512) return &xe2_q_h64_s512;
+            if (is_integrated) {
+                if (seq <= 1024) return &xe2_q_h64_s1024_integrated;
+            }
             return &xe2_q_h64;
         }
     }

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -153,12 +153,18 @@ sdpa_config_t xe2_q_h64_s384_2nd = {16, 16, 16, 16, 16, 1, 4, 1};
 sdpa_config_t xe2_q_h64_s512_2nd = {64, 16, 16, 16, 8, 1, 8, 1};
 sdpa_config_t xe2_q_h64_s768_2nd = {64, 16, 16, 16, 16, 1, 8, 1};
 
-sdpa_config_t xe2_q_h256_s128 = {16, 32, 64, 16, 8, 4, 4, 8};
-sdpa_config_t xe2_q_h256_s128_integrated = {32, 16, 64, 16, 4, 4, 4, 4};
+sdpa_config_t xe2_q_h256 = {16, 64, 16, 32, 32, 1, 16, 2};
+sdpa_config_t xe2_q_h256_s384 = {16, 32, 32, 32, 8, 2, 8, 2};
+sdpa_config_t xe2_q_h256_s128 = {16, 32, 32, 32, 8, 1, 8, 1};
+sdpa_config_t xe2_q_h256_s128_integrated = {16, 32, 32, 32, 8, 2, 8, 2};
+sdpa_config_t xe2_q_h256_s64_integrated = {16, 16, 16, 16, 16, 1, 16, 1};
 sdpa_config_t xe2_q_h256_s64 = {16, 32, 64, 16, 8, 2, 4, 4};
-sdpa_config_t xe2_q_h256_s64_integrated = {32, 16, 64, 16, 4, 4, 4, 4};
-sdpa_config_t xe2_q_h256_s32 = {16, 16, 64, 16, 4, 1, 4, 1};
-sdpa_config_t xe2_q_h256_s32_integrated = {16, 16, 16, 16, 16, 1, 16, 1};
+
+sdpa_config_t xe2_q_h256_2nd_integrated = {32, 16, 64, 16, 4, 1, 4, 1};
+sdpa_config_t xe2_q_h256_s1152_2nd_integrated = {16, 16, 64, 16, 4, 1, 4, 1};
+sdpa_config_t xe2_q_h256_s768_2nd_integrated = {64, 16, 16, 16, 16, 1, 16, 1};
+sdpa_config_t xe2_q_h256_s512_2nd_integrated = {32, 32, 32, 16, 16, 1, 8, 2};
+sdpa_config_t xe2_q_h256_s384_2nd_integrated = {16, 16, 16, 16, 16, 1, 16, 1};
 
 sdpa_config_t *choose_config_xehpg(
         dim_t head_size, dim_t seq, bool thin_q, bool quantized) {
@@ -320,14 +326,22 @@ sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
     if (head_size <= 256) {
         if (quantized) {
             if (is_integrated) {
-
-                if (seq <= 32) return &xe2_q_h256_s32_integrated;
+                if (thin_q) {
+                    if (seq < 384) return &xe2_q_h256_s384_2nd_integrated;
+                    if (seq < 512) return &xe2_q_h256_s512_2nd_integrated;
+                    if (seq < 768) return &xe2_q_h256_s768_2nd_integrated;
+                    if (seq < 1152) return &xe2_q_h256_s1152_2nd_integrated;
+                    return &xe2_q_h256_2nd_integrated;
+                }
                 if (seq <= 64) return &xe2_q_h256_s64_integrated;
                 if (seq <= 128) return &xe2_q_h256_s128_integrated;
             }
-            if (seq <= 32) return &xe2_q_h256_s32;
-            if (seq <= 64) return &xe2_q_h256_s64;
-            if (seq <= 128) return &xe2_q_h256_s128;
+            if (!thin_q) {
+                if (seq <= 64) return &xe2_q_h256_s64;
+                if (seq <= 128) return &xe2_q_h256_s128;
+                if (seq <= 384) return &xe2_q_h256_s384;
+                return &xe2_q_h256;
+            }
         }
     }
     return choose_config_xehpc(

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -152,6 +152,14 @@ sdpa_config_t xe2_q_h64_s128_2nd = {16, 16, 16, 16, 8, 2, 8, 2};
 sdpa_config_t xe2_q_h64_s384_2nd = {16, 16, 16, 16, 16, 1, 4, 1};
 sdpa_config_t xe2_q_h64_s512_2nd = {64, 16, 16, 16, 8, 1, 8, 1};
 sdpa_config_t xe2_q_h64_s768_2nd = {64, 16, 16, 16, 16, 1, 8, 1};
+
+sdpa_config_t xe2_q_h256_s128 = {16, 32, 64, 16, 8, 4, 4, 8};
+sdpa_config_t xe2_q_h256_s128_integrated = {32, 16, 64, 16, 4, 4, 4, 4};
+sdpa_config_t xe2_q_h256_s64 = {16, 32, 64, 16, 8, 2, 4, 4};
+sdpa_config_t xe2_q_h256_s64_integrated = {32, 16, 64, 16, 4, 4, 4, 4};
+sdpa_config_t xe2_q_h256_s32 = {16, 16, 64, 16, 4, 1, 4, 1};
+sdpa_config_t xe2_q_h256_s32_integrated = {16, 16, 16, 16, 16, 1, 16, 1};
+
 sdpa_config_t *choose_config_xehpg(
         dim_t head_size, dim_t seq, bool thin_q, bool quantized) {
     if (head_size <= 32) {
@@ -275,7 +283,6 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
 
 sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
         bool quantized, bool is_integrated) {
-
     if (head_size <= 64) {
         if (quantized) {
             if (thin_q) {
@@ -305,6 +312,24 @@ sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
         }
     }
 
+    if (head_size <= 128) {
+        return choose_config_xehpc(
+                head_size, seq, thin_q, quantized, is_integrated);
+    }
+
+    if (head_size <= 256) {
+        if (quantized) {
+            if (is_integrated) {
+
+                if (seq <= 32) return &xe2_q_h256_s32_integrated;
+                if (seq <= 64) return &xe2_q_h256_s64_integrated;
+                if (seq <= 128) return &xe2_q_h256_s128_integrated;
+            }
+            if (seq <= 32) return &xe2_q_h256_s32;
+            if (seq <= 64) return &xe2_q_h256_s64;
+            if (seq <= 128) return &xe2_q_h256_s128;
+        }
+    }
     return choose_config_xehpc(
             head_size, seq, thin_q, quantized, is_integrated);
 }


### PR DESCRIPTION
# Description

This PR optimizes the SDPA kernel for the 256 and 128 head sizes. We achieve this by further differentiating the HPC and Xe2 architectures as well as integrated and discrete GPUs and updating the tiling strategy for quantization scenarios.

Fixes: https://jira.devtools.intel.com/browse/MFDNN-11755
