### PR TITLE
src: gpu: intel: jit: gemm: add dual (src+wei) vector zero points

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/post_ops.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/post_ops.cxx
@@ -730,10 +730,10 @@ void BLASKernelGenerator<hw>::gemmApplyABOffset(const GEMMProblem &problem, cons
         if (!(aOffset && bOffset)) return Subregister{};
 
         auto ret = state.ra.alloc_sub(problem.Tc.ngen());
-
-        if (!boVector) mul(1, ret, state.k, state.inputs.bo);
-        else if (Tc.isFP()) mov(1, ret, state.k);
-        else stub();
+        if (!boVector)
+            mul(1, ret, state.k, state.inputs.bo);
+        else
+            mov(1, ret, state.k);
 
         return ret;
     }();
@@ -781,7 +781,7 @@ void BLASKernelGenerator<hw>::gemmApplyABOffset(const GEMMProblem &problem, cons
 
         if (aOffset && bOffset) for (int r = 0; r < state.Bs_regs.getLen(); r++) {
             auto ne = elementsPerGRF(hw, Tc);
-            auto Bs = state.Bs_regs[r];
+            auto Bs = state.Bs_regs[r].retype(Tc.ngen());
             boVector ? emad(ne, Bs, Bs, boData[r].retype(Tc.ngen()), temp, strategy, state)
                      : add(ne, Bs, Bs, temp);
         };


### PR DESCRIPTION
This resolves [MFDNN-12758](https://jira.devtools.intel.com/browse/MFDNN-12758).

<details>
<summary>Pass rate (100%)</summary>

```
$ LD_LIBRARY_PATH="../../src:$LD_LIBRARY_PATH" ./benchdnn --matmul --engine=gpu --mode=C --batch=./total_llm_gemm_12758

0:PASSED (21658 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-scratchpad=user 1104x3072:3072x16384
1:PASSED (12317 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-scratchpad=user 1104x3072:3072x9216
2:PASSED (43251 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-scratchpad=user 2208x3072:3072x16384
3:PASSED (24090 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-scratchpad=user 2208x3072:3072x9216
4:PASSED (1235 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-scratchpad=user 40x3072:3072x16384
5:PASSED (606 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-scratchpad=user 40x3072:3072x9216
6:PASSED (4161 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1103x3072:3072x3072
7:PASSED (8104 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2206x3072:3072x3072
8:PASSED (188 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x3072+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x3072+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 33x3072:3072x3072
9:PASSED (23742 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 1024x4096:4096x14336
10:PASSED (10128 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 1024x4096:4096x6144
11:PASSED (24972 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 1088x4096:4096x14336
12:PASSED (10680 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 1088x4096:4096x6144
13:PASSED (19360 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 1104x4096:4096x11008
14:PASSED (21380 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 1104x4096:4096x12288
15:PASSED (46404 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 2048x4096:4096x14336
16:PASSED (19966 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 2048x4096:4096x6144
17:PASSED (49495 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 2176x4096:4096x14336
18:PASSED (21043 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 2176x4096:4096x6144
19:PASSED (38628 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 2208x4096:4096x11008
20:PASSED (43093 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 2208x4096:4096x12288
21:PASSED (946 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 32x4096:4096x14336
22:PASSED (418 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 32x4096:4096x6144
23:PASSED (886 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 40x4096:4096x11008
24:PASSED (992 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-scratchpad=user 40x4096:4096x12288
25:PASSED (6685 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1024x4096:4096x4096
26:PASSED (7102 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1086x4096:4096x4096
27:PASSED (7141 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1104x4096:4096x4096
28:PASSED (13259 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2046x4096:4096x4096
29:PASSED (14480 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2171x4096:4096x4096
30:PASSED (14423 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2207x4096:4096x4096
31:PASSED (297 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 32x4096:4096x4096
32:PASSED (346 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 34x4096:4096x4096
33:PASSED (23651 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 1024x4096:4096x14336
34:PASSED (25160 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 1086x4096:4096x14336
35:PASSED (19560 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 1104x4096:4096x11008
36:PASSED (46981 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 2046x4096:4096x14336
37:PASSED (50176 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 2171x4096:4096x14336
38:PASSED (38795 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 2207x4096:4096x11008
39:PASSED (952 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 32x4096:4096x14336
40:PASSED (836 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x4096+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x4096+wei:per_oc:u8 --attr-post-ops=swish:1+mul:f16:3:ab --attr-scratchpad=user 34x4096:4096x11008
41:PASSED (10651 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x8192+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x8192+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1103x8192:8192x3072
42:PASSED (21297 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x8192+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x8192+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2206x8192:8192x3072
43:PASSED (504 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x8192+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x8192+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 33x8192:8192x3072
44:PASSED (19303 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x11008+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x11008+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1104x11008:11008x4096
45:PASSED (39033 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x11008+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x11008+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2207x11008:11008x4096
46:PASSED (980 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x11008+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x11008+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 34x11008:11008x4096
47:PASSED (23197 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1024x14336:14336x4096
48:PASSED (24698 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 1086x14336:14336x4096
49:PASSED (46489 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2046x14336:14336x4096
50:PASSED (49419 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 2171x14336:14336x4096
51:PASSED (904 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=src:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab --attr-scratchpad=user 32x14336:14336x4096
52:PASSED (2660 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-scratchpad=user 1024x2560:2560x2560
53:PASSED (5189 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-scratchpad=user 2048x2560:2560x2560
54:PASSED (130 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-scratchpad=user 32x2560:2560x2560
55:PASSED (2735 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab+add:f16:3:ab --attr-scratchpad=user 1022x2560:2560x2560
56:PASSED (5315 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab+add:f16:3:ab --attr-scratchpad=user 2044x2560:2560x2560
57:PASSED (135 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-post-ops=add:f16:3:ab+add:f16:3:ab --attr-scratchpad=user 31x2560:2560x2560
58:PASSED (10469 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-post-ops=gelu_tanh --attr-scratchpad=user 1024x2560:2560x10240
59:PASSED (21137 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-post-ops=gelu_tanh --attr-scratchpad=user 2048x2560:2560x10240
60:PASSED (464 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x2560+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x2560+wei:per_oc:u8 --attr-post-ops=gelu_tanh --attr-scratchpad=user 32x2560:2560x10240
61:PASSED (10405 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x10240+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x10240+wei:per_oc:u8 --attr-scratchpad=user 1024x10240:10240x2560
62:PASSED (20779 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x10240+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x10240+wei:per_oc:u8 --attr-scratchpad=user 2048x10240:10240x2560
63:PASSED (461 ms) __REPRO: --matmul --engine=gpu --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --attr-scales=src:per_ocic:f16:1x10240+wei:per_oc:f16 --attr-zero-points=src:per_ocic:u8:1x10240+wei:per_oc:u8 --attr-scratchpad=user 32x10240:10240x2560

tests:64 passed:64 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 1034.01s; create_pd: 0.02s (0%); create_prim: 1.76s (0%); fill: 7.98s (1%); execute: 1.42s (0%); compute_ref: 1016.61s (98%); compare: 1.85s (0%);

$ LD_LIBRARY_PATH="../../src:$LD_LIBRARY_PATH" ./benchdnn --matmul --engine=gpu --mode=F --batch=./total_llm_gemm_12758 | grep -c jit:gemm:any
64
```

</details>
<details>
<summary>Performance data @ DUT6233-BMGFRD</summary>

| #   |  f16, ms      |  int4, ms    |  int8, ms     |f16/int8, %|int4/int8, %|test|
|-----|-----|-----|-----|-----|-----|-----|
| 1   |  1.17871      |  0.955473    |  0.741235     |  159.01  |  128.90  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16                                                          1104x3072:3072x16384   |
| 2   |  0.643302     |  0.537752    |  0.443387     |  145.08  |  121.28  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16                                                          1104x3072:3072x9216    |
| 3   |  2.16296      |  1.62475     |  1.46408      |  147.73  |  110.97  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16                                                          2208x3072:3072x16384   |
| 4   |  1.22586      |  0.946297    |  0.838125     |  146.26  |  112.90  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16                                                          2208x3072:3072x9216    |
| 5   |  0.341205     |  0.112282    |  0.161184     |  211.68  |  69.66   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16                                                          40x3072:3072x16384     |
| 6   |  0.200387     |  0.0558862   |  0.0858173    |  233.50  |  65.12   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16                                                          40x3072:3072x9216      |
| 7   |  0.270683     |  0.206116    |  0.243156     |  111.32  |  84.76   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     1103x3072:3072x3072    |
| 8   |  0.549687     |  0.40207     |  0.460842     |  119.27  |  87.24   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     2206x3072:3072x3072    |
| 9   |  0.0422535    |  0.0305699   |  0.0228679    |  184.77  |  133.68  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x3072+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x3072+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     33x3072:3072x3072      |
| 10  |  1.0994       |  0.864791    |  0.713694     |  154.04  |  121.17  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          1024x4096:4096x14336   |
| 11  |  0.475702     |  0.362219    |  0.377471     |  126.02  |  95.95   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          1024x4096:4096x6144    |
| 12  |  1.31181      |  1.00284     |  0.785368     |  167.03  |  127.69  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          1088x4096:4096x14336   |
| 13  |  0.569183     |  0.433325    |  0.38871      |  146.42  |  111.47  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          1088x4096:4096x6144    |
| 14  |  1.03272      |  0.786338    |  0.616366     |  167.54  |  127.57  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          1104x4096:4096x11008   |
| 15  |  1.13387      |  0.867239    |  0.778966     |  145.56  |  111.33  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          1104x4096:4096x12288   |
| 16  |  2.17844      |  1.66598     |  1.37641      |  158.26  |  121.03  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          2048x4096:4096x14336   |
| 17  |  0.961003     |  0.743883    |  0.775849     |  123.86  |  95.87   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          2048x4096:4096x6144    |
| 18  |  2.38881      |  1.85573     |  1.46357      |  163.21  |  126.79  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          2176x4096:4096x14336   |
| 19  |  1.10984      |  0.813173    |  0.831899     |  133.41  |  97.74   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          2176x4096:4096x6144    |
| 20  |  1.84349      |  1.43213     |  1.18157      |  156.02  |  121.20  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          2208x4096:4096x11008   |
| 21  |  2.07121      |  1.61674     |  1.53161      |  135.23  |  105.55  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          2208x4096:4096x12288   |
| 22  |  0.27722      |  0.0992118   |  0.143921     |  192.61  |  68.93   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          32x4096:4096x14336     |
| 23  |  0.122707     |  0.0355939   |  0.0552772    |  221.98  |  64.39   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          32x4096:4096x6144      |
| 24  |  0.224763     |  0.106838    |  0.119214     |  188.53  |  89.61   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          40x4096:4096x11008     |
| 25  |  0.239162     |  0.110516    |  0.125041     |  191.26  |  88.38   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16                                                          40x4096:4096x12288     |
| 26  |  0.426153     |  0.325541    |  0.331047     |  128.72  |  98.33   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     1024x4096:4096x4096    |
| 27  |  0.445203     |  0.326723    |  0.374238     |  118.96  |  87.30   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     1086x4096:4096x4096    |
| 28  |  0.445602     |  0.326863    |  0.375646     |  118.62  |  87.01   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     1104x4096:4096x4096    |
| 29  |  0.801089     |  0.564002    |  0.618462     |  129.52  |  91.19   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     2046x4096:4096x4096    |
| 30  |  0.785232     |  0.644522    |  0.663106     |  118.41  |  97.19   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     2171x4096:4096x4096    |
| 31  |  0.786939     |  0.642665    |  0.70827      |  111.10  |  90.73   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     2207x4096:4096x4096    |
| 32  |  0.081978     |  0.034359    |  0.0179024    |  457.91  |  191.92  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     32x4096:4096x4096      |
| 33  |  0.088915     |  0.0396585   |  0.0311951    |  285.02  |  127.13  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     34x4096:4096x4096      |
| 34  |  1.34023      |  0.993664    |  1.11072      |  120.66  |  89.46   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   1024x4096:4096x14336   |
| 35  |  1.57379      |  1.15425     |  1.25025      |  125.87  |  92.32   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   1086x4096:4096x14336   |
| 36  |  1.23303      |  0.907881    |  0.964668     |  127.81  |  94.11   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   1104x4096:4096x11008   |
| 37  |  2.66373      |  1.87349     |  2.1669       |  122.92  |  86.45   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   2046x4096:4096x14336   |
| 38  |  2.65715      |  2.09856     |  2.31602      |  114.72  |  90.61   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   2171x4096:4096x14336   |
| 39  |  2.04129      |  1.6244      |  1.86059      |  109.71  |  87.30   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   2207x4096:4096x11008   |
| 40  |  0.283221     |  0.151335    |  0.158689     |  178.47  |  95.36   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   32x4096:4096x14336     |
| 41  |  0.241015     |  0.132769    |  0.136021     |  177.18  |  97.60   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x4096+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x4096+wei:per_oc:f16  --attr-post-ops=eltwise_swish:1.0+binary_mul:f16:3:ab   34x4096:4096x11008     |
| 42  |  0.623621     |  0.460217    |  0.43923      |  141.98  |  104.77  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x8192+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x8192+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     1103x8192:8192x3072    |
| 43  |  1.26068      |  0.895026    |  0.804511     |  156.70  |  111.25  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x8192+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x8192+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     2206x8192:8192x3072    |
| 44  |  0.141902     |  0.0743762   |  0.0712697    |  199.10  |  104.35  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x8192+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x8192+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab                     33x8192:8192x3072      |
| 45  |  1.09013      |  0.820368    |  0.697923     |  156.19  |  117.54  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x11008+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x11008+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     1104x11008:11008x4096  |
| 46  |  2.29277      |  1.57076     |  2.3551       |  97.35   |  66.69   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x11008+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x11008+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     2207x11008:11008x4096  |
| 47  |  0.256826     |  0.1048      |  0.135838     |  189.06  |  77.15   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x11008+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x11008+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     34x11008:11008x4096    |
| 48  |  1.41943      |  1.02399     |  1.31126      |  108.24  |  78.09   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     1024x14336:14336x4096  |
| 49  |  1.39548      |  1.04174     |  0.874574     |  159.56  |  119.11  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     1086x14336:14336x4096  |
| 50  |  2.59404      |  1.7497      |  2.6191       |  99.04   |  66.80   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     2046x14336:14336x4096  |
| 51  |  3.024        |  2.01479     |  2.76537      |  109.35  |  72.85   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     2171x14336:14336x4096  |
| 52  |  0.286324     |  0.112627    |  0.152474     |  187.78  |  73.86   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab                           --attr-zero-points=src0:per_ocic:u8:1x14336+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x14336+wei:per_oc:f16 --attr-post-ops=binary_add:f16:3:ab                     32x14336:14336x4096    |
| 53  |  0.121303     |  0.0938871   |  0.0786957    |  154.14  |  119.30  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16                                                          1024x2560:2560x2560    |
| 54  |  0.246901     |  0.182236    |  0.168927     |  146.15  |  107.87  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16                                                          2048x2560:2560x2560    |
| 55  |  0.00913203   |  0.0110291   |  0.00614664   |  148.56  |  179.43  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16                                                          32x2560:2560x2560      |
| 56  |  0.193494     |  0.12736     |  0.205982     |  93.93   |  61.83   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab+binary_add:f16:3:ab 1022x2560:2560x2560    |
| 57  |  0.382668     |  0.266618    |  0.441852     |  86.60   |  60.34   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab+binary_add:f16:3:ab 2044x2560:2560x2560    |
| 58  |  0.0119592    |  0.0229842   |  0.00893047   |  133.91  |  257.36  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16  --attr-post-ops=binary_add:f16:3:ab+binary_add:f16:3:ab 31x2560:2560x2560      |
| 59  |  0.498777     |  0.395653    |  0.375704     |  132.75  |  105.30  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16  --attr-post-ops=eltwise_gelu_tanh                       1024x2560:2560x10240   |
| 60  |  0.991259     |  0.770961    |  0.7343       |  134.99  |  104.99  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16  --attr-post-ops=eltwise_gelu_tanh                       2048x2560:2560x10240   |
| 61  |  0.128682     |  0.0409208   |  0.0593574    |  216.79  |  68.93   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x2560+wei:per_oc:u8  --attr-scales=src0:per_ocic:f16:1x2560+wei:per_oc:f16  --attr-post-ops=eltwise_gelu_tanh                       32x2560:2560x10240     |
| 62  |  0.492672     |  0.35973     |  0.28158      |  174.96  |  127.75  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x10240+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x10240+wei:per_oc:f16                                                         1024x10240:10240x2560  |
| 63  |  0.987424     |  0.704708    |  0.563059     |  175.36  |  125.15  |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x10240+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x10240+wei:per_oc:f16                                                         2048x10240:10240x2560  |
| 64  |  0.125596     |  0.0422299   |  0.0574281    |  218.70  |  73.53   |  --matmul --engine=gpu --attr-scratchpad=user --dt=s8:u8:f16 --stag=ab --wtag=ba --dtag=ab --bia-dt=f16 --bia_mask=2 --attr-zero-points=src0:per_ocic:u8:1x10240+wei:per_oc:u8 --attr-scales=src0:per_ocic:f16:1x10240+wei:per_oc:f16                                                         32x10240:10240x2560    |
| all |  58.12401473  |  42.3951376  |  44.01796691  |  132.04  |  96.31   |                                                                                                                                                                                                                                                                                                                      |
</details>