### PR TITLE
xe: binary_select: fix src_2 broadcasting

### DIFF
--- a/src/gpu/intel/ocl/simple_binary.cl
+++ b/src/gpu/intel/ocl/simple_binary.cl
@@ -101,9 +101,9 @@ __kernel void simple_binary(__global SRC0_DATA_T *src0,
                     dims0[4] * !SRC1_BCAST_DIM4, dims0[5] * !SRC1_BCAST_DIM5);
 #if IS_TERNARY
     int src2_off
-            = SRC0_OFF(dims0[0] * !SRC0_BCAST_DIM0, dims0[1] * !SRC0_BCAST_DIM1,
-                    dims0[2] * !SRC0_BCAST_DIM2, dims0[3] * !SRC0_BCAST_DIM3,
-                    dims0[4] * !SRC0_BCAST_DIM4, dims0[5] * !SRC0_BCAST_DIM5);
+            = SRC2_OFF(dims0[0] * !SRC2_BCAST_DIM0, dims0[1] * !SRC2_BCAST_DIM1,
+                    dims0[2] * !SRC2_BCAST_DIM2, dims0[3] * !SRC2_BCAST_DIM3,
+                    dims0[4] * !SRC2_BCAST_DIM4, dims0[5] * !SRC2_BCAST_DIM5);
 #endif
 
 #endif

--- a/src/gpu/intel/ocl/simple_binary.cpp
+++ b/src/gpu/intel/ocl/simple_binary.cpp
@@ -26,7 +26,7 @@ namespace ocl {
 status_t simple_binary_t::pd_t::init_conf(impl::engine_t *engine) {
     const memory_desc_wrapper src0_d(src_md(0));
     const memory_desc_wrapper src1_d(src_md(1));
-    const memory_desc_wrapper src2_d(is_ternary_op() ? src_md(2) : dst_md());
+    const memory_desc_wrapper src2_d(src_md(2));
     const memory_desc_wrapper dst_d(dst_md());
 
     const int ndims = src0_d.ndims();

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -426,6 +426,7 @@ struct binary_conf_t {
     int dim0[MAX_NDIMS];
     int src0_bcast_dims[MAX_NDIMS];
     int src1_bcast_dims[MAX_NDIMS];
+    int src2_bcast_dims[MAX_NDIMS];
     bool is_dense;
     bool is_same_md;
     bool same_src_dt;


### PR DESCRIPTION
# Description

Fixes incorrect results in binary_select with src_2 broadcasting on GPU. 

[MFDNN-13516](https://jira.devtools.intel.com/browse/MFDNN-13516)