### PR TITLE
xe: jit: gemm: remove invalid inv

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/post_ops.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/post_ops.cxx
@@ -244,7 +244,7 @@ bool BLASKernelGenerator<hw>::gemmBinaryOpC(BinaryOp op, bool row, bool column,
     auto globalCM = isLayoutColMajor(state.C_layout);
 
     bool recip = false;
-    if (op == BinaryOp::Div && one_of(Tco, Type::f32, Type::f16)) {
+    if (op == BinaryOp::Div && one_of(Tco, Type::f32)) {
         // Implement div as inv+mul for speed, especially when broadcasting.
         recip = true;
         op = BinaryOp::Mul;


### PR DESCRIPTION
To maintain proper precision, inv needs performed on the Tacc data type. This is already handled later in the code, rendering the inversion removed in this PR unnecessary.

Fixes [MFDNN-13468](https://jira.devtools.intel.com/browse/MFDNN-13468).