### PR TITLE
scripts: header check: fix exit codes + ignore tests/examples

### DIFF
--- a/scripts/fix_header_guards.py
+++ b/scripts/fix_header_guards.py
@@ -229,7 +229,7 @@ def fix_file(file, options):
     warn_repetitive_filename(status, file)
     if not status or (options.verbose and file_action is Action.FIX):
         print(f"[{status.color(sys.stdout)}] {file} ({status!s})")
-    return status is FileStatus.FAIL
+    return status.status is FileStatus.FAIL
 
 
 class Status:

--- a/scripts/fix_header_guards.py
+++ b/scripts/fix_header_guards.py
@@ -423,7 +423,7 @@ def adjust_content(file: str, guard: str, status: Status):
                 comment_guard = arg[2:-2].strip()
             if (
                 comment_guard is not None
-                and comment_guard != old_guard
+                and comment_guard != guard
                 and comment_guard.upper() != "HEADER GUARD"
             ):
                 if not options.inplace:

--- a/src/cpu/ppc64/ppc64_gemm_driver.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_driver.hpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef CPU_PPC64_GEMM_GEMM_DRIVER_HPP
-#define CPU_PPC64_GEMM_GEMM_DRIVER_HPP
+#ifndef CPU_PPC64_PPC64_GEMM_DRIVER_HPP
+#define CPU_PPC64_PPC64_GEMM_DRIVER_HPP
 
 namespace dnnl {
 namespace impl {
@@ -30,4 +30,4 @@ dnnl_status_t cblas_gemm_s8x8s32_ppc64(int, int, char const *, dim_t, dim_t,
 } // namespace cpu
 } // namespace impl
 } // namespace dnnl
-#endif // CPU_PPC64_GEMM_GEMM_DRIVER_HPP
+#endif // CPU_PPC64_PPC64_GEMM_DRIVER_HPP

--- a/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_s8x8s32.hpp
@@ -14,6 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
+#ifndef CPU_PPC64_PPC64_GEMM_S8X8S32_HPP
+#define CPU_PPC64_PPC64_GEMM_S8X8S32_HPP
+
 #include <altivec.h>
 #include "cpu/simple_q10n.hpp"
 
@@ -3072,3 +3075,5 @@ void gemm_kernel_8bit(dim_t m, dim_t n, dim_t k, float alpha, int8_t *A,
 
 } // namespace impl
 } // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/rvv_nchw_pooling.hpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.hpp
@@ -15,8 +15,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef RV64_NCHW_POOLING_HPP
-#define RV64_NCHW_POOLING_HPP
+#ifndef CPU_RV64_RVV_NCHW_POOLING_HPP
+#define CPU_RV64_RVV_NCHW_POOLING_HPP
 
 #include "common/primitive.hpp"
 #include "cpu/cpu_pooling_pd.hpp"

--- a/src/cpu/s390x/helpers.h
+++ b/src/cpu/s390x/helpers.h
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#ifndef CPU_S390X_VEC_H
-#define CPU_S390X_VEC_H
+#ifndef CPU_S390X_HELPERS_H
+#define CPU_S390X_HELPERS_H
 #include <vecintrin.h>
 namespace dnnl {
 namespace impl {

--- a/src/cpu/s390x/kernel_s16s16s32.hpp
+++ b/src/cpu/s390x/kernel_s16s16s32.hpp
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#ifndef CPU_S390X_KERNELS_S16S16S32_HPP
-#define CPU_S390X_KERNELS_S16S16S32_HPP
+#ifndef CPU_S390X_KERNEL_S16S16S32_HPP
+#define CPU_S390X_KERNEL_S16S16S32_HPP
 
 #include <cstdint>
 #include "common/utils.hpp"

--- a/src/cpu/s390x/pack.hpp
+++ b/src/cpu/s390x/pack.hpp
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#ifndef CPU_S390X_KERNELS_PACK_HPP
-#define CPU_S390X_KERNELS_PACK_HPP
+#ifndef CPU_S390X_PACK_HPP
+#define CPU_S390X_PACK_HPP
 #include "common/utils.hpp"
 #include "cpu/s390x/helpers.h"
 namespace dnnl {


### PR DESCRIPTION
1. Fix the exit code on failure
2. Exclude files outside of src/ and include/

See the [header guard check](https://github.com/uxlfoundation/oneDNN/actions/runs/14365944947/job/40278772887?pr=3032) from #3032, for example.