### PR TITLE
cpu: aarch64: Add BF16 support for eltwise JIT via reordering to FP32

### DIFF
--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -119,14 +119,13 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
             // - unpack BF16 to FP32 by zero-extending
             // - compute eltwise alg in FP32
             // - down convert back to BF16 using bfcvt, and pack result
-            mov(ZReg(tmp0).s, P_ALL_ONE, ZReg(vmm_src).s);
-            lsl(ZReg(vmm_src.getIdx()).s, ZReg(vmm_src).s, 16);
-            and_(ZReg(tmp0).s, 0xFFFF0000); // 0xFFFF0000
+            mov(tmp0.s, P_ALL_ONE, vmm_src.s);
+            lsl(vmm_src.s, vmm_src.s, 16);
+            and_(tmp0.s, 0xFFFF0000);
             eltwise_injector_->compute_vector_range(
                     {vmm_src.getIdx(), tmp0.getIdx()});
-            bfcvt(ZReg(vmm_src.getIdx()).h, P_ALL_ONE,
-                    ZReg(vmm_src.getIdx()).s);
-            bfcvtnt(ZReg(vmm_src.getIdx()).h, P_ALL_ONE, ZReg(tmp0.getIdx()).s);
+            bfcvt(vmm_src.h, P_ALL_ONE, vmm_src.s);
+            bfcvtnt(vmm_src.h, P_ALL_ONE, tmp0.s);
         } else {
             eltwise_injector_->compute_vector(vmm_src.getIdx());
         }

--- a/src/cpu/cpu_eltwise_list.cpp
+++ b/src/cpu/cpu_eltwise_list.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2024 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
-* Copyright 2021-2022 Arm Ltd. and affiliates
+* Copyright 2021-2022, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_X64(jit_uni_eltwise_int_fwd_t<sse41, u8>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_512, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, bf16>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_128, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s8>)

--- a/src/cpu/cpu_eltwise_list.cpp
+++ b/src/cpu/cpu_eltwise_list.cpp
@@ -68,6 +68,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_256, bf16>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_128, f32>)
+            CPU_INSTANCE_AARCH64(jit_uni_eltwise_fwd_t<sve_128, bf16>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s32>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s8>)
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, u8>)


### PR DESCRIPTION
Backport to [#2982 ](https://github.com/uxlfoundation/oneDNN/pull/2982) 

It fixes a major performance gap when using BF16 precision on aarch64. It should directly translate to improvement in performance for a majority of models in PyTorch. 