### PR TITLE
benchdnn: improve performance related to memory operations (fixes MFDNN-13451)

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -229,7 +229,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -82,7 +82,7 @@ int fill_mem(
             // Remove zeroes in src1 to avoid division by zero.
             if (input_idx == 1 && val == 0.0f) val = 1.0f;
             val = round_to_nearest_representable(mem_dt.dt(), val);
-            mem_fp.set_elem(idx, val);
+            mem_fp.set_f32_elem(idx, val);
         }
     });
 

--- a/tests/benchdnn/binary/ref_binary.cpp
+++ b/tests/benchdnn/binary/ref_binary.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ void compute_ref(
         const auto idx_B = dst.get_idx(i, broadcast_mask_B);
 
         const bool c_val = prb->is_ternary_op()
-                ? static_cast<bool>(src2.get_elem(idx_A))
+                ? static_cast<bool>(src2.get_f32_elem(idx_A))
                 : false;
 
         float res = compute_binary(

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -53,7 +53,7 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         float val = 0.f;
         if (cfg.check_alg_ != ALG_0 || (prb->flags & GLOB_STATS))
             val = 0.25f * (1 << (c % 7));
-        mem_fp.set_elem(c, val);
+        mem_fp.set_f32_elem(c, val);
     });
 
     if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp), WARN);
@@ -88,7 +88,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
                 // Shortcut for zero values.
                 if (cfg.check_alg_ == ALG_0
                         && !flip_coin(l / 2 * 257ULL, cfg.density_)) {
-                    mem_fp.set_elem(off + sp, 0);
+                    mem_fp.set_f32_elem(off + sp, 0);
                     continue;
                 }
 
@@ -104,7 +104,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
                                 == cfg.L_ - 1)) {
                     val = m;
                 }
-                mem_fp.set_elem(
+                mem_fp.set_f32_elem(
                         off + sp, round_to_nearest_representable(prb->dt, val));
             }
         }
@@ -152,7 +152,7 @@ int fill_variance(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
             }
             val /= cfg.L_;
         }
-        mem_fp.set_elem(c, val);
+        mem_fp.set_f32_elem(c, val);
     });
 
     if (mem_dt && prb->use_stats()) SAFE(mem_dt.reorder(mem_fp), WARN);
@@ -186,7 +186,7 @@ int fill_src_add(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
                 const float m = ref_mean.get_f32_elem(c);
 
                 if (!(prb->flags & GLOB_STATS) && s == 0) {
-                    mem_fp.set_elem(offset, 1.f);
+                    mem_fp.set_f32_elem(offset, 1.f);
                     return;
                 }
 
@@ -204,7 +204,7 @@ int fill_src_add(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
                     const int64_t sign_val = s < m ? -1 : 1;
                     val = mod2_val * sign_val;
                 }
-                mem_fp.set_elem(
+                mem_fp.set_f32_elem(
                         offset, round_to_nearest_representable(prb->dt, val));
             });
 
@@ -229,7 +229,7 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     benchdnn_parallel_nd(prb->ic, [&](int64_t c) {
         float val = (1.f / 8) * (1 << (c % 7));
         if (prb->flags & GLOB_STATS) val *= 8.f;
-        mem_fp.set_elem(c, val);
+        mem_fp.set_f32_elem(c, val);
     });
 
     if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
@@ -253,7 +253,7 @@ int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     benchdnn_parallel_nd(prb->ic, [&](int64_t c) {
         float val = ((c % 3) - 1) * (1.f / 512 * (1 << (c % 7)));
         if (prb->flags & GLOB_STATS) val *= 512.f;
-        mem_fp.set_elem(c, val);
+        mem_fp.set_f32_elem(c, val);
     });
 
     if (mem_dt) SAFE(mem_dt.reorder(mem_fp), WARN);
@@ -354,7 +354,7 @@ int prepare_bwd(
             float value = flip_coin(igen_coin(msr), sparsity)
                     ? round_to_nearest_representable(prb->dt, igen_val(msr))
                     : 0;
-            mem_fp.set_elem(idx, value);
+            mem_fp.set_f32_elem(idx, value);
         }
     });
 

--- a/tests/benchdnn/bnorm/ref_bnorm.cpp
+++ b/tests/benchdnn/bnorm/ref_bnorm.cpp
@@ -66,7 +66,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
             if (need_ws) ws_ptr[off] = !!res;
             maybe_post_ops(attr, res);
             dst_ptr[off] = res;
-            if (prb->dir & FLAG_BWD) src_hat.set_elem(off, x_hat);
+            if (prb->dir & FLAG_BWD) src_hat.set_f32_elem(off, x_hat);
         }
     });
 }
@@ -113,8 +113,8 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
             d_beta += dd;
         }
 
-        if (use_sc && (prb->dir & FLAG_WEI)) d_sc.set_elem(c, d_gamma);
-        if (use_sh && (prb->dir & FLAG_WEI)) d_sh.set_elem(c, d_beta);
+        if (use_sc && (prb->dir & FLAG_WEI)) d_sc.set_f32_elem(c, d_gamma);
+        if (use_sh && (prb->dir & FLAG_WEI)) d_sh.set_f32_elem(c, d_beta);
 
         for_(int64_t mb = 0; mb < MB; ++mb)
         for_(int64_t d = 0; d < D; ++d)
@@ -123,13 +123,13 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
             auto off = data_off(prb, mb, c, d, h, w);
             float dd = d_dst.get_f32_elem(off);
             if (fuse_relu && ws.get_elem(off) == 0) dd = 0;
-            if (fuse_add_relu) d_src_add.set_elem(off, dd);
+            if (fuse_add_relu) d_src_add.set_f32_elem(off, dd);
             float ds = dd;
 
             if (!glob_stats)
                 ds -= (d_beta + src_hat.get_f32_elem(off) * d_gamma) / MB_SP;
 
-            d_src.set_elem(off, rcp_denom * ds * gamma);
+            d_src.set_f32_elem(off, rcp_denom * ds * gamma);
         }
     });
 }

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -257,7 +257,7 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
             float val = 0;
             while (val <= 0)
                 val = gen(int_seed);
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     0, round_to_nearest_representable(cfg.get_dt(kind), val));
             idx_start += 1;
         }
@@ -265,11 +265,11 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
             if (!is_one) {
-                mem_fp.set_elem(idx, 0.f);
+                mem_fp.set_f32_elem(idx, 0.f);
                 continue;
             }
             float val = gen(int_seed);
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }
     });

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -264,7 +264,11 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
-            float val = is_one * gen(int_seed);
+            if (!is_one) {
+                mem_fp.set_elem(idx, 0.f);
+                continue;
+            }
+            float val = gen(int_seed);
             mem_fp.set_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }

--- a/tests/benchdnn/brgemm/ref_brgemm.cpp
+++ b/tests/benchdnn/brgemm/ref_brgemm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -59,8 +59,8 @@ void compute_ref_brgemm(const prb_t *prb, const args_t &args) {
     const bool has_dst_scale = !prb->attr.scales.get(DNNL_ARG_DST).is_def();
     assert(IMPLICATION(has_src_scale, src_scales.nelems() == 1));
     assert(IMPLICATION(has_dst_scale, dst_scales.nelems() == 1));
-    float src_scale = has_src_scale ? src_scales.get_elem(0) : 1.f;
-    float dst_scale = has_dst_scale ? 1.f / dst_scales.get_elem(0) : 1.f;
+    float src_scale = has_src_scale ? src_scales.get_f32_elem(0) : 1.f;
+    float dst_scale = has_dst_scale ? 1.f / dst_scales.get_f32_elem(0) : 1.f;
     const int wei_scale_mask = prb->attr.scales.get_mask(
             DNNL_ARG_WEIGHTS, dnnl_matmul, wei_m.ndims());
 
@@ -138,7 +138,7 @@ void compute_ref_brgemm(const prb_t *prb, const args_t &args) {
 
         float wei_scale = 1.f;
         if (has_wei_scale)
-            wei_scale = wei_scales.get_elem(wei_scale_mask > 0 ? n : 0);
+            wei_scale = wei_scales.get_f32_elem(wei_scale_mask > 0 ? n : 0);
         float tmp = ((float *)dst_tmp)[dst_off] * src_scale * wei_scale;
 
         if (prb->bia_dt != dnnl_data_type_undef) {

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -103,7 +103,7 @@ int fill_src(int input_idx, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
         std::uniform_int_distribution<> igen(min_val, max_val);
         // Most fp8 values can't be represented exactly with integers.
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
-            mem_fp.set_elem(idx,
+            mem_fp.set_f32_elem(idx,
                     round_to_nearest_representable(mem_dt.dt(), igen(msr)));
         }
     });

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -170,7 +170,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/concat/ref_concat.cpp
+++ b/tests/benchdnn/concat/ref_concat.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ void compute_ref(
             for (int64_t as = 0; as < i_axis_size; ++as) {
                 int64_t idx = as * inner_size + in;
                 dst_ptr[off_dst + idx]
-                        = src_i.get_elem(off_src + idx) * scale_i;
+                        = src_i.get_f32_elem(off_src + idx) * scale_i;
             }
             // the next input start point
             off_dst += i_axis_size * inner_size;

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -195,8 +195,11 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
-            float gen_val = gen(int_seed) * (1.f + is_s8s8);
-            float val = is_one * gen_val;
+            if (!is_one) {
+                mem_fp.set_elem(idx, 0.f);
+                continue;
+            }
+            float val = gen(int_seed) * (1.f + is_s8s8);
             val += src_zp + wei_zp; // Add zp so that it will be subtracted.
             mem_fp.set_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -111,8 +111,10 @@ int check_reorder_presence(
     if (wei_x8x8 || !is_def_zp) {
         // Check that s8 -> s8_comp exists in the library since users may have
         // already quantized data.
-        dnn_mem_t mem_fp_s8(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine());
-        dnn_mem_t mem_dt_s8(mem_dt.md_, get_test_engine());
+        dnn_mem_t mem_fp_s8(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine(),
+                /* prefill = */ true);
+        dnn_mem_t mem_dt_s8(
+                mem_dt.md_, get_test_engine(), /* prefill = */ true);
         SAFE(mem_fp_s8.reorder(mem_fp), WARN);
         SAFE(mem_dt_s8.reorder(mem_fp_s8), WARN);
         SAFE(mem_dt.size() == mem_dt_s8.size() ? OK : FAIL, WARN);
@@ -485,7 +487,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -188,7 +188,7 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
                 gen_val = gen(int_seed);
             float val = gen_val * (1.f + is_s8s8);
             val += src_zp + wei_zp; // Add zp so that it will be subtracted.
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     0, round_to_nearest_representable(cfg.get_dt(kind), val));
             idx_start += 1;
         }
@@ -196,12 +196,12 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
             if (!is_one) {
-                mem_fp.set_elem(idx, 0.f);
+                mem_fp.set_f32_elem(idx, 0.f);
                 continue;
             }
             float val = gen(int_seed) * (1.f + is_s8s8);
             val += src_zp + wei_zp; // Add zp so that it will be subtracted.
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }
     });

--- a/tests/benchdnn/conv/conv_dw_fusion.cpp
+++ b/tests/benchdnn/conv/conv_dw_fusion.cpp
@@ -154,7 +154,8 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
         const int exec_arg = entry.first;
         auto &mem = entry.second; // `mem` is modified by filler (reorder).
 
-        dnn_mem_t ref_mem(mem.md_, dnnl_f32, tag::abx, ref_engine);
+        dnn_mem_t ref_mem(
+                mem.md_, dnnl_f32, tag::abx, ref_engine, /* prefill = */ false);
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
@@ -254,7 +255,8 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
         int wei_scale_arg = DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS;
         int dw_wei_scale_arg = DNNL_ARG_ATTR_POST_OP_DW | wei_scale_arg;
         const auto &wei_scale_md = mem_map1.at(wei_scale_arg).md_;
-        mem_map[dw_wei_scale_arg] = dnn_mem_t(wei_scale_md, get_test_engine());
+        mem_map[dw_wei_scale_arg] = dnn_mem_t(
+                wei_scale_md, get_test_engine(), /* prefill = */ true);
         SAFE(fill_scales(prb1->attr, DNNL_ARG_WEIGHTS,
                      mem_map.at(dw_wei_scale_arg), mem_map1.at(wei_scale_arg)),
                 WARN);
@@ -264,7 +266,8 @@ int init_ref_memory_args(dnn_mem_map_t &mem_map0, dnn_mem_map_t &mem_map1,
         int dst_scale_arg = DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST;
         int dw_dst_scale_arg = DNNL_ARG_ATTR_POST_OP_DW | dst_scale_arg;
         const auto &dst_scale_md = mem_map1.at(dst_scale_arg).md_;
-        mem_map[dw_dst_scale_arg] = dnn_mem_t(dst_scale_md, get_test_engine());
+        mem_map[dw_dst_scale_arg] = dnn_mem_t(
+                dst_scale_md, get_test_engine(), /* prefill = */ true);
         SAFE(fill_scales(prb1->attr, DNNL_ARG_DST, mem_map.at(dw_dst_scale_arg),
                      mem_map1.at(dst_scale_arg)),
                 WARN);

--- a/tests/benchdnn/conv/ref_conv.cpp
+++ b/tests/benchdnn/conv/ref_conv.cpp
@@ -100,7 +100,7 @@ void compute_ref_direct_fwd(const prb_t *prb, const args_t &args) {
                         int64_t wei_off = ((ic * KD + kd) * KH + kh) * KW + kw;
                         float src_scale = 1.f;
                         if (has_src_scale)
-                            src_scale = src_scales.get_elem(
+                            src_scale = src_scales.get_f32_elem(
                                     src_scale_mask > 0 ? g * ICG + ic : 0);
                         int src_zp = has_src_zp ? src_zps.get_elem(
                                              src_zp_mask > 0 ? g * ICG + ic : 0)
@@ -130,11 +130,11 @@ void compute_ref_direct_fwd(const prb_t *prb, const args_t &args) {
                 //    dst = src_scale * wei_scale * conv(src - zp_src, wei)
                 float wei_scale = 1.f, dst_scale = 1.f;
                 if (has_wei_scale)
-                    wei_scale = wei_scales.get_elem(
+                    wei_scale = wei_scales.get_f32_elem(
                             wei_scale_mask > 0 ? g * OCG + oc : 0);
                 if (has_dst_scale)
                     dst_scale = 1.f
-                            / dst_scales.get_elem(
+                            / dst_scales.get_f32_elem(
                                     dst_scale_mask > 0 ? g * OCG + oc : 0);
 
                 conv_res *= wei_scale;
@@ -181,8 +181,8 @@ void compute_ref_direct_bwd_d(const prb_t *prb, const args_t &args) {
     const bool has_dst_scale = !prb->attr.scales.get(DNNL_ARG_DST).is_def();
     assert(IMPLICATION(has_src_scale, src_scales.nelems() == 1));
     assert(IMPLICATION(has_dst_scale, dst_scales.nelems() == 1));
-    float src_scale = has_src_scale ? src_scales.get_elem(0) : 1.f;
-    float dst_scale = has_dst_scale ? 1.f / dst_scales.get_elem(0) : 1.f;
+    float src_scale = has_src_scale ? src_scales.get_f32_elem(0) : 1.f;
+    float dst_scale = has_dst_scale ? 1.f / dst_scales.get_f32_elem(0) : 1.f;
     const int wei_scale_mask = prb->attr.scales.get_mask(
             DNNL_ARG_WEIGHTS, dnnl_convolution, wei_m.ndims(), prb->has_groups);
 
@@ -261,7 +261,7 @@ void compute_ref_direct_bwd_d(const prb_t *prb, const args_t &args) {
 
             float wei_scale = 1.f;
             if (has_wei_scale)
-                wei_scale = wei_scales.get_elem(
+                wei_scale = wei_scales.get_f32_elem(
                         wei_scale_mask > 0 ? g * ICG + ic : 0);
             float wei_val = (wei_loc[wei_off] - wei_zp) * wei_scale;
             ds += diff_dst_val * wei_val;
@@ -301,7 +301,7 @@ void compute_ref_direct_bwd_d(const prb_t *prb, const args_t &args) {
 
                         float wei_scale = 1.f;
                         if (has_wei_scale)
-                            wei_scale = wei_scales.get_elem(
+                            wei_scale = wei_scales.get_f32_elem(
                                     wei_scale_mask > 0 ? g * ICG + ic : 0);
                         float wei_val = (wei_loc[wei_off] - wei_zp) * wei_scale;
                         ds += diff_dst_val * wei_val;

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -193,7 +193,7 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
                 gen_val = gen(int_seed);
             float val = gen_val * (1.f + is_s8s8);
             val += src_zp; // Add zp so that it will be subtracted.
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     0, round_to_nearest_representable(cfg.get_dt(kind), val));
             idx_start += 1;
         }
@@ -201,12 +201,12 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
             if (!is_one) {
-                mem_fp.set_elem(idx, 0.f);
+                mem_fp.set_f32_elem(idx, 0.f);
                 continue;
             }
             float val = gen(int_seed) * (1.f + is_s8s8);
             val += src_zp; // Add zp so that it will be subtracted.
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }
     });

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -123,8 +123,10 @@ int check_reorder_presence(
     if (wei_x8x8 || !is_def_zp) {
         // Check that s8 -> s8_comp exists in the library since users may have
         // already quantized data.
-        dnn_mem_t mem_fp_s8(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine());
-        dnn_mem_t mem_dt_s8(mem_dt.md_, get_test_engine());
+        dnn_mem_t mem_fp_s8(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine(),
+                /* prefill = */ true);
+        dnn_mem_t mem_dt_s8(
+                mem_dt.md_, get_test_engine(), /* prefill = */ true);
         SAFE(mem_fp_s8.reorder(mem_fp), WARN);
         SAFE(mem_dt_s8.reorder(mem_fp_s8), WARN);
         SAFE(mem_dt.size() == mem_dt_s8.size() ? OK : FAIL, WARN);
@@ -435,7 +437,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 
@@ -456,8 +459,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 auto wei_tr_md = dnn_mem_t::init_md(
                         wei_ndims, wei_tr_dims, dnnl_f32, tag::abx);
 
-                ref_mem_map.emplace(
-                        DNNL_ARG_WEIGHTS_1, dnn_mem_t(wei_tr_md, ref_engine));
+                ref_mem_map.emplace(DNNL_ARG_WEIGHTS_1,
+                        dnn_mem_t(
+                                wei_tr_md, ref_engine, /* prefill = */ false));
                 SAFE(transpose_data_wei(
                              prb, ref_mem, ref_mem_map[DNNL_ARG_WEIGHTS_1]),
                         WARN);
@@ -491,7 +495,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 auto wei_tr_md = dnn_mem_t::init_md(
                         wei_ndims, wei_tr_dims, dnnl_f32, tag::abx);
                 ref_mem_map.emplace(DNNL_ARG_DIFF_WEIGHTS_1,
-                        dnn_mem_t(wei_tr_md, ref_engine));
+                        dnn_mem_t(
+                                wei_tr_md, ref_engine, /* prefill = */ false));
             } break;
             default:
                 SAFE(init_ref_memory_args_default_case(

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -200,8 +200,11 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
-            float gen_val = gen(int_seed) * (1.f + is_s8s8);
-            float val = is_one * gen_val;
+            if (!is_one) {
+                mem_fp.set_elem(idx, 0.f);
+                continue;
+            }
+            float val = gen(int_seed) * (1.f + is_s8s8);
             val += src_zp; // Add zp so that it will be subtracted.
             mem_fp.set_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1842,7 +1842,7 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
         TIME_FILL(SAFE(
                 fill_zero_points(attr, local_exec_arg, mem, ref_mem), WARN));
     } else if (is_dropout_p) {
-        ref_mem.set_elem(0, attr.dropout.p);
+        ref_mem.set_f32_elem(0, attr.dropout.p);
         TIME_FILL(SAFE(mem.reorder(ref_mem), WARN));
     } else if (is_dropout_seed) {
         ref_mem.set_elem(0, attr.dropout.seed);

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1192,7 +1192,8 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
             output_md = diff_src_md_size > 0 ? diff_src_md : diff_wei_md;
         }
 
-        if (!check_md_consistency_with_tag(output_md, tag::abx)) {
+        if (query_md_data_type(output_md) != dnnl_f32
+                || !check_md_consistency_with_tag(output_md, tag::abx)) {
             total_size_compare *= 2;
         }
     }

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -670,7 +670,8 @@ std::vector<float> prepare_po_vals(const dnn_mem_t &dst_m, const args_t &args,
 
     for (size_t d = 0; d < v_po_masks.size(); ++d) {
         const auto po_offset = dst_m.get_idx(dst_off, v_po_masks[d].second);
-        const float val = args.find(v_po_masks[d].first).get_elem(po_offset);
+        const float val
+                = args.find(v_po_masks[d].first).get_f32_elem(po_offset);
         v_vals[d] = val;
     }
     return v_vals;

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -147,6 +147,13 @@ struct dnn_mem_t {
         return static_cast<float *>(*this)[idx];
     }
     float get_elem(int64_t idx, int buffer_index = 0) const;
+
+    // This interface is a shortcut version of the one below to speed up access
+    // to the memory that is guaranteedly of f32 data type.
+    // Keep the body in the header to help compiler to inline better.
+    void set_f32_elem(int64_t idx, float value) const {
+        static_cast<float *>(*this)[idx] = value;
+    }
     void set_elem(int64_t idx, float value, int buffer_index = 0) const;
 
     int64_t get_idx(int64_t logical_idx, int dims_mask, const int ndims,

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -140,6 +140,12 @@ struct dnn_mem_t {
 
     explicit operator bool() const { return active_; }
 
+    // This interface is a shortcut version of the one below to speed up access
+    // to the memory that is guaranteedly of f32 data type.
+    // Keep the body in the header to help compiler to inline better.
+    float get_f32_elem(int64_t idx) const {
+        return static_cast<float *>(*this)[idx];
+    }
     float get_elem(int64_t idx, int buffer_index = 0) const;
     void set_elem(int64_t idx, float value, int buffer_index = 0) const;
 

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -45,18 +45,18 @@ struct dnn_mem_t {
     };
 
     dnn_mem_t() { map(); }
-    dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_engine_t engine,
+    dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_engine_t engine, bool prefill,
             const handle_info_t &handle_info = handle_info_t::allocate());
 
     dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
-            const std::string &tag, dnnl_engine_t engine);
+            const std::string &tag, dnnl_engine_t engine, bool prefill);
     dnn_mem_t(const_dnnl_memory_desc_t md, dnnl_data_type_t dt,
-            const dnnl_dims_t strides, dnnl_engine_t engine);
+            const dnnl_dims_t strides, dnnl_engine_t engine, bool prefill);
 
     dnn_mem_t(int ndims, const dnnl_dims_t dims, dnnl_data_type_t dt,
-            const std::string &tag, dnnl_engine_t engine);
+            const std::string &tag, dnnl_engine_t engine, bool prefill);
     dnn_mem_t(int ndims, const dnnl_dims_t dims, dnnl_data_type_t dt,
-            const dnnl_dims_t strides, dnnl_engine_t engine);
+            const dnnl_dims_t strides, dnnl_engine_t engine, bool prefill);
 
     dnn_mem_t(const dnn_mem_t &rhs, dnnl_data_type_t dt, const std::string &tag,
             dnnl_engine_t engine);
@@ -225,7 +225,18 @@ private:
     int initialize_memory_create_opencl(const handle_info_t &handle_info);
     int initialize_memory_create(const handle_info_t &handle_info);
 
-    int initialize(dnnl_engine_t engine,
+    // `prefill` is a flag that controls whether the underlying memory buffer
+    // will be accessed to set a special value across the buffer, such as NaN,
+    // to catch issues with no/bad access.
+    //
+    // Some memory objects created will be filled right away with different
+    // values, e.g., reference f32 memories. In that case, read/write access
+    // with a special value is a waste of memory bandwidth so developer decides
+    // when to enable/disable it.
+    //
+    // The flag is propagated to the toppest dnn_mem_t constructors. In case
+    // when in doubt, always use `true` to stay on the safe side of things.
+    int initialize(dnnl_engine_t engine, bool prefill,
             const handle_info_t &handle_info = handle_info_t::allocate());
 
     void set_dt(dnnl_data_type_t dt) const;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -275,7 +275,7 @@ int fill_data(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
             // passes through simple reorder which converts -0 into +0.
             if (value == -0.f) value = 0.f;
 
-            mem_fp.set_elem(idx, value);
+            mem_fp.set_f32_elem(idx, value);
         }
     });
 

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -425,7 +425,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 
@@ -466,8 +467,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
     const bool inplace_fwd = prb->inplace && (prb->dir & FLAG_FWD);
     if (inplace_fwd) {
         const auto &dst_md = mem_map.at(DNNL_ARG_SRC).md_;
-        ref_mem_map[DNNL_ARG_DST]
-                = dnn_mem_t(dst_md, dnnl_f32, tag::abx, ref_engine);
+        ref_mem_map[DNNL_ARG_DST] = dnn_mem_t(
+                dst_md, dnnl_f32, tag::abx, ref_engine, /* prefill = */ false);
     }
 
     return OK;

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -381,7 +381,7 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &dst = ref_args.find(DNNL_ARG_DST);
                 const auto &source
                         = ((prb->dir & FLAG_BWD) && prb->use_dst()) ? dst : src;
-                const float s = source.get_elem(args.idx);
+                const float s = source.get_f32_elem(args.idx);
                 if (check_abs_err(prb, s, args.trh))
                     return args.diff <= args.trh;
                 if (prb->attr.post_ops.binary_index() != -1)

--- a/tests/benchdnn/eltwise/ref_eltwise.cpp
+++ b/tests/benchdnn/eltwise/ref_eltwise.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
 
     benchdnn_parallel_nd(nelems, [&](int64_t i) {
         float res = compute_eltwise_fwd(
-                prb->alg, src.get_elem(i), prb->alpha, prb->beta);
+                prb->alg, src.get_f32_elem(i), prb->alpha, prb->beta);
 
         const auto v_po_vals = prepare_po_vals(dst, args, v_po_masks, i);
 
@@ -57,8 +57,8 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
     const auto nelems = src.nelems();
 
     benchdnn_parallel_nd(nelems, [&](int64_t i) {
-        d_src_ptr[i] = compute_eltwise_bwd(prb->alg, d_dst.get_elem(i),
-                source.get_elem(i), prb->alpha, prb->beta);
+        d_src_ptr[i] = compute_eltwise_bwd(prb->alg, d_dst.get_f32_elem(i),
+                source.get_f32_elem(i), prb->alpha, prb->beta);
     });
 }
 

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -80,7 +80,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 
     benchdnn_parallel_nd(prb->mb, prb->g, [&](int64_t mb, int64_t g) {
         const int64_t idx = mb * prb->g + g;
-        const float m = ref_mean.get_elem(idx);
+        const float m = ref_mean.get_f32_elem(idx);
         // Note: we use a different seed for each chunk to avoid
         // repeating patterns. We could use discard(idx_start) too but
         // it has a complexity in O(idx_start). We also add 1 to avoid
@@ -203,7 +203,7 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         if (prb->flags & GLOB_STATS) {
             val = ((idx % 7) << 1);
         } else {
-            const float m = ref_mean.get_elem(idx);
+            const float m = ref_mean.get_f32_elem(idx);
             for (int64_t c = prb->get_c_start(g); c < prb->get_c_start(g + 1);
                     ++c) {
                 int64_t off = data_off(prb, mb, c, 0, 0, 0);
@@ -212,7 +212,7 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
                 for_(int64_t h = 0; h < prb->ih; ++h)
                 for (int64_t w = 0; w < prb->iw; ++w) {
                     const int64_t sp = d * prb->ih * prb->iw + h * prb->iw + w;
-                    const float s = ref_src.get_elem(sp + off);
+                    const float s = ref_src.get_f32_elem(sp + off);
                     val += (s - m) * (s - m);
                 }
             }
@@ -359,7 +359,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         // random but we keep all values as pow2 values to have almost exact
         // summation result.
         int64_t idx = mb * prb->g + g;
-        const float m = ref_mean.get_elem(idx);
+        const float m = ref_mean.get_f32_elem(idx);
 
         for_(int64_t c = prb->get_c_start(g); c < prb->get_c_start(g + 1); ++c)
         for (int64_t sp = 0; sp < SP; ++sp) {
@@ -554,7 +554,7 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &dst = ref_args.find(DNNL_ARG_DST);
                 const int64_t c
                         = dst.get_idx(args.idx, 1 << 1 /* last_dim_mask */);
-                const float beta = sh.get_elem(c);
+                const float beta = sh.get_f32_elem(c);
                 // Using an empirically derived threshold, check if
                 // cancellation error in `|Y| = |a*X - (-b)|` is huge.
                 const float abs_exp = fabsf(args.exp);

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -638,7 +638,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 
@@ -649,8 +650,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             case DNNL_ARG_VARIANCE:
                 if (prb->dir & FLAG_INF) {
                     const dnnl_dims_t dims2d = {prb->mb, prb->g};
-                    ref_mem_map[exec_arg] = dnn_mem_t(
-                            2, dims2d, dnnl_f32, tag::abx, ref_engine);
+                    ref_mem_map[exec_arg] = dnn_mem_t(2, dims2d, dnnl_f32,
+                            tag::abx, ref_engine, /* prefill = */ false);
                 }
                 break;
             default: {

--- a/tests/benchdnn/gnorm/ref_gnorm.cpp
+++ b/tests/benchdnn/gnorm/ref_gnorm.cpp
@@ -121,8 +121,8 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
             }
         }
 
-        if (use_sc && (prb->dir & FLAG_WEI)) d_sc.set_elem(c, d_gamma);
-        if (use_sh && (prb->dir & FLAG_WEI)) d_sh.set_elem(c, d_beta);
+        if (use_sc && (prb->dir & FLAG_WEI)) d_sc.set_f32_elem(c, d_gamma);
+        if (use_sh && (prb->dir & FLAG_WEI)) d_sh.set_f32_elem(c, d_beta);
 
         for (int64_t mb = 0; mb < MB; ++mb) {
             int64_t stat_off = mb * G + g;
@@ -142,7 +142,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
                     ds -= (d_beta + x_hat * rcp_denom) / CSP;
                 }
 
-                d_src.set_elem(off, rcp_denom * ds * gamma);
+                d_src.set_f32_elem(off, rcp_denom * ds * gamma);
             }
         }
     });

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -51,8 +51,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         const int exec_arg = entry.first;
         auto &mem = entry.second;
 
-        ref_mem_map.emplace(
-                exec_arg, dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+        ref_mem_map.emplace(exec_arg,
+                dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                        /* prefill = */ false));
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
@@ -119,8 +120,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         const int exec_arg = entry.first;
         auto &mem = entry.second;
 
-        ref_mem_map.emplace(
-                exec_arg, dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+        ref_mem_map.emplace(exec_arg,
+                dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                        /* prefill = */ false));
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
@@ -185,8 +187,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         const int exec_arg = entry.first;
         auto &mem = entry.second;
 
-        ref_mem_map.emplace(
-                exec_arg, dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+        ref_mem_map.emplace(exec_arg,
+                dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                        /* prefill = */ false));
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
@@ -231,8 +234,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         const int exec_arg = entry.first;
         auto &mem = entry.second;
 
-        ref_mem_map.emplace(
-                exec_arg, dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+        ref_mem_map.emplace(exec_arg,
+                dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                        /* prefill = */ false));
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
@@ -251,7 +255,8 @@ int execute(const prb_t *prb, const args_t &args, res_t *res) {
     const dnn_mem_t &src = args.find(DNNL_ARG_SRC);
     dnn_mem_t &dst = const_cast<dnn_mem_t &>(args.find(DNNL_ARG_DST));
     // generate dense stride
-    dnn_mem_t pad(src.md_, src.dt(), tag::abx, get_test_engine());
+    dnn_mem_t pad(src.md_, src.dt(), tag::abx, get_test_engine(),
+            /* prefill = */ true);
     int ret = pad.reorder(src);
     if (ret != OK) { res->state = FAILED; }
     // update output shape with dense stride
@@ -343,7 +348,7 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
         mem_map.emplace(exec_arg,
                 dnn_mem_t(static_cast<int>(dims.size()), dnnl_dims,
                         std::get<2>(arg_mds_), ::std::get<0>(arg_mds_),
-                        test_engine));
+                        test_engine, /* prefill = */ true));
     }
 }
 

--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -74,7 +74,7 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
     if (is_op_input) {
         // Create graph memory with memory description from graph path.
         dnnl::memory::desc md(graph_dims_, data_type, graph_strides_);
-        mem_ = dnn_mem_t(md.get(), g_eng.get());
+        mem_ = dnn_mem_t(md.get(), g_eng.get(), /* prefill = */ true);
 
         if (!has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
             // Fill data from reference memories.
@@ -88,7 +88,7 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
             // argument in primitives, we need to create them with memory
             // description from graph path.
             dnnl::memory::desc md(graph_dims_, data_type, graph_strides_);
-            mem_ = dnn_mem_t(md.get(), g_eng.get());
+            mem_ = dnn_mem_t(md.get(), g_eng.get(), /* prefill = */ true);
 
         } else {
             // Use information from the reference memory descriptor to create
@@ -101,7 +101,8 @@ dnn_graph_mem_t::dnn_graph_mem_t(const dnn_mem_t &mem,
             dims_t strides(mem.strides(), mem.strides() + ndims);
             std::string mtag = strides2memory_tag(ndims, strides);
 
-            mem_ = dnn_mem_t(mem.md_, graph_dt, mtag, g_eng.get());
+            mem_ = dnn_mem_t(
+                    mem.md_, graph_dt, mtag, g_eng.get(), /* prefill = */ true);
         }
     }
 }
@@ -133,7 +134,8 @@ int dnn_graph_mem_t::fill_mem_with_data(
     if (src_dt != dst_dt || src_eng != dst_eng) {
         // If dt or eng is different, need to transfer data under same dt or
         // engine to perform a data copy.
-        dnn_mem_t c_mem(ndims, mem.dims(), dst_dt, mtag, dst_eng);
+        dnn_mem_t c_mem(
+                ndims, mem.dims(), dst_dt, mtag, dst_eng, /* prefill = */ true);
         SAFE_V(c_mem.reorder(mem));
         prim_to_graph_memcpy(mem_, c_mem);
     } else {

--- a/tests/benchdnn/graph/input_displacer.cpp
+++ b/tests/benchdnn/graph/input_displacer.cpp
@@ -544,7 +544,7 @@ int partition_data_displacer_t::gen_fixed_set_filling(dnn_mem_t &mem,
         const_dnnl_memory_desc_t md, const fill_cfg_t &fill_cfg,
         res_t *res) const {
 
-    dnn_mem_t m(md, get_test_engine());
+    dnn_mem_t m(md, get_test_engine(), /* prefill = */ false);
     const int64_t nelems = m.nelems();
 
     BENCHDNN_PRINT(6, "%s\n", fill_cfg.print_verbose().c_str());
@@ -580,7 +580,7 @@ int partition_data_displacer_t::gen_fixed_set_filling(dnn_mem_t &mem,
 int partition_data_displacer_t::gen_causal_mask_filling(
         dnn_mem_t &mem, const_dnnl_memory_desc_t md, res_t *res) const {
 
-    dnn_mem_t tmp_mem(md, get_test_engine());
+    dnn_mem_t tmp_mem(md, get_test_engine(), /* prefill = */ false);
 
     const int ndims = query_md_ndims(md);
     assert(ndims >= 2); // This was checked at displacer initialization.

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -220,7 +220,11 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
-            float val = is_one * gen(int_seed);
+            if (!is_one) {
+                mem_fp.set_elem(idx, 0.f);
+                continue;
+            }
+            float val = gen(int_seed);
             mem_fp.set_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -157,8 +157,10 @@ int check_reorder_presence(
     if (wei_x8x8 || !is_def_zp) {
         // Check that s8 -> s8_comp exists in the library since users may have
         // already quantized data.
-        dnn_mem_t mem_fp_s8(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine());
-        dnn_mem_t mem_dt_s8(mem_dt.md_, get_test_engine());
+        dnn_mem_t mem_fp_s8(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine(),
+                /* prefill = */ true);
+        dnn_mem_t mem_dt_s8(
+                mem_dt.md_, get_test_engine(), /* prefill = */ true);
         SAFE(mem_fp_s8.reorder(mem_fp), WARN);
         SAFE(mem_dt_s8.reorder(mem_fp_s8), WARN);
         SAFE(mem_dt.size() == mem_dt_s8.size() ? OK : FAIL, WARN);
@@ -327,7 +329,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -213,7 +213,7 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
             float val = 0;
             while (val <= 0)
                 val = gen(int_seed);
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     0, round_to_nearest_representable(cfg.get_dt(kind), val));
             idx_start += 1;
         }
@@ -221,11 +221,11 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             bool is_one = density == 1.f ? true : b_dist(b_seed);
             if (!is_one) {
-                mem_fp.set_elem(idx, 0.f);
+                mem_fp.set_f32_elem(idx, 0.f);
                 continue;
             }
             float val = gen(int_seed);
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }
     });

--- a/tests/benchdnn/ip/ref_ip.cpp
+++ b/tests/benchdnn/ip/ref_ip.cpp
@@ -37,8 +37,8 @@ void compute_ref_fwd_ip(const prb_t *prb, const args_t &args) {
     const bool has_dst_scale = !prb->attr.scales.get(DNNL_ARG_DST).is_def();
     assert(IMPLICATION(has_src_scale, src_scales.nelems() == 1));
     assert(IMPLICATION(has_dst_scale, dst_scales.nelems() == 1));
-    float src_scale = has_src_scale ? src_scales.get_elem(0) : 1.f;
-    float dst_scale = has_dst_scale ? 1.f / dst_scales.get_elem(0) : 1.f;
+    float src_scale = has_src_scale ? src_scales.get_f32_elem(0) : 1.f;
+    float dst_scale = has_dst_scale ? 1.f / dst_scales.get_f32_elem(0) : 1.f;
     const int wei_scale_mask
             = prb->attr.scales.get_mask(DNNL_ARG_WEIGHTS, dnnl_inner_product);
 
@@ -60,7 +60,7 @@ void compute_ref_fwd_ip(const prb_t *prb, const args_t &args) {
 
         float wei_scale = 1.f;
         if (has_wei_scale)
-            wei_scale = wei_scales.get_elem(wei_scale_mask > 0 ? oc : 0);
+            wei_scale = wei_scales.get_f32_elem(wei_scale_mask > 0 ? oc : 0);
 
         d *= src_scale * wei_scale;
 

--- a/tests/benchdnn/ip/ref_ip.cpp
+++ b/tests/benchdnn/ip/ref_ip.cpp
@@ -46,7 +46,8 @@ void compute_ref_fwd_ip(const prb_t *prb, const args_t &args) {
     int64_t N = prb->oc;
     int64_t K = prb->ic * prb->id * prb->ih * prb->iw;
 
-    dnn_mem_t dst_tmp(dst_m.md_, dnnl_f32, tag::abx, dst_m.engine());
+    dnn_mem_t dst_tmp(dst_m.md_, dnnl_f32, tag::abx, dst_m.engine(),
+            /* prefill = */ false);
 
     gemm("C", "N", "T", M, N, K, 1.f, (float *)src_m, K, (float *)wei_m, K, 0.f,
             (float *)dst_tmp, N);

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -595,7 +595,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 
@@ -606,7 +607,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                     const auto &src_md = mem_map[DNNL_ARG_SRC].md_;
                     const auto stat_dims = query_md_dims(src_md);
                     ref_mem_map[exec_arg] = dnn_mem_t(prb->ndims - 1, stat_dims,
-                            dnnl_f32, tag::abx, ref_engine);
+                            dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false);
                 }
                 break;
             default:

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -86,7 +86,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
     const float val_coeff = is_integral_dt(prb->dt[0]) ? 1.f : 0.25f;
 
     benchdnn_parallel_nd(prb->n, [&](int64_t n) {
-        const float m = ref_mean.get_elem(n);
+        const float m = ref_mean.get_f32_elem(n);
         // Note: we use a different seed for each chunk to avoid
         // repeating patterns. We could use discard(idx_start) too but
         // it has a complexity in O(idx_start). We also add 1 to avoid
@@ -164,10 +164,10 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         if (prb->flags & GLOB_STATS) {
             val = ((n % 7) << 1);
         } else if (prb->c > 0) {
-            const float m = ref_mean.get_elem(n);
+            const float m = ref_mean.get_f32_elem(n);
             for (int64_t c = 0; c < prb->c; ++c) {
                 const int64_t off = n * prb->c + c;
-                const float s = ref_src.get_elem(off);
+                const float s = ref_src.get_f32_elem(off);
                 val += (s - m) * (s - m);
             }
             val /= cfg.L_;
@@ -309,7 +309,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         // src data to (m+1) and (m-1) points, d_dst data is more or less
         // random but we keep all values as pow2 values to have almost exact
         // summation result.
-        const float m = ref_mean.get_elem(n);
+        const float m = ref_mean.get_f32_elem(n);
 
         for (int64_t c = 0; c < prb->c; ++c) {
             const int64_t off = n * prb->c + c;
@@ -510,7 +510,7 @@ void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
                 const auto &dst = ref_args.find(DNNL_ARG_DST);
                 const int64_t c = dst.get_idx(
                         args.idx, 1 << (prb->ndims - 1) /* last_dim_mask */);
-                const float beta = sh.get_elem(c);
+                const float beta = sh.get_f32_elem(c);
                 // Using an empirically derived threshold, check if
                 // cancellation error in `|Y| = |a*X - (-b)|` is huge.
                 const float abs_exp = fabsf(args.exp);

--- a/tests/benchdnn/lnorm/ref_lnorm.cpp
+++ b/tests/benchdnn/lnorm/ref_lnorm.cpp
@@ -95,8 +95,8 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
                 d_beta += dd;
             }
 
-            if (use_sc && (prb->dir & FLAG_WEI)) d_sc.set_elem(c, d_gamma);
-            if (use_sh && (prb->dir & FLAG_WEI)) d_sh.set_elem(c, d_beta);
+            if (use_sc && (prb->dir & FLAG_WEI)) d_sc.set_f32_elem(c, d_gamma);
+            if (use_sh && (prb->dir & FLAG_WEI)) d_sh.set_f32_elem(c, d_beta);
         });
     }
 
@@ -125,7 +125,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
                 ds -= (dd_gamma + x * dd_gamma_x * rcp_denom) / prb->c;
             }
 
-            d_src.set_elem(off, rcp_denom * ds);
+            d_src.set_f32_elem(off, rcp_denom * ds);
         }
     });
 }

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -52,7 +52,7 @@ int fill_dat(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
     benchdnn_parallel_nd(nelems, [&](int64_t i) {
         const int64_t gen = kind == SRC ? 1091 * i + 1637 : 1279 * i + 1009;
         const float value = f_min + gen % range;
-        mem_fp.set_elem(i, value);
+        mem_fp.set_f32_elem(i, value);
     });
 
     SAFE(mem_dt.reorder(mem_fp), WARN);

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -164,7 +164,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD && exec_arg != DNNL_ARG_WORKSPACE) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/lrn/ref_lrn.cpp
+++ b/tests/benchdnn/lrn/ref_lrn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2022 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ float get_omega(const prb_t *prb, const dnn_mem_t &src, int64_t mb, int64_t c,
 
         for (int64_t cs = c_st; cs < c_en; ++cs) {
             const auto off = data_off(prb, mb, cs, d, h, w);
-            const float s = src.get_elem(off);
+            const float s = src.get_f32_elem(off);
             sum += s * s;
         }
     } else if (prb->alg == WITHIN) {
@@ -53,7 +53,7 @@ float get_omega(const prb_t *prb, const dnn_mem_t &src, int64_t mb, int64_t c,
         for_(int64_t hs = h_st; hs < h_en; ++hs)
         for (int64_t ws = w_st; ws < w_en; ++ws) {
             const auto off = data_off(prb, mb, c, ds, hs, ws);
-            const float s = src.get_elem(off);
+            const float s = src.get_f32_elem(off);
             sum += s * s;
         }
     }
@@ -72,7 +72,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
                 const auto off = data_off(prb, mb, c, d, h, w);
                 const float omega = get_omega(prb, src, mb, c, d, h, w);
                 const float omega_in_beta = fast_powf(omega, prb->beta);
-                dst_ptr[off] = src.get_elem(off) * omega_in_beta;
+                dst_ptr[off] = src.get_f32_elem(off) * omega_in_beta;
             });
 }
 
@@ -99,9 +99,10 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
                         const float omega
                                 = get_omega(prb, src, mb, cs, d, h, w);
                         const float omega_in_beta = fast_powf(omega, prb->beta);
-                        const float tmp = omega_in_beta * d_dst.get_elem(off);
+                        const float tmp
+                                = omega_in_beta * d_dst.get_f32_elem(off);
                         if (cs == c) A = tmp;
-                        B += (tmp / omega * src.get_elem(off));
+                        B += (tmp / omega * src.get_f32_elem(off));
                     }
                 } else if (prb->alg == WITHIN) {
                     const int64_t d_st = MAX2(d - half_size + 0, 0);
@@ -118,13 +119,14 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
                         const float omega
                                 = get_omega(prb, src, mb, c, ds, hs, ws);
                         const float omega_in_beta = fast_powf(omega, prb->beta);
-                        const float tmp = omega_in_beta * d_dst.get_elem(off);
+                        const float tmp
+                                = omega_in_beta * d_dst.get_f32_elem(off);
                         if (ds == d && hs == h && ws == w) A = tmp;
-                        B += (tmp / omega * src.get_elem(off));
+                        B += (tmp / omega * src.get_f32_elem(off));
                     }
                 }
                 const auto off = data_off(prb, mb, c, d, h, w);
-                B *= (2.0f * prb->alpha * prb->beta * src.get_elem(off)
+                B *= (2.0f * prb->alpha * prb->beta * src.get_f32_elem(off)
                         / summands);
                 d_src_ptr[off] = A - B;
             });

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -869,12 +869,14 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         if (is_sparse && !is_sparse_wei_packed) {
             if (is_sparse_src) {
                 auto src_fp_d = create_md(prb, SRC);
-                ref_mem_map.emplace(exec_arg, dnn_mem_t(src_fp_d, ref_engine));
+                ref_mem_map.emplace(exec_arg,
+                        dnn_mem_t(src_fp_d, ref_engine, /* prefill = */ false));
             }
 
             if (is_sparse_wei) {
                 auto wei_fp_d = create_md(prb, WEI);
-                ref_mem_map.emplace(exec_arg, dnn_mem_t(wei_fp_d, ref_engine));
+                ref_mem_map.emplace(exec_arg,
+                        dnn_mem_t(wei_fp_d, ref_engine, /* prefill = */ false));
             }
         } else {
             if (exec_arg == DNNL_ARG_WEIGHTS) {
@@ -891,12 +893,14 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 strides[ndims - 2] = 1;
                 strides[ndims - 1] = dims[ndims - 2];
                 ref_mem_map.emplace(exec_arg,
-                        dnn_mem_t(mem.md_, dnnl_f32, strides, ref_engine));
+                        dnn_mem_t(mem.md_, dnnl_f32, strides, ref_engine,
+                                /* prefill = */ false));
             } else if (exec_arg != DNNL_ARG_SCRATCHPAD) {
                 // Scratchpad memory relates to a primitive. If reference needs
                 // it, use switch below to define a memory desc for it.
                 ref_mem_map.emplace(exec_arg,
-                        dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                        dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                                /* prefill = */ false));
             }
         }
         auto &ref_mem = ref_mem_map[exec_arg];
@@ -924,7 +928,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
             } break;
             case DNNL_ARG_ATTR_DROPOUT_SEED: {
-                ref_mem = dnn_mem_t(mem.md_, dnnl_s32, tag::abx, ref_engine);
+                ref_mem = dnn_mem_t(mem.md_, dnnl_s32, tag::abx, ref_engine,
+                        /* prefill = */ false);
                 // No break to fall back into `default` call with initialization.
             }
             default:

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -441,7 +441,7 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
             while (val <= 0)
                 val = gen(int_seed);
             val += src_zp + wei_zp; // Add zp so that it will be subtracted.
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     0, round_to_nearest_representable(cfg.get_dt(kind), val));
             idx_start += 1;
         }
@@ -450,25 +450,25 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
             for (int64_t idx = idx_start; idx < idx_end; ++idx) {
                 const bool is_one = nnz_mask[idx];
                 if (!is_one) {
-                    mem_fp.set_elem(idx, 0.f);
+                    mem_fp.set_f32_elem(idx, 0.f);
                     continue;
                 }
                 float val = 0.f;
                 while (val == 0.f)
                     val = gen(int_seed);
-                mem_fp.set_elem(idx,
+                mem_fp.set_f32_elem(idx,
                         round_to_nearest_representable(cfg.get_dt(kind), val));
             }
         } else {
             for (int64_t idx = idx_start; idx < idx_end; ++idx) {
                 bool is_one = density == 1.f ? true : b_dist(b_seed);
                 if (!is_one) {
-                    mem_fp.set_elem(idx, 0.f);
+                    mem_fp.set_f32_elem(idx, 0.f);
                     continue;
                 }
                 float val = gen(int_seed);
                 val += src_zp + wei_zp; // Add zp so that it will be subtracted.
-                mem_fp.set_elem(idx,
+                mem_fp.set_f32_elem(idx,
                         round_to_nearest_representable(cfg.get_dt(kind), val));
             }
         }

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -202,7 +202,7 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
         }
         float dst_val = dst_scale * dst + dst_zp;
         maybe_round(prb->attr, DNNL_ARG_DST, dst_val, dst_off, prb->dst_dt());
-        dst_m.set_elem(dst_off, dst_val);
+        dst_m.set_f32_elem(dst_off, dst_val);
     });
 }
 
@@ -244,7 +244,7 @@ void compute_ref_sparse_matmul(const prb_t *prb, const args_t &args) {
     // Batch is not supported.
     const int64_t mb = 0;
     benchdnn_parallel_nd(M, N, [&](int64_t m, int64_t n) {
-        dst_m.set_elem(dst_off_f(prb, mb, m, n), 0.0f);
+        dst_m.set_f32_elem(dst_off_f(prb, mb, m, n), 0.0f);
     });
 
     if (is_wei_sparse) {
@@ -275,7 +275,7 @@ void compute_ref_sparse_matmul(const prb_t *prb, const args_t &args) {
                     const float wei_val = wei_m.get_elem(n, 0);
                     float dst_val = dst_m.get_f32_elem(dst_idx);
                     dst_val += src_val * wei_val;
-                    dst_m.set_elem(dst_idx, dst_val);
+                    dst_m.set_f32_elem(dst_idx, dst_val);
                 }
             }
         });
@@ -306,7 +306,7 @@ void compute_ref_sparse_matmul(const prb_t *prb, const args_t &args) {
                     const float wei_val = wei_m.get_f32_elem(wei_idx);
                     dst_val += src_val * wei_val;
                 }
-                dst_m.set_elem(dst_idx, dst_val);
+                dst_m.set_f32_elem(dst_idx, dst_val);
             }
         });
     }

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -131,8 +131,10 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
 
         int src_zp = has_src_single_zp ? src_zps.get_elem(0) : 0;
         int wei_zp = has_wei_single_zp ? wei_zps.get_elem(0) : 0;
-        float src_scale = has_src_single_scale ? src_scales.get_elem(0) : 1.f;
-        float wei_scale = has_wei_single_scale ? wei_scales.get_elem(0) : 1.f;
+        float src_scale
+                = has_src_single_scale ? src_scales.get_f32_elem(0) : 1.f;
+        float wei_scale
+                = has_wei_single_scale ? wei_scales.get_f32_elem(0) : 1.f;
 
         for (int64_t gK = 0; gK < n_k_groups; gK++) {
             const auto src_gK_off
@@ -155,12 +157,12 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
             if (has_src_scale && !has_src_single_scale) {
                 const auto src_scale_idx = src_m.get_idx(src_gK_off,
                         src_scale_mask, src_m.ndims(), src_scale_groups);
-                src_scale = src_scales.get_elem(src_scale_idx);
+                src_scale = src_scales.get_f32_elem(src_scale_idx);
             }
             if (has_wei_scale && !has_wei_single_scale) {
                 const auto wei_scale_idx = wei_m.get_idx(wei_gK_off,
                         wei_scale_mask, wei_m.ndims(), wei_scale_groups);
-                wei_scale = wei_scales.get_elem(wei_scale_idx);
+                wei_scale = wei_scales.get_f32_elem(wei_scale_idx);
             }
 
             for (int64_t k = 0; k < smallest_k_group; ++k) {
@@ -169,8 +171,8 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
                 const auto wei_off = wei_ba_off_f(
                         prb, wei_mb, gK * smallest_k_group + k, n);
 
-                auto s = src_scale * (src_m.get_elem(src_off) - src_zp);
-                auto w = wei_scale * (wei_m.get_elem(wei_off) - wei_zp);
+                auto s = src_scale * (src_m.get_f32_elem(src_off) - src_zp);
+                auto w = wei_scale * (wei_m.get_f32_elem(wei_off) - wei_zp);
 
                 dst += s * w;
             }
@@ -179,13 +181,13 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
         const auto dst_off = dst_off_f(prb, mb, m, n);
         if (prb->bia_dt != dnnl_data_type_undef) {
             const auto bia_idx = dst_m.get_idx(dst_off, bias_broadcast_mask);
-            dst += bia_m.get_elem(bia_idx);
+            dst += bia_m.get_f32_elem(bia_idx);
         }
 
         const auto v_po_vals
                 = prepare_po_vals(dst_m, args, v_po_masks, dst_off);
         maybe_dropout(prb->attr, dst, dst_off, dropout);
-        const auto sum_val = dst_m.get_elem(dst_off);
+        const auto sum_val = dst_m.get_f32_elem(dst_off);
         maybe_post_ops(prb->attr, dst, sum_val, v_po_vals);
 
         int dst_zp = 0;
@@ -195,7 +197,8 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
         }
         float dst_scale = 1.f;
         if (has_dst_scale) {
-            dst_scale = 1.f / dst_scales.get_elem(dst_scale_mask > 0 ? n : 0);
+            dst_scale
+                    = 1.f / dst_scales.get_f32_elem(dst_scale_mask > 0 ? n : 0);
         }
         float dst_val = dst_scale * dst + dst_zp;
         maybe_round(prb->attr, DNNL_ARG_DST, dst_val, dst_off, prb->dst_dt());
@@ -268,9 +271,9 @@ void compute_ref_sparse_matmul(const prb_t *prb, const args_t &args) {
                     const int64_t src_idx = src_off_f(prb, mb, m, k);
                     const int64_t dst_idx
                             = dst_off_f(prb, mb, m, wei_indices[n]);
-                    const float src_val = src_m.get_elem(src_idx);
+                    const float src_val = src_m.get_f32_elem(src_idx);
                     const float wei_val = wei_m.get_elem(n, 0);
-                    float dst_val = dst_m.get_elem(dst_idx);
+                    float dst_val = dst_m.get_f32_elem(dst_idx);
                     dst_val += src_val * wei_val;
                     dst_m.set_elem(dst_idx, dst_val);
                 }
@@ -294,13 +297,13 @@ void compute_ref_sparse_matmul(const prb_t *prb, const args_t &args) {
             const int64_t row_end = src_pointers[m + 1];
             for (int64_t n = 0; n < N; n++) {
                 const int64_t dst_idx = dst_off_f(prb, mb, m, n);
-                float dst_val = dst_m.get_elem(dst_idx);
+                float dst_val = dst_m.get_f32_elem(dst_idx);
 
                 for (int64_t k = row_start; k < row_end; k++) {
                     const int64_t wei_idx
                             = wei_ba_off_f(prb, mb, src_indices[k], n);
                     const float src_val = src_m.get_elem(k, 0);
-                    const float wei_val = wei_m.get_elem(wei_idx);
+                    const float wei_val = wei_m.get_f32_elem(wei_idx);
                     dst_val += src_val * wei_val;
                 }
                 dst_m.set_elem(dst_idx, dst_val);

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -70,14 +70,14 @@ int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
             float val = 0;
             while (val <= 0)
                 val = gen(int_seed);
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     0, round_to_nearest_representable(cfg.get_dt(kind), val));
             idx_start += 1;
         }
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             float val = gen(int_seed);
-            mem_fp.set_elem(
+            mem_fp.set_f32_elem(
                     idx, round_to_nearest_representable(cfg.get_dt(kind), val));
         }
     });

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -282,7 +282,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD && exec_arg != DNNL_ARG_WORKSPACE) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 
@@ -296,8 +297,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             case DNNL_ARG_WORKSPACE: {
                 const auto ws_dt
                         = is_integral_dt(mem.dt()) ? dnnl_s32 : dnnl_f32;
-                ref_mem_map[exec_arg]
-                        = dnn_mem_t(mem.md_, ws_dt, tag::abx, ref_engine);
+                ref_mem_map[exec_arg] = dnn_mem_t(mem.md_, ws_dt, tag::abx,
+                        ref_engine, /* prefill = */ false);
                 if (prb->dir & FLAG_FWD) SAFE(fill_ws(prb, mem, ref_mem), WARN);
                 break;
             }

--- a/tests/benchdnn/pool/ref_pool.cpp
+++ b/tests/benchdnn/pool/ref_pool.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
                     const int64_t iw = ow * SW - PW + kw * (DW + 1);
                     if (iw < 0 || iw >= IW) continue;
 
-                    float s = src.get_elem(src_off_f(prb, mb, ic, id, ih, iw));
+                    float s = src.get_f32_elem(
+                            src_off_f(prb, mb, ic, id, ih, iw));
                     if (s > max_value) {
                         max_value = s;
                         ws_off = ker_off_f(prb, kd, kh, kw);
@@ -99,7 +100,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
 
     auto ker = [&](int64_t mb, int64_t ic, int64_t od, int64_t oh, int64_t ow) {
         const auto d_dst_off = dst_off_f(prb, mb, ic, od, oh, ow);
-        float d_dst_val = d_dst.get_elem(d_dst_off);
+        float d_dst_val = d_dst.get_f32_elem(d_dst_off);
         int ws_off = (prb->alg == max) ? ws.get_elem(d_dst_off) : 0;
 
         const int64_t ID = prb->id, IH = prb->ih, IW = prb->iw;

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -194,7 +194,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -87,7 +87,7 @@ int fill_data(data_kind_t kind, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
                     : flip_coin(idx, 0.1f)      ? -1.f
                                                 : 1.f;
             value = round_to_nearest_representable(mem_dt.dt(), sign * value);
-            mem_fp.set_elem(idx, value);
+            mem_fp.set_f32_elem(idx, value);
         }
     });
 

--- a/tests/benchdnn/prelu/ref_prelu.cpp
+++ b/tests/benchdnn/prelu/ref_prelu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
 
     benchdnn_parallel_nd(nelems, [&](int64_t i) {
         const auto wei_idx = src.get_idx(i, weights_broadcast_mask);
-        const float s = src.get_elem(i);
-        float res = s * (s > 0 ? 1.f : wei.get_elem(wei_idx));
+        const float s = src.get_f32_elem(i);
+        float res = s * (s > 0 ? 1.f : wei.get_f32_elem(wei_idx));
         maybe_saturate(prb->sdt[0], res);
         dst_ptr[i] = res;
     });
@@ -57,9 +57,9 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
     const auto wei_nelems = d_wei.nelems();
 
     const auto ker = [&](int64_t i, int64_t wei_idx, int64_t d_wei_idx) {
-        float s = src.get_elem(i);
-        float dd = d_dst.get_elem(i);
-        float d_src = dd * (s > 0 ? 1.f : wei.get_elem(wei_idx));
+        float s = src.get_f32_elem(i);
+        float dd = d_dst.get_f32_elem(i);
+        float d_src = dd * (s > 0 ? 1.f : wei.get_f32_elem(wei_idx));
         maybe_saturate(prb->sdt[0], d_src);
         d_src_ptr[i] = d_src;
         d_wei_buf[d_wei_idx] += MIN2(0.f, s) * dd;

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -167,7 +167,8 @@ int fill_mem(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp,
                     value = -value;
             }
             value += shift;
-            mem_fp.set_elem(idx, round_to_nearest_representable(sdt, value));
+            mem_fp.set_f32_elem(
+                    idx, round_to_nearest_representable(sdt, value));
         }
     });
     SAFE(mem_dt.reorder(mem_fp), WARN);

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -282,7 +282,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/reduction/ref_reduction.cpp
+++ b/tests/benchdnn/reduction/ref_reduction.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ void compute_ref(
             dims_t reduce_pos = off2dims_idx(reduce_dims, r);
             const int64_t src_reduce_off = md_off_v(src, reduce_pos.data());
             const int64_t src_off = src_idle_off + src_reduce_off;
-            accumulate(acc, src.get_elem(src_off), alg, p, eps);
+            accumulate(acc, src.get_f32_elem(src_off), alg, p, eps);
         }
         finalize(acc, alg, p, eps, reduce_size);
 

--- a/tests/benchdnn/reorder/ref_reorder.cpp
+++ b/tests/benchdnn/reorder/ref_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -75,19 +75,19 @@ void compute_ref(
                     = src.get_idx(idx, src_zp_mask, src.ndims(), src_zp_groups);
             src_zp = src_zps.get_elem(src_zp_idx);
         }
-        float s = src.get_elem(idx) - src_zp;
+        float s = src.get_f32_elem(idx) - src_zp;
         float d = 0;
-        if (beta_idx >= 0) d = dst.get_elem(idx) - dst_zero_point;
+        if (beta_idx >= 0) d = dst.get_f32_elem(idx) - dst_zero_point;
 
         float src_scale = 1.f, dst_scale = 1.f;
         if (has_src_scale) {
             int64_t src_mask_idx = src.get_idx(
                     idx, src_scale_mask, src.ndims(), src_scale_groups);
-            src_scale = src_scales.get_elem(src_mask_idx);
+            src_scale = src_scales.get_f32_elem(src_mask_idx);
         }
         if (has_dst_scale) {
             int64_t dst_mask_idx = dst.get_idx(idx, dst_scale_mask);
-            dst_scale = dst_scales.get_elem(dst_mask_idx);
+            dst_scale = dst_scales.get_f32_elem(dst_mask_idx);
         }
         float value = (s8_scale_factor * src_scale * s + beta * d) / dst_scale
                 + dst_zero_point;
@@ -146,15 +146,16 @@ void compute_ref(
             float src_scale = 1.f, dst_scale = 1.f;
             if (has_src_scale) {
                 int64_t src_mask_idx = src.get_idx(src_off, src_scale_mask);
-                src_scale = src_scales.get_elem(src_mask_idx);
+                src_scale = src_scales.get_f32_elem(src_mask_idx);
             }
             if (has_dst_scale) {
                 int64_t dst_mask_idx = dst.get_idx(src_off, dst_scale_mask);
-                dst_scale = dst_scales.get_elem(dst_mask_idx);
+                dst_scale = dst_scales.get_f32_elem(dst_mask_idx);
             }
 
             const float alpha = src_scale / dst_scale;
-            const float value = src.get_elem(src_off) * alpha * s8_scale_factor;
+            const float value
+                    = src.get_f32_elem(src_off) * alpha * s8_scale_factor;
             comp_val -= maybe_saturate(dst_dt, value);
         }
         if (need_zp_comp) zp_comp.set_elem(f, comp_val);

--- a/tests/benchdnn/reorder/ref_reorder.cpp
+++ b/tests/benchdnn/reorder/ref_reorder.cpp
@@ -96,7 +96,7 @@ void compute_ref(
             value = BENCHDNN_S32_TO_F32_SAT_CONST;
         maybe_round(prb->attr, DNNL_ARG_DST, value, idx, dst_dt);
 
-        dst.set_elem(idx, round_to_nearest_representable(dst_dt, value));
+        dst.set_f32_elem(idx, round_to_nearest_representable(dst_dt, value));
     });
 
     if (!need_comp) return;

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -71,7 +71,7 @@ int fill_mem(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
         const int64_t table_idx = kind == SRC
                 ? (i % table_size)
                 : ((i * (table_size + 1) / table_size) % table_size);
-        mem_fp.set_elem(
+        mem_fp.set_f32_elem(
                 i, round_to_nearest_representable(conf->dt, gen[table_idx]));
         if (zero_out_wa) mem_dt.set_elem(i, 0);
     });

--- a/tests/benchdnn/resampling/ref_resampling.cpp
+++ b/tests/benchdnn/resampling/ref_resampling.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2022 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
         const int64_t id = near(od, OD, ID);
         const int64_t ih = near(oh, OH, IH);
         const int64_t iw = near(ow, OW, IW);
-        result = src.get_elem(src_off_f(prb, mb, ic, id, ih, iw));
+        result = src.get_f32_elem(src_off_f(prb, mb, ic, id, ih, iw));
     };
 
     auto ker_linear = [&](float &result, int64_t mb, int64_t ic, int64_t od,
@@ -73,9 +73,11 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
         float cd[2][2] = {{0}};
         for_(int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++)
-            cd[i][j] = src.get_elem(src_off_f(prb, mb, ic, id[0], ih[i], iw[j]))
+            cd[i][j] = src.get_f32_elem(
+                               src_off_f(prb, mb, ic, id[0], ih[i], iw[j]))
                             * wd[0]
-                    + src.get_elem(src_off_f(prb, mb, ic, id[1], ih[i], iw[j]))
+                    + src.get_f32_elem(
+                              src_off_f(prb, mb, ic, id[1], ih[i], iw[j]))
                             * wd[1];
 
         float ch[2] = {0};
@@ -101,8 +103,8 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
                 const auto v_po_vals
                         = prepare_po_vals(dst, args, v_po_masks, dst_off);
 
-                maybe_post_ops(
-                        prb->attr, result, dst.get_elem(dst_off), v_po_vals);
+                maybe_post_ops(prb->attr, result, dst.get_f32_elem(dst_off),
+                        v_po_vals);
                 dst_ptr[dst_off] = result;
             });
 }
@@ -125,7 +127,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
     auto ker_nearest
             = [&](int64_t mb, int64_t ic, int64_t od, int64_t oh, int64_t ow) {
                   const auto d_dst_off = dst_off_f(prb, mb, ic, od, oh, ow);
-                  float d_dst_val = d_dst.get_elem(d_dst_off);
+                  float d_dst_val = d_dst.get_f32_elem(d_dst_off);
                   const int64_t id = near(od, OD, ID);
                   const int64_t ih = near(oh, OH, IH);
                   const int64_t iw = near(ow, OW, IW);
@@ -135,7 +137,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
     auto ker_linear = [&](int64_t mb, int64_t ic, int64_t od, int64_t oh,
                               int64_t ow) {
         const auto d_dst_off = dst_off_f(prb, mb, ic, od, oh, ow);
-        float d_dst_val = d_dst.get_elem(d_dst_off);
+        float d_dst_val = d_dst.get_f32_elem(d_dst_off);
         const int64_t id[2] = {left(od, OD, ID), right(od, OD, ID)};
         const int64_t ih[2] = {left(oh, OH, IH), right(oh, OH, IH)};
         const int64_t iw[2] = {left(ow, OW, IW), right(ow, OW, IW)};

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -55,7 +55,7 @@ int fill_dat(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
                 ? (f_min + gen) * (1.0f + 4.0f / range)
                 : (f_min + gen) / range;
 
-        mem_fp.set_elem(i, round_to_nearest_representable(dt, value));
+        mem_fp.set_f32_elem(i, round_to_nearest_representable(dt, value));
     });
 
     SAFE(mem_dt.reorder(mem_fp), WARN);

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -190,7 +190,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -145,8 +145,9 @@ int check_s8s8_reorder(const prb_t &prb, rnn_data_kind_t kind,
     // alignment as packed buffer is aligned internally and the offset
     // is kept in the metadata.
     // Works fine with dnn_mem_t as it is align to 2MB large page boundary
-    dnn_mem_t mem_s8_src(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine());
-    dnn_mem_t mem_s8_dst(mem_dt.md_, get_test_engine());
+    dnn_mem_t mem_s8_src(mem_fp.md_, dnnl_s8, tag::abx, get_cpu_engine(),
+            /* prefill = */ true);
+    dnn_mem_t mem_s8_dst(mem_dt.md_, get_test_engine(), /* prefill = */ true);
 
     /* 1. compute f32_plain --quant--> s8_plain_quantized */
     /* Do fixed partitioning to have same filling for any number of threads */
@@ -435,7 +436,8 @@ int fill_weights(const prb_t &prb, rnn_data_kind_t kind, dnn_mem_t &mem_dt,
     assert(kind == WEIGHTS_PROJECTION ? mem_fp.ndims() == 4
                                       : mem_fp.ndims() == 5);
 
-    dnn_mem_t mem_pure_fp(mem_dt.md_, dnnl_f32, tag::abx, get_cpu_engine());
+    dnn_mem_t mem_pure_fp(mem_dt.md_, dnnl_f32, tag::abx, get_cpu_engine(),
+            /* prefill = */ false);
 
     const auto dt = prb.cfg[kind].dt;
     const auto &dims = mem_fp.dims();
@@ -1102,7 +1104,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD && exec_arg != DNNL_ARG_WORKSPACE) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/rnn/rnn.cpp
+++ b/tests/benchdnn/rnn/rnn.cpp
@@ -159,7 +159,7 @@ int check_s8s8_reorder(const prb_t &prb, rnn_data_kind_t kind,
         int64_t idx_end = MIN2(idx_start + chunk_size, nelems);
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             const float current_scale = scales[idx % nscales];
-            float val_f32 = mem_fp.get_elem(idx);
+            float val_f32 = mem_fp.get_f32_elem(idx);
             int8_t val_s8
                     = maybe_saturate(dnnl_s8, val_f32 * current_scale + shift);
             mem_s8_src.set_elem(idx, val_s8);

--- a/tests/benchdnn/self/compare.cpp
+++ b/tests/benchdnn/self/compare.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ static int check_compare() {
         res_t res {};
         res.state = EXECUTED;
         dnnl_dims_t dims {100};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         compare::compare_t cmp;
         cmp.set_zero_trust_percent(100.f);
         for (int i = 0; i < dims[0]; i++) {
@@ -48,8 +50,10 @@ static int check_compare() {
         res_t res {};
         res.state = EXECUTED;
         dnnl_dims_t dims {100};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         compare::compare_t cmp;
         cmp.set_threshold(99.f);
         for (int i = 0; i < dims[0]; i++) {

--- a/tests/benchdnn/self/graph_example.cpp
+++ b/tests/benchdnn/self/graph_example.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -214,8 +214,8 @@ int check_correctness(std::unordered_map<int, graph_link_t> &op_graph,
         // non-f32 data type and non-abx data format, so we reorder `mem_fp` to
         // a golden standard first.
         const auto &mem_fp_md = mem_fp.md_;
-        dnn_mem_t mem_fp_golden(
-                mem_fp_md, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t mem_fp_golden(mem_fp_md, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ true);
         SAFE(mem_fp_golden.reorder(mem_fp), WARN);
 
         SAFE(cmp.compare(mem_fp_golden, mem_dt, attr_t(), res), WARN);

--- a/tests/benchdnn/self/memory.cpp
+++ b/tests/benchdnn/self/memory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,27 +29,33 @@ static int check_bool_operator() {
         SELF_CHECK_EQ(bool(m), false);
     }
     {
-        dnn_mem_t m(md, get_test_engine());
+        dnn_mem_t m(md, get_test_engine(), /* prefill = */ false);
         SELF_CHECK_EQ(bool(m), true);
-        dnn_mem_t n(md0, get_test_engine());
+        dnn_mem_t n(md0, get_test_engine(), /* prefill = */ false);
         SELF_CHECK_EQ(bool(n), false);
     }
     {
-        dnn_mem_t m(1, &dims, dnnl_f32, tag::abx, get_test_engine());
+        dnn_mem_t m(1, &dims, dnnl_f32, tag::abx, get_test_engine(),
+                /* prefill = */ false);
         SELF_CHECK_EQ(bool(m), true);
-        dnn_mem_t n(0, &dims, dnnl_f32, tag::abx, get_test_engine());
+        dnn_mem_t n(0, &dims, dnnl_f32, tag::abx, get_test_engine(),
+                /* prefill = */ false);
         SELF_CHECK_EQ(bool(n), false);
     }
     {
-        dnn_mem_t m(1, &dims, dnnl_f32, &dims /* strides */, get_test_engine());
+        dnn_mem_t m(1, &dims, dnnl_f32, &dims /* strides */, get_test_engine(),
+                /* prefill = */ false);
         SELF_CHECK_EQ(bool(m), true);
-        dnn_mem_t n(0, &dims, dnnl_f32, &dims /* strides */, get_test_engine());
+        dnn_mem_t n(0, &dims, dnnl_f32, &dims /* strides */, get_test_engine(),
+                /* prefill = */ false);
         SELF_CHECK_EQ(bool(n), false);
     }
     {
-        dnn_mem_t m(md, dnnl_f32, tag::abx, get_test_engine());
+        dnn_mem_t m(md, dnnl_f32, tag::abx, get_test_engine(),
+                /* prefill = */ false);
         SELF_CHECK_EQ(bool(m), true);
-        dnn_mem_t n(md0, dnnl_f32, tag::abx, get_test_engine());
+        dnn_mem_t n(md0, dnnl_f32, tag::abx, get_test_engine(),
+                /* prefill = */ false);
         SELF_CHECK_EQ(bool(n), false);
     }
     return OK;

--- a/tests/benchdnn/self/norm.cpp
+++ b/tests/benchdnn/self/norm.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,8 +109,10 @@ static int check_diff_norm() {
 
 static int check_compare_norm() {
     dnnl_dim_t dims {10};
-    dnn_mem_t m0(1, &dims, dnnl_f32, tag::abx, get_test_engine());
-    dnn_mem_t m1(1, &dims, dnnl_f32, tag::abx, get_test_engine());
+    dnn_mem_t m0(1, &dims, dnnl_f32, tag::abx, get_test_engine(),
+            /* prefill = */ false);
+    dnn_mem_t m1(1, &dims, dnnl_f32, tag::abx, get_test_engine(),
+            /* prefill = */ false);
 
 #define N 10
     for (int i = 1; i <= N; i++) {

--- a/tests/benchdnn/self/res.cpp
+++ b/tests/benchdnn/self/res.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2023 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,8 +28,10 @@ static int check_status_change() {
         res_t res {};
         res.state = EXECUTED;
         dnnl_dims_t dims {10};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         for (int i = 0; i < dims[0]; i++) {
             m0.set_elem(i, 0);
             m1.set_elem(i, 0);
@@ -50,8 +52,10 @@ static int check_status_change() {
         res_t res {};
         res.state = EXECUTED;
         dnnl_dims_t dims {10};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         compare::compare_t cmp;
         for (int i = 0; i < dims[0]; i++) {
             m0.set_elem(i, i);
@@ -80,8 +84,10 @@ static int check_status_change() {
         res_t res {};
         res.state = EXECUTED;
         dnnl_dims_t dims {10};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         for (int i = 0; i < dims[0]; i++) {
             m0.set_elem(i, i);
             m1.set_elem(i, i - 1);
@@ -94,8 +100,10 @@ static int check_status_change() {
         res_t res {};
         res.state = FAILED;
         dnnl_dims_t dims {10};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         for (int i = 0; i < dims[0]; i++) {
             m0.set_elem(i, 0);
             m1.set_elem(i, 0);
@@ -108,8 +116,10 @@ static int check_status_change() {
         res_t res {};
         res.state = FAILED;
         dnnl_dims_t dims {10};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         for (int i = 0; i < dims[0]; i++) {
             m0.set_elem(i, i);
             m1.set_elem(i, i);
@@ -122,8 +132,10 @@ static int check_status_change() {
         res_t res {};
         res.state = FAILED;
         dnnl_dims_t dims {10};
-        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
-        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine());
+        dnn_mem_t m0(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
+        dnn_mem_t m1(1, dims, dnnl_f32, tag::abx, get_cpu_engine(),
+                /* prefill = */ false);
         for (int i = 0; i < dims[0]; i++) {
             m0.set_elem(i, i);
             m1.set_elem(i, i - 1);

--- a/tests/benchdnn/shuffle/ref_shuffle.cpp
+++ b/tests/benchdnn/shuffle/ref_shuffle.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2022 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ void compute_ref(
             [&](int64_t ou, int64_t a, int64_t in) {
                 auto src_off = ou * dim + a * inner_size + in;
                 auto dst_off = ou * dim + transpose(a) * inner_size + in;
-                dst_ptr[dst_off] = src.get_elem(src_off);
+                dst_ptr[dst_off] = src.get_f32_elem(src_off);
             });
 }
 

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -142,7 +142,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -58,7 +58,7 @@ int fill_src(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
         const float value = (prb->dt == dnnl_bf16 || prb->dt == dnnl_f16)
                 ? (f_min + gen) / range
                 : (f_min + gen) * (1.0f + 4.0f / range);
-        mem_fp.set_elem(i, round_to_nearest_representable(prb->dt, value));
+        mem_fp.set_f32_elem(i, round_to_nearest_representable(prb->dt, value));
     });
 
     SAFE(mem_dt.reorder(mem_fp), WARN);

--- a/tests/benchdnn/softmax/ref_softmax.cpp
+++ b/tests/benchdnn/softmax/ref_softmax.cpp
@@ -37,8 +37,8 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
     assert(IMPLICATION(has_src_scale, src_scale.nelems() == 1));
     assert(IMPLICATION(has_dst_scale, dst_scale.nelems() == 1));
 
-    const float src_scale_val = has_src_scale ? src_scale.get_elem(0) : 1.f;
-    const float dst_scale_val = has_dst_scale ? dst_scale.get_elem(0) : 1.f;
+    const float src_scale_val = has_src_scale ? src_scale.get_f32_elem(0) : 1.f;
+    const float dst_scale_val = has_dst_scale ? dst_scale.get_f32_elem(0) : 1.f;
     const float r_dst_scale_val = 1.0f / dst_scale_val;
 
     auto v_po_masks = prb->attr.post_ops.get_po_masks();
@@ -50,12 +50,12 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
 
         for (int64_t as = 0; as < axis_size; ++as) {
             int64_t idx = ou_in_offset + as * inner_size;
-            space_max = MAX2(space_max, src.get_elem(idx));
+            space_max = MAX2(space_max, src.get_f32_elem(idx));
         }
 
         for (int64_t as = 0; as < axis_size; ++as) {
             int64_t idx = ou_in_offset + as * inner_size;
-            float s = src.get_elem(idx);
+            float s = src.get_f32_elem(idx);
             if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 float D = dst_ptr[idx] = expf(s - space_max);
                 space_denom += D;
@@ -104,8 +104,8 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
 
         for (int64_t as = 0; as < axis_size; ++as) {
             int64_t idx = ou_in_offset + as * inner_size;
-            float d = dst.get_elem(idx);
-            float dd = d_dst.get_elem(idx);
+            float d = dst.get_f32_elem(idx);
+            float dd = d_dst.get_f32_elem(idx);
             if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 part_deriv_sum += dd * d;
             } else if (alg == LOGSOFTMAX) {
@@ -115,8 +115,8 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
 
         for (int64_t as = 0; as < axis_size; ++as) {
             int64_t idx = ou_in_offset + as * inner_size;
-            float d = dst.get_elem(idx);
-            float dd = d_dst.get_elem(idx);
+            float d = dst.get_f32_elem(idx);
+            float dd = d_dst.get_f32_elem(idx);
             if (alg == SOFTMAX || alg == SOFTMAX_INF_AS_ZERO) {
                 d_src_ptr[idx] = d * (dd - part_deriv_sum);
             } else if (alg == LOGSOFTMAX) {

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -350,7 +350,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -172,7 +172,7 @@ int fill_data_fwd(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
                     n_top[i]--;
                     if (n_top[i] == 0) i++;
                 }
-                mem_fp.set_elem(offset,
+                mem_fp.set_f32_elem(offset,
                         round_to_nearest_representable(mem_dt.dt(), value));
             }
         }
@@ -211,7 +211,7 @@ int fill_data_bwd(data_kind_t data_kind, const prb_t *prb, dnn_mem_t &mem_dt,
         const float gen = ((11 * i) + 37 + 19 * seed) % range;
         float coeff = data_kind == DIFF_DST ? sign * 1.f : sign * (1.f / range);
         float value = coeff * gen;
-        mem_fp.set_elem(i, value);
+        mem_fp.set_f32_elem(i, value);
     });
 
     SAFE(mem_dt.reorder(mem_fp), WARN);

--- a/tests/benchdnn/sum/ref_sum.cpp
+++ b/tests/benchdnn/sum/ref_sum.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ void compute_ref(
         float res = 0;
         for (int i_input = 0; i_input < prb->n_inputs(); ++i_input) {
             const dnn_mem_t &src_i = args.find(DNNL_ARG_MULTIPLE_SRC + i_input);
-            res += (src_i.get_elem(k) * prb->input_scales[i_input]);
+            res += (src_i.get_f32_elem(k) * prb->input_scales[i_input]);
         }
         dst.set_elem(k, res);
     });

--- a/tests/benchdnn/sum/ref_sum.cpp
+++ b/tests/benchdnn/sum/ref_sum.cpp
@@ -32,7 +32,7 @@ void compute_ref(
             const dnn_mem_t &src_i = args.find(DNNL_ARG_MULTIPLE_SRC + i_input);
             res += (src_i.get_f32_elem(k) * prb->input_scales[i_input]);
         }
-        dst.set_elem(k, res);
+        dst.set_f32_elem(k, res);
     });
 }
 

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -86,7 +86,7 @@ int fill_src(int input_idx, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
         const float value = (dt == dnnl_bf16 || dt == dnnl_f16)
                 ? (f_min + gen) / range
                 : (f_min + gen) * (1.0f + 4.0f / range);
-        mem_fp.set_elem(i, round_to_nearest_representable(dt, value));
+        mem_fp.set_f32_elem(i, round_to_nearest_representable(dt, value));
     });
 
     SAFE(mem_dt.reorder(mem_fp), WARN);

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -144,7 +144,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         // use switch below to define a memory desc for it.
         if (exec_arg != DNNL_ARG_SCRATCHPAD) {
             ref_mem_map.emplace(exec_arg,
-                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine));
+                    dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                            /* prefill = */ false));
         }
         auto &ref_mem = ref_mem_map[exec_arg];
 

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -165,7 +165,9 @@ cold_cache_t::cold_cache_t(
         auto orig_cc_mem_md = query_md(orig_mem);
 
         for (size_t i = 0; i < n_buffers_; i++) {
-            cc_entry[i] = dnn_mem_t(orig_cc_mem_md, get_test_engine());
+            // Data will be filled/reordered, no need to prefill it.
+            cc_entry[i] = dnn_mem_t(
+                    orig_cc_mem_md, get_test_engine(), /* prefill = */ false);
 
             // Sparse memories require this call to replicate the exact original
             // data distribution because the data structure affects performance
@@ -283,8 +285,10 @@ int cold_cache_t::thrash_reorder(size_t mem_size, size_t granularity) const {
     const dnnl_dims_t dims {div_up(nelems, stride)};
     const dnnl_dims_t strides {stride};
 
-    dnn_mem_t src_m(1, dims, dnnl_f32, strides, engine);
-    dnn_mem_t dst_m(1, dims, dnnl_f32, strides, engine);
+    // Since it's a thrash reorder, just need memory pages to go through, no
+    // need to prefill data.
+    dnn_mem_t src_m(1, dims, dnnl_f32, strides, engine, /* prefill = */ false);
+    dnn_mem_t dst_m(1, dims, dnnl_f32, strides, engine, /* prefill = */ false);
 
     dnnl_primitive_desc_t r_pd {};
     dnnl_primitive_attr_t attr {};

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -268,7 +268,8 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
     dnn_mem_t got_f32(got_mem, dnnl_f32, tag::abx, get_cpu_engine());
     dnn_mem_t exp_f32_plain;
     if (has_prim_ref_
-            && !check_md_consistency_with_tag(exp_mem.md_, tag::abx)) {
+            && (query_md_data_type(exp_mem.md_) != dnnl_f32
+                    || !check_md_consistency_with_tag(exp_mem.md_, tag::abx))) {
         exp_f32_plain
                 = dnn_mem_t(exp_mem, dnnl_f32, tag::abx, get_cpu_engine());
     }

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -160,9 +160,9 @@ compare_t::driver_check_func_args_t::driver_check_func_args_t(
         const dnnl_data_type_t data_type, const float trh)
     : dt(data_type)
     , idx(i)
-    , exp_f32(exp_mem.get_elem(idx))
+    , exp_f32(exp_mem.get_f32_elem(idx))
     , exp(round_to_nearest_representable(dt, exp_f32))
-    , got(got_f32.get_elem(idx))
+    , got(got_f32.get_f32_elem(idx))
     , diff(fabsf(exp - got))
     , rel_diff(diff / (fabsf(exp) > FLT_MIN ? fabsf(exp) : 1))
     , trh(trh) {}
@@ -349,8 +349,8 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
         // calls to this function.
         static thread_local auto &out_data = thread_data.get();
 
-        const auto got_val = got_f32.get_elem(i);
-        bool ok = exp_f32.get_elem(i) == got_val;
+        const auto got_val = got_f32.get_f32_elem(i);
+        bool ok = exp_f32.get_f32_elem(i) == got_val;
 
         static thread_local driver_check_func_args_t args;
         for (int z = ok; z < 1; z++) {

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -364,6 +364,11 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
                 break;
             }
 
+            // Discard tiny values very close to each other. It's impossible to
+            // compare them reliably and fit into any criterion.
+            ok = fabsf(args.exp) <= 1e-5f && args.diff < epsilon_dt(dnnl_f32);
+            if (ok) break;
+
             // Standard check for relative diff is under set threshold.
             ok = (fabsf(args.exp) > 1e-5f ? args.rel_diff : args.diff) <= trh_;
             if (ok) break;

--- a/tests/benchdnn/utils/compare.hpp
+++ b/tests/benchdnn/utils/compare.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,18 +28,19 @@ bool compare_extreme_values(float a, float b);
 
 struct compare_t {
     struct driver_check_func_args_t {
+        driver_check_func_args_t() = default;
         driver_check_func_args_t(const dnn_mem_t &exp_mem,
                 const dnn_mem_t &got_f32, const int64_t i,
                 const dnnl_data_type_t data_type, const float trh);
 
-        const dnnl_data_type_t dt = dnnl_data_type_undef;
-        const int64_t idx = 0;
-        const float exp_f32 = 0.f;
-        const float exp = 0.f;
-        const float got = 0.f;
-        const float diff = 0.f;
-        const float rel_diff = 0.f;
-        const float trh = 0.f;
+        dnnl_data_type_t dt = dnnl_data_type_undef;
+        int64_t idx = 0;
+        float exp_f32 = 0.f;
+        float exp = 0.f;
+        float got = 0.f;
+        float diff = 0.f;
+        float rel_diff = 0.f;
+        float trh = 0.f;
     };
 
     compare_t() = default;

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -271,7 +271,7 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
             return orig_val;
         };
 
-        const float elem_first_val = adjust_val(mem_ref.get_elem(0));
+        const float elem_first_val = adjust_val(mem_ref.get_f32_elem(0));
         mem_ref.set_elem(
                 0, round_to_nearest_representable(round_dt, elem_first_val));
     }

--- a/tests/benchdnn/utils/fill.cpp
+++ b/tests/benchdnn/utils/fill.cpp
@@ -112,7 +112,7 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
 
     if (e.policy == policy_t::COMMON) {
         assert(nelems == 1);
-        mem_fp.set_elem(0, e.scale);
+        mem_fp.set_f32_elem(0, e.scale);
         if (mem_dt) mem_dt.set_elem(0, e.scale);
     } else {
         /* Do fixed partitioning to have same filling for any number of threads */
@@ -136,7 +136,7 @@ int fill_scales(const attr_t::arg_scales_t::entry_t &e, dnn_mem_t &mem_dt,
                 const float gen_val
                         = pow2 < 0 ? (1.f / pow2_shift) : pow2_shift;
                 const float val = gen_val;
-                mem_fp.set_elem(idx, val);
+                mem_fp.set_f32_elem(idx, val);
                 if (mem_dt) mem_dt.set_elem(idx, val);
             }
         });
@@ -155,7 +155,7 @@ int fill_zero_points(
     const auto &e = attr.zero_points.get(arg);
     if (e.policy == policy_t::COMMON) {
         assert(nelems == 1);
-        mem_fp.set_elem(0, e.value);
+        mem_fp.set_f32_elem(0, e.value);
         if (mem_dt) mem_dt.set_elem(0, e.value);
     } else {
         /* Do fixed partitioning to have same filling for any number of threads */
@@ -176,7 +176,7 @@ int fill_zero_points(
 
             for (int64_t idx = idx_start; idx < idx_end; ++idx) {
                 const float zp_val = gen(int_seed);
-                mem_fp.set_elem(idx, zp_val);
+                mem_fp.set_f32_elem(idx, zp_val);
                 if (mem_dt) mem_dt.set_elem(idx, zp_val);
             }
         });
@@ -235,7 +235,7 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
 
         for (int64_t idx = idx_start; idx < idx_end; ++idx) {
             float val = get_val();
-            mem_ref.set_elem(
+            mem_ref.set_f32_elem(
                     idx, round_to_nearest_representable(round_dt, val));
         }
     });
@@ -272,7 +272,7 @@ int fill_random_real_dense(dnn_mem_t &mem, dnn_mem_t &mem_ref, res_t *res,
         };
 
         const float elem_first_val = adjust_val(mem_ref.get_f32_elem(0));
-        mem_ref.set_elem(
+        mem_ref.set_f32_elem(
                 0, round_to_nearest_representable(round_dt, elem_first_val));
     }
 

--- a/tests/benchdnn/utils/numeric.cpp
+++ b/tests/benchdnn/utils/numeric.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -154,12 +154,13 @@ float max_dt(dnnl_data_type_t dt) {
 #undef CASE
     return 0;
 }
-#undef CASE_ALL
 
-float saturate_and_round(dnnl_data_type_t dt, float value) {
-    const float dt_max = max_dt(dt);
-    const float dt_min = lowest_dt(dt);
-    if (dt == dnnl_s32 && value >= max_dt(dnnl_s32)) return max_dt(dnnl_s32);
+template <dnnl_data_type_t dt>
+float saturate_and_round(float value) {
+    static const float dt_max = max_dt(dt);
+    static const float dt_min = lowest_dt(dt);
+    static const float max_dt_s32 = max_dt(dnnl_s32);
+    if (dt == dnnl_s32 && value >= max_dt_s32) return max_dt_s32;
     if (value > dt_max) value = dt_max;
     if (value < dt_min) value = dt_min;
     return mxcsr_cvt(value);
@@ -170,12 +171,23 @@ bool is_integral_dt(dnnl_data_type_t dt) {
             || dt == dnnl_u4;
 }
 
-float maybe_saturate(dnnl_data_type_t dt, float value) {
+template <dnnl_data_type_t dt>
+float maybe_saturate_templ(float value) {
     if (!is_integral_dt(dt)) return value;
-    return saturate_and_round(dt, value);
+    return saturate_and_round<dt>(value);
 }
 
-float round_to_nearest_representable(dnnl_data_type_t dt, float value) {
+float maybe_saturate(dnnl_data_type_t dt, float value) {
+#define CASE(dt) \
+    case dt: return maybe_saturate_templ<dt>(value)
+
+    CASE_ALL(dt)
+#undef CASE
+    return value;
+}
+
+template <dnnl_data_type_t dt>
+float round_to_nearest_representable_templ(float value) {
     switch (dt) {
         case dnnl_f32: break;
         case dnnl_f64: break;
@@ -198,12 +210,23 @@ float round_to_nearest_representable(dnnl_data_type_t dt, float value) {
         case dnnl_s8:
         case dnnl_u8:
         case dnnl_s4:
-        case dnnl_u4: value = maybe_saturate(dt, value); break;
+        case dnnl_u4: value = maybe_saturate_templ<dt>(value); break;
         default: SAFE_V(FAIL);
     }
 
     return value;
 }
+
+float round_to_nearest_representable(dnnl_data_type_t dt, float value) {
+#define CASE(dt) \
+    case dt: return round_to_nearest_representable_templ<dt>(value)
+
+    CASE_ALL(dt)
+#undef CASE
+    return value;
+}
+
+#undef CASE_ALL
 
 bool is_subbyte_type(const dnnl_data_type_t &type) {
     return type == dnnl_f4_e2m1 || type == dnnl_f4_e3m0 || type == dnnl_u4

--- a/tests/benchdnn/utils/numeric.hpp
+++ b/tests/benchdnn/utils/numeric.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ int digits_dt(dnnl_data_type_t dt);
 float epsilon_dt(dnnl_data_type_t dt);
 float lowest_dt(dnnl_data_type_t dt);
 float max_dt(dnnl_data_type_t dt);
-float saturate_and_round(dnnl_data_type_t dt, float value);
 bool is_integral_dt(dnnl_data_type_t dt);
 float maybe_saturate(dnnl_data_type_t dt, float value);
 float round_to_nearest_representable(dnnl_data_type_t dt, float value);

--- a/tests/benchdnn/zeropad/zeropad.cpp
+++ b/tests/benchdnn/zeropad/zeropad.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -138,7 +138,8 @@ int doit(const prb_t *prb, res_t *res) {
 
     const auto &test_engine = get_test_engine();
 
-    dnn_mem_t test_mem(data_md, test_engine);
+    // `NaN` prefilling is essential for zero-padding.
+    dnn_mem_t test_mem(data_md, test_engine, /* prefill = */ true);
 
     args_t args;
     args.set(0, test_mem);


### PR DESCRIPTION
MFDNN-13451

Thanks to @echeresh, who pivoted all the optimizations from the tracker and provided a PoC for them.

This PR implements 4 out of 6 of specified in the tracker. 2 not included is check_zero_pad on inputs and simplified RNG-related filling changes.

On a list attached to the tracker the speed up looks like this:
Before:
```
total: 76.37s; create_pd: 0.04s (0%); create_prim: 7.55s (10%); fill: 31.24s (41%); execute: 2.17s (3%); compute_ref: 9.06s (12%); compare: 23.82s (31%);
```
After:
```
total: 54.19s; create_pd: 0.04s (0%); create_prim: 7.19s (13%); fill: 19.07s (35%); execute: 2.13s (4%); compute_ref: 8.65s (16%); compare: 15.23s (28%);
```