### PR TITLE
cpu: aarch64: conv: fix fast math NAN issue

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -170,6 +170,10 @@ status_t execute_forward_conv_acl(const exec_ctx_t &ctx,
                     arm_compute::TensorShape(aux_mem[id].size), 1,
                     arm_compute::DataType::U8);
             auto buffer = scratchpad.get<void>(key.second);
+            // Set Im2Col input buffer
+            // Temporary fix for https://github.com/uxlfoundation/oneDNN/issues/2303
+            if (id == 10) { std::memset(buffer, 0, aux_mem[id].size); }
+
             tmp_tensors[id].allocator()->init(info, aux_mem[id].alignment);
             tmp_tensors[id].allocator()->import_memory(buffer);
             pack.add_tensor(aux_mem[id].slot, &tmp_tensors[id]);


### PR DESCRIPTION
Temporary fix for https://github.com/uxlfoundation/oneDNN/issues/2303 while the main issue gets resolved in ComputeLibrary.

The bug mentioned in the issue appears when NANs exist in one of the buffers while calling CpuGemmConv2d. This can be resolved by setting the buffer to all 0s. This is however not an ideal solution so the ComputeLibrary team is working on a long-term solution. This fix should be removed once that fix has been merged to ComputeLibrary.