### PR TITLE
graph: backend: dnnl: fix int8 sdpa with softmax

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -77,11 +77,14 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_post_ops);
     BACKEND_DNNL_ADD_PASS(pipeline, insert_permute_for_matmul);
     if (quantized) {
+        BACKEND_DNNL_ADD_PASS(pipeline, remove_quant_data_with_no_effect);
         BACKEND_DNNL_ADD_PASS(pipeline, convert_to_runtime_dst_scales);
         BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_scales);
         BACKEND_DNNL_ADD_PASS(pipeline, convert_to_runtime_dst_zero_points);
         BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_zero_points);
-        BACKEND_DNNL_ADD_PASS(pipeline, remove_quant_data_with_no_effect);
+        // fuse those new post-binaries converted from add_zps and mul_scales
+        BACKEND_DNNL_ADD_PASS(pipeline, replace_quant_data_with_binary_post_op);
+        BACKEND_DNNL_ADD_PASS(pipeline, fuse_post_ops);
     }
     pipeline.reset_visualize_arg(true, false);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_predecessor);

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -118,8 +118,7 @@ public:
                             mem_map[ori_mem.get()][tid]
                                     = memory(ori_mem.get_desc(),
                                             ori_mem.get_engine(), nullptr);
-                            if (iter.first >= DNNL_ARG_ATTR_SCALES
-                                    && iter.first <= DNNL_ARG_ATTR_POST_OP_DW) {
+                            if (iter.first >= DNNL_ARG_ATTR_SCALES) {
                                 mem_map[ori_mem.get()][tid].set_data_handle(
                                         ori_mem.get_data_handle());
                             }

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -109,7 +109,7 @@ public:
     //mm1
     memory sub_mm1_src, sub_mm1_wei, sub_mm1_dst;
     // sub_mm1_post_mem contains [post_scale, attn_mask(optional)]
-    std::vector<memory> sub_mm1_post_mem;
+    std::vector<memory> sub_mm1_post_mem, sub_softmax_post_mem;
     //select binary
     memory sub_select_cond, sub_select_src0, sub_select_dst;
     //softmax


### PR DESCRIPTION
# Description

- Support int8 output softmax with scale and zp in large partition and decompose kernel
- For int8 output softmax
    - Only with scale, we would treat the scale as the dst scale
    - With scale and zp, or only zp, we would treat the scale and zp as post-binary.
