### PR TITLE
xe: jit: ir: normalize IR reorder layouts

### DIFF
--- a/src/gpu/intel/jit/ir/reorder.hpp
+++ b/src/gpu/intel/jit/ir/reorder.hpp
@@ -19,6 +19,7 @@
 
 #include "gpu/intel/jit/ir/ir.hpp"
 #include "gpu/intel/jit/ir/tensor.hpp"
+#include "gpu/intel/jit/reorder/normalization.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -32,8 +33,10 @@ class reorder_t : public func_impl_t {
 public:
     IR_DECL_DERIVED_TYPE_ID(reorder_t, func_impl_t)
 
-    static func_t make(const layout_t &src_layout, const layout_t &dst_layout) {
-        return func_t(new reorder_t(src_layout, dst_layout));
+    static func_t make(layout_t src_layout, layout_t dst_layout) {
+        reorder::normalize(src_layout, dst_layout);
+        return func_t(
+                new reorder_t(std::move(src_layout), std::move(dst_layout)));
     }
 
     std::string str() const override {
@@ -49,10 +52,10 @@ public:
     layout_t dst_layout;
 
 private:
-    reorder_t(const layout_t &src_layout, const layout_t &dst_layout)
+    reorder_t(layout_t src_layout, layout_t dst_layout)
         : func_impl_t(_type_info())
-        , src_layout(src_layout)
-        , dst_layout(dst_layout) {}
+        , src_layout(std::move(src_layout))
+        , dst_layout(std::move(dst_layout)) {}
 };
 
 inline stmt_t create_reorder_stmt(const layout_t &src, const layout_t &dst,

--- a/src/gpu/intel/jit/reorder/normalization.cpp
+++ b/src/gpu/intel/jit/reorder/normalization.cpp
@@ -162,6 +162,12 @@ struct layout_normalization_t {
         , blocks_(normalized_blocks(layout, dim_empty)) {}
 
 private:
+    static bool can_combine(const block_t &last, const block_t &next) {
+        if (last.dim_idx != next.dim_idx) return false;
+        if (last.stride * last.block != next.stride) return false;
+        return true;
+    }
+
     static std::vector<block_t> normalized_blocks(
             const layout_t &layout, std::vector<bool> dim_empty) {
         std::vector<block_t> normalized_blocks;
@@ -170,7 +176,7 @@ private:
             if (blk.block != 1
                     || (layout.is_outermost(eb) && !dim_empty[blk.dim_idx])) {
                 if (normalized_blocks.empty()
-                        || normalized_blocks.back().dim_idx != blk.dim_idx) {
+                        || !can_combine(normalized_blocks.back(), blk)) {
                     normalized_blocks.push_back(blk);
                     dim_empty[blk.dim_idx] = true;
                 } else {


### PR DESCRIPTION
Normalizes the layouts used in IR reorder to try to dispatch to 2d reorder more often. Partially addresses [MFDNN-8974](https://jira.devtools.intel.com/browse/MFDNN-8974).

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
- [x] Have you submitted performance data that demonstrates performance improvements? [perf CI](https://intel-ci.intel.com/f0119b8c-a7b7-f1c7-99a5-b49691d8dc7c)