### PR TITLE
benchdnn: inputs: graph: add more cases using f32 intermediate

### DIFF
--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -12,13 +12,30 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
+
 # f16 inputs + f32 intermediates + f16 outputs
 --reset --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 --reset --dt=1:f16+2:f16+3:f16+4:f16+6:f16+104:f16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
+--reset --dt=4:f32+9:f32+14:f32 --case=complex_fusion/mha/GQA-fp16-v2.json
+--reset --dt=4:f32+9:f32+14:f32 --case=complex_fusion/mha/GQA-fp16.json
+--reset --dt=3:f16+4:f16+2:f16+1:f16+11:f16+0:f16+12:f16+14:f16+16:f16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
+--reset --dt=0:f16+1:f16+3:f16+7:f16+2:f16+8:f16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
+--reset --dt=15:f32+16:f32+5:f32+21:f32 --case=complex_fusion/mha/sdpa-compressed-kv-implicit-causal-mask-int8-gs128.json
+--reset --dt=2:f32+4:f32+6:f32 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
+--reset --dt=2:f32+5:f32 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
+--reset --dt=2:f32+6:f32 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+--reset --dt=3:bf16+4:bf16+2:bf16+1:bf16+11:bf16+0:bf16+12:bf16+14:bf16+16:bf16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
+--reset --dt=4:f32+9:f32+14:f32+1:bf16+3:bf16+8:bf16+11:bf16+16:bf16+20:bf16+19:bf16 --case=complex_fusion/mha/GQA-fp16-v2.json
+--reset --dt=4:f32+9:f32+14:f32+0:bf16+1:bf16+2:bf16+3:bf16+11:bf16+12:bf16+18:bf16+19:bf16+8:bf16+16:bf16+20:bf16+23:bf16 --case=complex_fusion/mha/GQA-fp16.json
+--reset --dt=0:bf16+1:bf16+3:bf16+7:bf16+2:bf16+8:bf16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
 --reset --dt=1:bf16+2:bf16+3:bf16+4:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
+--reset --dt=2:f32+4:f32+6:f32+0:bf16+1:bf16+3:bf16+5:bf16+7:bf16+8:bf16+9:bf16 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
+--reset --dt=2:f32+5:f32+0:bf16+1:bf16+4:bf16+7:bf16+9:bf16+10:bf16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
+--reset --dt=2:f32+6:f32+0:bf16+1:bf16+5:bf16+7:bf16+8:bf16+9:bf16  --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
+
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -14,9 +14,11 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
 # f16 inputs + f32 intermediates + f16 outputs
 --reset --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+--reset --dt=4:f32+9:f32+14:f32 --case=complex_fusion/mha/GQA-fp16-v2.json
+
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
-
+--reset --dt=4:f32+9:f32+14:f32+1:bf16+3:bf16+8:bf16+11:bf16+16:bf16+20:bf16+19:bf16 --case=complex_fusion/mha/GQA-fp16-v2.json
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json


### PR DESCRIPTION
## General

A follow-up task of [PR#2894](https://github.com/uxlfoundation/oneDNN/pull/2894
) which fixed the intermediate datatypes in SDPA patterns of Graph API. This PR adds more test cases with f32 intermediate data types. As we need to support both f16/bf16 computation, the cases are added through `--dt` knob rather than new JSON files.

The next step might be enhancing the dt rewrite mechanism to support larger coverage.