### PR TITLE
[GPU] Apply GEMM dim fixup to src scale

### DIFF
--- a/src/gpu/intel/ocl/gemm_matmul.hpp
+++ b/src/gpu/intel/ocl/gemm_matmul.hpp
@@ -241,8 +241,9 @@ struct gemm_matmul_t : public gpu_primitive_t {
                     }
 
                     if (!attr()->scales_.has_default_values())
-                        CHECK(adjust_scales_mask(scales, DNNL_ARG_WEIGHTS,
-                                orig_dims - reshape_size));
+                        for (auto i : {DNNL_ARG_WEIGHTS, DNNL_ARG_SRC})
+                            CHECK(adjust_scales_mask(
+                                    scales, i, orig_dims - reshape_size));
                     if (!attr()->zero_points_.has_default_values())
                         CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, DNNL_ARG_A, true,
                                 orig_dims - reshape_size));

--- a/src/gpu/intel/ocl/gemm_matmul.hpp
+++ b/src/gpu/intel/ocl/gemm_matmul.hpp
@@ -95,7 +95,8 @@ struct gemm_matmul_t : public gpu_primitive_t {
                           return status::success;
                       };
             if (!attr()->zero_points_.has_default_values()) {
-                CHECK(map_gemm_zp(DNNL_ARG_SRC, DNNL_ARG_B));
+                CHECK(map_gemm_zp(
+                        DNNL_ARG_SRC, DNNL_ARG_B, false, orig_dims - 2));
                 CHECK(map_gemm_zp(
                         DNNL_ARG_WEIGHTS, DNNL_ARG_A, false, orig_dims - 2));
                 CHECK(map_gemm_zp(DNNL_ARG_DST, DNNL_ARG_C));
@@ -244,9 +245,12 @@ struct gemm_matmul_t : public gpu_primitive_t {
                         for (auto i : {DNNL_ARG_WEIGHTS, DNNL_ARG_SRC})
                             CHECK(adjust_scales_mask(
                                     scales, i, orig_dims - reshape_size));
-                    if (!attr()->zero_points_.has_default_values())
+                    if (!attr()->zero_points_.has_default_values()) {
                         CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, DNNL_ARG_A, true,
                                 orig_dims - reshape_size));
+                        CHECK(map_gemm_zp(DNNL_ARG_SRC, DNNL_ARG_B, true,
+                                orig_dims - reshape_size));
+                    }
                     post_ops = tmp_post_ops;
                     gemm_attr.scales_ = std::move(scales);
                     a_md = &a_md_reshaped;


### PR DESCRIPTION
# Description

Apply dim adjustment to src scales as well as wei, fixes this case dispatching to ref because of unadjusted scale mask: 

```
 ./tests/benchdnn/benchdnn -v5 --matmul --reset --allow-enum-tags-only=0 --engine=gpu:0 --runtime_dims_masks= --dt=s8:u4:f16 --stag=abc --wtag=cab --dtag=abc --strides=:: --attr-post-ops=binary_add:f16:6:abc --attr-scales=src0:per_ocic:f16:1x11008+wei:per_oc:f16:128x1 --attr-zero-points=wei:per_ocic:u8:128x1 --attr-scratchpad=user 1x6x11008:1x11008x4096
create: --matmul --engine=gpu --allow-enum-tags-only=false --dt=s8:u4:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:per_ocic:f16:1x11008+wei:per_oc:f16:128x1 --attr-zero-points=wei:per_ocic:u8:128x1 --attr-post-ops=add:f16:6:abc --attr-scratchpad=user 1x6x11008:1x11008x4096
oneDNN implementation: ocl:ref:any
[IMPL_FILTER] All implementations were skipped!
[IMPL_FILTER] All implementations were skipped!
run: --matmul --engine=gpu --allow-enum-tags-only=false --dt=s8:u4:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:per_ocic:f16:1x11008+wei:per_oc:f16:128x1 --attr-zero-points=wei:per_ocic:u8:128x1 --attr-post-ops=add:f16:6:abc --attr-scratchpad=user 1x6x11008:1x11008x4096
0:PASSED (964 ms) __REPRO: --matmul --engine=gpu --allow-enum-tags-only=false --dt=s8:u4:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=src:per_ocic:f16:1x11008+wei:per_oc:f16:128x1 --attr-zero-points=wei:per_ocic:u8:128x1 --attr-post-ops=add:f16:6:abc --attr-scratchpad=user 1x6x11008:1x11008x4096
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.97s; create_pd: 0.00s (0%); create_prim: 0.01s (1%); fill: 0.37s (39%); execute: 0.09s (10%); compute_ref: 0.14s (14%); compare: 0.02s (2%);
```

Fixes # (github issue)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

