### PR TITLE
test: benchdnn: stop test_conv_fp4 running on ci_cpu

### DIFF
--- a/tests/benchdnn/inputs/conv/test_conv_fp4
+++ b/tests/benchdnn/inputs/conv/test_conv_fp4
@@ -1,4 +1,0 @@
---reset --mb=1 --dt=f4_e2m1:f4_e2m1:bf16,f4_e3m0:f4_e3m0:bf16 --dir=fwd_d --batch=shapes_4bit
---reset --mb=1 --dt=f16:f4_e2m1:f4_e2m1,f32:f4_e3m0:f4_e3m0 --dir=bwd_d --batch=shapes_4bit
---reset --mb=1 --dt=f4_e2m1:f16:f4_e2m1,f4_e3m0:f32:f4_e3m0 --dir=bwd_w --batch=shapes_4bit
---reset --mb=1 --dt=f4_e2m1,f4_e3m0 --dir=fwd_d --batch=shapes_4bit

--- a/tests/benchdnn/inputs/conv/test_conv_gpu
+++ b/tests/benchdnn/inputs/conv/test_conv_gpu
@@ -158,8 +158,10 @@ mb128ic3ih230oc64oh112kh7sh2ph0
 --batch=shapes_basic_gpu
 
 # Test fp4
---reset
---batch=test_conv_fp4
+--reset --mb=1 --dt=f4_e2m1:f4_e2m1:bf16,f4_e3m0:f4_e3m0:bf16 --dir=fwd_d --batch=shapes_4bit
+--reset --mb=1 --dt=f16:f4_e2m1:f4_e2m1,f32:f4_e3m0:f4_e3m0 --dir=bwd_d --batch=shapes_4bit
+--reset --mb=1 --dt=f4_e2m1:f16:f4_e2m1,f4_e3m0:f32:f4_e3m0 --dir=bwd_w --batch=shapes_4bit
+--reset --mb=1 --dt=f4_e2m1,f4_e3m0 --dir=fwd_d --batch=shapes_4bit
 
 # dw gen9 fwd conv
 --reset


### PR DESCRIPTION
https://github.com/uxlfoundation/oneDNN/pull/2987 has introduced a nightly unit test failure for aarch64 by enabling fp4 tests meant only for gpus on cpu as well. The failure can be seen first occurring in https://github.com/uxlfoundation/oneDNN/actions/runs/14235330209. This PR moves this test so that it is only run on gpu devices.

cc: @kealan-barbieri 