### PR TITLE
[rls-v3.8] graph: use const reference per coverity's warnings

### DIFF
--- a/src/graph/backend/dnnl/passes/memory_planning.cpp
+++ b/src/graph/backend/dnnl/passes/memory_planning.cpp
@@ -565,7 +565,7 @@ status_t memory_planner_t::assign_internal_temporary_buffer(
             assign_info_t info = buffer_assignments_.at(out.get());
             if (info.kind_ != internal_temporary) continue;
 
-            auto consumers = out->get_consumers();
+            const auto &consumers = out->get_consumers();
             if (consumers.empty()) {
                 --temporary_buffer_ref_count[info.index_];
                 if (enable_standard_sharing) {

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -1068,7 +1068,6 @@ status_t fuse_src_zero_points(std::shared_ptr<subgraph_t> &sg) {
                 value_ptr in1_val = zp_op->get_input_value(1);
                 in1_val->remove_consumer(*zp_op, 1);
                 value_ptr out_val = zp_op->get_output_value(0);
-                auto consumers = out_val->get_consumers();
                 in0_val->add_consumer(next_op, offset);
                 next_op.connect_input(offset, in0_val);
                 if (not_all_zero) {
@@ -1169,7 +1168,6 @@ status_t fuse_src_scales(std::shared_ptr<subgraph_t> &sg) {
                 value_ptr in1_val = scale_op->get_input_value(1);
                 in1_val->remove_consumer(*scale_op, 1);
                 value_ptr out_val = scale_op->get_output_value(0);
-                auto consumers = out_val->get_consumers();
                 in0_val->add_consumer(next_op, offset);
                 next_op.connect_input(offset, in0_val);
                 next_op.add_input(in1_val);
@@ -1336,7 +1334,6 @@ status_t fuse_dst_zero_points(std::shared_ptr<subgraph_t> &sg) {
                 "zp_op should have only one output value, but got %zu",
                 zp_op->num_outputs());
         auto out_val = zp_op->get_output_values()[0];
-        auto consumers = out_val->get_consumers();
 
         auto in_val = zp_op->get_input_values()[0];
         if (!in_val->has_producer()) continue;
@@ -4159,7 +4156,7 @@ impl::status_t replace_select_values(std::shared_ptr<subgraph_t> &sg) {
         if (select_kind.count(cur_op->get_kind())) {
             auto out_val = cur_op->get_output_value(0);
             if (out_val->get_consumers().size() == 1) {
-                auto consumer = out_val->get_consumers()[0].get_op();
+                const auto &consumer = out_val->get_consumers()[0].get_op();
                 if (consumer.get_kind() == op_kind::dnnl_matmul) {
                     out_ops.emplace_back(cur_op);
                 }

--- a/src/graph/interface/graph.cpp
+++ b/src/graph/interface/graph.cpp
@@ -127,7 +127,7 @@ status_t dnnl_graph_graph::finalize() {
     std::unordered_map<size_t, logical_tensor_t> id_to_tensor;
 
     for (const auto &op : ops_) {
-        auto in_values = op->get_input_values();
+        const auto &in_values = op->get_input_values();
         auto out_values = op->get_output_values();
         if (!logical_tensor_sanity_check(id_to_tensor, in_values)
                 || !logical_tensor_sanity_check(id_to_tensor, out_values)) {

--- a/src/graph/utils/pm/nested_matcher.cpp
+++ b/src/graph/utils/pm/nested_matcher.cpp
@@ -768,8 +768,8 @@ inline std::vector<op_t *> reorder_matched_list(
         }
         auto &outputs = op->get_output_values();
         for (auto it = outputs.begin(); it != outputs.end(); ++it) {
-            auto cons = (*it)->get_consumers();
-            for (auto &con : (*it)->get_consumers()) {
+            const auto &cons = (*it)->get_consumers();
+            for (auto &con : cons) {
                 op_t &con_op = con.get_op();
                 if (std::find(dq.begin(), dq.end(), &con_op) == dq.end()
                         && std::find(fusion_ops.begin(), fusion_ops.end(),
@@ -1237,7 +1237,7 @@ bool repetition_matcher_t::verify_current_matching_round(
     oport_t oport = pmap_.first;
     op_t *cur_op = local_cached_ctx.out_port_map.at(oport).first;
     size_t cur_op_port = local_cached_ctx.out_port_map.at(oport).second;
-    auto cons = cur_op->get_output_value(cur_op_port)->get_consumers();
+    const auto &cons = cur_op->get_output_value(cur_op_port)->get_consumers();
     if (cons.size() <= 1) return true;
 
     // if current op has more than 1 consumers, while the repetition unit

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -203,7 +203,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
 int execute(const prb_t *prb, const args_t &args, res_t *res) {
     const auto &src = args.find(DNNL_ARG_SRC);
-    auto tag = ::std::get<0>(prb->arg_mds_.at(DNNL_ARG_SRC));
+    const auto &tag = ::std::get<0>(prb->arg_mds_.at(DNNL_ARG_SRC));
     dnn_mem_t pad(src, src.dt(), tag, get_test_engine());
     ::graph::permute_md(pad, prb->order);
     int ret = const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST)).reorder(pad);

--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -143,7 +143,7 @@ op deserialized_op_t::create() const {
         const auto &attr_value = it->second;
         const auto &type = attr_value.type_;
         if (type == "string") {
-            const auto value = attr_value.str_value_;
+            const auto &value = attr_value.str_value_;
             aop.set_attr(attr, value);
         } else if (type == "bool") {
             const auto value = attr_value.bool_value_;
@@ -152,13 +152,13 @@ op deserialized_op_t::create() const {
             const auto value = attr_value.s64_value_;
             aop.set_attr(attr, value);
         } else if (type == "s64[]") {
-            const auto value = attr_value.s64_vector_;
+            const auto &value = attr_value.s64_vector_;
             aop.set_attr(attr, value);
         } else if (type == "f32") {
             const auto value = attr_value.f32_value_;
             aop.set_attr(attr, value);
         } else if (type == "f32[]") {
-            const auto value = attr_value.f32_vector_;
+            const auto &value = attr_value.f32_vector_;
             aop.set_attr(attr, value);
         }
     }
@@ -294,9 +294,8 @@ void deserialized_graph_t::load(const std::string &pass_config_json) {
         for (const auto &lt : aop.out_lts_) {
             out_lt_2_op_[lt.id_] = aop;
             // collect graph internal and output tensors memory layout
-            std::string mtag
+            lt_2_mtag_[lt.id_]
                     = strides2memory_tag(lt.shape_.size(), lt.stride_, false);
-            lt_2_mtag_[lt.id_] = mtag;
         }
     }
 

--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -1143,15 +1143,15 @@ void flex_rewrite_t::op_attrs_rewrite(deserialized_graph_t &dgraph) {
         auto &temp_op = dgraph.ops_[std::distance(op_ids_.begin(), iter)];
         const auto attrs = parse_attrs(temp_attrs.second);
         for (const auto &new_attr : attrs) {
-            auto attr_name = new_attr.first;
+            const auto &attr_name = new_attr.first;
             if (!temp_op.attrs_.count(attr_name)) {
                 BENCHDNN_PRINT(0,
                         "graph: rewrite: no attr name `%s` in op %zd.\n",
                         attr_name.c_str(), temp_attrs.first);
                 SAFE_V(FAIL);
             }
-            auto new_val = new_attr.second;
-            auto attr_type = temp_op.attrs_[attr_name].type_;
+            const auto &new_val = new_attr.second;
+            const auto &attr_type = temp_op.attrs_[attr_name].type_;
             if (attr_type == "string") {
                 temp_op.attrs_[attr_name].str_value_ = new_val;
             } else if (attr_type == "bool") {

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -485,7 +485,7 @@ int doit(const prb_t *prb, res_t *res) {
     if (res->state == SKIPPED) return OK;
 
     const auto &dg = prb->dg;
-    const auto graph_in_ports = dg.get_input_ports();
+    const auto &graph_in_ports = dg.get_input_ports();
     auto ograph = dg.to_graph(prb->fpmath_mode);
     DNN_GRAPH_SAFE(ograph.finalize(), WARN, res);
     const auto partitions = ograph.get_partitions();

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -91,7 +91,7 @@ int ref_partition_t::init_ref(
         // Check whether the op has any output logical tensor that is the
         // output of the partition. If so, the driver need to allocate memory
         // for correctness check.
-        const auto check_mem_sizes_args = res->mem_size_args;
+        const auto &check_mem_sizes_args = res->mem_size_args;
         const auto is_output = is_output_op(par_op_ref.get());
         SAFE_V(check_partition_total_size(
                 check_mem_sizes_args, is_output, res));
@@ -320,8 +320,8 @@ int ref_partition_t::check_partition_correctness(
 
     for (const auto &op : partition_ops_ref_) {
         size_t op_id = op.get().id_;
-        const auto op_kind = op.get().kind_;
-        const auto ref_prim = ref_prims_.at(op_id);
+        const auto &op_kind = op.get().kind_;
+        const auto &ref_prim = ref_prims_.at(op_id);
 
         // if there is eltwise post-ops or binary div post-ops (GPU test), need
         // to relax compare critria.

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1467,8 +1467,7 @@ bool get_pool_dt(const deserialized_op_t &base_op_ref,
 }
 
 bool get_pool_alg(const deserialized_op_t &base_op_ref, ::pool::alg_t &alg) {
-
-    const auto op_kind_ = base_op_ref.kind_;
+    const auto &op_kind_ = base_op_ref.kind_;
     if (op_kind_ == "MaxPool" || op_kind_ == "MaxPoolBackward") {
         alg = ::pool::alg_t::max;
     } else if (op_kind_ == "AvgPool" || op_kind_ == "AvgPoolBackward") {
@@ -1799,7 +1798,7 @@ bool get_reorder_attrs(const deserialized_op_t &base_op_ref,
 ::reorder::settings_t get_setting(
         const deserialized_op_t &base_op_ref, res_t *res) {
     ::reorder::settings_t op_setting;
-    const auto op_kind = base_op_ref.kind_;
+    const auto &op_kind = base_op_ref.kind_;
 
     DNN_GRAPH_CHECK_SETTINGS(
             get_prb_dims(base_op_ref, op_setting.prb_dims), res);


### PR DESCRIPTION
- Backports #3072 