### PR TITLE
[GPU] xe: binary: enable support for select algorithm 

### DIFF
--- a/src/gpu/intel/ocl/binary_common.h
+++ b/src/gpu/intel/ocl/binary_common.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #define DST_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(DST, x0, x1, x2, x3, x4, x5)
 #define SRC0_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(SRC0, x0, x1, x2, x3, x4, x5)
 #define SRC1_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(SRC1, x0, x1, x2, x3, x4, x5)
+#define SRC2_OFF(x0, x1, x2, x3, x4, x5) OFF_MD(SRC2, x0, x1, x2, x3, x4, x5)
 
 #if SRC1_DT_BF16
 #define SRC1_TO_FLOAT cvt_bf16_to_f32
@@ -38,6 +39,8 @@
 #else
 #define SRC0_TO_FLOAT CONVERT_FLOAT_T
 #endif
+
+#define SRC2_TO_FLOAT CONVERT_FLOAT_T
 
 #if SRC0_DT_BF8
 #define SRC0_BLOCK_READ(src) \
@@ -395,6 +398,18 @@ DEF_binary_op(float2, float);
 DEF_binary_op(float4, float);
 DEF_binary_op(float8, float);
 #undef DEF_binary_op
+
+#define DEF_ternary_op(dt, special_dt) \
+    dt __attribute__((overloadable)) \
+            ternary_op(int alg, dt src0, dt src1, dt src2) { \
+        return (src2 != 0) ? src0 : src1; \
+    }
+
+DEF_ternary_op(float, float);
+DEF_ternary_op(float2, float);
+DEF_ternary_op(float4, float);
+DEF_ternary_op(float8, float);
+#undef DEF_ternary_op
 
 #define READ_DATA(size, name, source_ptr, dest_ptr, scale) \
     { \

--- a/src/gpu/intel/ocl/binary_common.h
+++ b/src/gpu/intel/ocl/binary_common.h
@@ -40,7 +40,16 @@
 #define SRC0_TO_FLOAT CONVERT_FLOAT_T
 #endif
 
-#define SRC2_TO_FLOAT CONVERT_FLOAT_T
+#if SRC2_DT_S8
+#define SRC2_BLOCK_READ(src) \
+    as_char(intel_sub_group_block_read_uc((const __global uchar *)(src)))
+#define SRC2_BLOCK_READ2(src) \
+    as_char2(intel_sub_group_block_read_uc2((const __global uchar *)(src)))
+#define SRC2_BLOCK_READ4(src) \
+    as_char4(intel_sub_group_block_read_uc4((const __global uchar *)(src)))
+#define SRC2_BLOCK_READ8(src) \
+    as_char8(intel_sub_group_block_read_uc8((const __global uchar *)(src)))
+#endif // SRC2_DT_S8
 
 #if SRC0_DT_BF8
 #define SRC0_BLOCK_READ(src) \

--- a/src/gpu/intel/ocl/binary_common.h
+++ b/src/gpu/intel/ocl/binary_common.h
@@ -410,7 +410,7 @@ DEF_binary_op(float8, float);
 
 #define DEF_ternary_op(dt, special_dt) \
     dt __attribute__((overloadable)) \
-            ternary_op(int alg, dt src0, dt src1, dt src2) { \
+            ternary_op(int alg, dt src0, dt src1, char src2) { \
         return (src2 != 0) ? src0 : src1; \
     }
 

--- a/src/gpu/intel/ocl/gen9_binary.cl
+++ b/src/gpu/intel/ocl/gen9_binary.cl
@@ -58,9 +58,8 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
     int dst_off = DST_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
     dst += dst_off;
-
 #if IS_TERNARY
-    int src2_off = SRC2_OFF(
+    int src2_off = DST_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
     src2 += src2_off;
 #endif
@@ -74,8 +73,6 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
 #else
 #define src1_scale_val 1
 #endif
-#define src2_scale_val 1
-
     float tmp_src0[NVECT];
     READ_DATA(NVECT, SRC0, (&src0[0]), (&tmp_src0[0]), src0_scale_val);
 
@@ -88,10 +85,9 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
     READ_DATA(NVECT, SRC1, (&src1[0]), (&tmp_src1[0]), src1_scale_val);
 #define SRC1_IDX_MASK 1
 #endif
-
 #if IS_TERNARY
-    int tmp_src2[NVECT];
-    READ_DATA(NVECT, SRC2, (&src2[0]), (&tmp_src2[0]), src2_scale_val);
+    char tmp_src2[NVECT];
+    READ_CHAR_DATA(NVECT, SRC2, (&src2[0]), (&tmp_src2[0]));
 #endif
 
     float tmp[NVECT];
@@ -175,7 +171,7 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
     SRC0_DATA_T tmp_buf0[d01_block] = {0};
     SRC1_DATA_T tmp_buf1[d01_block] = {0};
 #if IS_TERNARY
-    SRC2_DATA_T tmp_buf2[d01_block] = {0};
+    char tmp_buf2[d01_block] = {0};
 #endif
     DST_DATA_T res_buf[d01_block] = {0};
 
@@ -234,7 +230,7 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
             float tmp_src0 = CONVERT_FLOAT_T(tmp_buf0[i]);
             float tmp_src1 = CONVERT_FLOAT_T(tmp_buf1[i]);
 #if IS_TERNARY
-            float tmp_src2 = tmp_buf2[i];
+            char tmp_src2 = tmp_buf2[i];
 #endif
             float res;
             float dst_data;
@@ -311,7 +307,7 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
         __global DST_DATA_T *t_dst = dst + dst_off;
         __global SRC0_DATA_T *t_src0 = src0 + src0_off;
 #if IS_TERNARY
-        __global SRC2_DATA_T *t_src2 = src2 + src2_off;
+        __global char *t_src2 = src2 + src2_off;
 #endif
 
         if ((SRC0_D1 % SUB_GROUP_SIZE != 0)

--- a/src/gpu/intel/ocl/gen9_binary.cl
+++ b/src/gpu/intel/ocl/gen9_binary.cl
@@ -321,7 +321,7 @@ __kernel void gen9_binary(__global SRC0_DATA_T *src0,
             float8 tmp_src0 = CONVERT_FLOAT8_T(SRC0_BLOCK_READ8(&t_src0[0]));
             float8 tmp_src1 = CONVERT_FLOAT8_T(SRC1_BLOCK_READ8(&t_src1[0]));
 #if IS_TERNARY
-            char8 tmp_src2 = CONVERT_FLOAT8_T(SRC2_BLOCK_READ8(&t_src2[0]));
+            char8 tmp_src2 = SRC2_BLOCK_READ8(&t_src2[0]);
 #endif
 #if WITH_SRC0_SCALE
             tmp_src0 = tmp_src0 * src0_scale[0];

--- a/src/gpu/intel/ocl/gen9_binary.cpp
+++ b/src/gpu/intel/ocl/gen9_binary.cpp
@@ -288,7 +288,7 @@ status_t gen9_binary_t::pd_t::init_kernel_ctx(
     def_binary_alg_kinds(kernel_ctx);
     kernel_ctx.define_int("BINARY_ALG", conf.alg);
     kernel_ctx.define_int(
-            "IS_SELECT_BINARY", (conf.alg == dnnl_binary_select) ? 1 : 0);
+            "IS_TERNARY", (conf.alg == alg_kind::binary_select) ? 1 : 0);
 
     kernel_ctx.set_data_type(conf.src0_data_type);
     kernel_ctx.define_int("SUB_GROUP_SIZE", 16);
@@ -317,7 +317,7 @@ status_t gen9_binary_t::pd_t::init_kernel_ctx(
     def_memory_desc_info(kernel_ctx, conf.src1_md_info, "SRC1");
     def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");
 
-    if (conf.alg == dnnl_binary_select) {
+    if (conf.alg == alg_kind::binary_select) {
         def_memory_desc_info(kernel_ctx, conf.src2_md_info, "SRC2");
     }
 

--- a/src/gpu/intel/ocl/gen9_binary.hpp
+++ b/src/gpu/intel/ocl/gen9_binary.hpp
@@ -64,10 +64,6 @@ struct gen9_binary_t : public gpu_primitive_t {
                                      utils::one_of(src_md(2)->data_type, s8)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_BINARY(
-                    IMPLICATION(is_ternary_op(),
-                            dnnl_memory_desc_equal(src_md(0), src_md(2))),
-                    VERBOSE_INCONSISTENT_NDIMS, "src_0", "src_2");
-            VDISPATCH_BINARY(
                     IMPLICATION(!attr()->scales_.has_default_values(),
                             utils::one_of(dst_md()->data_type, s8, u8)),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
@@ -152,22 +148,19 @@ struct gen9_binary_t : public gpu_primitive_t {
         auto &src1_scale
                 = CTX_IN_STORAGE(DNNL_ARG_SRC_1 | DNNL_ARG_ATTR_SCALES);
 
-        unsigned arg_idx;
+        unsigned arg_idx = 0;
         compute::kernel_arg_list_t arg_list;
-        arg_list.set(0, src0);
-        arg_list.set(1, src1);
+        arg_list.set(arg_idx++, src0);
+        arg_list.set(arg_idx++, src1);
 
         if (pd()->is_ternary_op()) {
             auto &src2 = CTX_IN_STORAGE(DNNL_ARG_SRC_2);
-            arg_list.set(2, src2);
-            arg_list.set(3, dst);
-            arg_idx = append_post_ops_to_arg_list(
-                    ctx, arg_list, 4, pd()->attr()->post_ops_);
-        } else {
-            arg_list.set(2, dst);
-            arg_idx = append_post_ops_to_arg_list(
-                    ctx, arg_list, 3, pd()->attr()->post_ops_);
+            arg_list.set(arg_idx++, src2);
         }
+
+        arg_list.set(arg_idx++, dst);
+        arg_idx = append_post_ops_to_arg_list(
+                ctx, arg_list, arg_idx, pd()->attr()->post_ops_);
 
         arg_list.set(arg_idx++, src0_scale);
         arg_list.set(arg_idx, src1_scale);

--- a/src/gpu/intel/ocl/gen9_binary.hpp
+++ b/src/gpu/intel/ocl/gen9_binary.hpp
@@ -64,8 +64,8 @@ struct gen9_binary_t : public gpu_primitive_t {
                                      utils::one_of(src_md(2)->data_type, s8)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_BINARY(
-                    (is_ternary_op()
-                            && dnnl_memory_desc_equal(src_md(0), src_md(2))),
+                    IMPLICATION(is_ternary_op(),
+                            dnnl_memory_desc_equal(src_md(0), src_md(2))),
                     VERBOSE_INCONSISTENT_NDIMS, "src_0", "src_2");
             VDISPATCH_BINARY(
                     IMPLICATION(!attr()->scales_.has_default_values(),

--- a/src/gpu/intel/ocl/gen9_binary.hpp
+++ b/src/gpu/intel/ocl/gen9_binary.hpp
@@ -60,9 +60,8 @@ struct gen9_binary_t : public gpu_primitive_t {
                                     && utils::one_of(dst_md()->data_type, f16,
                                             f32, s8, u8, s32))),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_BINARY(
-                    (is_ternary_op()
-                            && utils::one_of(src_md(2)->data_type, s8, u8)),
+            VDISPATCH_BINARY(IMPLICATION(is_ternary_op(),
+                                     utils::one_of(src_md(2)->data_type, s8)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_BINARY(
                     (is_ternary_op()

--- a/src/gpu/intel/ocl/simple_binary.cl
+++ b/src/gpu/intel/ocl/simple_binary.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,12 +19,18 @@
 #if IS_TENSOR_OP && IS_DENSE && IS_SAME_MD && !WITH_BINARY_POST_OP
 KERNEL_ATTR
 __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
+#if IS_SELECT_BINARY
+        __global char *src2,
+#endif
         __global DST_DATA_T *dst POST_OP_ARGS, __global float *src0_scale,
         __global float *src1_scale) {
     int off = GWS_GET_IDX();
 
     float tmp_src0 = SRC0_TO_FLOAT(src0[off]);
     float tmp_src1 = SRC1_TO_FLOAT(src1[off]);
+#if IS_SELECT_BINARY
+    float tmp_src2 = SRC2_TO_FLOAT(src2[off]);
+#endif
     float d = 0;
 
 #if WITH_SRC0_SCALE
@@ -33,8 +39,11 @@ __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
 #if WITH_SRC1_SCALE
     tmp_src1 = tmp_src1 * (*src1_scale);
 #endif
-
+#if IS_SELECT_BINARY
+    d = ternary_op(BINARY_ALG, tmp_src0, tmp_src1, tmp_src2);
+#else
     d = binary_op(BINARY_ALG, tmp_src0, tmp_src1);
+#endif
 
     float dst_data;
 #if WITH_SUM
@@ -48,8 +57,12 @@ __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
 #else
 KERNEL_ATTR
 __kernel void simple_binary(__global SRC0_DATA_T *src0,
-        __global SRC1_DATA_T *src1, __global DST_DATA_T *dst POST_OP_ARGS,
-        __global float *src0_scale, __global float *src1_scale) {
+        __global SRC1_DATA_T *src1,
+#if IS_SELECT_BINARY
+        __global char *src2,
+#endif
+        __global DST_DATA_T *dst POST_OP_ARGS, __global float *src0_scale,
+        __global float *src1_scale) {
 
     // since gws = no. of total elems in A, id will be the logical offset
     int dims0[6] = {0};
@@ -63,7 +76,10 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
     int dims0_po[6]
             = {dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]};
     int d1_init = GWS_GET_D1();
-
+#if IS_SELECT_BINARY
+    int src2_off = SRC2_OFF(
+            dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
+#endif
     int dst_off = DST_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
 #if TENSOR_OP
@@ -71,6 +87,7 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
     int src1_off = SRC1_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
+
 #else
     int src0_off
             = SRC0_OFF(dims0[0] * !SRC0_BCAST_DIM0, dims0[1] * !SRC0_BCAST_DIM1,
@@ -98,6 +115,9 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
         for (int ic = 0; ic < block_size; ++ic) {
             float tmp_src0 = SRC0_TO_FLOAT(src0[src0_off]);
             float tmp_src1 = SRC1_TO_FLOAT(src1[src1_off]);
+#if IS_SELECT_BINARY
+            float tmp_src2 = SRC2_TO_FLOAT(src2[src2_off]);
+#endif
             float d = 0;
 
 #if WITH_SRC0_SCALE
@@ -106,7 +126,12 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
 #if WITH_SRC1_SCALE
             tmp_src1 = tmp_src1 * (*src1_scale);
 #endif
+
+#if IS_SELECT_BINARY
+            d = ternary_op(BINARY_ALG, tmp_src0, tmp_src1, tmp_src2);
+#else
             d = binary_op(BINARY_ALG, tmp_src0, tmp_src1);
+#endif
 
             float dst_data;
 #if WITH_SUM
@@ -133,6 +158,9 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
         for (int ic = 0; ic < DST_D1 - d1_init; ic++) {
             float tmp_src0 = SRC0_TO_FLOAT(src0[src0_off]);
             float tmp_src1 = SRC1_TO_FLOAT(src1[src1_off]);
+#if IS_SELECT_BINARY
+            float tmp_src2 = SRC2_TO_FLOAT(src2[src2_off]);
+#endif
             float d = 0;
 
 #if WITH_SRC0_SCALE
@@ -141,7 +169,12 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
 #if WITH_SRC1_SCALE
             tmp_src1 = tmp_src1 * (*src1_scale);
 #endif
+
+#if IS_SELECT_BINARY
+            d = ternary_op(BINARY_ALG, tmp_src0, tmp_src1, tmp_src2);
+#else
             d = binary_op(BINARY_ALG, tmp_src0, tmp_src1);
+#endif
 
             float dst_data;
 #if WITH_SUM

--- a/src/gpu/intel/ocl/simple_binary.cl
+++ b/src/gpu/intel/ocl/simple_binary.cl
@@ -76,10 +76,7 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
     int dims0_po[6]
             = {dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]};
     int d1_init = GWS_GET_D1();
-#if IS_TERNARY
-    int src2_off = SRC2_OFF(
-            dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
-#endif
+
     int dst_off = DST_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
 #if TENSOR_OP
@@ -87,6 +84,11 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
     int src1_off = SRC1_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
+
+#if IS_TERNARY
+    int src2_off = SRC2_OFF(
+            dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
+#endif
 
 #else
     int src0_off
@@ -97,6 +99,13 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
             = SRC1_OFF(dims0[0] * !SRC1_BCAST_DIM0, dims0[1] * !SRC1_BCAST_DIM1,
                     dims0[2] * !SRC1_BCAST_DIM2, dims0[3] * !SRC1_BCAST_DIM3,
                     dims0[4] * !SRC1_BCAST_DIM4, dims0[5] * !SRC1_BCAST_DIM5);
+#if IS_TERNARY
+    int src2_off
+            = SRC0_OFF(dims0[0] * !SRC0_BCAST_DIM0, dims0[1] * !SRC0_BCAST_DIM1,
+                    dims0[2] * !SRC0_BCAST_DIM2, dims0[3] * !SRC0_BCAST_DIM3,
+                    dims0[4] * !SRC0_BCAST_DIM4, dims0[5] * !SRC0_BCAST_DIM5);
+#endif
+
 #endif
 
     // SRC1_D1 = IC for SRC1, using the dispatch ap

--- a/src/gpu/intel/ocl/simple_binary.cl
+++ b/src/gpu/intel/ocl/simple_binary.cl
@@ -19,7 +19,7 @@
 #if IS_TENSOR_OP && IS_DENSE && IS_SAME_MD && !WITH_BINARY_POST_OP
 KERNEL_ATTR
 __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
-#if IS_SELECT_BINARY
+#if IS_TERNARY
         __global char *src2,
 #endif
         __global DST_DATA_T *dst POST_OP_ARGS, __global float *src0_scale,
@@ -28,8 +28,8 @@ __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
 
     float tmp_src0 = SRC0_TO_FLOAT(src0[off]);
     float tmp_src1 = SRC1_TO_FLOAT(src1[off]);
-#if IS_SELECT_BINARY
-    float tmp_src2 = SRC2_TO_FLOAT(src2[off]);
+#if IS_TERNARY
+    char tmp_src2 = src2[off];
 #endif
     float d = 0;
 
@@ -39,7 +39,7 @@ __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
 #if WITH_SRC1_SCALE
     tmp_src1 = tmp_src1 * (*src1_scale);
 #endif
-#if IS_SELECT_BINARY
+#if IS_TERNARY
     d = ternary_op(BINARY_ALG, tmp_src0, tmp_src1, tmp_src2);
 #else
     d = binary_op(BINARY_ALG, tmp_src0, tmp_src1);
@@ -58,7 +58,7 @@ __kernel void simple_binary(__global DATA_T *src0, __global DATA_T *src1,
 KERNEL_ATTR
 __kernel void simple_binary(__global SRC0_DATA_T *src0,
         __global SRC1_DATA_T *src1,
-#if IS_SELECT_BINARY
+#if IS_TERNARY
         __global char *src2,
 #endif
         __global DST_DATA_T *dst POST_OP_ARGS, __global float *src0_scale,
@@ -76,7 +76,7 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
     int dims0_po[6]
             = {dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]};
     int d1_init = GWS_GET_D1();
-#if IS_SELECT_BINARY
+#if IS_TERNARY
     int src2_off = SRC2_OFF(
             dims0[0], dims0[1], dims0[2], dims0[3], dims0[4], dims0[5]);
 #endif
@@ -115,8 +115,8 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
         for (int ic = 0; ic < block_size; ++ic) {
             float tmp_src0 = SRC0_TO_FLOAT(src0[src0_off]);
             float tmp_src1 = SRC1_TO_FLOAT(src1[src1_off]);
-#if IS_SELECT_BINARY
-            float tmp_src2 = SRC2_TO_FLOAT(src2[src2_off]);
+#if IS_TERNARY
+            char tmp_src2 = src2[src2_off];
 #endif
             float d = 0;
 
@@ -127,7 +127,7 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
             tmp_src1 = tmp_src1 * (*src1_scale);
 #endif
 
-#if IS_SELECT_BINARY
+#if IS_TERNARY
             d = ternary_op(BINARY_ALG, tmp_src0, tmp_src1, tmp_src2);
 #else
             d = binary_op(BINARY_ALG, tmp_src0, tmp_src1);
@@ -158,8 +158,8 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
         for (int ic = 0; ic < DST_D1 - d1_init; ic++) {
             float tmp_src0 = SRC0_TO_FLOAT(src0[src0_off]);
             float tmp_src1 = SRC1_TO_FLOAT(src1[src1_off]);
-#if IS_SELECT_BINARY
-            float tmp_src2 = SRC2_TO_FLOAT(src2[src2_off]);
+#if IS_TERNARY
+            char tmp_src2 = src2[src2_off];
 #endif
             float d = 0;
 
@@ -170,7 +170,7 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
             tmp_src1 = tmp_src1 * (*src1_scale);
 #endif
 
-#if IS_SELECT_BINARY
+#if IS_TERNARY
             d = ternary_op(BINARY_ALG, tmp_src0, tmp_src1, tmp_src2);
 #else
             d = binary_op(BINARY_ALG, tmp_src0, tmp_src1);

--- a/src/gpu/intel/ocl/simple_binary.cpp
+++ b/src/gpu/intel/ocl/simple_binary.cpp
@@ -121,7 +121,7 @@ status_t simple_binary_t::pd_t::init_kernel_ctx(
     def_binary_alg_kinds(kernel_ctx);
     kernel_ctx.define_int("BINARY_ALG", conf.alg);
     kernel_ctx.define_int(
-            "IS_SELECT_BINARY", (conf.alg == dnnl_binary_select) ? 1 : 0);
+            "IS_TERNARY", (conf.alg == alg_kind::binary_select) ? 1 : 0);
 
     kernel_ctx.set_data_type(conf.src0_data_type);
     kernel_ctx.set_data_type(conf.src1_data_type);
@@ -156,7 +156,7 @@ status_t simple_binary_t::pd_t::init_kernel_ctx(
     def_memory_desc_info(kernel_ctx, conf.src1_md_info, "SRC1");
     def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");
 
-    if (conf.alg == dnnl_binary_select) {
+    if (conf.alg == alg_kind::binary_select) {
         def_memory_desc_info(kernel_ctx, conf.src2_md_info, "SRC2");
     }
 

--- a/src/gpu/intel/ocl/simple_binary.cpp
+++ b/src/gpu/intel/ocl/simple_binary.cpp
@@ -27,8 +27,6 @@ status_t simple_binary_t::pd_t::init_conf(impl::engine_t *engine) {
     const memory_desc_wrapper src0_d(src_md(0));
     const memory_desc_wrapper src1_d(src_md(1));
     const memory_desc_wrapper dst_d(dst_md());
-    const memory_desc_wrapper src2_d
-            = is_ternary_op() ? memory_desc_wrapper(src_md(2)) : nullptr;
 
     const int ndims = src0_d.ndims();
     conf.src0_md_info = memory_desc_info_t::create(src0_d);
@@ -36,6 +34,7 @@ status_t simple_binary_t::pd_t::init_conf(impl::engine_t *engine) {
     conf.dst_md_info = memory_desc_info_t::create(dst_d);
 
     if (is_ternary_op()) {
+        const memory_desc_wrapper src2_d(src_md(2));
         conf.src2_md_info = memory_desc_info_t::create(src2_d);
         conf.src2_data_type = src2_d.data_type();
     } else {
@@ -120,8 +119,7 @@ status_t simple_binary_t::pd_t::init_kernel_ctx(
         compute::kernel_ctx_t &kernel_ctx) const {
     def_binary_alg_kinds(kernel_ctx);
     kernel_ctx.define_int("BINARY_ALG", conf.alg);
-    kernel_ctx.define_int(
-            "IS_TERNARY", (conf.alg == alg_kind::binary_select) ? 1 : 0);
+    kernel_ctx.define_int("IS_TERNARY", (conf.alg == alg_kind::binary_select));
 
     kernel_ctx.set_data_type(conf.src0_data_type);
     kernel_ctx.set_data_type(conf.src1_data_type);
@@ -180,25 +178,19 @@ status_t simple_binary_t::execute_simple(const exec_ctx_t &ctx) const {
     const auto &conf = pd()->conf;
 
     auto &src0_scale = CTX_IN_STORAGE(DNNL_ARG_SRC_0 | DNNL_ARG_ATTR_SCALES);
-
     auto &src1_scale = CTX_IN_STORAGE(DNNL_ARG_SRC_1 | DNNL_ARG_ATTR_SCALES);
 
-    unsigned arg_idx;
+    unsigned arg_idx = 0;
     compute::kernel_arg_list_t arg_list;
-    arg_list.set(0, src0);
-    arg_list.set(1, src1);
-
+    arg_list.set(arg_idx++, src0);
+    arg_list.set(arg_idx++, src1);
     if (pd()->is_ternary_op()) {
         auto &src2 = CTX_IN_STORAGE(DNNL_ARG_SRC_2);
-        arg_list.set(2, src2);
-        arg_list.set(3, dst);
-        arg_idx = append_post_ops_to_arg_list(
-                ctx, arg_list, 4, pd()->attr()->post_ops_);
-    } else {
-        arg_list.set(2, dst);
-        arg_idx = append_post_ops_to_arg_list(
-                ctx, arg_list, 3, pd()->attr()->post_ops_);
+        arg_list.set(arg_idx++, src2);
     }
+    arg_list.set(arg_idx++, dst);
+    arg_idx = append_post_ops_to_arg_list(
+            ctx, arg_list, arg_idx, pd()->attr()->post_ops_);
 
     arg_list.set(arg_idx++, src0_scale);
     arg_list.set(arg_idx, src1_scale);

--- a/src/gpu/intel/ocl/simple_binary.hpp
+++ b/src/gpu/intel/ocl/simple_binary.hpp
@@ -62,7 +62,6 @@ struct simple_binary_t : public gpu_primitive_t {
                                     && src_md(1)->data_type == f32
                                     && dst_md()->data_type == bf16)),
                     VERBOSE_UNSUPPORTED_DT);
-
             VDISPATCH_BINARY(IMPLICATION(is_ternary_op(),
                                      utils::one_of(src_md(2)->data_type, s8)),
                     VERBOSE_UNSUPPORTED_DT);

--- a/src/gpu/intel/ocl/simple_binary.hpp
+++ b/src/gpu/intel/ocl/simple_binary.hpp
@@ -64,10 +64,12 @@ struct simple_binary_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_DT);
 
             VDISPATCH_BINARY(
+                    (is_ternary_op()
+                            && utils::one_of(src_md(2)->data_type, s8, u8)),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_BINARY(
                     !memory_desc_ndims_ok(src_md(0), src_md(1), dst_md()),
-                    VERBOSE_INCONSISTENT_NDIMS, "src", "dst");
-
-            VDISPATCH_BINARY(!is_ternary_op(), VERBOSE_BAD_ALGORITHM);
+                    VERBOSE_INCONSISTENT_NDIMS, "src_0", "dst");
 
             VDISPATCH_BINARY(IMPLICATION(!attr()->scales_.has_default_values(),
                                      check_scales_mask()),

--- a/src/gpu/intel/ocl/simple_binary.hpp
+++ b/src/gpu/intel/ocl/simple_binary.hpp
@@ -63,9 +63,8 @@ struct simple_binary_t : public gpu_primitive_t {
                                     && dst_md()->data_type == bf16)),
                     VERBOSE_UNSUPPORTED_DT);
 
-            VDISPATCH_BINARY(
-                    (is_ternary_op()
-                            && utils::one_of(src_md(2)->data_type, s8, u8)),
+            VDISPATCH_BINARY(IMPLICATION(is_ternary_op(),
+                                     utils::one_of(src_md(2)->data_type, s8)),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_BINARY(
                     !memory_desc_ndims_ok(src_md(0), src_md(1), dst_md()),

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -415,6 +415,7 @@ struct binary_conf_t {
     bool isXa16b;
     data_type_t src0_data_type;
     data_type_t src1_data_type;
+    data_type_t src2_data_type;
     data_type_t dst_data_type;
     alg_kind_t alg;
     // bool is_ne;
@@ -434,6 +435,7 @@ struct binary_conf_t {
 
     memory_desc_info_t src0_md_info;
     memory_desc_info_t src1_md_info;
+    memory_desc_info_t src2_md_info;
     memory_desc_info_t dst_md_info;
 
     attr_info_t attr_info;

--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -140,12 +140,6 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             res->reason = skip_reason::data_type_not_supported;
             return;
         }
-
-        if (prb->is_ternary_op()) {
-            res->state = SKIPPED;
-            res->reason = skip_reason::case_not_supported;
-            return;
-        }
     }
 }
 


### PR DESCRIPTION
# Description

Currently the select algorithm for the binary primitive is only supported on CPU. This PR introduces initial ternary op support for ref gpu binary kernels. 

$$dst[i] = src_2[i] ? src_0[i] : src_1[i]$$

[MFDNN-13247](https://jira.devtools.intel.com/browse/MFDNN-13247)
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
