### PR TITLE
benchdnn: graph: inputs: clean removed mha test cases

### DIFF
--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -13,7 +13,7 @@
 --reset --dt=f32,bf16,f16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
 
 # f16 inputs + f32 intermediates + f16 outputs
---reset --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+--reset --op-kind=1:Multiply,1:Divide --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 --reset --in-shapes=1:1x16x32x512+2:1x16x32x512+3:1x16x32x512+5:1x1x32x32,\
                     1:1x16x64x512+2:1x16x64x512+3:1x16x64x512+5:1x1x64x64,\
                     1:1x16x128x512+2:1x16x128x512+3:1x16x128x512+5:1x1x128x128,\
@@ -35,18 +35,16 @@
 --reset --dt=3:f16+4:f16+2:f16+1:f16+11:f16+0:f16+12:f16+14:f16+16:f16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=0:f16+1:f16+3:f16+7:f16+2:f16+8:f16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
 --reset --dt=15:f32+16:f32+5:f32+21:f32 --case=complex_fusion/mha/sdpa-compressed-kv-implicit-causal-mask-int8-gs128.json
---reset --dt=2:f32+4:f32+6:f32 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --dt=2:f32+5:f32 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
 --reset --dt=2:f32+6:f32 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
---reset --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+--reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 --reset --dt=3:bf16+4:bf16+2:bf16+1:bf16+11:bf16+0:bf16+12:bf16+14:bf16+16:bf16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=4:f32+9:f32+14:f32+1:bf16+3:bf16+8:bf16+11:bf16+16:bf16+20:bf16+19:bf16 --case=complex_fusion/mha/GQA-fp16-v2.json
 --reset --dt=4:f32+9:f32+14:f32+0:bf16+1:bf16+2:bf16+3:bf16+11:bf16+12:bf16+18:bf16+19:bf16+8:bf16+16:bf16+20:bf16+23:bf16 --case=complex_fusion/mha/GQA-fp16.json
 --reset --dt=0:bf16+1:bf16+3:bf16+7:bf16+2:bf16+8:bf16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
 --reset --dt=1:bf16+2:bf16+3:bf16+4:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
---reset --dt=2:f32+4:f32+6:f32+0:bf16+1:bf16+3:bf16+5:bf16+7:bf16+8:bf16+9:bf16 --case=complex_fusion/mha/sdpa-plain-scale-by-mul-f16.json
 --reset --dt=2:f32+5:f32+0:bf16+1:bf16+4:bf16+7:bf16+9:bf16+10:bf16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json
 --reset --dt=2:f32+6:f32+0:bf16+1:bf16+5:bf16+7:bf16+8:bf16+9:bf16  --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 


### PR DESCRIPTION
## General

- Clean the test cases for JSON file `sdpa-plain-scale-by-mul-f16.json`, which was removed in https://github.com/uxlfoundation/oneDNN/pull/2949.
- Add test cases for multiply scales with `--op-kind` rewrite for `sdpa-plain-simplified-f16-f32.json`