### PR TITLE
[backport][rls-v3.8] fixup: common: matmul: allow single scale/zp group of any size (fixes MFDNN-13507)

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -79,8 +79,10 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     }
 
     memory_desc_t src_md_reduced, dst_md_reduced;
-    memory_desc_reshape(src_md_reduced, src_md, non_unit_dim, non_unit_dims);
-    memory_desc_reshape(dst_md_reduced, dst_md, non_unit_dim, non_unit_dims);
+    CHECK(memory_desc_reshape(
+            src_md_reduced, src_md, non_unit_dim, non_unit_dims));
+    CHECK(memory_desc_reshape(
+            dst_md_reduced, dst_md, non_unit_dim, non_unit_dims));
 
     const memory_desc_wrapper id(src_md_reduced), od(dst_md_reduced);
 


### PR DESCRIPTION
Backport of #3070