### PR TITLE
tests: benchdnn: remove fpmath=f16 for some cases

### DIFF
--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -186,7 +186,6 @@
 --wtag=any,ab,ba
 --dt=s8:s8:f16
 --attr-scales=src:common:0.5:f32+wei:per_oc:f16
---attr-fpmath=,f16:true
 4x256:256x64
 6x384:384x100
 
@@ -194,14 +193,12 @@
 --dt=s8:s4:f16
 --attr-scales=src:per_ocic:f16:1x256+wei:per_ocic:f16:128x1
 --attr-zero-points=wei:per_ocic:s4:128x1,src:per_ocic:s4:1x128+wei:per_ocic:s4:128x1
---attr-fpmath=,f16:true
 4x256:256x64
 6x256:256x100
 
 --wtag=any,ab,ba
 --dt=s8:u8:f16
 --attr-scales=src:per_ocic:f16:1x256+wei:per_ocic:f16:128x1
---attr-fpmath=,f16:true
 4x256:256x64
 6x256:256x100
 
@@ -209,7 +206,6 @@
 --dt=s8:u4:f32
 --attr-scales=src:per_ocic:f16:1x192+wei:per_ocic:f16:192x1
 --attr-zero-points=wei:per_ocic:u4:192x1,src:per_ocic:s4:1x192+wei:per_ocic:u4:192x1
---attr-fpmath=,f16:true
 12x4x576:12x576x192
 12x6x192:12x192x100
 
@@ -217,6 +213,5 @@
 --dt=s8:s4:f16
 --attr-scales=src:per_ocic:f16:1x256+wei:per_tensor:f16:128x1
 --attr-zero-points=wei:per_tensor:s4:128x1,src:per_ocic:u4:1x256+wei:per_tensor:s4:128x1
---attr-fpmath=,f16:true
 2x3x4x256:2x3x256x64
 2x3x6x256:2x3x256x100


### PR DESCRIPTION
These test cases  are not supported by cpu and return unimplemented. Revert back to original cases.

Fixup for #2366.
