### PR TITLE
xe: jit: gemm: fix zero pool memory leak under SYCL when not recording

### DIFF
--- a/src/gpu/intel/compute/zero_pool.cpp
+++ b/src/gpu/intel/compute/zero_pool.cpp
@@ -75,7 +75,7 @@ status_t lookup_zero_pool(compute::compute_engine_t *engine,
     // If recording, get a per-graph zero pool.
     const auto *sycl_stream
             = utils::downcast<const gpu::intel::sycl::stream_t *>(stream);
-    if (sycl_stream->recording()) {
+    if (sycl_stream && sycl_stream->recording()) {
         {
             std::lock_guard<std::mutex> lock(zero_pool_cache_mutex);
             auto &pool = recorded_zero_pool_cache


### PR DESCRIPTION
Backport of #3005 to `rls-v3.8`.