### PR TITLE
xe: jit: gemm: misc fixes

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
@@ -1562,7 +1562,6 @@ bool BLASKernelGenerator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStr
             Cr_unrollX = panel;
             period = outerProductCount(hw, problem, strategy);
         }
-        period = std::min(period, 64);
 
         makeUnbackedRegLayout(Tc_compute, state.Cr_layout, Cr_unrollM, Cr_unrollN, globalCM, 1, strategy.C.tileR, strategy.C.tileC, true);
     }

--- a/src/gpu/intel/jit/gemm/generator/strategy.cpp
+++ b/src/gpu/intel/jit/gemm/generator/strategy.cpp
@@ -429,10 +429,14 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     if (blocking[LoopM] <= 0) blocking[LoopM] = defaultMBlock;
     if (blocking[LoopN] <= 0) blocking[LoopN] = defaultNBlock;
     if (blocking[LoopK] <= 0) {
-        int points = 1;
-        if (slmA || (problem.A.layout != MatrixLayout::T)) points++;
-        if (slmB || (problem.B.layout != MatrixLayout::N)) points++;
-        blocking[LoopK] = std::min(2048, (2048 * points) / problem.Ta);
+        if (hw >= HW::XeHPG)
+            blocking[LoopK] = 16777216;
+        else {
+            int points = 1;
+            if (slmA || (problem.A.layout != MatrixLayout::T)) points++;
+            if (slmB || (problem.B.layout != MatrixLayout::N)) points++;
+            blocking[LoopK] = std::min(2048, (2048 * points) / problem.Ta);
+        }
     }
 
     auto defaultBlockAltK = blocking[LoopK];


### PR DESCRIPTION
Closes MFDNN-13294, MFDNN-13453. Two fixes, one functional, both for performance:

* (Functional/performance) Upstream gemmstone does not use k blocking by default on newer GPUs (`bk0`), but oneDNN behavior did not match
* (Performance) oneDNN is imposing an arbitrary limit on the C repacking period that isn't needed.