### PR TITLE
fix for big shapes pr

### DIFF
--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -1475,26 +1475,6 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
-
-    const bool is_src_layout_blocked = jcp.src_tag == dat_tag_nCx8c;
-    const bool is_dst_layout_blocked = jcp.dst_tag == dat_tag_nCx8c;
-
-    dim_t src_size = static_cast<dim_t>(jcp.mb)
-            * (is_src_layout_blocked ? rnd_up(jcp.ic, jcp.ic_block) : jcp.ic)
-            * jcp.id * jcp.ih * jcp.iw * jcp.typesize_in;
-
-    VDISPATCH_CONV_IC(src_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "src size > INT_MAX is not supported");
-
-    dim_t diff_dst_size = static_cast<dim_t>(jcp.mb)
-            * (is_dst_layout_blocked ? rnd_up(jcp.oc, jcp.oc_block) : jcp.oc)
-            * jcp.id * jcp.ih * jcp.iw * jcp.typesize_in;
-
-    VDISPATCH_CONV_IC(diff_dst_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "diff_dst size > INT_MAX is not supported");
-
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -4123,24 +4123,14 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32::init_conf(
     jcp.typesize_in = typesize;
     jcp.typesize_out = typesize;
 
-    dim_t src_size = static_cast<dim_t>(jcp.mb)
-            * (is_data_layout_nxc ? jcp.ic : rnd_up(jcp.ic, jcp.ic_block))
-            * jcp.id * jcp.ih * jcp.iw * jcp.typesize_in;
-
-    VDISPATCH_CONV_IC(src_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "src size > INT_MAX is not supported");
-
-    dim_t diff_dst_size = static_cast<dim_t>(jcp.mb)
-            * (is_data_layout_nxc ? jcp.oc : rnd_up(jcp.oc, jcp.oc_block))
-            * jcp.id * jcp.ih * jcp.iw * jcp.typesize_in;
-
-    VDISPATCH_CONV_IC(diff_dst_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "diff_dst size > INT_MAX is not supported");
-
     bool use_nxc_harness = false;
     if (is_data_layout_nxc) {
         dim_t kernel_size = static_cast<dim_t>(jcp.ic) * jcp.oc * jcp.kd
                 * jcp.kh * jcp.kw * jcp.typesize_out;
+        dim_t src_size = static_cast<dim_t>(jcp.mb) * jcp.ic * jcp.id * jcp.ih
+                * jcp.iw * jcp.typesize_in;
+        dim_t diff_dst_size = static_cast<dim_t>(jcp.mb) * jcp.oc * jcp.id
+                * jcp.ih * jcp.iw * jcp.typesize_in;
         dim_t data_size = src_size + diff_dst_size;
 
         // The advantage of the nxc kernel is cache traversal, this comes at a

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -3922,18 +3922,6 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
-    const dim_t src_size = (dim_t)jcp.mb * jcp.id * jcp.ih * jcp.iw
-            * (jcp.is_nspc ? jcp.ic : rnd_up(jcp.ic, jcp.ic_block))
-            * jcp.typesize_in;
-    VDISPATCH_CONV_IC(src_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "src size > INT_MAX is not supported");
-
-    const dim_t dst_size = (dim_t)jcp.mb * jcp.od * jcp.oh * jcp.ow
-            * (jcp.is_nspc ? jcp.oc : rnd_up(jcp.oc, jcp.oc_block))
-            * jcp.typesize_out;
-    VDISPATCH_CONV_IC(dst_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "dst size > INT_MAX is not supported");
-
     jcp.nb_ic = jcp.ic / jcp.ic_block;
     jcp.nb_oc = jcp.oc / jcp.oc_block;
     jcp.nb_oc_int = div_up(jcp.oc, jcp.oc_block_int);
@@ -5424,21 +5412,12 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
         // TODO: Optimize memory allocation when threaded on height and depth
         jcp.tr_src_buf_size = static_cast<size_t>(jcp.tr_iw) * jcp.ic_block
                 * jcp.ih * jcp.id;
-        const auto src_max_size = jcp.tr_src_buf_size * jcp.typesize_in;
-        VDISPATCH_CONV_IC(src_max_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-                "scr size > INT_MAX is not supported");
-
         jcp.tr_src_buf_count = jcp.global_transpose
                 ? jcp.nthr_mb * jcp.nb_ic * jcp.ngroups
                 : jcp.nthr;
 
         jcp.tr_diff_dst_buf_size = static_cast<size_t>(jcp.tr_ow) * jcp.oc_block
                 * jcp.oh * jcp.od;
-        const auto diff_dst_max_size
-                = jcp.tr_diff_dst_buf_size * jcp.typesize_in;
-        VDISPATCH_CONV_IC(diff_dst_max_size <= INT_MAX,
-                VERBOSE_UNSUPPORTED_FEATURE,
-                "diff_dst size > INT_MAX is not supported");
         jcp.tr_diff_dst_buf_count = jcp.global_transpose
                 ? jcp.nthr_mb * jcp.nb_oc * jcp.ngroups
                 : jcp.nthr;

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1981,17 +1981,6 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         VDISPATCH_CONV_IC(!allow_perf_heuristics(jcp),
                 VERBOSE_IMPL_HEURISTIC_FAIL,
                 "no optimization for 1x1 convolution");
-
-    dim_t src_size
-            = (dim_t)jcp.mb * jcp.id * jcp.ih * jcp.iw * jcp.ic * jcp.src_dsz;
-    VDISPATCH_CONV_IC(src_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "src size > INT_MAX is not supported");
-
-    dim_t dst_size
-            = (dim_t)jcp.mb * jcp.od * jcp.oh * jcp.ow * jcp.oc * jcp.dst_dsz;
-    VDISPATCH_CONV_IC(dst_size <= INT_MAX, VERBOSE_UNSUPPORTED_FEATURE,
-            "dst size > INT_MAX is not supported");
-
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper weights_d(&weights_md);
     const memory_desc_wrapper dst_d(&dst_md);


### PR DESCRIPTION
This is a fix for [MFDNN-13409](https://jira.devtools.intel.com/browse/MFDNN-13409)
- remove unnecessary checks for size in convolutions: we have unified check by using `has_large_size` after #2827 
- update `has_large_size` function: exclude minibatch from size calculation because we process data image by image in all convolutions

Pre-commit shows no new fails excepting those that have already been in CI.