### PR TITLE
gtest: graph: unit: limit decompose kernel test thread

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/test_mqa_decomp.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_mqa_decomp.cpp
@@ -174,6 +174,13 @@ TEST(test_mqa_decomp_execute, MultithreaMqaDecomp_CPU) {
     SKIP_IF(eng->kind() == graph::engine_kind::gpu,
             "Skip for GPU - not supported yet.");
 
+// Limit OMP threads in multithread test scenario to avoid out_of_resource
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    int max_threads = dnnl_get_current_num_threads();
+    int test_threads = max_threads / 4 > 0 ? max_threads / 4 : 1;
+    omp_set_num_threads(test_threads);
+#endif
+
     int batch_size = 56;
     graph::graph_t g(eng->kind());
     utils::construct_dnnl_float_JAX_MQA(
@@ -243,6 +250,11 @@ TEST(test_mqa_decomp_execute, MultithreaMqaDecomp_CPU) {
     t2.join();
     t3.join();
     t4.join();
+
+// Set OMP threads back
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(max_threads);
+#endif
 }
 
 // Test correctness

--- a/tests/gtests/graph/unit/backend/dnnl/test_sdp_decomp.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_sdp_decomp.cpp
@@ -453,6 +453,13 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecomp_CPU) {
                     && eng->kind() == graph::engine_kind::cpu,
             "Skip bf16 tests for systems that do not support avx512_core.");
 
+// Limit OMP threads in multithread test scenario to avoid out_of_resource
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    int max_threads = dnnl_get_current_num_threads();
+    int test_threads = max_threads / 4 > 0 ? max_threads / 4 : 1;
+    omp_set_num_threads(test_threads);
+#endif
+
     size_t ndims = 4;
     int batch_size = 56, seq_len = 384, num_head = 16, head_dim = 1024,
         size_per_head = head_dim / num_head;
@@ -542,6 +549,11 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecomp_CPU) {
         t3.join();
         t4.join();
     }
+
+// Set OMP threads back
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(max_threads);
+#endif
 }
 
 // Test correctness
@@ -1488,6 +1500,13 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecompCorr_CPU) {
                     && eng->kind() == graph::engine_kind::cpu,
             "Skip bf16 tests for systems that do not support avx512_core.");
 
+// Limit OMP threads in multithread test scenario to avoid out_of_resource
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    int max_threads = dnnl_get_current_num_threads();
+    int test_threads = max_threads / 2 > 0 ? max_threads / 2 : 1;
+    omp_set_num_threads(test_threads);
+#endif
+
     size_t ndims = 4;
     int batch_size = 56, seq_len = 2, num_head = 16, head_dim = 64,
         size_per_head = head_dim / num_head;
@@ -1594,4 +1613,9 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecompCorr_CPU) {
         t1.join();
         t2.join();
     }
+
+// Set OMP threads back
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(max_threads);
+#endif
 }


### PR DESCRIPTION
Found in CI, sporadic failures for decompose kernel, so we decide to limit the thread num used in multithread-related gtest cases. 
Logs:
```
[ RUN      ] test_sdp_decomp_execute.MultithreaSdpDecomp_CPU
OMP: Error #34: System unable to allocate necessary resources for OMP thread:
OMP: System error #11: Resource temporarily unavailable
OMP: Hint Try decreasing the value of OMP_NUM_THREADS.
```
Gtest passed in local CI run, but not the same machine with reported one. Let's keep monitoring if this fix the case.