### PR TITLE
Bug fixes, relax matmul weights decompressions condition for a single group

### DIFF
--- a/src/cpu/platform.cpp
+++ b/src/cpu/platform.cpp
@@ -138,6 +138,8 @@ bool has_data_type_support(data_type_t data_type) {
 #else
             return false;
 #endif
+        case data_type::f4_e3m0:
+        case data_type::f4_e2m1: return false;
         default: return true;
     }
 }

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -227,7 +227,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
         const auto cblock = oblocks[d];
         // do not allow excess pdim other than required for rounding-up of dim.
         VDISPATCH_REORDER_IC(utils::rnd_up(dim, cblock) == pdim,
-                VERBOSE_UNSUPPORTED_PAD_FEATURE);
+                VERBOSE_UNSUPPORTED_PAD_FEATURE, "dst");
     }
 
     utils::array_set(i_tails, 0, im_d.ndims());

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -932,10 +932,11 @@ void jit_uni_x8s8s32x_1x1_conv_kernel<isa>::init_scratchpad(
         const jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr) {
     using namespace dnnl::impl::memory_tracking::names;
 
-    const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
-    const dim_t scales_count
-            = wei_mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
-    const dim_t count = nstl::max<dim_t>(scales_count, 8);
+    dim_t count = 8;
+    if (!attr.scales_.has_default_values(DNNL_ARG_WEIGHTS)) {
+        const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
+        if (wei_mask > 0) count = jcp.oc * jcp.ngroups;
+    }
     scratchpad.book<float>(key_conv_adjusted_scales, count);
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -1618,11 +1618,11 @@ template <cpu_isa_t isa>
 void jit_uni_x8s8s32x_fwd_kernel<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
-
-    const int mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
-    const dim_t scales_count
-            = mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
-    dim_t count = scales_count == 1 ? (dim_t)8 : scales_count;
+    dim_t count = 8;
+    if (!attr.scales_.has_default_values(DNNL_ARG_WEIGHTS)) {
+        const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
+        if (wei_mask > 0) count = jcp.oc * jcp.ngroups;
+    }
     scratchpad.book<float>(key_conv_adjusted_scales, count);
 }
 

--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -172,6 +172,14 @@
 --attr-fpmath=f16:true
 2x3x5x512:2x3x512x1024
 
+--reset
+--skip-impl=ref
+--dt=f16:s4:f16,f16:u4:f16
+--strides=:1x128: # Need strides over tag to overcome the API limitation
+--attr-scales=wei:per_tensor:f16:127x1
+--attr-fpmath=f16:true
+32x127:127x63_n"odd_k_single_group"
+
 # Dynamic quantization (int8 src, int4/int8 weights)
 --reset
 --skip-impl=ref


### PR DESCRIPTION
Fixes MFDNN-13445, MFDNN-13449

OV asked to relax the condition on a single group for odd dense sizes.