### PR TITLE
cpu: x64: fix using new scale mask interface

### DIFF
--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -1229,8 +1229,12 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel::init_scratchpad(
     using namespace dnnl::impl::memory_tracking::names;
 
     const int wei_mask = attr.scales_.get_mask(DNNL_ARG_WEIGHTS);
+
+    // The implementation always uses scales, regardless of whether they have
+    // been set or not.
     const dim_t scales_count
-            = wei_mask == 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
+            = wei_mask <= 0 ? 1 : static_cast<dim_t>(jcp.oc) * jcp.ngroups;
+
     const dim_t count = nstl::max<dim_t>(scales_count, (dim_t)jcp.ic_block);
     scratchpad.book<float>(key_conv_adjusted_scales, count);
 }

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -346,6 +346,12 @@ private:
             const void *post_ops_binary_rhs_arg_vec,
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    const float *adjust_oscales(const memory_tracking::grantor_t &scratchpad,
+            const float *src_scales, const float *wei_scales) const;
+    const float *maybe_adjust_dw_oscales(
+            const memory_tracking::grantor_t &scratchpad,
+            const float *dst_scales, const float *dw_wei_scales) const;
+
     std::unique_ptr<jit_avx512_core_x8s8s32x_1x1_conv_kernel> kernel_;
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
     using dw_conv_kernel_t = jit_avx512_core_x8s8s32x_fwd_kernel;


### PR DESCRIPTION
Fixes MFDNN-13473 (large buffer case).

The issue is not related to the large shapes directly. Using the large shapes results in falling back to this implementation that had a bug manifesting as a segfault. We recently changed the interface of scales mask but overlooked this place that required some adjustments. 