### PR TITLE
xe: sdpa: Safe softmax support for microkernel SDPA

### DIFF
--- a/doc/graph/operations/Softmax.md
+++ b/doc/graph/operations/Softmax.md
@@ -14,6 +14,13 @@ where \f$ C \f$ is a size of tensor along axis dimension.
 | Attribute Name                           | Description                                               | Value Type | Supported Values                     | Required or Optional |
 |:-----------------------------------------|:----------------------------------------------------------|:-----------|:-------------------------------------|:---------------------|
 | [axis](@ref dnnl::graph::op::attr::axis) | Represents the axis from which the SoftMax is calculated. | s64        | Arbitrary s64 value (`1` in default) | Optional             |
+| [mode](@ref dnnl::graph::op::attr::mode) | Specifies the computation mode of SoftMax                 | string     | `none` (default), `inf_as_zero`      | Optional             |
+
+When the operation attribute `mode` is not set or set to `none`, the operation
+performs the normal SoftMax calculation. In this case, the operation will
+generate `NaN` if all the input elements are `-infinity` along the `axis`
+dimension. To prevent this, you can set the attribute to `inf_as_zero` so that
+the operation generates zeros for `-infinity` inputs. 
 
 ## Execution arguments
 

--- a/examples/graph/sdpa.cpp
+++ b/examples/graph/sdpa.cpp
@@ -319,6 +319,7 @@ void bench_sdpa(engine::kind ekind, logical_tensor::data_type dt,
     auto probs = logical_tensor(id++, dt, score_sz, layout_type::strided);
     auto softmax = op(id++, op::kind::SoftMax, "softmax");
     softmax.set_attr<int64_t>(op::attr::axis, -1);
+    softmax.set_attr<std::string>(op::attr::mode, "inf_as_zero");
     softmax.add_inputs({masked_score});
     softmax.add_outputs({probs});
 

--- a/examples/graph/sdpa_stacked_qkv.cpp
+++ b/examples/graph/sdpa_stacked_qkv.cpp
@@ -181,6 +181,7 @@ void bench_sdpa(engine::kind ekind, logical_tensor::data_type dt,
     auto probs = logical_tensor(id++, dt, score_sz, layout_type::strided);
     auto softmax = op(id++, op::kind::SoftMax, "softmax");
     softmax.set_attr<int64_t>(op::attr::axis, -1);
+    softmax.set_attr<std::string>(op::attr::mode, "inf_as_zero");
     softmax.add_inputs({masked_score});
     softmax.add_outputs({probs});
 

--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -962,9 +962,9 @@ public:
         = dnnl_graph_op_attr_coordinate_transformation_mode,
         /// Specifies a data_format of an op. The value can be "NCX" or "NXC".
         data_format = dnnl_graph_op_attr_data_format,
-        /// Specifies a mode attribute of an op. The value can be "nearest",
-        /// "linear", "bilinear", or "trilinear". The attribute is defined for
-        /// Interpolate operations.
+        /// Specifies a mode attribute of an op.
+        /// Interpolate: "nearest", "linear", "bilinear", or "trilinear".
+        /// SoftMax: "none", "inf_as_zero".
         mode = dnnl_graph_op_attr_mode,
         /// Specifies a qtype attribute to an op. The value can be "per_channel"
         /// or "per_tensor". The attribute is defined for quantization

--- a/include/oneapi/dnnl/dnnl_graph_types.h
+++ b/include/oneapi/dnnl/dnnl_graph_types.h
@@ -371,9 +371,9 @@ typedef enum {
     dnnl_graph_op_attr_coordinate_transformation_mode,
     /// Specifies a data_format of an op. The value can be "NCX" or "NXC".
     dnnl_graph_op_attr_data_format,
-    /// Specifies a mode attribute of an op. The value can be "nearest",
-    /// "linear", "bilinear", or "trilinear". The attribute is defined for
-    /// Interpolate operations.
+    /// Specifies a mode attribute of an op.
+    /// Interpolate: "nearest", "linear", "bilinear", or "trilinear".
+    /// SoftMax: "none", "inf_as_zero".
     dnnl_graph_op_attr_mode,
     /// Specifies a qtype attribute to an op. The value can be "per_channel" or
     /// "per_tensor". The attribute is defined for quantization operations.

--- a/scripts/generate_dnnl_debug.py
+++ b/scripts/generate_dnnl_debug.py
@@ -35,8 +35,9 @@ def template(body, banner):
 %s""" % (
         banner,
         os.path.basename(__file__),
-        body
+        body,
     )
+
 
 def header(body):
     return (
@@ -232,8 +233,11 @@ def func_to_str(enum, values):
     func += func_to_str_decl(enum) + " {\n"
     for v in values:
         func += '%sif (v == %s) return "%s";\n' % (indent, v, sanitize_value(v))
-    if (enum == "dnnl_primitive_kind_t"):
-        func += '%sif (v == dnnl::impl::primitive_kind::sdpa) return "sdpa";\n' % indent
+    if enum == "dnnl_primitive_kind_t":
+        func += (
+            '%sif (v == dnnl::impl::primitive_kind::sdpa) return "sdpa";\n'
+            % indent
+        )
     func += '%sassert(!"unknown %s");\n' % (indent, abbrev)
     func += '%sreturn "unknown %s";\n}\n' % (indent, abbrev)
     return func
@@ -301,12 +305,18 @@ def generate(ifile, banners):
         enum = v_enum.attrib["name"]
         if maybe_skip(enum):
             continue
-        values = [v_value.attrib["name"] for v_value in v_enum.findall("EnumValue")]
+        values = [
+            v_value.attrib["name"] for v_value in v_enum.findall("EnumValue")
+        ]
 
         h_body += func_to_str_decl(enum, is_header=True) + ";\n"
         s_body += func_to_str(enum, values) + "\n"
 
-        if enum in ["dnnl_format_tag_t", "dnnl_data_type_t", "dnnl_sparse_encoding_t"]:
+        if enum in [
+            "dnnl_format_tag_t",
+            "dnnl_data_type_t",
+            "dnnl_sparse_encoding_t",
+        ]:
             h_benchdnn_body += (
                 str_to_func_decl(enum, is_header=True, is_dnnl=False) + ";\n"
             )
@@ -336,6 +346,7 @@ $ castxml --castxml-cc-gnu-c clang --castxml-output=1 \\
     )
     sys.exit(1)
 
+
 for arg in sys.argv:
     if "-help" in arg:
         usage()
@@ -354,8 +365,8 @@ file_paths = (
 banners = []
 for file_path in file_paths:
     with open(file_path, "r") as f:
-        m = re.match(r'^/\*+\n(\*.*\n)+\*+/\n', f.read())
-        banners.append('' if m == None else m.group(0))
+        m = re.match(r"^/\*+\n(\*.*\n)+\*+/\n", f.read())
+        banners.append("" if m == None else m.group(0))
 
 for file_path, file_body in zip(file_paths, generate(ifile, banners)):
     with open(file_path, "w") as f:

--- a/scripts/generate_dnnl_debug.py
+++ b/scripts/generate_dnnl_debug.py
@@ -238,6 +238,11 @@ def func_to_str(enum, values):
             '%sif (v == dnnl::impl::primitive_kind::sdpa) return "sdpa";\n'
             % indent
         )
+    if enum == "dnnl_alg_kind_t":
+        func += (
+            '%sif (v == dnnl::impl::alg_kind::softmax_accurate_inf_as_zero) return "softmax_accurate_inf_as_zero";\n'
+            % indent
+        )
     func += '%sassert(!"unknown %s");\n' % (indent, abbrev)
     func += '%sreturn "unknown %s";\n}\n' % (indent, abbrev)
     return func

--- a/src/common/c_types_map.hpp
+++ b/src/common/c_types_map.hpp
@@ -148,6 +148,10 @@ const alg_kind_t internal_only_start = (alg_kind_t)(1 << 12);
 // GPU only via jit_eltwise injector.
 const alg_kind_t eltwise_stochastic_round
         = (alg_kind_t)(internal_only_start + 1);
+// Internal algorithm for softmax to convert NaNs/-inf into 0.f in case when
+// all axis values are -inf.
+const alg_kind_t softmax_accurate_inf_as_zero
+        = (alg_kind_t)(internal_only_start + 2);
 } // namespace alg_kind
 
 using data_type_t = dnnl_data_type_t;

--- a/src/common/dnnl_debug_autogenerated.cpp
+++ b/src/common/dnnl_debug_autogenerated.cpp
@@ -1851,6 +1851,7 @@ const char *dnnl_alg_kind2str(dnnl_alg_kind_t v) {
     if (v == dnnl_reduction_norm_lp_power_p_sum) return "reduction_norm_lp_power_p_sum";
     if (v == dnnl_softmax_accurate) return "softmax_accurate";
     if (v == dnnl_softmax_log) return "softmax_log";
+    if (v == dnnl::impl::alg_kind::softmax_accurate_inf_as_zero) return "softmax_accurate_inf_as_zero";
     assert(!"unknown alg_kind");
     return "unknown alg_kind";
 }

--- a/src/common/opdesc.hpp
+++ b/src/common/opdesc.hpp
@@ -516,8 +516,8 @@ struct softmax_desc_t : public op_desc_t {
     memory_desc_t diff_src_desc;
     // The axis along which to perform the softmax.
     int softmax_axis {};
-    // Softmax algorithm. Possible values: #dnnl_softmax_accurate and
-    // #dnnl_softmax_log.
+    // Softmax algorithm. Possible values: #dnnl_softmax_accurate,
+    // #dnnl_softmax_log, dnnl::impl::alg_kind::softmax_accurate_inf_as_zero.
     alg_kind_t alg_kind {};
     // Destination memory descriptor.
     memory_desc_t dst_desc;

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -745,6 +745,7 @@ size_t get_desc_hash(const sdpa_desc_t &desc) {
     seed = hash_combine(seed, desc.invert_scale);
     seed = hash_combine(seed, desc.kv_head_number);
     seed = hash_combine(seed, static_cast<size_t>(desc.mask_type));
+    seed = hash_combine(seed, static_cast<size_t>(desc.softmax_alg));
     // Combined hash for sdpa desc
     return seed;
 }

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -589,6 +589,7 @@ void serialize(serialization_stream_t &sstream, const sdpa_desc_t &desc) {
     sstream.append(desc.invert_scale);
     sstream.append(desc.kv_head_number);
     sstream.append(desc.mask_type);
+    sstream.append(desc.softmax_alg);
 }
 
 } // namespace impl

--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -30,7 +30,8 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
         const_dnnl_memory_desc_t mask_desc, dnnl_data_type_t scale_dt,
         bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
-        const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
+        dnnl_alg_kind_t softmax_alg, const_dnnl_primitive_attr_t attr,
+        const_dnnl_primitive_attr_t kq_attr,
         const_dnnl_primitive_attr_t vs_attr) {
     CHECK(sdpa_desc_check(query_desc, key_desc, value_desc, dst_desc, mask_desc,
             engine, attr, kq_attr, vs_attr));
@@ -40,7 +41,8 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
     dnnl::impl::sdpa_desc_t sdpa_desc = dnnl::impl::create_sdpa_desc(query_desc,
             key_desc, value_desc, dst_desc, mask_desc,
             (dnnl::impl::data_type_t)scale_dt, invert_scale, kv_head_number,
-            static_cast<attn_mask_type_t>(attn_mask_type), kq_attr, vs_attr);
+            static_cast<attn_mask_type_t>(attn_mask_type), softmax_alg, kq_attr,
+            vs_attr);
     return dnnl::impl::primitive_desc_create(primitive_desc_iface, engine,
             (const dnnl::impl::op_desc_t *)&sdpa_desc, nullptr, attr);
 }

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -86,6 +86,7 @@ struct sdpa_desc_t : public op_desc_t {
     dim_t kv_head_number {};
 
     attn_mask_type_t mask_type = attn_mask_type::undef;
+    alg_kind_t softmax_alg = alg_kind::softmax_accurate;
 
     // Number of queries.
     dnnl_dim_t queries() const { return q_desc.dims[q_desc.ndims - 2]; }

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -136,8 +136,8 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
         const memory_desc_t *k_md, const memory_desc_t *v_md,
         const memory_desc_t *dst_md, const memory_desc_t *attn_mask_md,
         data_type_t scale_dt, bool invert_scale, dim_t kv_head_number,
-        attn_mask_type_t attn_mask_type, const primitive_attr_t *kq_attr,
-        const primitive_attr_t *vs_attr) {
+        attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
+        const primitive_attr_t *kq_attr, const primitive_attr_t *vs_attr) {
     auto sdpa_desc = sdpa_desc_t();
     sdpa_desc.primitive_kind = primitive_kind::sdpa;
     sdpa_desc.q_desc = *q_md;
@@ -157,6 +157,7 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     sdpa_desc.invert_scale = invert_scale;
     sdpa_desc.kv_head_number = kv_head_number;
     sdpa_desc.mask_type = attn_mask_type;
+    sdpa_desc.softmax_alg = softmax_alg;
     return sdpa_desc;
 }
 
@@ -166,16 +167,16 @@ static inline status_t create_sdpa_pd(
         const memory_desc_t *v_md, const memory_desc_t *dst_md,
         const memory_desc_t *attn_mask_md, data_type_t scale_dt,
         bool invert_scale, dim_t kv_head_number,
-        attn_mask_type_t attn_mask_type, const primitive_attr_t *attr,
-        const primitive_attr_t *kq_attr = nullptr,
+        attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
+        const primitive_attr_t *attr, const primitive_attr_t *kq_attr = nullptr,
         const primitive_attr_t *vs_attr = nullptr) {
     CHECK(sdpa_attr_check(q_md, k_md, v_md, engine, attr, kq_attr, vs_attr));
     CHECK(sdpa_desc_check(q_md, k_md, v_md, dst_md, attn_mask_md, engine, attr,
             kq_attr, vs_attr));
 
     auto sdpa_desc = create_sdpa_desc(q_md, k_md, v_md, dst_md, attn_mask_md,
-            scale_dt, invert_scale, kv_head_number, attn_mask_type, kq_attr,
-            vs_attr);
+            scale_dt, invert_scale, kv_head_number, attn_mask_type, softmax_alg,
+            kq_attr, vs_attr);
 
     primitive_attr_t sdpa_attr = attr ? *attr : default_attr();
 

--- a/src/common/softmax.cpp
+++ b/src/common/softmax.cpp
@@ -49,7 +49,8 @@ status_t softmax_desc_init(softmax_desc_t *softmax_desc, prop_kind_t prop_kind,
     VCHECK_SOFTMAX(
             IMPLICATION(!is_fwd, !any_null(diff_src_desc, diff_dst_desc)),
             VERBOSE_NULL_ARG);
-    VCHECK_SOFTMAX(one_of(alg_kind, softmax_accurate, softmax_log),
+    VCHECK_SOFTMAX(one_of(alg_kind, softmax_accurate, softmax_log,
+                           softmax_accurate_inf_as_zero),
             VERBOSE_BAD_ALGORITHM);
     VCHECK_SOFTMAX(0 <= softmax_axis && softmax_axis < dst_desc->ndims,
             VERBOSE_BAD_AXIS);

--- a/src/common/softmax_pd.hpp
+++ b/src/common/softmax_pd.hpp
@@ -99,7 +99,10 @@ struct softmax_pd_t : public primitive_desc_t {
     }
 
     alg_kind_t alg_kind() const { return desc()->alg_kind; }
-    bool is_softmax() const { return alg_kind() == alg_kind::softmax_accurate; }
+    bool is_softmax() const {
+        return utils::one_of(alg_kind(), alg_kind::softmax_accurate,
+                alg_kind::softmax_accurate_inf_as_zero);
+    }
     bool is_logsoftmax() const { return alg_kind() == alg_kind::softmax_log; }
 
 protected:

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -984,7 +984,8 @@ inline bool operator==(const sdpa_desc_t &lhs, const sdpa_desc_t &rhs) {
             && COMPARE_DESC_MEMBERS(scale_dt)
             && COMPARE_DESC_MEMBERS(invert_scale)
             && COMPARE_DESC_MEMBERS(kv_head_number)
-            && COMPARE_DESC_MEMBERS(mask_type);
+            && COMPARE_DESC_MEMBERS(mask_type)
+            && COMPARE_DESC_MEMBERS(softmax_alg);
     return ret;
 }
 

--- a/src/cpu/ref_softmax.cpp
+++ b/src/cpu/ref_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -289,10 +289,11 @@ status_t ref_softmax_fwd_t::execute_forward_generic(
                         : dst_off;
                 float d = io::load_float_value(
                         interim_dt, interim_ptr, interim_off);
-                float sd = space_denom[in];
                 if (pd()->is_softmax()) {
+                    float sd = space_denom[in] ? space_denom[in] : 1.f;
                     d /= sd;
                 } else if (pd()->is_logsoftmax()) {
+                    float sd = space_denom[in];
                     d -= sd;
                 }
                 d *= src_scales[0];

--- a/src/gpu/intel/ocl/gen9_softmax.cl
+++ b/src/gpu/intel/ocl/gen9_softmax.cl
@@ -187,7 +187,7 @@ gen9_softmax_fwd(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0f / denom_;
+    denom_ = (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) ? 1.0f : 1.0f / denom_;
 #endif
 
     for (int i = 0; i < num_buf; i++) {
@@ -267,7 +267,7 @@ gen9_softmax_fwd(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0f / denom_;
+    denom_ = (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) ? 1.0f : 1.0f / denom_;
 #endif
 
     dst += data_off;
@@ -377,7 +377,7 @@ gen9_softmax_fwd(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0f / denom_;
+    denom_ = (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) ? 1.0f : 1.0f / denom_;
 #endif
 
     dst += data_off;

--- a/src/gpu/intel/ocl/gen9_softmax.hpp
+++ b/src/gpu/intel/ocl/gen9_softmax.hpp
@@ -212,6 +212,8 @@ struct gen9_softmax_fwd_t : public gpu_primitive_t {
         kernel_ctx.define_int("IS_WRITE_ALIGNED", pd()->is_write_aligned);
         kernel_ctx.define_int("IS_FWD", 1);
         kernel_ctx.add_option("-cl-std=CL2.0");
+        kernel_ctx.define_int("SOFTMAX_INF_AS_ZERO",
+                pd()->alg_kind() == alg_kind::softmax_accurate_inf_as_zero);
         kernel_ctx.define_int("LOGSOFTMAX", pd()->is_logsoftmax());
         kernel_ctx.define_int("WITH_SRC_SCALES",
                 !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));

--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -546,6 +546,11 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         tile_load_full(&S_max_tile, S_max_slm, ugemm_kq_wg_tile_n, sg_j0_kq, 0);
 #endif
 
+#if SAFE_SOFTMAX
+#define set_zeros(v) vselect(-FLT_MAX, v, visfinite(v))
+        tile_elementwise(S_max_tile, set_zeros);
+#endif
+
         tile_vbroadcast_sub(&S_tile, S_max_tile);
 
 /* Scale + exponentiate */
@@ -747,8 +752,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     tile_elementwise(A_tile, v_scale_op);
 #endif
 
+#if SAFE_SOFTMAX
+#define set_zeros2(v) (vselect(native_vrecip(v), 1.f, v == 0))
+    tile_elementwise(A_scale_tile, set_zeros2);
+#else
     /* Rescale by 1 / (column sums) */
     tile_elementwise(A_scale_tile, native_vrecip);
+#endif
     tile_hbroadcast_mul(&A_tile, A_scale_tile);
 
     /* Convert to half precision and store */

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -500,6 +500,9 @@ status_t micro_sdpa_t::init(impl::engine_t *engine) {
         kernel_ctx.define_int("PREFETCH_D_MAX", nstl::min(pd()->d_max(), 64));
     }
 
+    kernel_ctx.define_int("SAFE_SOFTMAX",
+            d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
+
     /* Generate microkernel shims */
     ShimOptions shimOptions;
     shimOptions.subgroupSize = pd()->sg_size();

--- a/src/gpu/intel/ocl/ocl_generic_vector_ops.h
+++ b/src/gpu/intel/ocl/ocl_generic_vector_ops.h
@@ -20,6 +20,7 @@
 typedef half __attribute__((ext_vector_type(1))) half1;
 typedef uint __attribute__((ext_vector_type(1))) uint1;
 typedef float __attribute__((ext_vector_type(1))) float1;
+typedef int __attribute__((ext_vector_type(1))) int1;
 
 float1 __attribute__((overloadable)) vmad(float1 a, float1 b, float1 c) {
     c[0] = mad(a[0], b[0], c[0]);
@@ -70,6 +71,40 @@ float8 __attribute__((overloadable)) native_vexp2(float8 x) {
 }
 float16 __attribute__((overloadable)) native_vexp2(float16 x) {
     return native_exp2(x);
+}
+
+float1 __attribute__((overloadable)) vselect(float1 x, float1 y, int1 c) {
+    x[0] = select(x[0], y[0], c[0]);
+    return x;
+}
+float2 __attribute__((overloadable)) vselect(float2 x, float2 y, int2 c) {
+    return select(x, y, c);
+}
+float4 __attribute__((overloadable)) vselect(float4 x, float4 y, int4 c) {
+    return select(x, y, c);
+}
+float8 __attribute__((overloadable)) vselect(float8 x, float8 y, int8 c) {
+    return select(x, y, c);
+}
+float16 __attribute__((overloadable)) vselect(float16 x, float16 y, int16 c) {
+    return select(x, y, c);
+}
+
+int1 __attribute__((overloadable)) visfinite(float1 x) {
+    int1 out = isfinite(x[0]);
+    return out;
+}
+int2 __attribute__((overloadable)) visfinite(float2 x) {
+    return isfinite(x);
+}
+int4 __attribute__((overloadable)) visfinite(float4 x) {
+    return isfinite(x);
+}
+int8 __attribute__((overloadable)) visfinite(float8 x) {
+    return isfinite(x);
+}
+int16 __attribute__((overloadable)) visfinite(float16 x) {
+    return isfinite(x);
 }
 
 #endif

--- a/src/gpu/intel/ocl/reusable_softmax.cl
+++ b/src/gpu/intel/ocl/reusable_softmax.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,7 +56,9 @@ reusable_softmax_fwd_generic(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
     if (USE_WORKGROUP_REDUCTION) { denom_ = work_group_reduce_add(denom_); }
     if (USE_SUBGROUP_REDUCTION) { denom_ = sub_group_reduce_add(denom_); }
 
-    denom_ = LOGSOFTMAX ? log(denom_) : 1.0f / denom_;
+    denom_ = LOGSOFTMAX                              ? log(denom_)
+            : (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) ? 1.0f
+                                                     : 1.0f / denom_;
 
     for (off_t c = begin; c < end; c += softmax_axis_stride) {
         FLT_ACC_DATA_T unscaled = LOGSOFTMAX

--- a/src/gpu/intel/ocl/reusable_softmax.cpp
+++ b/src/gpu/intel/ocl/reusable_softmax.cpp
@@ -199,6 +199,7 @@ status_t reusable_softmax_fwd_t::pd_t::init_dispatch_workgroup_per_reduction(
 
 compute::kernel_ctx_t reusable_softmax_params_t::get_kernel_ctx() const {
     compute::kernel_ctx_t kernel_ctx;
+    kernel_ctx.define_int("SOFTMAX_INF_AS_ZERO", is_softmax_inf_as_zero);
     kernel_ctx.define_int("LOGSOFTMAX", is_logsoftmax);
     kernel_ctx.define_int("MANY_REDUCTIONS_PER_WORKGROUP",
             algorithm_number == many_reductions_per_workgroup);

--- a/src/gpu/intel/ocl/reusable_softmax.hpp
+++ b/src/gpu/intel/ocl/reusable_softmax.hpp
@@ -73,8 +73,9 @@ struct reusable_softmax_params_t {
     data_type_t dst_data_type;
     int algorithm_number;
     bool is_logsoftmax;
+    bool is_softmax_inf_as_zero;
 
-    uint8_t padding[3] = {0};
+    uint8_t padding[2] = {0};
 
     compute::dispatch_compile_params_t gws_params;
 };
@@ -157,6 +158,8 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
 
             // compile-time configuration setup
             conf.is_logsoftmax = is_logsoftmax();
+            conf.is_softmax_inf_as_zero
+                    = alg_kind() == alg_kind::softmax_accurate_inf_as_zero;
             conf.src_data_type = src_dt;
             conf.dst_data_type = dst_dt;
 

--- a/src/gpu/intel/ocl/simple_softmax.cl
+++ b/src/gpu/intel/ocl/simple_softmax.cl
@@ -124,7 +124,7 @@ simple_softmax_fwd_generic(__global SRC_DATA_T *src, __global DATA_T *dst,
 #if LOGSOFTMAX
     denom_ = log(denom_);
 #else
-    denom_ = 1.0f / denom_;
+    denom_ = (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) ? 1.0f : 1.0f / denom_;
 #endif
 
     for (int i = begin; i < end; ++i) {

--- a/src/gpu/intel/ocl/simple_softmax.hpp
+++ b/src/gpu/intel/ocl/simple_softmax.hpp
@@ -137,6 +137,8 @@ struct simple_softmax_fwd_t : public gpu_primitive_t {
         kernel_ctx.define_int("SUB_GROUP_SIZE", pd()->subgroup_size);
         kernel_ctx.define_int("IS_FWD", 1);
         kernel_ctx.add_option("-cl-std=CL2.0");
+        kernel_ctx.define_int("SOFTMAX_INF_AS_ZERO",
+                pd()->alg_kind() == alg_kind::softmax_accurate_inf_as_zero);
         kernel_ctx.define_int("LOGSOFTMAX", pd()->is_logsoftmax());
         kernel_ctx.define_int("WITH_SRC_SCALES",
                 !pd()->attr()->scales_.has_default_values(DNNL_ARG_SRC));

--- a/src/graph/backend/dnnl/dnnl_op_def.hpp
+++ b/src/graph/backend/dnnl/dnnl_op_def.hpp
@@ -1002,6 +1002,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_softmax, 1,
                 .set_output(1, "scratchpad")
                 // Attributes inherited from SoftMax
                 .set_attr(op_attr::axis, false, attribute_kind::i, (int64_t)1)
+                .set_attr(op_attr::mode, false, attribute_kind::s, "none",
+                        {"none", "inf_as_zero"})
                 // New added attributes
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,

--- a/src/graph/backend/dnnl/dnnl_op_def.hpp
+++ b/src/graph/backend/dnnl/dnnl_op_def.hpp
@@ -1177,6 +1177,7 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_sdpa, 1,
                 // mask_type attribute indicates existence of explicit mask,
                 // top-left implicit causal mask or bottm-right implicit causal mask
                 .set_attr(op_attr::mask_type, true, attribute_kind::i)
+                .set_attr(op_attr::mode, true, attribute_kind::s)
                 .set_shape_inference_function(infer_dnnl_sdpa_output_shape)
                 .SET_LAYOUT_PROPAGATOR(layout_propagator_for_sdpa)
                 .SET_EXECUTABLE_CREATOR(executable_creator<sdpa_executable_t>)

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -230,9 +230,14 @@ impl::status_t sdp_decomp_config_t::construct_params(
     // create softmax primitive attr
     dnnl::primitive_attr sub_softmax_attr = make_primitive_attr(sdp_op[2], mgr);
     sub_softmax_dst_md = memory::desc(sub_mm1_dst_dims, dt_src_user, tag::abcd);
+    const auto mode = sdp_op[2]->get_attr<std::string>(op_attr::mode);
+    const dnnl::algorithm algo = mode == "inf_as_zero"
+            ? static_cast<dnnl::algorithm>(
+                    dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)
+            : dnnl::algorithm::softmax_accurate;
     auto sub_softmax_pd = softmax_forward::primitive_desc(p_engine,
-            prop_kind::forward_inference, algorithm::softmax_accurate,
-            sub_mm1_dst_md, sub_softmax_dst_md, sub_mm1_dst_md.get_ndims() - 1,
+            prop_kind::forward_inference, algo, sub_mm1_dst_md,
+            sub_softmax_dst_md, sub_mm1_dst_md.get_ndims() - 1,
             sub_softmax_attr);
     sub_softmax_prim = softmax_forward(sub_softmax_pd);
 

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -276,15 +276,11 @@ status_t sdp_primitive_config_t::initial_check(
                         "mask(optional)");
             }
 
-            // TODO(xxx): remove this when gpu ukernel sdpa supports it.
             if (post_op) {
                 if (post_op->get_kind() == graph::op_kind::SoftMax) {
                     const auto &softmax = post_op;
-                    const auto mode
+                    softmax_mode_
                             = softmax->get_attr<std::string>(op_attr::mode);
-                    VCHECK_SDP_PRIMITIVE(mode != "inf_as_zero",
-                            status::unimplemented,
-                            "Not support softmax with mode=inf_as_zero");
                 }
             }
         } else {
@@ -376,10 +372,13 @@ status_t sdp_primitive_config_t::init(std::shared_ptr<subgraph_t> &sg,
         vs_attr = make_dnnl_primitive_attr(mm2_, mgr.get_info(key));
     }
 
+    const alg_kind_t softmax_alg = softmax_mode_ == "inf_as_zero"
+            ? alg_kind::softmax_accurate_inf_as_zero
+            : alg_kind::softmax_accurate;
     CHECK(create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(), md_k.get(),
             md_v.get(), md_dst.get(), md_mask.get(), scale_dt, invert_scale_,
-            kv_head_number_, mask_type_, alg_kind::softmax_accurate, attr.get(),
-            qk_attr.get(), vs_attr.get()));
+            kv_head_number_, mask_type_, softmax_alg, attr.get(), qk_attr.get(),
+            vs_attr.get()));
 
     auto status = sdpa_pd_->create_primitive(sdpa_prim_, p_engine.get());
 

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -275,6 +275,18 @@ status_t sdp_primitive_config_t::initial_check(
                         "Not support select after scale(optional) and "
                         "mask(optional)");
             }
+
+            // TODO(xxx): remove this when gpu ukernel sdpa supports it.
+            if (post_op) {
+                if (post_op->get_kind() == graph::op_kind::SoftMax) {
+                    const auto &softmax = post_op;
+                    const auto mode
+                            = softmax->get_attr<std::string>(op_attr::mode);
+                    VCHECK_SDP_PRIMITIVE(mode != "inf_as_zero",
+                            status::unimplemented,
+                            "Not support softmax with mode=inf_as_zero");
+                }
+            }
         } else {
             mm2 = cur_op;
         }

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -378,8 +378,8 @@ status_t sdp_primitive_config_t::init(std::shared_ptr<subgraph_t> &sg,
 
     CHECK(create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(), md_k.get(),
             md_v.get(), md_dst.get(), md_mask.get(), scale_dt, invert_scale_,
-            kv_head_number_, mask_type_, attr.get(), qk_attr.get(),
-            vs_attr.get()));
+            kv_head_number_, mask_type_, alg_kind::softmax_accurate, attr.get(),
+            qk_attr.get(), vs_attr.get()));
 
     auto status = sdpa_pd_->create_primitive(sdpa_prim_, p_engine.get());
 

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.hpp
@@ -63,6 +63,7 @@ public:
     bool quantized_ = false;
     attn_mask_type_t mask_type_ = attn_mask_type::undef;
     dim_t kv_head_number_;
+    std::string softmax_mode_ = "none";
 
     // SDP pd and primitive.
     std::shared_ptr<primitive_desc_t> sdpa_pd_;

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -2820,10 +2820,16 @@ struct sdpa_executable_t : public op_executable_t {
 
         dim_t kv_head_number
                 = op->get_input_value(1)->get_logical_tensor().dims[1];
+
+        const std::string &softmax_mode
+                = op->get_attr<std::string>(op_attr::mode);
+        const alg_kind_t softmax_alg = softmax_mode == "inf_as_zero"
+                ? alg_kind::softmax_accurate_inf_as_zero
+                : alg_kind::softmax_accurate;
         status_t s = create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(),
                 md_k.get(), md_v.get(), md_dst.get(), md_mask.get(), scale_dt,
-                is_invert_scale_, kv_head_number, mask_type_,
-                alg_kind::softmax_accurate, attr.get());
+                is_invert_scale_, kv_head_number, mask_type_, softmax_alg,
+                attr.get());
         if (s != dnnl::impl::status::success) {
             is_initialized_ = false;
         } else {

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -2822,7 +2822,8 @@ struct sdpa_executable_t : public op_executable_t {
                 = op->get_input_value(1)->get_logical_tensor().dims[1];
         status_t s = create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(),
                 md_k.get(), md_v.get(), md_dst.get(), md_mask.get(), scale_dt,
-                is_invert_scale_, kv_head_number, mask_type_, attr.get());
+                is_invert_scale_, kv_head_number, mask_type_,
+                alg_kind::softmax_accurate, attr.get());
         if (s != dnnl::impl::status::success) {
             is_initialized_ = false;
         } else {

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -4205,6 +4205,9 @@ status_t fuse_sdpa(std::shared_ptr<subgraph_t> &sg) {
         else if (op->get_kind() == op_kind::dnnl_mask) {
             sdpa_op->set_attr(op_attr::mask_type,
                     op->get_attr<int64_t>(op_attr::mask_type));
+        } else if (op->get_kind() == op_kind::dnnl_softmax) {
+            sdpa_op->set_attr(
+                    op_attr::mode, op->get_attr<std::string>(op_attr::mode));
         }
     }
 

--- a/src/graph/interface/op_def.hpp
+++ b/src/graph/interface/op_def.hpp
@@ -1039,6 +1039,8 @@ DNNL_GRAPH_OP_SCHEMA(SoftMax, 1,
                 .set_input(0, "src", "T1")
                 .set_output(0, "dst", "T2")
                 .set_attr(op_attr::axis, false, attribute_kind::i, (int64_t)1)
+                .set_attr(op_attr::mode, false, attribute_kind::s, "none",
+                        {"none", "inf_as_zero"})
                 .set_type_constraints(
                         "T1", {data_type::f32, data_type::bf16, data_type::f16})
                 .set_type_constraints(

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -593,6 +593,9 @@ int partition_data_displacer_t::gen_causal_mask_filling(
     benchdnn_parallel_nd(batch, M, N, [&](int64_t b, int64_t m, int64_t n) {
         int64_t idx = b * M * N + m * N + n;
         float val = m >= n ? 0.f : -INFINITY;
+        // The line below masks out the whole prompt to verify the softmax
+        // output returns zeroes, not NaNs, as expected by PyTorch.
+        if (m == M - 1) val = -INFINITY;
         tmp_mem.set_elem(idx, val);
     });
 

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -368,6 +368,18 @@ int ref_partition_t::check_partition_correctness(
         // reset the state
         res->state = EXECUTED;
 
+        // TODO(zhitao): need to check whether the operation that produces the
+        // output args is the children of the operations that affect
+        // output_has_nans, such as:
+        //
+        //             |
+        //       _____MatMul_______
+        //      |                  |
+        //      |                  |
+        //     SQRT              ReLU
+        //      |                  |
+        // The graph driver allows nans from the branch of Sqrt, but for the
+        // other branch, the driver should not tolerate that.
         ref_prim->check_correctness(
                 output_args, has_eltwise, output_has_nans, res);
         if (res->state == FAILED) {

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1942,7 +1942,15 @@ bool get_softmax_sdt_and_ddt(const deserialized_op_t &base_op_ref,
 bool get_softmax_alg(
         const deserialized_op_t &base_op_ref, ::softmax::alg_t &alg) {
     const auto &op_kind = base_op_ref.kind_;
-    if (op_kind == "SoftMax" || op_kind == "SoftMaxBackward") {
+    if (op_kind == "SoftMax") {
+        alg = ::softmax::alg_t::SOFTMAX;
+
+        std::string mode;
+        if (base_op_ref.get_attr_string(mode, "mode")
+                && mode == "inf_as_zero") {
+            alg = ::softmax::alg_t::softmax_accurate_inf_as_zero;
+        }
+    } else if (op_kind == "SoftMaxBackward") {
         alg = ::softmax::alg_t::SOFTMAX;
     } else if (op_kind == "LogSoftmax" || op_kind == "LogSoftmaxBackward") {
         alg = ::softmax::alg_t::LOGSOFTMAX;

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16-v2.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16-v2.json
@@ -243,7 +243,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/GQA-fp16.json
@@ -431,7 +431,11 @@
                 "axis": {
                     "type": "s64",
                     "value": -1
-                }
+                },
+                "mode": {
+                   "type": "string",
+                   "value": "inf_as_zero"
+                 }
             },
             "inputs": [
                 {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/JAX-MHA-inf-fp32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/JAX-MHA-inf-fp32.json
@@ -226,7 +226,11 @@
                 "axis": {
                     "type": "s64",
                     "value": 3
-                }
+                },
+                "mode": {
+                   "type": "string",
+                   "value": "inf_as_zero"
+                 }
             },
             "inputs": [
                 {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/JAX-MQA-inf-fp32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/JAX-MQA-inf-fp32.json
@@ -270,6 +270,10 @@
                 "axis": {
                     "type": "s64",
                     "value": 3
+                },
+                "mode": {
+                    "type": "string",
+                    "value": "inf_as_zero"
                 }
             },
             "inputs": [

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
@@ -301,7 +301,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
@@ -527,7 +527,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
@@ -222,7 +222,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
@@ -442,7 +442,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
@@ -235,7 +235,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
@@ -461,7 +461,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
@@ -156,7 +156,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
@@ -327,7 +327,11 @@
           "axis": {
             "type": "s64",
             "value": 3
-          }
+          },
+          "mode": {
+             "type": "string",
+             "value": "inf_as_zero"
+           }
         },
         "inputs": [
           {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-kv-implicit-causal-mask-int8-gs128.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-kv-implicit-causal-mask-int8-gs128.json
@@ -510,7 +510,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-kv-int4-gs32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-kv-int4-gs32.json
@@ -327,7 +327,11 @@
           "axis": {
             "type": "s64",
             "value": 3
-          }
+          },
+          "mode": {
+             "type": "string",
+             "value": "inf_as_zero"
+           }
         },
         "inputs": [
           {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-v-int8-gs32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-compressed-v-int8-gs32.json
@@ -225,7 +225,11 @@
           "axis": {
             "type": "s64",
             "value": 3
-          }
+          },
+          "mode": {
+             "type": "string",
+             "value": "inf_as_zero"
+           }
         },
         "inputs": [
           {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
@@ -530,6 +530,10 @@
         "axis": {
           "type": "s64",
           "value": -1
+        },
+        "mode": {
+          "type": "string",
+          "value": "inf_as_zero"
         }
       },
       "inputs": [

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
@@ -410,7 +410,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
@@ -227,7 +227,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-simplified-f16.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-simplified-f16.json
@@ -226,7 +226,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-wo-mask-f16.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-wo-mask-f16.json
@@ -157,7 +157,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
@@ -162,7 +162,11 @@
         "axis": {
           "type": "s64",
           "value": -1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
@@ -379,7 +379,11 @@
         "axis": {
           "type": "s64",
           "value": 3
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "inf_as_zero"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/op/f32/softmax.json
+++ b/tests/benchdnn/inputs/graph/op/f32/softmax.json
@@ -11,7 +11,11 @@
         "axis": {
           "type": "s64",
           "value": 1
-        }
+        },
+        "mode": {
+           "type": "string",
+           "value": "none"
+         }
       },
       "inputs": [
         {

--- a/tests/benchdnn/inputs/graph/op/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f32_all
@@ -241,6 +241,7 @@
 --reset --in-shapes=0:8x384x1024*acb --op-attrs=0:axis:1 --case=op/f32/logsoftmax.json
 --reset --in-shapes=0:8x384x1024*acb --op-attrs=0:axis:0 --case=op/f32/logsoftmax.json
 --reset --in-shapes=0:8x384x1024*acb --op-attrs=0:axis:2 --case=op/f32/logsoftmax.json
+--reset --op-attrs=0:mode:inf_as_zero --case=op/f32/softmax.json
 --reset --in-shapes=0:8x384x1024 --op-attrs=0:axis:1 --case=op/f32/softmax.json
 --reset --in-shapes=0:8x384x1024 --op-attrs=0:axis:0 --case=op/f32/softmax.json
 --reset --in-shapes=0:8x384x1024 --op-attrs=0:axis:2 --case=op/f32/softmax.json

--- a/tests/benchdnn/softmax/ref_softmax.cpp
+++ b/tests/benchdnn/softmax/ref_softmax.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
         for (int64_t as = 0; as < axis_size; ++as) {
             int64_t idx = ou_in_offset + as * inner_size;
             float s = src.get_elem(idx);
-            if (alg == SOFTMAX) {
+            if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 float D = dst_ptr[idx] = expf(s - space_max);
                 space_denom += D;
             } else if (alg == LOGSOFTMAX) {
@@ -65,7 +65,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
             }
         }
 
-        if (alg == SOFTMAX) {
+        if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
             space_denom = space_denom ? (1.f / space_denom) : 1.f;
         } else if (alg == LOGSOFTMAX) {
             space_denom = logf(space_denom);
@@ -73,7 +73,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
 
         for (int64_t as = 0; as < axis_size; ++as) {
             int64_t idx = ou_in_offset + as * inner_size;
-            if (alg == SOFTMAX) {
+            if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 dst_ptr[idx] *= space_denom;
             } else if (alg == LOGSOFTMAX) {
                 dst_ptr[idx] -= space_denom;
@@ -106,7 +106,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
             int64_t idx = ou_in_offset + as * inner_size;
             float d = dst.get_elem(idx);
             float dd = d_dst.get_elem(idx);
-            if (alg == SOFTMAX) {
+            if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 part_deriv_sum += dd * d;
             } else if (alg == LOGSOFTMAX) {
                 part_deriv_sum += dd;
@@ -117,7 +117,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
             int64_t idx = ou_in_offset + as * inner_size;
             float d = dst.get_elem(idx);
             float dd = d_dst.get_elem(idx);
-            if (alg == SOFTMAX) {
+            if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 d_src_ptr[idx] = d * (dd - part_deriv_sum);
             } else if (alg == LOGSOFTMAX) {
                 d_src_ptr[idx] = dd - expf(d) * part_deriv_sum;

--- a/tests/benchdnn/softmax/softmax.hpp
+++ b/tests/benchdnn/softmax/softmax.hpp
@@ -33,8 +33,10 @@ enum alg_t {
     UNDEF,
     SOFTMAX,
     LOGSOFTMAX,
+    SOFTMAX_INF_AS_ZERO,
     softmax_accurate = SOFTMAX,
     softmax_log = LOGSOFTMAX,
+    softmax_accurate_inf_as_zero = SOFTMAX_INF_AS_ZERO,
 };
 alg_t str2alg(const char *str);
 const char *alg2str(alg_t alg);

--- a/tests/benchdnn/softmax/softmax_aux.cpp
+++ b/tests/benchdnn/softmax/softmax_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ alg_t str2alg(const char *str) {
     CASE(softmax_accurate);
     CASE(LOGSOFTMAX);
     CASE(softmax_log);
+    CASE(SOFTMAX_INF_AS_ZERO);
+    CASE(softmax_accurate_inf_as_zero);
 #undef CASE
     assert(!"unknown algorithm");
     return UNDEF;
@@ -38,6 +40,7 @@ alg_t str2alg(const char *str) {
 const char *alg2str(alg_t alg) {
     if (alg == SOFTMAX) return "SOFTMAX";
     if (alg == LOGSOFTMAX) return "LOGSOFTMAX";
+    if (alg == SOFTMAX_INF_AS_ZERO) return "SOFTMAX_INF_AS_ZERO";
     assert(!"unknown algorithm");
     return "UNDEF";
 }

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -198,10 +198,9 @@ int compare_t::compare_norm(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
         static thread_local diff_norm_t diff_norm_ithr;
         driver_check_func_args_t args(exp_mem, got_f32, i, dt, trh_);
 
-        if ((std::isnan(args.exp_f32) && is_integral_dt(dt))
-                || std::isinf(args.exp)) {
-            // Don't include integer max values or inf values into norm as they
-            // make it irrelevant for validation.
+        if ((std::isnan(args.exp_f32)) || std::isinf(args.exp)) {
+            // Don't include nan inf values into norm as they make it
+            // irrelevant for validation.
             ;
         } else if (is_cpu() && dt == dnnl_s32 && args.exp == max_dt(dnnl_s32)
                 && args.got >= BENCHDNN_S32_TO_F32_SAT_CONST

--- a/tests/gtests/graph/unit/interface/test_op_schema_cpu.cpp
+++ b/tests/gtests/graph/unit/interface/test_op_schema_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -3519,8 +3519,9 @@ TEST(test_interface_op_schema, SoftMax) {
     const op_kind_t op_kind_ = op_kind::SoftMax;
     const size_t expected_in_size = 1;
     const size_t expected_out_size = 1;
-    const size_t expected_attr_size = 1;
-    const std::map<op_attr_t, bool> attrs_data = {{op_attr::axis, false}};
+    const size_t expected_attr_size = 2;
+    const std::map<op_attr_t, bool> attrs_data
+            = {{op_attr::axis, false}, {op_attr::mode, false}};
 
     verify_op_schema(op_kind_, expected_in_size, expected_out_size,
             expected_attr_size, attrs_data);

--- a/tests/gtests/internals/sdpa_internal.hpp
+++ b/tests/gtests/internals/sdpa_internal.hpp
@@ -42,7 +42,8 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
         const_dnnl_memory_desc_t mask_desc, dnnl_data_type_t scale_dt,
         bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
-        const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
+        dnnl_alg_kind_t softmax_alg, const_dnnl_primitive_attr_t attr,
+        const_dnnl_primitive_attr_t kq_attr,
         const_dnnl_primitive_attr_t vs_attr);
 
 namespace dnnl {
@@ -60,7 +61,7 @@ struct sdpa : public dnnl::primitive {
                 const memory::desc &key_desc, const memory::desc &value_desc,
                 const memory::desc *attn_mask_desc, memory::data_type scale_dt,
                 const memory::desc &output_desc, bool invert_scale,
-                memory::dim kv_head_number, int attn_mask_type,
+                memory::dim kv_head_number, int attn_mask_type, int softmax_alg,
                 const primitive_attr &attr = default_attr(),
                 const primitive_attr &kq_attr = default_attr(),
                 const primitive_attr &vs_attr = default_attr()) {
@@ -70,8 +71,9 @@ struct sdpa : public dnnl::primitive {
                     aengine.get(), query_desc.get(), key_desc.get(),
                     value_desc.get(), output_desc.get(),
                     optional_arg(attn_mask_desc), (dnnl_data_type_t)scale_dt,
-                    invert_scale, kv_head_number, attn_mask_type, attr.get(),
-                    kq_attr.get(), vs_attr.get());
+                    invert_scale, kv_head_number, attn_mask_type,
+                    (dnnl_alg_kind_t)softmax_alg, attr.get(), kq_attr.get(),
+                    vs_attr.get());
 
             dnnl::error::wrap_c_api(status,
                     "could not create a primitive descriptor for a sdpa "


### PR DESCRIPTION
# Description

This PR adds support for safe softmax to the SDPA microkernel. Safe softmax avoids returning NaN values when an entire row is masked out. This PR was built on top of #2979 