### PR TITLE
[GPU] xe: jit: add debug log level and improve logging

### DIFF
--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -2023,7 +2023,7 @@ std::string conv_config_t::str() const {
     oss << "  Estimated GRF usage:        " << estimated_peak_regs << std::endl;
     oss << "  AB Swap Transpose:          " << to_string(prb().ab_swap_transpose) << std::endl;
     oss << "  Kernel grid walk order:     " << walk_order() << std::endl;
-    oss << "  Configuration line:         " << get_config_line() << std::endl;
+    oss << "  Configuration line:         " << get_config_line();
     // clang-format on
     return oss.str();
 }

--- a/src/gpu/intel/jit/conv/ir_builder.cpp
+++ b/src/gpu/intel/jit/conv/ir_builder.cpp
@@ -772,7 +772,7 @@ void conv_ir_builder_t::build() {
     verify_buffer_access(stmt_, ir_ctx);
 #endif
 
-    gpu_trace() << "Convolution kernel body:\n" << stmt_;
+    gpu_debug() << "Convolution kernel body:\n" << stmt_;
     trace_perf();
 }
 

--- a/src/gpu/intel/jit/pooling/ir_builder.cpp
+++ b/src/gpu/intel/jit/pooling/ir_builder.cpp
@@ -549,8 +549,8 @@ stmt_t pooling_ir_builder_t::try_build(pooling_ir_builder_t &pb,
 
     const int regs = get_peak_regs(stmt, exec.grf_size());
 
-    gpu_trace() << "Pooling kernel body:\n" << stmt;
-    gpu_trace() << "Pooling cfg (~" << regs << " regs):\n" << cfg;
+    gpu_debug() << "Pooling kernel body:\n" << stmt;
+    gpu_debug() << "Pooling cfg (~" << regs << " regs):\n" << cfg;
 
     return (regs > exec.regs()) ? stmt_t() : std::move(stmt);
 }

--- a/src/gpu/intel/jit/reorder/ir_builder.cpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.cpp
@@ -268,7 +268,7 @@ bool reorder_ir_builder_t::try_build(
         return false;
     }
 
-    gpu_trace() << "Reorder kernel body:\n" << stmt_;
+    gpu_debug() << "Reorder kernel body:\n" << stmt_;
     return true;
 }
 

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -269,7 +269,9 @@ bool kernel_desc_t::is_supported(const hw_t &hw, const problem_t *prb) const {
                 << "Output/accumulator types must match for Stream-K";
     }
     gpu_check(is_grf_usage_ok(*this)) << "GRF usage exceeded";
-    if (prb) gpu_check(matches(*prb)) << "Descriptor does not match problem";
+    if (prb)
+        gpu_check(matches(*prb))
+                << "Descriptor " << cmd_str() << " does not match problem";
     return true;
 }
 
@@ -365,9 +367,9 @@ bool is_compatible(
     gpu_check(is_compatible(desc.hw_desc, prb.hw(), exact))
             << "HW does not match";
     gpu_check(prb.prop() == desc.prop) << "Propagation kind does not match";
-    gpu_check(is_compatible(tensor_kind_t::a, desc, prb, exact));
-    gpu_check(is_compatible(tensor_kind_t::b, desc, prb, exact));
-    gpu_check(is_compatible(tensor_kind_t::c, desc, prb, exact));
+    if (!is_compatible(tensor_kind_t::a, desc, prb, exact)) return false;
+    if (!is_compatible(tensor_kind_t::b, desc, prb, exact)) return false;
+    if (!is_compatible(tensor_kind_t::c, desc, prb, exact)) return false;
     gpu_check(prb.is_depthwise() == desc.is_dw)
             << "Mixing depthwise/non-depthwise descriptor and problem";
     if (desc.use_stream_k) {

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -391,7 +391,9 @@ bool is_compatible(
                     << "Bias is not supported";
         }
     }
-    gpu_check(desc.reqs().fits(prb.shape()));
+    auto fitted_desc = desc;
+    fitted_desc.fit_to(prb);
+    gpu_check(fitted_desc.reqs().fits(prb.shape()));
     return true;
 }
 

--- a/src/gpu/intel/jit/v2/conv/plan_registry.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan_registry.cpp
@@ -56,6 +56,7 @@ kernel_desc_t plan_registry_t::find_best(
         auto desc = e.desc;
         desc.spec.mode = spec_mode;
         desc.spec.specialize(prb);
+        gpu_trace() << "Trying kernel desc: " << desc.cmd_str();
         if (!desc.can_fit(prb)) continue;
         float time = e.model_set.time(prb, desc);
         if (time < min_time) {
@@ -65,6 +66,7 @@ kernel_desc_t plan_registry_t::find_best(
         auto sk_desc = to_stream_k(e.desc);
         sk_desc.spec.mode = spec_mode;
         sk_desc.spec.specialize(prb);
+        gpu_trace() << "Trying kernel desc: " << sk_desc.cmd_str();
         if (sk_desc.is_empty() || !sk_desc.can_fit(prb)) continue;
         time = e.model_set.time(prb, sk_desc);
         if (time < min_time) {

--- a/src/gpu/intel/logging.hpp
+++ b/src/gpu/intel/logging.hpp
@@ -35,6 +35,7 @@ enum class log_level_t {
     warning = 100,
     suggestion = 120,
     info = 150,
+    debug = 160,
     perf = 170,
     trace = 200,
 };
@@ -101,6 +102,7 @@ private:
             case log_level_t::warning: out_ << "[ WARN]"; break;
             case log_level_t::suggestion: out_ << "[SUGGESTION]"; break;
             case log_level_t::info: out_ << "[ INFO]"; break;
+            case log_level_t::debug: out_ << "[DEBUG]"; break;
             case log_level_t::perf: out_ << "[ PERF]"; break;
             case log_level_t::trace: out_ << "[TRACE]"; break;
             default: gpu_error_not_expected();
@@ -135,6 +137,13 @@ private:
             dnnl::impl::gpu::intel::log_level_t::info>::is_enabled() \
             && dnnl::impl::gpu::intel::logger_t< \
                     dnnl::impl::gpu::intel::log_level_t::info>( \
+                    __FILENAME__, __LINE__)
+
+#define gpu_debug() \
+    dnnl::impl::gpu::intel::logger_t< \
+            dnnl::impl::gpu::intel::log_level_t::debug>::is_enabled() \
+            && dnnl::impl::gpu::intel::logger_t< \
+                    dnnl::impl::gpu::intel::log_level_t::debug>( \
                     __FILENAME__, __LINE__)
 
 #define gpu_warning() \


### PR DESCRIPTION
As the trace output (`gpu_trace()`) is quite verbose now, this PR adds an intermediate level `debug` (`ONEDNN_VERBOSE=debuginfo=160`) for GPU IR primitives to limit output to the final IR and configuration details (no intermediate passes, no assembly dump).