### PR TITLE
x64: brgemm matmul: update extendable_k_ condition

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -949,7 +949,7 @@ void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
         // TODO: review extendable_k_ condition to cover more cases
         extendable_k_ = (K % wei_k_blk != 0) && (brgemm_k_elems > wei_k_blk)
                 && wei_zp_type == none && !use_buffer_a
-                && !packed_sparse_weights;
+                && !packed_sparse_weights && current_lda_ == K;
 
         if (extendable_k_) {
             if (brgemm_k_elems >= K) {


### PR DESCRIPTION
Tomasz discovered correctness error for case:
benchdnn --matmul --allow-enum-tags-only=false --dt=f16:f16:f16 --wtag=ab **--strides=64x1::112x1** -v5 20x36:36x108

This PR is a fix for this error in matmul with stride for matrix A. In the above example the K is 36 but LDA is 64. We can't use extandable_k for such shapes. 