### PR TITLE
ngen: add cross-thread data relocations for GTPin

### DIFF
--- a/third_party/ngen/ngen.hpp
+++ b/third_party/ngen/ngen.hpp
@@ -177,8 +177,8 @@ protected:
     Product product;
     int declaredGRFs = 128;
 
-    Label _labelLocalIDsLoaded;
-    Label _labelArgsLoaded;
+    InterfaceLabels _interfaceLabels;
+
     Label _lastFenceLabel;
     RegData _lastFenceDst;
 
@@ -345,7 +345,8 @@ protected:
 #endif
 
     // Labels.
-    inline void mark(Label &label)          { streamStack.back()->mark(label, labelManager); }
+    void mark(Label &label)            { streamStack.back()->mark(label, labelManager); }
+    void markIfUndefined(Label &label) { if (!label.defined(labelManager)) mark(label); }
 
     // Instructions.
     template <typename DT = void>

--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -497,8 +497,8 @@ protected:
     std::ostream *defaultOutput;
     bool lineNumbers = false;
 
-    Label _labelLocalIDsLoaded;
-    Label _labelArgsLoaded;
+    InterfaceLabels _interfaceLabels;
+
     Label _lastFenceLabel;
     RegData _lastFenceDst;
 
@@ -1560,7 +1560,8 @@ public:
         opX(Opcode::directive, DataType::ud, InstructionModifier::createAutoSWSB(), GRF(static_cast<int>(Directive::pvcwarwa)), NullRegister());
     }
 
-    inline void mark(Label &label)          { streamStack.back()->mark(label, labelManager); }
+    void mark(Label &label)            { streamStack.back()->mark(label, labelManager); }
+    void markIfUndefined(Label &label) { if (!label.defined(labelManager)) mark(label); }
 
     using _self = AsmCodeGenerator;
 
@@ -1628,7 +1629,7 @@ void AsmCodeGenerator::getCode(std::ostream &out)
         if (i.isLabel()) {
             i.dst.label.outputText(out, PrintDetail::full, labelManager);
             out << ':' << std::endl;
-            if (i.dst.label == _labelLocalIDsLoaded)
+            if (i.dst.label == _interfaceLabels.localIDsLoaded)
                 lineNo = 0;
         } else if (i.isComment())
             out << "// " << i.comment << std::endl;

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -668,6 +668,13 @@ public:
 static inline bool operator==(const RegData &r1, const RegData &r2);
 static inline bool operator!=(const RegData &r1, const RegData &r2);
 
+// Special set of labels used for prologues.
+struct InterfaceLabels {
+    Label localIDsLoaded;
+    Label argsLoaded;
+    Label crossThreadPatches[2];
+};
+
 // Superclass for registers, subregisters, and register regions, possibly
 // with source modifiers.
 class RegData {

--- a/third_party/ngen/ngen_pseudo.hpp
+++ b/third_party/ngen/ngen_pseudo.hpp
@@ -563,6 +563,8 @@ void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127
                 and_<uint32_t>(1, temp[2], r0[0], uint32_t(~0x1F), loc);
                 and_<uint16_t>(1, temp[0], r0[4], uint16_t(0xFF), loc);
                 add<uint32_t>(1, temp[2], temp[2], uint16_t(argBytes), loc);
+                markIfUndefined(_interfaceLabels.crossThreadPatches[0]);
+                add<uint32_t>(1, temp[2], temp[2], Immediate::ud(0), loc);  /* relocation */
                 if (simd == 1) {
                     mad<uint32_t>(1, tempAddr, temp[2], temp.uw(0), uint16_t(grfSize), loc);
                     lsc ? load(1, r1, D32T(4) | L1C_L3C,      A32,   temp, loc)
@@ -593,8 +595,7 @@ void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127
                 nop(loc);
         }
 
-        if (!_labelLocalIDsLoaded.defined(labelManager))
-            mark(_labelLocalIDsLoaded);
+        markIfUndefined(_interfaceLabels.localIDsLoaded);
 
     }
 }
@@ -612,6 +613,8 @@ void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inP
                 if (!lsc)
                     mov<uint32_t>(8, temp, uint16_t(0), loc);
                 and_<uint32_t>(1, tempAddr, r0[0], uint32_t(~0x1F), loc);
+                markIfUndefined(_interfaceLabels.crossThreadPatches[1]);
+                add<uint32_t>(1, tempAddr, tempAddr, Immediate::ud(0), loc);  /* relocation */
                 while (argGRFs > 0) {
                     int nload = std::min(utils::rounddown_pow2(argGRFs), lsc ? 8 : 4);
                     int loadBytes = nload * GRF::bytes(hardware);
@@ -627,8 +630,7 @@ void loadargs(const GRF &base, int argGRFs, const GRF &temp = GRF(127), bool inP
             defaultModifier = dmSave;
         }
 
-        if (!_labelArgsLoaded.defined(labelManager))
-            mark(_labelArgsLoaded);
+        markIfUndefined(_interfaceLabels.argsLoaded);
     }
 }
 


### PR DESCRIPTION
Addresses a GTPin request to support the addition of an implicit argument buffer prior to the cross-thread data (normal kernel arguments), by inserting relocations into the prologue.

GTPin uses this for its new HLIF (high-level instrumentation framework) tooling, and in some cases it might be needed for debugging under gdb.