### PR TITLE
cmake, doc: add GROUP_NORMALIZATION value for ONEDNN_ENABLE_PRIMITIVE

### DIFF
--- a/cmake/configuring_primitive_list.cmake
+++ b/cmake/configuring_primitive_list.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2021-2024 Intel Corporation
+# Copyright 2021-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ else()
     foreach(impl ${DNNL_ENABLE_PRIMITIVE})
         string(TOUPPER ${impl} uimpl)
         if(NOT "${uimpl}" MATCHES
-                "^(BATCH_NORMALIZATION|BINARY|CONCAT|CONVOLUTION|DECONVOLUTION|ELTWISE|INNER_PRODUCT|LAYER_NORMALIZATION|LRN|MATMUL|POOLING|PRELU|REDUCTION|REORDER|RESAMPLING|RNN|SDPA|SHUFFLE|SOFTMAX|SUM)$")
+                "^(BATCH_NORMALIZATION|BINARY|CONCAT|CONVOLUTION|DECONVOLUTION|ELTWISE|GROUP_NORMALIZATION|INNER_PRODUCT|LAYER_NORMALIZATION|LRN|MATMUL|POOLING|PRELU|REDUCTION|REORDER|RESAMPLING|RNN|SDPA|SHUFFLE|SOFTMAX|SUM)$")
             message(FATAL_ERROR "Unsupported primitive: ${uimpl}")
         endif()
         set(BUILD_${uimpl} TRUE)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -122,9 +122,9 @@ set(DNNL_ENABLE_PRIMITIVE "ALL" CACHE STRING
     - ALL (the default). Includes all primitives to be enabled.
     - <PRIMITIVE_NAME>. Includes only the selected primitive to be enabled.
       Possible values are: BATCH_NORMALIZATION, BINARY, CONCAT, CONVOLUTION,
-      DECONVOLUTION, ELTWISE, INNER_PRODUCT, LAYER_NORMALIZATION, LRN, MATMUL,
-      POOLING, PRELU, REDUCTION, REORDER, RESAMPLING, RNN, SDPA, SHUFFLE,
-      SOFTMAX, SUM.
+      DECONVOLUTION, ELTWISE, GROUP_NORMALIZATION, INNER_PRODUCT,
+      LAYER_NORMALIZATION, LRN, MATMUL, POOLING, PRELU, REDUCTION, REORDER,
+      RESAMPLING, RNN, SDPA, SHUFFLE, SOFTMAX, SUM.
     - <PRIMITIVE_NAME>;<PRIMITIVE_NAME>;... Includes only selected primitives to
       be enabled at build time. This is treated as CMake string, thus, semicolon
       is a mandatory delimiter between names. This is the way to specify several

--- a/doc/build/build_options.md
+++ b/doc/build/build_options.md
@@ -86,14 +86,14 @@ dependencies for forward propagation kind part.
 #### ONEDNN_ENABLE_PRIMITIVE
 This option supports several values: `ALL` (the default) which enables all
 primitives implementations or a set of `BATCH_NORMALIZATION`, `BINARY`,
-`CONCAT`, `CONVOLUTION`, `DECONVOLUTION`, `ELTWISE`, `INNER_PRODUCT`,
-`LAYER_NORMALIZATION`, `LRN`, `MATMUL`, `POOLING`, `PRELU`, `REDUCTION`,
-`REORDER`, `RESAMPLING`, `RNN`, `SDPA`, `SHUFFLE`, `SOFTMAX`, `SUM`. When a set
-is used, only those selected primitives implementations will be available.
-Attempting to use other primitive implementations will end up returning an
-unimplemented status when creating primitive descriptor. In order to specify a
-set, a CMake-style string should be used, with semicolon delimiters, as in this
-example:
+`CONCAT`, `CONVOLUTION`, `DECONVOLUTION`, `ELTWISE`, `GROUP_NORMALIZATION`,
+`INNER_PRODUCT`, `LAYER_NORMALIZATION`, `LRN`, `MATMUL`, `POOLING`, `PRELU`,
+`REDUCTION`, `REORDER`, `RESAMPLING`, `RNN`, `SDPA`, `SHUFFLE`, `SOFTMAX`,
+`SUM`. When a set is used, only those selected primitives implementations will
+be available. Attempting to use other primitive implementations will end up
+returning an unimplemented status when creating primitive descriptor. In order
+to specify a set, a CMake-style string should be used, with semicolon
+delimiters, as in this example:
 ```
 -DONEDNN_ENABLE_PRIMITIVE=CONVOLUTION;MATMUL;REORDER
 ```


### PR DESCRIPTION
Internally implementation for `BUILD_GROUP_NORMALIZATION`/`REG_GNORM_P` already exists, however related value for the build option `ONEDNN_ENABLE_PRIMITIVE` was missing, so adding into cmake and updating documentation.

(passed local testing w -DONEDNN_ENABLE_PRIMITIVE="REORDER;GROUP_NORMALIZATION" and `./build/tests/benchdnn/benchdnn --gnorm --batch=test_gnorm_ci`)

Addresses MFDNN-12937.
