### PR TITLE
xe: jit: gemm: fix zero pool memory leak under SYCL when not recording

### DIFF
--- a/src/gpu/intel/compute/zero_pool.cpp
+++ b/src/gpu/intel/compute/zero_pool.cpp
@@ -75,7 +75,7 @@ status_t lookup_zero_pool(compute::compute_engine_t *engine,
     // If recording, get a per-graph zero pool.
     const auto *sycl_stream
             = utils::downcast<const gpu::intel::sycl::stream_t *>(stream);
-    if (sycl_stream->recording()) {
+    if (sycl_stream && sycl_stream->recording()) {
         {
             std::lock_guard<std::mutex> lock(zero_pool_cache_mutex);
             auto &pool = recorded_zero_pool_cache


### PR DESCRIPTION
Closes MFDNN-13250. A memory leak was inadvertently introduced when introducing initial SYCL graph recording support for zero pools in GEMM. The memory leak is expected when under recording mode (temporary measure -- will be replaced with async malloc/free when graph recording support available), but not in regular execution.