### PR TITLE
benchdnn: add zmalloc memory tracing

### DIFF
--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -166,6 +166,7 @@ void init_fp_mode();
 
 void *zmalloc(size_t size, size_t align);
 void zfree(void *ptr);
+void set_zmalloc_max_expected_size(size_t size);
 
 bool str2bool(const char *str);
 const char *bool2str(bool value);
@@ -219,4 +220,5 @@ struct summary_t {
 
 extern summary_t summary;
 
+std::string smart_bytes(double bytes);
 #endif

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1084,29 +1084,6 @@ int get_gpu_cache_size(size_t &cache_size) {
     return OK;
 }
 
-std::string smart_bytes(double bytes) {
-    std::string s;
-    static constexpr int oneK = 1024;
-
-    if (bytes < oneK) {
-        s = std::to_string(static_cast<size_t>(bytes)) + " B";
-        return s;
-    }
-    auto KB = bytes / oneK;
-    if (KB < oneK) {
-        s = std::to_string(KB) + " KB";
-        return s;
-    }
-    auto MB = KB / oneK;
-    if (MB < oneK) {
-        s = std::to_string(MB) + " MB";
-        return s;
-    }
-    auto GB = MB / oneK;
-    s = std::to_string(GB) + " GB";
-    return s;
-}
-
 // The function logic is the following:
 // `checkit` function verifies that the bare minimum (the library and the stock
 // reference) memory requirements are complied with the limits.
@@ -1197,6 +1174,7 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
     size_t total_size_cpu = total_size_ref
             + check_mem_size_args.total_size_compare
             + check_mem_size_args.total_size_mapped;
+
     // If the problem runs on CPU, the combined memory represents requirements
     // for the library and for the reference paths.
     // If the problem runs on a device, the combined memory represents potential
@@ -1207,6 +1185,8 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
     bool fits_cpu_ram = cpu_and_device_size
             <= (is_cpu() ? benchdnn_cpu_limit : benchdnn_combined_limit);
 
+    set_zmalloc_max_expected_size(
+            is_cpu() ? cpu_and_device_size : total_size_cpu);
     // Check combined size against CPU capacity as the simpler method to account
     // for integrated devices and mapping/unmapping memory.
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -235,7 +235,6 @@ int get_gpu_ram_sizes(size_t &ram_size, size_t &max_alloc_size);
 int get_cpu_cache_size(cpu_cache_args_t &cache_args);
 int get_gpu_cache_size(size_t &cache_size);
 
-std::string smart_bytes(double bytes);
 int check_total_size(res_t *res, dnnl_primitive_t prim_ref = nullptr);
 bool is_fwd_training(dnnl_prop_kind_t prop_kind);
 bool is_fwd_prop_kind(dnnl_prop_kind_t prop_kind);


### PR DESCRIPTION
Adds zmalloc allocation tracing to make identifying memory allocation issues easier and fixes some of the issues caught by the tracing. Sample use case:

```
$ ~/dnnl/build/tests/benchdnn/benchdnn -v1 --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
create: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
run: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
run ref: --conv --engine=cpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
[CHECK_MEM][WARNING]: zmalloc allocation exceeded expected size 22.546154 GB
0:PASSED (28311 ms) __REPRO: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 28.31s; create_pd: 0.00s (0%); create_prim: 0.03s (0%); fill: 9.44s (33%); execute: 0.65s (2%); compute_ref: 0.15s (1%); compare: 16.61s (59%);
```

```
$ ~/dnnl/build/tests/benchdnn/benchdnn -v6 --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
create: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
oneDNN implementation: jit:ir
CPU reference oneDNN implementation: brg_conv_fwd:avx2_vnni_2
[CHECK_MEM][FWD]: Requested: 4.174807 GB; benchdnn_device_limit: 8.499902 GB; device_RAM_capacity: 11.333202 GB; gpu_max_alloc: 11.333202 GB;
[CHECK_MEM][FWD]: benchdnn_CPU_limit: 46.161684 GB; CPU_RAM_capacity: 61.548912 GB;
[CHECK_MEM][FWD]: Sizes: {409.728516 MB, 74.000000 KB, 0 B (Scratchpad), 3.774611 GB, };
[CHECK_MEM][FWD]: Requested: 22.546154 GB (Service), 26.720961 GB (combined);
run: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
[FILL_CFG] SRC_s8=[-4;4]; WEI_s8=[-2;2]; DST_u8=[0;160];
[CHECKK_MEM]: zmalloc request with size 14.401892 GB, total allocation size: 14.401892 GB
[CHECKK_MEM]: zmalloc request with size 3.600473 GB, total allocation size: 18.002365 GB
[CHECKK_MEM]: zmalloc request with size 267.343750 KB, total allocation size: 3.600728 GB
[FILL_CFG][WEI] n_acc=118 safe_n_acc=N/A; density=1.000000
[CHECKK_MEM]: zmalloc request with size 71.250000 KB, total allocation size: 3.600796 GB
[CHECKK_MEM]: zmalloc request with size 1.475337 GB, total allocation size: 5.075878 GB
[FILL_CFG][SRC] n_acc=118 safe_n_acc=32; density=0.813559
[CHECKK_MEM]: zmalloc request with size 377.686291 MB, total allocation size: 5.444712 GB
run ref: --conv --engine=cpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
[COMPARE][DST]: zero_trust%=85.00% extra=has_prim_ref:true;
[CHECKK_MEM]: zmalloc request with size 14.401892 GB, total allocation size: 18.371267 GB
[CHECKK_MEM]: zmalloc request with size 14.401892 GB, total allocation size: 32.773159 GB
[CHECK_MEM][WARNING]: zmalloc allocation exceeded expected size 22.546154 GB
[COMPARE_STATS][DST]: trh=0 err_max_diff:       0 err_max_rdiff:       0 all_max_diff:       0 all_max_rdiff:       0
[COMPARE_TRUST][DST]: z:51% (>85%) (z: 1954535039, total: 3865978400)
0:PASSED (28674 ms) __REPRO: --conv --engine=gpu --dir=FWD_D --dt=s8:s8:u8 mb46940ic59iw143oc580ow142kw2pw0
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 28.69s; create_pd: 0.04s (0%); create_prim: 0.11s (0%); fill: 9.53s (33%); execute: 0.65s (2%); compute_ref: 0.15s (1%); compare: 16.66s (58%);
```

Fixes [MFDNN-13476](https://jira.devtools.intel.com/browse/MFDNN-13476).