### PR TITLE
xe: conv: adjust layout heuristic for small channels

### DIFF
--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -416,7 +416,10 @@ struct nc_block_t {
             }
         }
         auto default_n_blk = (type.size() <= 2) ? 32 : 16;
-        int n_block = (c_block == 1) ? 1 : pick_block(n, 16, default_n_blk);
+        int n_block = (c_block == 1)
+                ? 1
+                : (c_block < 8 ? pick_block(n, default_n_blk)
+                               : pick_block(n, 16, default_n_blk));
         return nc_block_t(n_block, c_block);
     }
 


### PR DESCRIPTION
Related Jira: [MFDNN-13336](https://jira.devtools.intel.com/browse/MFDNN-13336)
No broad performance impact: there are a very few speed-ups and regressions without affecting KPIs much but it helps the above request so let's change the heuristic:

```
# before
perf,gpu,jit:ir,,--mode=F --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s8 --bia-dt=f32 --stag=abcd --attr-post-ops=mul:f32:2+swish:1+linear:2.68555 mb16ic3ih640oc48oh320kh6sh2ph2,16.9162,55.3884,0.922812,18331.2,0.938702,18020.9

# after
perf,gpu,jit:ir,,--mode=F --conv --engine=gpu --dir=FWD_I --dt=u8:s8:s8 --bia-dt=f32 --stag=abcd --attr-post-ops=mul:f32:2+swish:1+linear:2.68555 mb16ic3ih640oc48oh320kh6sh2ph2,16.9162,52.032,0.770729,21948.3,0.784391,21566.1
```