### PR TITLE
benchdnn: graph: improve skip logic for cases with unsupported dt

### DIFF
--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -418,7 +418,22 @@ std::string case_to_str(const std::string &json_file,
     return s.str();
 }
 
-void skip_unimplemented_ops(const dnnl::graph::partition &partition,
+/// @brief check if the current partition is actually an End op
+/// @param parti the current partition
+/// @param end_op_ids a collection of End op's ids
+/// @return return true, when current partition is an End op
+bool is_single_end_op_partition(const dnnl::graph::partition &parti,
+        const std::vector<size_t> &end_op_ids) {
+    const auto &parti_op_ids = parti.get_ops();
+    if (!end_op_ids.empty() && parti_op_ids.size() == 1
+            && std::count(end_op_ids.begin(), end_op_ids.end(),
+                    parti_op_ids.front())) {
+        return true;
+    }
+    return false;
+}
+
+int skip_unimplemented_ops(const dnnl::graph::partition &partition,
         const deserialized_graph_t &dg, res_t *res) {
     // A list of ops that don't have DNNL backend support so far.
     static const std::vector<std::string> unimplemented_ops {"Pow"};
@@ -442,7 +457,7 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
                     2, "[INFO]: Unimplemented op: %s.\n", dg_op_kind.c_str());
             res->state = SKIPPED;
             res->reason = skip_reason::case_not_supported;
-            return;
+            return OK;
         }
 
         if (is_gpu) {
@@ -456,54 +471,36 @@ void skip_unimplemented_ops(const dnnl::graph::partition &partition,
                         dg_op_kind.c_str());
                 res->state = SKIPPED;
                 res->reason = skip_reason::case_not_supported;
-                return;
+                return OK;
             }
         }
     }
+    return OK;
 }
 
-/// @brief check if the current partition is actually an End op
-/// @param parti the current partition
-/// @param end_op_ids a collection of End op's ids
-/// @return return true, when current partition is an End op
-bool is_single_end_op_partition(const dnnl::graph::partition &parti,
-        const std::vector<size_t> &end_op_ids) {
-    const auto parti_op_ids = parti.get_ops();
-    if (!end_op_ids.empty() && parti_op_ids.size() == 1
-            && std::count(end_op_ids.begin(), end_op_ids.end(),
-                    parti_op_ids.front())) {
-        return true;
-    }
-    return false;
-}
-
-int doit(const prb_t *prb, res_t *res) {
-    if (bench_mode == bench_mode_t::list) return res->state = LISTED, OK;
-
-    skip_start(res);
-    if (res->state == SKIPPED) return OK;
-
-    const auto &dg = prb->dg;
-    const auto &graph_in_ports = dg.get_input_ports();
-    auto ograph = dg.to_graph(prb->fpmath_mode);
-    DNN_GRAPH_SAFE(ograph.finalize(), WARN, res);
-    const auto partitions = ograph.get_partitions();
-    // a collection of End op's id in this graph
-    std::vector<size_t> end_opid_v {};
-    for (const auto &aop : dg.ops_) {
-        if (aop.kind_ == "End") { end_opid_v.emplace_back(aop.id_); }
-    }
+int skip_unimplemented_partitions(const std::vector<partition> &partitions,
+        const deserialized_graph_t &dg, const prb_t *prb,
+        std::vector<size_t> &end_opid_v, res_t *res) {
 
     if (partitions.empty()) {
         BENCHDNN_PRINT(0, "%s\n", "Error: partitions are empty");
-        return res->state = FAILED, FAIL;
+        SAFE(FAIL, WARN);
     }
 
     BENCHDNN_PRINT(3, "[INFO]: n_partitions:%zd; ops_in_partitions:%s\n",
             partitions.size(), verbose_partitions_n_ops(partitions).c_str());
 
+    // a collection of End op's id in this graph
+    for (const auto &aop : dg.ops_) {
+        if (aop.kind_ == "End") { end_opid_v.emplace_back(aop.id_); }
+    }
+    const bool partition_num_mismatch = (prb->expected_n_partition > 0
+            && partitions.size() != prb->expected_n_partition);
+
     for (size_t i = 0; i < partitions.size(); ++i) {
-        if (partitions[i].is_supported()) continue;
+        // If the partition number mismatches the requirement, check whether
+        // there are unsupported data types.
+        if (partitions[i].is_supported() && !partition_num_mismatch) continue;
 
         // End operation is not supported in the library, and it's fine to
         // continue validation as it's a knob without functional meaning.
@@ -555,25 +552,41 @@ int doit(const prb_t *prb, res_t *res) {
                 }
             }
         }
+        if (in_out_dt.empty()) continue;
         skip_unimplemented_data_type(in_out_dt, dir, res);
         if (res->state == SKIPPED) return OK;
 
         BENCHDNN_PRINT(3, "[INFO]: partition #%zd is unsupported!\n", i);
-        res->state = UNIMPLEMENTED;
-        return FAIL;
+        return res->state = UNIMPLEMENTED, FAIL;
     }
 
-    if (prb->expected_n_partition != 0
-            && partitions.size() != prb->expected_n_partition) {
+    if (partition_num_mismatch) {
         BENCHDNN_PRINT(0,
                 "Error: the expected number of partitions (%zu) doesn't "
                 "coincide with the actual number of partitions returned "
                 "(%zu).\n ",
                 prb->expected_n_partition, partitions.size());
-        return res->state = FAILED, FAIL;
+        SAFE(FAIL, WARN);
     }
+    return OK;
+}
 
-    if (res->state == SKIPPED || res->state == UNIMPLEMENTED) return OK;
+int doit(const prb_t *prb, res_t *res) {
+    if (bench_mode == bench_mode_t::list) return res->state = LISTED, OK;
+
+    skip_start(res);
+    if (res->state == SKIPPED) return OK;
+
+    const auto &dg = prb->dg;
+    const auto &graph_in_ports = dg.get_input_ports();
+    auto ograph = dg.to_graph(prb->fpmath_mode);
+    DNN_GRAPH_SAFE(ograph.finalize(), WARN, res);
+
+    const auto &partitions = ograph.get_partitions();
+    std::vector<size_t> end_opid_v;
+    SAFE(skip_unimplemented_partitions(partitions, dg, prb, end_opid_v, res),
+            WARN);
+    if (res->state == SKIPPED) return OK;
 
     const auto &eng = get_graph_engine();
     const dnnl::engine &dnnl_eng = static_cast<const dnnl::engine>(eng);

--- a/tests/benchdnn/inputs/graph/pattern/harness_f8_all
+++ b/tests/benchdnn/inputs/graph/pattern/harness_f8_all
@@ -1,11 +1,10 @@
-# f8 cases: skip partition number check as they may not fuse on some platforms.
---reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_add_add_fusion.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_fwd.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_post_ops_fusion.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_post_ops_int8_add_fusion.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_bias_relu_fusion.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_matmul.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_bf16_matmul_add_fusion.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_bf16_matmul_sum_add_mul_relu.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_matmul_sum_add_mul_relu.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_f32_matmul_mul_add_fusion.json
+--reset --case=pattern/f8/f8_conv_add_add_fusion.json
+--reset --case=pattern/f8/f8_conv_fwd.json
+--reset --case=pattern/f8/f8_conv_post_ops_fusion.json
+--reset --case=pattern/f8/f8_conv_post_ops_int8_add_fusion.json
+--reset --case=pattern/f8/f8_conv_bias_relu_fusion.json
+--reset --case=pattern/f8/f8_matmul.json
+--reset --case=pattern/f8/f8_bf16_matmul_add_fusion.json
+--reset --case=pattern/f8/f8_bf16_matmul_sum_add_mul_relu.json
+--reset --case=pattern/f8/f8_matmul_sum_add_mul_relu.json
+--reset --case=pattern/f8/f8_f32_matmul_mul_add_fusion.json

--- a/tests/benchdnn/inputs/graph/pattern/harness_f8_ci
+++ b/tests/benchdnn/inputs/graph/pattern/harness_f8_ci
@@ -1,3 +1,2 @@
-# f8 cases: skip partition number check as they may not fuse on some platforms.
---reset --expected-n-partitions=0 --case=pattern/f8/f8_conv_fwd.json
---reset --expected-n-partitions=0 --case=pattern/f8/f8_matmul.json
+--reset --case=pattern/f8/f8_conv_fwd.json
+--reset --case=pattern/f8/f8_matmul.json


### PR DESCRIPTION
## General

Improve the skipping logic for data types with limited support such as fp8. Currently in benchdnn graph driver, the fp8 fusion cases will return several partitions on platforms where fp8 is not supported, and these partitions will be executed separately. However, as we have have independent tests for these separate patterns, we can skip such cases to simplify the testing. 

Before:
```
ONEDNN_VERBOSE=1 ./build/tests/benchdnn/benchdnn --graph --expected-n-partitions=0 --case=pattern/f8/f8_matmul.json
onednn_verbose,v1,info,oneDNN v3.9.0 (commit 692a6a1a577e718408c9015c56b608826eec4548)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:128
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with Intel DL Boost
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:ab::f0 dst:f8_e4m3::blocked:ab::f0,,,10x10,14.281
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f8_e4m3::blocked:ab::f0 dst:f32::blocked:ab::f0,attr-scales:src0:0:f32,,10x10,12.571
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:a::f0 dst:f32::blocked:a::f0,,,1,0.00878906
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f8_e4m3::blocked:ab::f0 dst:f32::blocked:ab::f0,attr-scratchpad:user attr-scales:src0:0:f32,,10x10,4.74292
onednn_verbose,v1,graph,exec,cpu,100002,misc_post_ops,dequant0,,in0_f8_e4m3:0:strided:undef:10x10:10s1 out0_f32:1:strided:undef:10x10:10s1,fpm:strict,quantize_dequantize_t,dnnl_backend,5.74512
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00488281
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00390625
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:ab::f0 dst:f8_e4m3::blocked:ab::f0,,,10x10,0.0629883
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f8_e4m3::blocked:ab::f0 dst:f32::blocked:ab::f0,attr-scales:src0:0:f32,,10x10,0.0598145
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:a::f0 dst:f32::blocked:a::f0,,,1,0.00512695
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f8_e4m3::blocked:ab::f0 dst:f32::blocked:ab::f0,attr-scratchpad:user attr-scales:src0:0:f32,,10x10,0.0571289
onednn_verbose,v1,graph,exec,cpu,100003,misc_post_ops,dequant1,,in0_f8_e4m3:3:strided:undef:10x10:10s1 out0_f32:4:strided:undef:10x10:10s1,fpm:strict,quantize_dequantize_t,dnnl_backend,0.246094
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00390625
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00390625
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ba::f0 dst:f32::blocked:ab::f0,,,10x10,0.0090332
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00708008
onednn_verbose,v1,primitive,exec,cpu,matmul,brg_matmul:avx512_core,undef,src:f32::blocked:ab::f0 wei:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10:10x10,0.0820312
onednn_verbose,v1,primitive,exec,cpu,reorder,brgemm_matmul_copy_reorder_t,undef,src:f32::blocked:ab::f0 dst:f32:p:blocked:AB16a64b::f0,attr-scratchpad:user,,10x10,0.052002
onednn_verbose,v1,primitive,exec,cpu,matmul,brg_matmul:avx512_core,undef,src:f32:a:blocked:ab::f0 wei:f32:ap:blocked:AB16a64b::f0 dst:f32:a:blocked:ab::f0,attr-scratchpad:user,,10x10:10x10,0.0268555
onednn_verbose,v1,graph,exec,cpu,100004,matmul_post_ops,matmul,,in0_f32:1:strided:undef:10x10:10s1 in1_f32:4:strided:undef:10x10:10s1 out0_f32:6:strided:undef:10x10:10s1,fpm:strict,matmul_t,dnnl_backend,0.356934
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00610352
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,10x10,0.00390625
0:PASSED (95 ms) __REPRO: --graph --expected-n-partitions=0 --case=pattern/f8/f8_matmul.json
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.10s; create_pd: 0.00s (1%); create_prim: 0.00s (1%); fill: 0.00s (0%); execute: 0.01s (13%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```

After:
```
ONEDNN_VERBOSE=1 ./build/tests/benchdnn/benchdnn --graph --case=pattern/f8/f8_matmul.json
0:SKIPPED (Data type not supported) (4 ms) __REPRO: --graph --case=pattern/f8/f8_matmul.json
tests:1 passed:0 skipped:1 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.00s (0%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```