### PR TITLE
common: logging: catch fmt::v11::format_error

### DIFF
--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -57,6 +57,9 @@ log_manager_t::log_manager_t()
     } catch (spdlog::spdlog_ex &exception) {
         printf("onednn_verbose,info,exception while creating logfile: %s\n",
                 exception.what());
+    } catch (fmt::v11::format_error &exception) {
+        printf("onednn_verbose,info,exception while creating logfile: %s\n",
+                exception.what());
     }
 }
 


### PR DESCRIPTION
Prevents the escape of exceptions from fmtlib bundled with spdlog into noexcept contexts.

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?