### PR TITLE
xe: compute: dispatch: map vectorized dim to index 0

### DIFF
--- a/src/gpu/intel/ocl/gen9_pooling.cpp
+++ b/src/gpu/intel/ocl/gen9_pooling.cpp
@@ -144,16 +144,17 @@ static status_t init_conf_common(pool_conf_t &conf, offsets_t &off,
             "%s," VERBOSE_IMPL_HEURISTIC_FAIL, pd->info(engine),
             "ocl ref_kernel is faster");
 
+    conf.dispatch.define_dim("C", 0, c_padded, conf.chunks_per_c_block);
+
     if (conf.num_batches > 1) {
-        conf.dispatch.define_dim("MB", 0,
+        conf.dispatch.define_dim("MB", 1,
                 nstl::min(
                         static_cast<dim_t>(conf.mb_block_size), conf.mb_padded),
                 conf.chunks_per_mb_block);
     } else {
-        conf.dispatch.define_dim("MB", 0, conf.mb_padded / conf.unroll_mb_count,
+        conf.dispatch.define_dim("MB", 1, conf.mb_padded / conf.unroll_mb_count,
                 conf.chunks_per_mb_block);
     }
-    conf.dispatch.define_dim("C", 1, c_padded, conf.chunks_per_c_block);
 
     int ndims = conf.ndims;
     if (!conf.is_backward) {


### PR DESCRIPTION
The mapping from local_ids to sub_group_local_ids is not specified in the OpenCL specification. Some OpenCL implementations, such as the gen9_pooling implementation, assume this mapping occurs on the vectorized dimension. To avoid this limitation, this patch moves the vectorized dimension to be innermost as that causes the desired behavior (I hope) in the Intel OpenCL runtime. This fixes such an issue that occurs on the large buffer shape:

```
benchdnn --pool --engine=gpu --dir=BWD_D --dt=f16:f16 --tag=axb --alg=avg_p --impl=gen9 mb4294967311ic1iw1ow1kw3pw1
```

Edit: Looks like the original change produced too many performance regressions, so I modified this to be restricted to the pooling implementation. There were some large performance improvements in some cases, so I filed [MFDNN-13559](https://jira.devtools.intel.com/browse/MFDNN-13559) to look into them.