### PR TITLE
[rls-v3.8] xe: sdpa: Add support for bottom right causal mask type

### DIFF
--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -746,7 +746,7 @@ size_t get_desc_hash(const sdpa_desc_t &desc) {
     seed = hash_combine(seed, static_cast<size_t>(desc.scale_dt));
     seed = hash_combine(seed, desc.invert_scale);
     seed = hash_combine(seed, desc.kv_head_number);
-    seed = hash_combine(seed, desc.causal_mask);
+    seed = hash_combine(seed, static_cast<size_t>(desc.mask_type));
     // Combined hash for sdpa desc
     return seed;
 }

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -588,7 +588,7 @@ void serialize(serialization_stream_t &sstream, const sdpa_desc_t &desc) {
     sstream.append(desc.scale_dt);
     sstream.append(desc.invert_scale);
     sstream.append(desc.kv_head_number);
-    sstream.append(desc.causal_mask);
+    sstream.append(desc.mask_type);
 }
 
 } // namespace impl

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -110,8 +110,11 @@ struct sdpa_pd_t : public primitive_desc_t {
         return (attn_mask_md()->data_type != data_type::undef);
     }
 
-    /// If true, the attention mask is causal mask
-    bool with_causal_mask() const { return desc_.causal_mask; }
+    /// If true, the attention mask is a causal mask
+    bool with_causal_mask() const {
+        return desc_.mask_type == attn_mask_type::top_left
+                || desc_.mask_type == attn_mask_type::bottom_right;
+    }
 
     /// If true, dequantize the K tensor using scaling in the KQ matmul
     bool with_key_scales() const {

--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -29,7 +29,7 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         const_dnnl_memory_desc_t query_desc, const_dnnl_memory_desc_t key_desc,
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
         const_dnnl_memory_desc_t mask_desc, dnnl_data_type_t scale_dt,
-        bool invert_scale, dnnl_dim_t kv_head_number, bool causal_mask,
+        bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
         const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
         const_dnnl_primitive_attr_t vs_attr) {
     CHECK(sdpa_desc_check(query_desc, key_desc, value_desc, dst_desc, mask_desc,
@@ -40,7 +40,7 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
     dnnl::impl::sdpa_desc_t sdpa_desc = dnnl::impl::create_sdpa_desc(query_desc,
             key_desc, value_desc, dst_desc, mask_desc,
             (dnnl::impl::data_type_t)scale_dt, invert_scale, kv_head_number,
-            causal_mask, kq_attr, vs_attr);
+            static_cast<attn_mask_type_t>(attn_mask_type), kq_attr, vs_attr);
     return dnnl::impl::primitive_desc_create(primitive_desc_iface, engine,
             (const dnnl::impl::op_desc_t *)&sdpa_desc, nullptr, attr);
 }

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -33,6 +33,31 @@ namespace impl {
 #define DNNL_ARG_VALUES DNNL_ARG_SRC_2
 #define DNNL_ARG_ATTN_MASK DNNL_ARG_SHIFT
 
+// NOLINTBEGIN(modernize-use-using)
+/// Types of attention mask
+typedef enum {
+    dnnl_attn_mask_undef = 0,
+    /// explicit attention masks defined in a buffer
+    dnnl_attn_mask_buffer = 1,
+
+    /// causal mask with the diagonal starting from the top left hand side of
+    /// the mask tensor
+    dnnl_attn_mask_top_left = 2,
+
+    /// causal mask with the diagonal starting from the bottom right hand side
+    /// of the mask tensor
+    dnnl_attn_mask_bottom_right = 3,
+} dnnl_attn_mask_type_t;
+// NOLINTEND(modernize-use-using)
+
+using attn_mask_type_t = dnnl_attn_mask_type_t;
+namespace attn_mask_type {
+const attn_mask_type_t undef = dnnl_attn_mask_undef;
+const attn_mask_type_t buffer = dnnl_attn_mask_buffer;
+const attn_mask_type_t top_left = dnnl_attn_mask_top_left;
+const attn_mask_type_t bottom_right = dnnl_attn_mask_bottom_right;
+} // namespace attn_mask_type
+
 // A descriptor for a scaled dot product attention (SDPA) operation.
 struct sdpa_desc_t : public op_desc_t {
     sdpa_desc_t() : op_desc_t(primitive_kind::sdpa) {}
@@ -60,9 +85,7 @@ struct sdpa_desc_t : public op_desc_t {
     bool invert_scale {};
     dim_t kv_head_number {};
 
-    // causal_mask = false: use mask descriptor
-    // causal_mask = true: causal mask used. mask descriptor not used
-    bool causal_mask {};
+    attn_mask_type_t mask_type = attn_mask_type::undef;
 
     // Number of queries.
     dnnl_dim_t queries() const { return q_desc.dims[q_desc.ndims - 2]; }

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -136,7 +136,7 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
         const memory_desc_t *k_md, const memory_desc_t *v_md,
         const memory_desc_t *dst_md, const memory_desc_t *attn_mask_md,
         data_type_t scale_dt, bool invert_scale, dim_t kv_head_number,
-        bool causal_mask, const primitive_attr_t *kq_attr,
+        attn_mask_type_t attn_mask_type, const primitive_attr_t *kq_attr,
         const primitive_attr_t *vs_attr) {
     auto sdpa_desc = sdpa_desc_t();
     sdpa_desc.primitive_kind = primitive_kind::sdpa;
@@ -156,7 +156,7 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     sdpa_desc.scale_dt = scale_dt;
     sdpa_desc.invert_scale = invert_scale;
     sdpa_desc.kv_head_number = kv_head_number;
-    sdpa_desc.causal_mask = causal_mask;
+    sdpa_desc.mask_type = attn_mask_type;
     return sdpa_desc;
 }
 
@@ -165,15 +165,16 @@ static inline status_t create_sdpa_pd(
         const memory_desc_t *q_md, const memory_desc_t *k_md,
         const memory_desc_t *v_md, const memory_desc_t *dst_md,
         const memory_desc_t *attn_mask_md, data_type_t scale_dt,
-        bool invert_scale, dim_t kv_head_number, bool causal_mask,
-        const primitive_attr_t *attr, const primitive_attr_t *kq_attr = nullptr,
+        bool invert_scale, dim_t kv_head_number,
+        attn_mask_type_t attn_mask_type, const primitive_attr_t *attr,
+        const primitive_attr_t *kq_attr = nullptr,
         const primitive_attr_t *vs_attr = nullptr) {
     CHECK(sdpa_attr_check(q_md, k_md, v_md, engine, attr, kq_attr, vs_attr));
     CHECK(sdpa_desc_check(q_md, k_md, v_md, dst_md, attn_mask_md, engine, attr,
             kq_attr, vs_attr));
 
     auto sdpa_desc = create_sdpa_desc(q_md, k_md, v_md, dst_md, attn_mask_md,
-            scale_dt, invert_scale, kv_head_number, causal_mask, kq_attr,
+            scale_dt, invert_scale, kv_head_number, attn_mask_type, kq_attr,
             vs_attr);
 
     primitive_attr_t sdpa_attr = attr ? *attr : default_attr();

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -984,7 +984,7 @@ inline bool operator==(const sdpa_desc_t &lhs, const sdpa_desc_t &rhs) {
             && COMPARE_DESC_MEMBERS(scale_dt)
             && COMPARE_DESC_MEMBERS(invert_scale)
             && COMPARE_DESC_MEMBERS(kv_head_number)
-            && COMPARE_DESC_MEMBERS(causal_mask);
+            && COMPARE_DESC_MEMBERS(mask_type);
     return ret;
 }
 

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1592,7 +1592,10 @@ std::string init_info_sdpa(const engine_t *e, const pd_t *pd) {
         ss << ",msk:" << pd->attn_mask_md()->data_type << ":"
            << md2dim_str(pd->attn_mask_md());
     } else if (pd->with_causal_mask()) {
-        ss << ",msk:causal";
+        if (desc->mask_type == attn_mask_type::top_left)
+            ss << ",msk:causal:top_left";
+        else
+            ss << ",msk:causal:bottom_right";
     }
 
     return ss.str();

--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -33,12 +33,6 @@
 #define sg_per_wg (ugemm_kq_sg_per_wg_m * ugemm_kq_sg_per_wg_n)
 #define q_tile_sg_n DIV_UP(ugemm_kq_wg_tile_n, sg_per_wg)
 
-typedef enum {
-    dnnl_attn_mask_buffer,
-    dnnl_attn_mask_top_left,
-    dnnl_attn_mask_bottom_right
-} dnnl_attn_mask_type_t;
-
 /* Instantiate tile types and operations */
 typedef ugemm_kq_c_type s_tile_type;
 typedef ugemm_vs_c_type a_tile_type;
@@ -211,8 +205,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         const global KEY_ATTR_SCALES_DATA_T *K_scales,
         const global KEY_ATTR_ZP_DATA_T *K_zp,
         const global VAL_ATTR_SCALES_DATA_T *V_scales,
-        const global VAL_ATTR_ZP_DATA_T *V_zp,
-        const dnnl_attn_mask_type_t attn_mask_type
+        const global VAL_ATTR_ZP_DATA_T *V_zp, const int attn_mask_type
 #if WITH_ATTN_MASK
         ,
         const global MSK_DATA_T *msk
@@ -486,7 +479,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #define less_than(offset_k, offset_q) (offset_q < offset_k)
 
         int col_offset = wg_j0 + sg_j0_kq;
-        if (attn_mask_type == dnnl_attn_mask_bottom_right) col_offset += k - q;
+        if (attn_mask_type == ATTN_MASK_BOTTOM_RIGHT) col_offset += k - q;
 
         /* Apply causal mask */
         tile_predicated_assignment_t(S_tile, k0 + sg_i0_kq, col_offset,

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -453,6 +453,11 @@ status_t micro_sdpa_t::init(impl::engine_t *engine) {
     def_data_type(kernel_ctx, d->scale_dt, "SCALE");
     kernel_ctx.define_int("INVERT_SCALE", d->invert_scale);
     kernel_ctx.define_int("WITH_ATTN_SCALE", pd()->with_attn_scale());
+    kernel_ctx.define_int("ATTN_MASK_UNDEF", attn_mask_type::undef);
+    kernel_ctx.define_int("ATTN_MASK_BUFFER", attn_mask_type::buffer);
+    kernel_ctx.define_int("ATTN_MASK_TOP_LEFT", attn_mask_type::top_left);
+    kernel_ctx.define_int(
+            "ATTN_MASK_BOTTOM_RIGHT", attn_mask_type::bottom_right);
 
     kernel_ctx.define_int("WITH_ATTN_MASK",
             pd()->with_attn_mask() && !pd()->with_causal_mask());

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -547,20 +547,20 @@ status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
 
     int mask_type = static_cast<int>(pd()->desc()->mask_type);
     compute::kernel_arg_list_t arg_list;
-    arg_list.set(0, key);
-    arg_list.set(1, qry);
-    arg_list.set(2, val);
-    arg_list.set(3, dst);
-    arg_list.set(4, scale);
-    arg_list.set(5, (int)D);
-    arg_list.set(6, (int)K);
-    arg_list.set(7, (int)Q);
-    arg_list.set(8, key_scales);
-    arg_list.set(9, key_zp);
-    arg_list.set(10, value_scales);
-    arg_list.set(11, value_zp);
-    arg_list.set(12, mask_type);
-    if (pd()->with_attn_mask()) arg_list.set(13, attn_mask);
+    arg_list.append(key);
+    arg_list.append(qry);
+    arg_list.append(val);
+    arg_list.append(dst);
+    arg_list.append(scale);
+    arg_list.append((int)D);
+    arg_list.append((int)K);
+    arg_list.append((int)Q);
+    arg_list.append(key_scales);
+    arg_list.append(key_zp);
+    arg_list.append(value_scales);
+    arg_list.append(value_zp);
+    arg_list.append(mask_type);
+    if (pd()->with_attn_mask()) arg_list.append(attn_mask);
 
     compute::range_t lws = {(size_t)pd()->sg_size(), (size_t)sg_per_wg, 1};
     compute::range_t gws = lws;

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -545,6 +545,7 @@ status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
     auto sg_per_wg = gemm_kq.getSetting("sg_per_wg_m")
             * gemm_kq.getSetting("sg_per_wg_n");
 
+    int mask_type = static_cast<int>(pd()->desc()->mask_type);
     compute::kernel_arg_list_t arg_list;
     arg_list.set(0, key);
     arg_list.set(1, qry);
@@ -558,7 +559,8 @@ status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
     arg_list.set(9, key_zp);
     arg_list.set(10, value_scales);
     arg_list.set(11, value_zp);
-    if (pd()->with_attn_mask()) arg_list.set(12, attn_mask);
+    arg_list.set(12, mask_type);
+    if (pd()->with_attn_mask()) arg_list.set(13, attn_mask);
 
     compute::range_t lws = {(size_t)pd()->sg_size(), (size_t)sg_per_wg, 1};
     compute::range_t gws = lws;

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -363,8 +363,9 @@ status_t sdp_primitive_config_t::init(std::shared_ptr<subgraph_t> &sg,
 
     CHECK(create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(), md_k.get(),
             md_v.get(), md_dst.get(), md_mask.get(), scale_dt, invert_scale_,
-            kv_head_number_, causal_mask_, attr.get(), qk_attr.get(),
-            vs_attr.get()));
+            kv_head_number_,
+            causal_mask_ ? attn_mask_type::top_left : attn_mask_type::buffer,
+            attr.get(), qk_attr.get(), vs_attr.get()));
 
     auto status = sdpa_pd_->create_primitive(sdpa_prim_, p_engine.get());
 

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -2746,7 +2746,10 @@ struct sdpa_executable_t : public op_executable_t {
                 = op->get_input_value(1)->get_logical_tensor().dims[1];
         status_t s = create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(),
                 md_k.get(), md_v.get(), md_dst.get(), md_mask.get(), scale_dt,
-                is_invert_scale_, kv_head_number, is_causal_mask_, attr.get());
+                is_invert_scale_, kv_head_number,
+                is_causal_mask_ ? attn_mask_type::top_left
+                                : attn_mask_type::buffer,
+                attr.get());
         if (s != dnnl::impl::status::success) {
             is_initialized_ = false;
         } else {

--- a/tests/gtests/internals/sdpa_internal.hpp
+++ b/tests/gtests/internals/sdpa_internal.hpp
@@ -41,7 +41,7 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         const_dnnl_memory_desc_t query_desc, const_dnnl_memory_desc_t key_desc,
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
         const_dnnl_memory_desc_t mask_desc, dnnl_data_type_t scale_dt,
-        bool invert_scale, dnnl_dim_t kv_head_number, bool causal_mask,
+        bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
         const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
         const_dnnl_primitive_attr_t vs_attr);
 
@@ -60,7 +60,7 @@ struct sdpa : public dnnl::primitive {
                 const memory::desc &key_desc, const memory::desc &value_desc,
                 const memory::desc *attn_mask_desc, memory::data_type scale_dt,
                 const memory::desc &output_desc, bool invert_scale,
-                memory::dim kv_head_number, bool causal_mask,
+                memory::dim kv_head_number, int attn_mask_type,
                 const primitive_attr &attr = default_attr(),
                 const primitive_attr &kq_attr = default_attr(),
                 const primitive_attr &vs_attr = default_attr()) {
@@ -70,7 +70,7 @@ struct sdpa : public dnnl::primitive {
                     aengine.get(), query_desc.get(), key_desc.get(),
                     value_desc.get(), output_desc.get(),
                     optional_arg(attn_mask_desc), (dnnl_data_type_t)scale_dt,
-                    invert_scale, kv_head_number, causal_mask, attr.get(),
+                    invert_scale, kv_head_number, attn_mask_type, attr.get(),
                     kq_attr.get(), vs_attr.get());
 
             dnnl::error::wrap_c_api(status,


### PR DESCRIPTION
# Description

Backport of #3012

This PR adds support for the bottom right causal mask for the SDPA micro kernel.

Fixes: https://jira.devtools.intel.com/browse/MFDNN-13388