### PR TITLE
[backport][rls-v3.8]benchdnn: graph: resume ref memory init for perf mode

### DIFF
--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -74,8 +74,8 @@ int ref_partition_t::init_ref(
         const std::vector<size_t> &graph_in_ports, res_t *res) {
 
     // Not create reference primitives and filling data with pre-designed
-    // strategies if correctness check is not enabled.
-    if (!has_bench_mode_bit(mode_bit_t::corr)) return OK;
+    // strategies if reference memories are not required.
+    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) return OK;
 
     for (const auto &par_op_ref : partition_ops_ref_) {
         // res should be independent from op to op


### PR DESCRIPTION
Backport of https://github.com/uxlfoundation/oneDNN/pull/3034