### PR TITLE
xe: conv: avoid reorder with NCHW when possible

### DIFF
--- a/src/gpu/intel/jit/conv/problem.hpp
+++ b/src/gpu/intel/jit/conv/problem.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "common/c_types_map.hpp"
+#include "common/convolution_pd.hpp"
 #include "gpu/intel/jit/ir/problem.hpp"
 
 namespace dnnl {
@@ -296,6 +297,16 @@ inline pvar_t to_gemm(const pvar_t &d, const conv_problem_t &prb) {
 inline pvar_tile_t to_gemm(const pvar_tile_t &t, const conv_problem_t &prb) {
     return to_gemm(t, prb.prop_kind(), prb.ab_swap_transpose);
 }
+
+// Matches the user-provided descriptor against the list of supported plain tags.
+std::string get_plain_user_tag(
+        const conv_problem_t &prb, const memory_desc_t &md, bool is_wei);
+
+// Checks if using NCHW layout for activations is optimal, this is dependent on:
+// - Whether the user-side layout is NCHW
+// - Whether the tensor sizes allow to use optimal loads (block 2D messages)
+bool is_nchw_ok(const conv_problem_t &prb, ngen::HW hw, tensor_kind_t kind,
+        bool nested = false);
 
 } // namespace jit
 } // namespace intel

--- a/src/gpu/intel/jit/ir/tensor_config.cpp
+++ b/src/gpu/intel/jit/ir/tensor_config.cpp
@@ -90,6 +90,14 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
     }
 }
 
+bool matches_tag(const layout_t &layout, const std::string &tag,
+        const std::vector<dim_t> &dims) {
+    if (layout.is_empty()) return false;
+    auto tag_layout = make_layout(layout.type(), dims, tag);
+    if (layout != tag_layout) return false;
+    return true;
+}
+
 } // namespace jit
 } // namespace intel
 } // namespace gpu

--- a/src/gpu/intel/jit/ir/tensor_config.hpp
+++ b/src/gpu/intel/jit/ir/tensor_config.hpp
@@ -126,6 +126,19 @@ inline layout_t make_layout(const type_t &type, const std::vector<dim_t> &dims,
     return layout_t(type, 0, tag, dims, /*do_normalize=*/false);
 }
 
+bool matches_tag(const layout_t &layout, const std::string &tag,
+        const std::vector<dim_t> &dims);
+
+inline bool matches_tag(const layout_t &layout, const std::string &tag) {
+    return matches_tag(layout, tag, layout.dims());
+}
+
+inline bool matches_tag(const memory_desc_t &md, const std::string &tag) {
+    if (md.format_kind == format_kind::any) return false;
+    std::vector<dim_t> dims(md.dims, md.dims + md.ndims);
+    return matches_tag(make_layout(md), tag, dims);
+}
+
 inline void set_default_format(memory_desc_t &md, const std::string &tag) {
     if (md.format_kind != format_kind::any) return;
     md = make_layout(md, tag).to_dnnl(md.dims);


### PR DESCRIPTION
Jira: [MFDNN-12923](https://jira.devtools.intel.com/browse/MFDNN-12923)

Performance data from BMG:

| Case                                                                                             | base perf (GOps/sec) | test perf (GOps/sec) | Ratio |
|--------------------------------------------------------------------------------------------------|----------------------|----------------------|-------|
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb128ic64ih64oc256oh64kh1ph0    | 3605.594             | 21190.681            | 5.88  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb64ic64ih128oc128oh128kh1ph0   | 3201.723             | 17190.661            | 5.37  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb256ic128ih72oc128oh72kh1ph0   | 5168.633             | 25795.306            | 4.99  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb128ic256ih64oc128oh64kh1ph0   | 7003.993             | 34561.331            | 4.93  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb256ic64ih144oc64oh144kh1ph0   | 2642.833             | 12802.686            | 4.84  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb128ic32ih128oc64oh128kh3ph1   | 14154.447            | 14187.520            | 1.00  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb256ic128ih72oc128oh72kh3ph1   | 37082.280            | 37114.164            | 1.00  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb64ic32ih128oc64oh128kh3ph1    | 14999.980            | 15005.511            | 1.00  |
| --dir=FWD_D --dt=bf16:bf16:bf16 --stag=abx --wtag=abx --dtag=abx mb64ic32ih256oc64oh128kh3sh2ph1 | 8451.155             | 8451.155             | 1.00  |


Improvements are expected for "good" sizes for 1x1 convolution with unit strides.