### PR TITLE
Update fp4 Documentation

### DIFF
--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -173,15 +173,18 @@ source, destination, and weights memory objects:
 | forward        | u8, s8           | s8                    | u8, s8, s32, f32, f16, bf16      | u8, s8, s32, f32, f16, bf16 |
 | forward        | bf16             | bf16                  | f32, bf16                        | f32, bf16                   |
 | forward        | f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3      | f8_e5m2, f8_e4m3, f32, f16, bf16 | f32                         |
+| forward        | f4_e2m1, f4_e3m0 | f4_e2m1, f4_e3m0      | f4_e2m1, f4_e3m0, f32, f16, bf16 | f32                         |
 | forward        | f64              | f64                   | f64                              | f64                         |
 | backward       | f32, bf16        | bf16                  | bf16                             |                             |
 | backward       | f32, f16         | f16                   | f16                              |                             |
 | backward       | f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3      | f8_e5m2, f8_e4m3                 |                             |
+| backward       | f4_e2m1, f4_e3m0 | f4_e2m1, f4_e3m0      | f4_e2m1, f4_e3m0                 |                             |
 | backward       | f32              | f32                   | f32                              | f32                         |
 | backward       | f64              | f64                   | f64                              | f64                         |
 | weights update | bf16             | f32, bf16             | bf16, s8, u8                     | f32, bf16                   |
 | weights update | f16              | f32, f16              | f16                              | f32, f16                    |
 | weights update | f8_e5m2, f8_e4m3 | f32, f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3                 | f32                         |
+| weights update | f4_e2m1, f4_e3m0 | f32, f4_e2m1, f4_e3m0 | f4_e2m1, f4_e3m0                 | f32                         |
 
 @warning
     There might be hardware and/or implementation specific restrictions.
@@ -444,6 +447,7 @@ of Winograd algorithm implementations.
 4. **CPU**
    - Only reference support for fp8 data types (f8_e5m2, f8_e4m3) is
      is available on CPU.
+   - No support is available for f4_e3m0 or f4_e2m1.
    - No support is available for f64.
 
 ## Performance Tips

--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -103,6 +103,7 @@ types for source, destination, weights, and bias tensors:
 | bf16             | bf16, u8, s8, u4, s4 | f32, bf16                        | f32, bf16                   |
 | f32, bf16, f16   | u8, s8               | f32, bf16, f16                   | f32, bf16, f16              |
 | f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3     | f32, f16, bf16, f8_e5m2, f8_e4m3 | f32, bf16, f16              |
+| f4_e2m1, f4_e3m0 | f4_e2m1, f4_e3m0     | f32, f16, bf16, f4_e2m1, f4_e3m0 | f32, bf16, f16              |
 | u8, s8           | s8                   | u8, s8, s32, f32, f16, bf16      | u8, s8, s32, f32, f16, bf16 |
 
 

--- a/doc/programming_model/data_types.md
+++ b/doc/programming_model/data_types.md
@@ -30,10 +30,10 @@ in comparison to fp32.
 
 oneDNN supports training and inference with the following data types:
 
-| Usage mode | CPU                                                                               | GPU                                                         |
-|:-----------|:----------------------------------------------------------------------------------|:------------------------------------------------------------|
-| Inference  | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f4\_e2m1, f4\_e3m0, s8/u8, s4/u4, s32, boolean | f32, bf16, f16, f8\_e5m2/f8\_e4m3, s8/u8, s32, f64, boolean |
-| Training   | f32, bf16, f16, f8\_e5m2/f8\_e4m3                                                 | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f64                      |
+| Usage mode | CPU                                                                          | GPU                                                                              |
+|:-----------|:-----------------------------------------------------------------------------|:---------------------------------------------------------------------------------|
+| Inference  | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f4\_e2m1/f4\_e3m0, s8/u8, s4/u4, boolean  | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f4\_e2m1/f4\_e3m0, s8/u8, s4/u4, f64, boolean |
+| Training   | f32, bf16, f16, f8\_e5m2/f8\_e4m3                                            | f32, bf16, f16, f8\_e5m2/f8\_e4m3, f64                                           |
 
 @note
     Using lower precision arithmetic may require changes in the deep learning
@@ -47,6 +47,12 @@ oneDNN supports training and inference with the following data types:
     s4/u4 data types are only supported as a storage data type for weights argument
     in case of weights decompression. For more details, refer to
     [Matmul Tutorial: weights decompression](@ref weights_decompression_matmul_cpp).
+
+@note
+    f8\_e5m2/f8\_e4m3 and f4\_e2m1/f4\_e3m0 data types are only supported by
+    convolution, matmul, and reorder primitives on Intel(R) Data Center GPU
+    Max Series or newer. Compute primitives provide support through internal
+    converison into f16 as current GPU architectures lack native support.
 
 See topics for the corresponding data types details:
  * @ref dev_guide_inference_int8


### PR DESCRIPTION
# Description

- Add fp4/int4 inference support to GPU side of data_type matrix
- Note general limitations on fp4/fp8 support 
- Update conv, matmul primitives with fp4