### PR TITLE
build: fix hash sub for out-of-tree builds

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2019-2024 Intel Corporation
+# Copyright 2019-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,11 +29,12 @@ list(GET VERSION_LIST 2 DNNL_VERSION_PATCH)
 
 find_package(Git)
 if(GIT_FOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE} -c log.showSignature=false log --no-abbrev-commit --oneline -1 --format=%H
+    execute_process(COMMAND ${GIT_EXECUTABLE} --git-dir ${PROJECT_SOURCE_DIR}/.git -c log.showSignature=false log --no-abbrev-commit --oneline -1 --format=%H
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         RESULT_VARIABLE RESULT
         OUTPUT_VARIABLE DNNL_VERSION_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
 endif()
 
 if(NOT GIT_FOUND OR RESULT)


### PR DESCRIPTION
When building oneDNN outside of the git tree, but inside that of a different repository, the commit hash that is substituted is from the parent repository. This change limits git to the oneDNN root directory, and silences the error message when the git command fails.

For example:
```bash
git clone https://github.com/uxlfoundation/oneDNN.git dnnl
mkdir test_fail
git --git-dir dnnl/.git --work-tree test_fail checkout origin/main .
cmake -S test_fail -B test_fail/build
grep "#define DNNL_VERSION_HASH" test_fail/build/include/oneapi/dnnl/dnnl_version_hash.h
```
Before (out-of-tree):
```
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
...
-- Found Git: /usr/bin/git (found version "2.30.2")
fatal: not a git repository (or any of the parent directories): .git
-- Enabled testing coverage: CI
...
-- Build files have been written to: test_fail/build
#define DNNL_VERSION_HASH  "N/A"
```
Before (within, say, the [latest IGC at the time of writing](https://github.com/intel/intel-graphics-compiler/commit/8f182b27f4622f71af9f675d43c4944d6357b4b8)):
```
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
...
-- Found Git: /usr/bin/git (found version "2.30.2")
-- Enabled testing coverage: CI
...
-- Build files have been written to: test_fail/build
#define DNNL_VERSION_HASH  "8f182b27f4622f71af9f675d43c4944d6357b4b8"
```
After:
```
-- CMAKE_BUILD_TYPE is unset, defaulting to Release
...
-- Found Git: /usr/bin/git (found version "2.30.2")
-- Enabled testing coverage: CI
...
-- Build files have been written to: test_fail/build
#define DNNL_VERSION_HASH  "N/A"
```