### PR TITLE
benchdnn: graph: fix false positives by reducing the matmul range

### DIFF
--- a/tests/benchdnn/graph/ref_primitive.cpp
+++ b/tests/benchdnn/graph/ref_primitive.cpp
@@ -302,7 +302,7 @@ void ref_primitive_t::check_correctness(
         //
         // Note: the following threshold is obtained from actual runs on
         // different hardware.
-        cmp.set_threshold(1e-4f);
+        cmp.set_threshold(2.5e-3f);
         cmp.set_norm_validation_mode(true);
         cmp.compare(mem_fp_abx, mem_dt, attr, res);
     }

--- a/tests/benchdnn/matmul/cfg.cpp
+++ b/tests/benchdnn/matmul/cfg.cpp
@@ -77,7 +77,7 @@ cfg_t::cfg_entry_t::cfg_map_t cfg_t::get_cfg_map(data_kind_t kind) const {
     static const cfg_t::cfg_entry_t::cfg_map_t wei_cfg_map = {
             {{dnnl_f64}, {-128, 128}},
             {{dnnl_f32}, {-128, 128}},
-            {{dnnl_bf16}, {-8, 8}},
+            {{dnnl_bf16}, {-2, 2}}, // Must be same as f16 for graph's SDPA.
             {{dnnl_f16}, {-2, 2}},
             {{dnnl_f4_e2m1}, {-1, 1}},
             {{dnnl_f4_e3m0}, {-1, 1}},


### PR DESCRIPTION
And bumping L2 norm trh as there are still cases not addressed by reduced filling.

Should cover all cases MFDNN-13052