### PR TITLE
[GPU] jit: gemm: add A/B offset restriction (aboffset)

### DIFF
--- a/src/gpu/intel/jit/gemm/include/gemmstone/kernel_catalog.hpp
+++ b/src/gpu/intel/jit/gemm/include/gemmstone/kernel_catalog.hpp
@@ -62,6 +62,7 @@ enum RestrictionTags : char {
     ReqBatchMultiDim = 'W',  ReqNoBatchMultiDim = 'w',
     ReqSumA = 'Q',           ReqNoSumA = 'q',
     ReqSumB = 'P',           ReqNoSumB = 'p',
+    ReqABOffset = 'R',       ReqNoABOffset = 'r',
     ReqIntegrated = 'H',     ReqNoIntegrated = 'h',
     ReqBatchN = 'N',         ReqNoBatchN = 'n',
     ReqOffsetMultiDim = 'O', ReqNoOffsetMultiDim = 'o',

--- a/src/gpu/intel/jit/gemm/selector/kernel_selector.cpp
+++ b/src/gpu/intel/jit/gemm/selector/kernel_selector.cpp
@@ -338,6 +338,9 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
             *tagPtr++ = ReqBatchMultiDim;
     }
 
+    if (problem.aOffset != ABOffset::None || problem.bOffset != ABOffset::None)
+        *tagPtr++ = ReqABOffset;
+
     if (problem.aoPtrDims > 0 || problem.boPtrDims > 0)
         *tagPtr++ = ReqOffsetMultiDim;
 


### PR DESCRIPTION
PR adds one more gemm kernel restriction kind. 
Some kernels currently being tuned for BMG failed ktool's g-tests and so they require this limitation. PR is synced with the latest gemmstone changes.