### PR TITLE
Fix postop support checks during primitive descriptor creation

### DIFF
--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -80,7 +80,7 @@ status_t binary_attr_check(const binary_desc_t &desc, const engine_t *engine,
                 VERBOSE_UNSUPPORTED_POSTOP);
 
         // Note: verbose support is inside the call.
-        CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+        CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
     }
     return status::success;
 }

--- a/src/common/convolution.cpp
+++ b/src/common/convolution.cpp
@@ -242,7 +242,7 @@ status_t conv_attr_check(const convolution_desc_t &desc, const engine_t *engine,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         auto bwd_attr_mask = smask_t::fpmath_mode | smask_t::accumulation_mode;

--- a/src/common/deconvolution.cpp
+++ b/src/common/deconvolution.cpp
@@ -219,7 +219,7 @@ status_t deconv_attr_check(const deconvolution_desc_t &desc,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         auto bwd_attr_mask = smask_t::fpmath_mode;

--- a/src/common/eltwise.cpp
+++ b/src/common/eltwise.cpp
@@ -138,7 +138,7 @@ status_t eltwise_attr_check(const eltwise_desc_t &desc, const engine_t *engine,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         VCHECK_ELTWISE_IMPL(false, VERBOSE_UNSUPPORTED_ATTR);

--- a/src/common/group_normalization.cpp
+++ b/src/common/group_normalization.cpp
@@ -176,7 +176,7 @@ status_t group_normalization_attr_check(const group_normalization_desc_t &desc,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         VCHECK_GNORM_UNIMPL(false, VERBOSE_UNSUPPORTED_ATTR);

--- a/src/common/inner_product.cpp
+++ b/src/common/inner_product.cpp
@@ -158,7 +158,7 @@ status_t ip_attr_check(const inner_product_desc_t &desc, const engine_t *engine,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         auto bwd_attr_mask = smask_t::fpmath_mode | smask_t::accumulation_mode;

--- a/src/common/layer_normalization.cpp
+++ b/src/common/layer_normalization.cpp
@@ -186,7 +186,7 @@ status_t layer_normalization_attr_check(const layer_normalization_desc_t &desc,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         VCHECK_LNORM_UNIMPL(false, VERBOSE_UNSUPPORTED_ATTR);

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -287,7 +287,7 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
                 VERBOSE_UNSUPPORTED_POSTOP);
 
         // Note: verbose support is inside the call.
-        CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+        CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
     }
 
     return status::success;

--- a/src/common/pooling.cpp
+++ b/src/common/pooling.cpp
@@ -155,7 +155,7 @@ status_t pooling_attr_check(const pooling_desc_t &desc, const engine_t *engine,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         VCHECK_POOLING_IMPL(false, VERBOSE_UNSUPPORTED_ATTR);

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -328,21 +328,25 @@ bool post_ops_t::check_sum_consistency(const data_type_t dst_dt,
             && check_sum_consistent_quantization(dst_dt, is_int8);
 }
 
-status_t post_ops_t::entry_t::validate_binary_with_dst_consistency(
-        const memory_desc_t *dst_md) const {
+status_t post_ops_t::entry_t::validate_binary(
+        engine_kind_t engine_kind, const memory_desc_t *dst_md) const {
     if (!is_binary()) return status::success;
 
     VCHECK_ATTR(dst_md->ndims == binary.user_src1_desc.ndims,
             VERBOSE_INCONSISTENT_NDIMS_WITH_VALS, "dst", "bin_po",
             dst_md->ndims, binary.user_src1_desc.ndims);
 
+    VCHECK_ATTR(IMPLICATION(engine_kind == dnnl_cpu,
+                        binary.user_src1_desc.data_type != data_type::f64),
+            VERBOSE_INVALID_DATATYPE, "bin_po src1");
+
     return status::success;
 }
 
-status_t post_ops_t::validate_binary_with_dst_consistency(
-        const memory_desc_t *dst_md) const {
+status_t post_ops_t::validate_binary(
+        engine_kind_t engine_kind, const memory_desc_t *dst_md) const {
     for (const auto &e : entry_) {
-        CHECK(e.validate_binary_with_dst_consistency(dst_md));
+        CHECK(e.validate_binary(engine_kind, dst_md));
     }
 
     return status::success;

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -366,7 +366,8 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
 
         bool is_like_binary() const { return is_binary() || is_prelu(); }
 
-        dnnl::impl::status_t validate_binary_with_dst_consistency(
+        dnnl::impl::status_t validate_binary(
+                dnnl::impl::engine_kind_t engine_kind,
                 const dnnl::impl::memory_desc_t *dst_desc) const;
 
         bool operator==(const entry_t &rhs) const {
@@ -487,7 +488,7 @@ struct dnnl_post_ops : public dnnl::impl::c_compatible {
                 || entry_[sum_ind].sum.dt == dst_dt;
     }
 
-    dnnl::impl::status_t validate_binary_with_dst_consistency(
+    dnnl::impl::status_t validate_binary(dnnl::impl::engine_kind_t engine_kind,
             const dnnl::impl::memory_desc_t *dst_desc) const;
 
     bool contain(dnnl::impl::primitive_kind_t kind, int index) const {

--- a/src/common/reduction.cpp
+++ b/src/common/reduction.cpp
@@ -126,7 +126,7 @@ status_t reduction_attr_check(const reduction_desc_t &desc,
                 VERBOSE_UNSUPPORTED_POSTOP);
 
         // Note: verbose support is inside the call.
-        CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+        CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
     }
 
     return status::success;

--- a/src/common/resampling.cpp
+++ b/src/common/resampling.cpp
@@ -133,7 +133,7 @@ status_t resampling_attr_check(const resampling_desc_t &desc,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         VCHECK_RS_UNIMPL(false, VERBOSE_UNSUPPORTED_ATTR);

--- a/src/common/softmax.cpp
+++ b/src/common/softmax.cpp
@@ -137,7 +137,7 @@ status_t softmax_attr_check(const softmax_desc_t &desc, const engine_t *engine,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // Note: verbose support is inside the call.
-            CHECK(po.validate_binary_with_dst_consistency(&desc.dst_desc));
+            CHECK(po.validate_binary(engine->kind(), &desc.dst_desc));
         }
     } else {
         VCHECK_SOFTMAX_UNIMPL(false, VERBOSE_UNSUPPORTED_ATTR);

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -244,8 +244,8 @@ private:
     void apply_postops(int ur_bc, int ur_w, int c_block,
             const std::function<bool(int, bool)> &is_tail_predicate);
 
-    static bool post_ops_ok(jit_pool_conf_t &jpp, const primitive_attr_t &attr,
-            const memory_desc_wrapper &dst_d);
+    static bool init_post_ops_conf(jit_pool_conf_t &jpp,
+            const primitive_attr_t &attr, const memory_desc_wrapper &dst_d);
 
     inline bool use_bf16_emulation() const {
         return jpp.is_bf16 && !isa_has_bf16(jpp.isa) && isa != avx2_vnni_2;


### PR DESCRIPTION
1) Primitives that use ref_post_ops_t did not catch error cases when a binary post-op has an unsupported src1_desc.data_type during a primitive descriptor creation. Errors were detected only during a primitive execution, and only debug asserts were used, and NAN was used as a result of the operation in release binaries.
The PR has a minimal fix for reference implementations: those errors are caught during a primitive descriptor creation.

Update: Creation of primitives with binary post-op with user_src1_desc.data_type == f64 is disabled for CPU engine.

2) A similar issue existed in jit_uni_pool_kernel_t (used by jit_uni_pooling_fwd_t, jit_uni_pooling_bwd_t) and jit_uni_i8i8_pooling_fwd_ker_t (used by jit_uni_i8i8_pooling_fwd_t):
a) a support of src data type of a binary post-op was not checked during a primitive descriptor creation; a binary injector did nothing in release binaries,
b) and the result of eltwise_injector::is_supported was only taken into account for the last eltwise post-op, and its failure was ignored.  
In the case of jit_uni_pool_kernel_t, these checks were performed before updating binary.src1_desc by the function set_binary_postops_formats (it did not look natural even if the modification of binary.src1_desc did not change the result of binary_injector::is_supported, and postops-related data in jpp were set in two places).
The PR fixes that too.

The PR is partially related to [MFDNN-13286](https://jira.devtools.intel.com/browse/MFDNN-13286) (the issues were identified during its logs analysis) and is a continuation of [PR #2974: skip f64 inputs](https://github.com/uxlfoundation/oneDNN/pull/2974)