### PR TITLE
oneDNN v3.7.3 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.7.2")
+set(PROJECT_VERSION "3.7.3")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.7.2:
* Fixed correctness issue in matmul with non-trivial strides for the first tensor on processors with Intel AMX instruction set support (e18c622a3cbf766854b649de695271cfd4c19e89)
* Removed spurious warning messages for SDPA subgraph on Intel GPUs (05541bb8004587eff64a69840a3d75b8245ed099, 9e9a3a6f0a611f5f5a023f2d10e8dac94a75e195)
* Fixed `segfault` in `fp32` matmul with `bf16` math mode on processors with Intel AVX2 instruction set support (7d495ae13d6ce8f9a21a7db29d157e3f34bffb81)
* Fixed performance regression in `bf16` 3D convolution backpropagation on processors with Intel AVX-512 and Intel DL Boost instruction set support (c38e02c577e92080da92c29fb2bf6f9a0b00dbb6, 67afc74d6d681ab6556a12f897a8269e7dbd22f6)
* Worked around GCC 12.3 bug causing accuracy issues in `fp8` functionality on Intel GPUs (69b38d74a8eccbe8a65a4ac6b4c2584c884d4d2e)
* Removed `-fcf-protection` build option for GCC 7 and earlier versions (813725d15ab1f3ed937e55bec404e64c16d53041)
