### PR TITLE
common: fixing minor Coverity issues

### DIFF
--- a/examples/graph/graph_example_utils.hpp
+++ b/examples/graph/graph_example_utils.hpp
@@ -206,8 +206,7 @@ inline void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
                                          q.get_context()),
                 sycl_deletor_t {q.get_context()});
 
-        dnnl::graph::tensor new_ts {lt, eng, data_buffer.back().get()};
-        tensors.push_back(new_ts);
+        tensors.emplace_back(lt, eng, data_buffer.back().get());
     }
 }
 
@@ -236,8 +235,7 @@ inline void allocate_sycl_graph_mem(std::vector<dnnl::graph::tensor> &tensors,
                                          q.get_context()),
                 sycl_deletor_t {q.get_context()});
 
-        dnnl::graph::tensor new_ts {lt, eng, data_buffer.back().get()};
-        tensors.push_back(new_ts);
+        tensors.emplace_back(lt, eng, data_buffer.back().get());
 
         // record the connection relationship between partitions
         if (!is_input) global_outputs_ts_map[lt_id] = tensors.back();

--- a/examples/primitives/concat.cpp
+++ b/examples/primitives/concat.cpp
@@ -82,15 +82,12 @@ void concat_example(dnnl::engine::kind engine_kind) {
     std::vector<memory> src_mems;
 
     for (int n = 0; n < num_src; ++n) {
-        auto md = memory::desc(
+        src_mds.emplace_back(
                 src_dims, memory::data_type::f32, memory::format_tag::nchw);
-        auto mem = memory(md, engine);
+        src_mems.emplace_back(src_mds.back(), engine);
 
         // Write data to memory object's handle.
-        write_to_dnnl_memory(src_data.data(), mem);
-
-        src_mds.push_back(md);
-        src_mems.push_back(mem);
+        write_to_dnnl_memory(src_data.data(), src_mems.back());
     }
 
     // Create primitive descriptor.

--- a/examples/primitives/sum.cpp
+++ b/examples/primitives/sum.cpp
@@ -81,15 +81,12 @@ void sum_example(dnnl::engine::kind engine_kind) {
     std::vector<memory> src_mem;
 
     for (int n = 0; n < num_src; ++n) {
-        auto md = memory::desc(
+        src_md.emplace_back(
                 src_dims, memory::data_type::f32, memory::format_tag::nchw);
-        auto mem = memory(md, engine);
+        src_mem.emplace_back(src_md.back(), engine);
 
         // Write data to memory object's handle.
-        write_to_dnnl_memory(src_data.data(), mem);
-
-        src_md.push_back(md);
-        src_mem.push_back(mem);
+        write_to_dnnl_memory(src_data.data(), src_mem.back());
     }
 
     // Create primitive descriptor.

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -73,9 +73,8 @@ void log_manager_t::log(const char *msg, log_level_t log_level) const {
     // (by default the fmt library appends a '\n' character to
     // the logged message)
     size_t msg_len = strlen(msg);
-    auto nmsg = (msg_len > 0 && msg[msg_len - 1] == '\n')
-            ? std::string(msg, msg_len - 1)
-            : msg;
+    const std::string nmsg(
+            msg, msg_len - (msg_len > 0 && msg[msg_len - 1] == '\n'));
 
     switch (log_level) {
         case off: break;

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -44,6 +44,8 @@ const quant_entry_t &default_quant_entry();
 
 struct quant_entry_t : public c_compatible {
     quant_entry_t() = default;
+    quant_entry_t(const quant_entry_t &e) = default;
+    ~quant_entry_t() = default;
 
     // `set(...)` approach is taken over constructors as the usage model assumes
     // the change of state of this object but it doesn't require its destruction

--- a/src/common/reorder.cpp
+++ b/src/common/reorder.cpp
@@ -93,7 +93,7 @@ status_t reorder_primitive_desc_create(std::shared_ptr<primitive_desc_t> &pd,
     if (attr == nullptr) attr = &default_attr();
 
     // Zero points are only allowed for integral data types
-    auto zero_points = attr->zero_points_;
+    const auto &zero_points = attr->zero_points_;
     VCHECK_REORDER(IMPLICATION(!types::is_integral_dt(src_md->data_type),
                            zero_points.has_default_values(DNNL_ARG_SRC)),
             VERBOSE_UNSUPPORTED_ZP_CFG);

--- a/src/common/resource.hpp
+++ b/src/common/resource.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ struct resource_mapper_t {
     using mapped_t = std::unique_ptr<resource_t>;
 
     resource_mapper_t() = default;
+    ~resource_mapper_t() = default;
 
     bool has_resource(const primitive_t *p) const {
         return primitive_to_resource_.count(p);

--- a/src/common/thread_local_storage.hpp
+++ b/src/common/thread_local_storage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2022 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ namespace utils {
 template <typename T>
 struct thread_local_storage_t {
     thread_local_storage_t() = default;
+    ~thread_local_storage_t() = default;
 
     DNNL_DISALLOW_COPY_AND_ASSIGN(thread_local_storage_t);
 

--- a/src/cpu/cpu_memory_storage.hpp
+++ b/src/cpu/cpu_memory_storage.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2021 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ class cpu_memory_storage_t : public memory_storage_t {
 public:
     cpu_memory_storage_t(engine_t *engine)
         : memory_storage_t(engine), data_(nullptr, release) {}
+    ~cpu_memory_storage_t() override = default;
 
     status_t get_data_handle(void **handle) const override {
         *handle = data_.get();

--- a/src/xpu/ocl/buffer_memory_storage.hpp
+++ b/src/xpu/ocl/buffer_memory_storage.hpp
@@ -40,6 +40,8 @@ public:
             impl::engine_t *engine, const memory_storage_t *root_storage)
         : memory_storage_base_t(engine, root_storage) {}
 
+    ~buffer_memory_storage_t() override = default;
+
     status_t get_data_handle(void **handle) const override {
         *handle = static_cast<void *>(mem_object_.get());
         return status::success;

--- a/src/xpu/sycl/usm_memory_storage.hpp
+++ b/src/xpu/sycl/usm_memory_storage.hpp
@@ -39,6 +39,7 @@ public:
 
     usm_memory_storage_t(engine_t *engine, ::sycl::usm::alloc usm_kind)
         : memory_storage_base_t(engine), usm_kind_(usm_kind) {}
+    ~usm_memory_storage_t() override = default;
 
     uint8_t *usm_ptr() const { return static_cast<uint8_t *>(usm_ptr_.get()); }
 

--- a/src/xpu/sycl/verbose.hpp
+++ b/src/xpu/sycl/verbose.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,11 +54,13 @@ void print_verbose_header(engine_kind_t kind) {
                             eng->impl())
                     : nullptr;
 
-            auto s_backend = engine_impl ? to_string(engine_impl->backend())
-                                         : "unknown";
-            auto s_name = engine_impl ? engine_impl->name() : "unknown";
-            auto s_ver = engine_impl ? engine_impl->runtime_version().str()
-                                     : "unknown";
+            const auto &s_backend = engine_impl
+                    ? to_string(engine_impl->backend())
+                    : "unknown";
+            const auto &s_name = engine_impl ? engine_impl->name() : "unknown";
+            const auto &s_ver = engine_impl
+                    ? engine_impl->runtime_version().str()
+                    : "unknown";
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
             if (kind == engine_kind::gpu) {
                 auto *dev_info = eng

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -127,6 +127,7 @@ int get_cache_blob(std::vector<uint8_t> &cache_blob, dnnl_primitive_t prim) {
 
 struct lru_cache_t {
     lru_cache_t(size_t capacity) : capacity_(capacity) {}
+    ~lru_cache_t() = default;
 
     const std::vector<uint8_t> &get(const std::vector<uint8_t> &key) {
         auto it = cache_mapper_.find(key);

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -549,7 +549,7 @@ void dnn_mem_t::memset(int value, size_t size, int buffer_index) const {
                     ::sycl::accessor<uint8_t, 1, ::sycl::access::mode::write,
                             target_device>
                             acc(buf, cgh);
-                    cgh.fill(acc, static_cast<uint8_t>(value));
+                    cgh.fill(std::move(acc), static_cast<uint8_t>(value));
                 });
                 DNN_SAFE_V(dnnl_stream_wait(stream));
                 return;

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -326,7 +326,11 @@ struct prb_t : public desc_t {
         , attr(attr)
         , ctx_init(ctx_init)
         , ctx_exe(ctx_exe)
-        , impl_filter(impl_filter) {
+        , impl_filter(impl_filter)
+        , wei_nscales(0)
+        , wei_scales_mask(0x0)
+        , wei_proj_nscales(0)
+        , wei_proj_scales_mask(0x0) {
 
         if (n_layer) this->n_layer = n_layer;
         if (n_iter) this->n_iter = n_iter;

--- a/tests/benchdnn/self/common.cpp
+++ b/tests/benchdnn/self/common.cpp
@@ -318,43 +318,47 @@ static int check_attr() {
 
 void append_sum(attr_t::post_ops_t &po, float ascale = 1.f,
         int32_t zero_point = 0, dnnl_data_type_t adt = dnnl_data_type_undef) {
-    attr_t::post_ops_t::entry_t e(pk_t::SUM);
+    po.entry.emplace_back(pk_t::SUM);
+    auto &e = po.entry.back();
+
     e.sum.scale = ascale;
     e.sum.zero_point = zero_point;
     e.sum.dt = adt;
-    po.entry.push_back(e);
 }
 
 void append_convolution(attr_t::post_ops_t &po, pk_t akind, int kernel,
         int stride, int padding, dnnl_data_type_t adst_dt = dnnl_f32) {
-    attr_t::post_ops_t::entry_t e(akind);
+    po.entry.emplace_back(akind);
+    auto &e = po.entry.back();
+
     e.convolution.kernel = kernel;
     e.convolution.stride = stride;
     e.convolution.padding = padding;
     e.convolution.dst_dt = adst_dt;
-    po.entry.push_back(e);
 }
 
 void append_eltwise(attr_t::post_ops_t &po, pk_t akind, float aalpha = 0.f,
         float abeta = 0.f) {
-    attr_t::post_ops_t::entry_t e(akind);
+    po.entry.emplace_back(akind);
+    auto &e = po.entry.back();
+
     e.eltwise.alg = attr_t::post_ops_t::kind2dnnl_kind(akind);
     e.eltwise.alpha = aalpha;
     e.eltwise.beta = abeta;
-    po.entry.push_back(e);
 }
 
 void append_binary(attr_t::post_ops_t &po, pk_t akind, dnnl_data_type_t src_dt1,
         attr_t::post_ops_t::entry_t::binary_t::mask_input_t mask_input,
         int64_t mask, attr_t::policy_t policy, const std::string &tag) {
-    attr_t::post_ops_t::entry_t e(akind);
+    po.entry.emplace_back(akind);
+    auto &e = po.entry.back();
+
     e.binary.alg = attr_t::post_ops_t::kind2dnnl_kind(akind);
     e.binary.src1_dt = src_dt1;
     e.binary.mask_input = mask_input;
     e.binary.mask = mask;
     e.binary.policy = policy;
     e.binary.tag = tag;
-    po.entry.push_back(e);
 }
 
 static int check_post_ops2str() {

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -454,7 +454,7 @@ cold_cache_input_t str2cold_cache_input(const std::string &s) {
                         size * 1024 * 1024 * (last_char == 'G' ? 1024 : 1));
 
                 // Save the input string once all values are verified.
-                c.cold_tlb_size_str_ = ext_aux_str;
+                c.cold_tlb_size_str_ = std::move(ext_aux_str);
             }
         } else {
             BENCHDNN_PRINT(0,

--- a/tests/gtests/internals/test_utils.cpp
+++ b/tests/gtests/internals/test_utils.cpp
@@ -333,7 +333,7 @@ std::ostream &operator<<(std::ostream &ss, const memory::data_type &dt) {
     return ss;
 }
 
-void dynamic_iterate_alldims(std::vector<int64_t> dims,
+void dynamic_iterate_alldims(const std::vector<int64_t> &dims,
         const std::function<void(std::vector<int64_t> idxs)> &fn) {
     size_t ndims = dims.size();
     assert(ndims > 1); // TODO: will fail w/ndim == 1

--- a/tests/gtests/internals/test_utils.hpp
+++ b/tests/gtests/internals/test_utils.hpp
@@ -161,7 +161,7 @@ void fill_random_quantized(std::vector<T> &out, const dnnl::memory::desc &desc,
     }
 }
 
-void dynamic_iterate_alldims(std::vector<int64_t> dims,
+void dynamic_iterate_alldims(const std::vector<int64_t> &dims,
         const std::function<void(std::vector<int64_t> idxs)> &fn);
 
 template <typename T>

--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -157,10 +157,8 @@ protected:
 
         std::vector<memory::desc> srcs_md;
         std::vector<memory> srcs;
-        for (size_t i = 0; i < p.srcs_cds.size(); i++) {
-            auto md = memory::desc(p.srcs_cds[i], data_type, p.srcs_format[i]);
-            srcs_md.push_back(md);
-        }
+        for (size_t i = 0; i < p.srcs_cds.size(); i++)
+            srcs_md.emplace_back(p.srcs_cds[i], data_type, p.srcs_format[i]);
 
         auto dst_desc = memory::desc(p.dst_cds, data_type, p.dst_format);
         auto concat_pd = pd_t(
@@ -196,7 +194,7 @@ protected:
             const size_t sz = src_memory.get_desc().get_size() / sizeof(data_t);
             fill_data<data_t>(sz, src_memory);
             check_zero_tail<data_t>(1, src_memory);
-            srcs.push_back(src_memory);
+            srcs.push_back(std::move(src_memory));
         }
 
         for (int i = 0; i < (int)srcs.size(); i++)

--- a/tests/gtests/test_convolution_backward_data_common.hpp
+++ b/tests/gtests/test_convolution_backward_data_common.hpp
@@ -90,7 +90,7 @@ class convolution_backward_data_test_t
     : public ::testing::TestWithParam<test_convolution_params_t> {
 protected:
     void SetUp() override {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 test_convolution_params_t>::GetParam();
 
         SKIP_IF_CUDA(
@@ -216,7 +216,7 @@ protected:
     }
 
     void Test() {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 test_convolution_params_t>::GetParam();
         ASSERT_EQ(p.aalgorithm, algorithm::convolution_direct);
         auto eng = get_test_engine();

--- a/tests/gtests/test_convolution_backward_weights_common.hpp
+++ b/tests/gtests/test_convolution_backward_weights_common.hpp
@@ -122,7 +122,7 @@ class convolution_backward_weights_test_t
     : public ::testing::TestWithParam<test_convolution_params_t> {
 protected:
     void SetUp() override {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 test_convolution_params_t>::GetParam();
 
         SKIP_IF_CUDA(
@@ -253,7 +253,7 @@ protected:
     }
 
     void Test() {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 test_convolution_params_t>::GetParam();
 
         ASSERT_EQ(p.aalgorithm, algorithm::convolution_direct);

--- a/tests/gtests/test_convolution_forward_common.hpp
+++ b/tests/gtests/test_convolution_forward_common.hpp
@@ -127,7 +127,7 @@ protected:
         SKIP_IF(unsupported_data_type(data_type_wei),
                 "Engine does not support this data type.");
 
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 test_convolution_params_t>::GetParam();
 
         SKIP_IF_CUDA(
@@ -214,7 +214,7 @@ protected:
     }
 
     void Test() {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 test_convolution_params_t>::GetParam();
         ASSERT_EQ(p.aalgorithm, algorithm::convolution_direct);
         auto eng = get_test_engine();

--- a/tests/gtests/test_deconvolution.cpp
+++ b/tests/gtests/test_deconvolution.cpp
@@ -139,7 +139,7 @@ protected:
         SKIP_IF(unsupported_data_type(data_type),
                 "Engine does not support this data type.");
 
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 deconvolution_test_params_t>::GetParam();
 
         SKIP_IF_CUDA(
@@ -394,7 +394,7 @@ protected:
     }
 
     void BackwardData() {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 deconvolution_test_params_t>::GetParam();
         // deconv specific types and values
         using pd_t = deconvolution_backward_data::primitive_desc;
@@ -467,7 +467,7 @@ protected:
     }
 
     void BackwardWeights() {
-        auto p = ::testing::TestWithParam<
+        const auto &p = ::testing::TestWithParam<
                 deconvolution_test_params_t>::GetParam();
 
         // deconv specific types and values

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -205,10 +205,8 @@ protected:
         std::vector<memory::desc> srcs_md;
         std::vector<memory> srcs;
 
-        for (size_t i = 0; i < num_srcs; i++) {
-            auto desc = memory::desc(p.dims, src_data_type, p.srcs_format[i]);
-            srcs_md.push_back(desc);
-        }
+        for (size_t i = 0; i < num_srcs; i++)
+            srcs_md.emplace_back(p.dims, src_data_type, p.srcs_format[i]);
 
         memory dst;
         sum::primitive_desc sum_pd;


### PR DESCRIPTION
A lot of minor Coverity issues, almost all about using `const auto &`, `std::move` or missing default destructor.