### PR TITLE
cpu: aarch64: dispatch fpmath_mode::bf16 conv to ACL

### DIFF
--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -54,6 +55,13 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
 
         status_t init(engine_t *engine) {
             using namespace utils;
+#if (DNNL_AARCH64_USE_ACL)
+            if (get_fpmath_mode() == fpmath_mode::bf16) {
+                // prefer ACL to jit for fpmath_mode::bf16 if available
+                // since it supports lower precision calculation
+                return status::unimplemented;
+            }
+#endif
 
             bool ok = true && is_fwd()
                     && set_default_alg_kind(alg_kind::convolution_direct)

--- a/src/cpu/aarch64/jit_sve_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_convolution.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,6 +46,14 @@ struct jit_sve_convolution_fwd_t : public primitive_t {
                 jit_sve_convolution_fwd_t);
 
         status_t init(engine_t *engine) {
+#if (DNNL_AARCH64_USE_ACL)
+            if (get_fpmath_mode() == fpmath_mode::bf16) {
+                // prefer ACL to jit for fpmath_mode::bf16 if available
+                // since it supports lower precision calculation
+                return status::unimplemented;
+            }
+#endif
+
             bool ok = true && mayiuse(isa) && is_fwd()
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(src_type, wei_type, dst_type, dst_type,


### PR DESCRIPTION
Backport of #2838

jit_sve_conv is above acl_conv in the convolution list since it performs better for fp32, however for fpmath_mode::bf16 jit_conv does not support lower precision calculation so we skip it for acl_conv if oneDNN was compiled with ACL

When tested with ResNet50 and `ONEDNN_DEFAULT_FPMATH_MODE=BF16` we see:

- ~1.34x speedup for 8 threads
- ~1.41x speedup for 16 threads
- ~1.17x speedup for 32 threads

These are in line with results when ACL conv was above jit conv for `FPMATH_MODE::BF16`

For a minimal benchdnn reproducer use:
```
OMP_NUM_THREADS=16 ONEDNN_DEFAULT_FPMATH_MODE=BF16 ./build/tests/benchdnn/benchdnn -v5 --mode=p --conv mb1_ic256oc256_ih28oh14kh3sh2dh0ph1_iw28ow14kw3sw2dw0pw1 mb1_ic1024oc2048_ih14oh7kh1sh2dh0ph0_iw14ow7kw1sw2dw0pw0
```