### PR TITLE
clang-tidy: on a way to enable mandatory full (cpp + hpp) clang check for each PR

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -53,33 +53,15 @@ jobs:
       - name: Check source files
         run: |
           echo -e "Checking Clang-Tidy $(clang-tidy --version)\n"
-          touch source-check.log
+          touch clang-tidy.log
           for file in $(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | grep -E '\.cpp$'); 
           do
             if grep -q "$file" "build/compile_commands.json"; then
               echo -e "\nAnalyzing $file"
-              clang-tidy -p build --header-filter='' $file 2>&1 | tee -a source-check.log
+              clang-tidy -p build $file 2>&1 | tee -a clang-tidy.log
             else
               echo "Skipped $file as it's not built in x64 OpenMP/OpenCL configuration."
             fi
           done
-          grep -i -E "warning:|error:" source-check.log | sort -u
-          grep -q -i -E "warning:|error:" source-check.log && exit 1 || true
-
-      - name: Check header files
-        if: always()
-        continue-on-error: true
-        run: |
-          echo -e "Checking Clang-Tidy $(clang-tidy --version)\n"
-          touch headers-check.log
-          for file in $(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }} | grep -E '\.cpp$'); 
-          do
-            if grep -q "$file" "build/compile_commands.json"; then
-              echo -e "\nAnalyzing $file"
-              clang-tidy -p build $file 2>&1 | tee -a headers-check.log
-            else
-              echo "Skipped $file as it's not built in x64 OpenMP/OpenCL configuration."
-            fi
-          done
-          grep -i -E "warning:|error:" headers-check.log | sort -u
-          grep -q -i -E "warning:|error:" headers-check.log && exit 1 || true
+          grep -i -E "warning:|error:" clang-tidy.log | sort -u
+          grep -q -i -E "warning:|error:" clang-tidy.log && exit 1 || true

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -368,8 +368,6 @@ set(DNNL_USE_CLANG_TIDY "NONE" CACHE STRING
     - NONE (default)
       Clang-tidy is disabled.
     - CHECK
-      Enables checks from .clang-tidy for source code
-    - CHECK_ALL
       Enables checks from .clang-tidy.
     - FIX
       Enables checks from .clang-tidy and fix found issues.

--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -343,18 +343,12 @@ elseif(UNIX OR MINGW)
                    "-fsanitize-blacklist=${PROJECT_SOURCE_DIR}/.clang-ignorelist")
         endif()
 
-        if(DNNL_USE_CLANG_TIDY MATCHES "(CHECK|CHECK_ALL|FIX)")
+        if(DNNL_USE_CLANG_TIDY MATCHES "(CHECK|FIX)")
             find_program(CLANG_TIDY NAMES clang-tidy)
             if(NOT CLANG_TIDY)
                 message(FATAL_ERROR "Clang-tidy not found")
             else()
-                # FIXME: Remove --header-filter option once clang-tidy warnings
-                # are addressed
                 if(DNNL_USE_CLANG_TIDY STREQUAL "CHECK")
-                    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY}
-                        --header-filter='')
-                    message(STATUS "Using clang-tidy to run checks for source")
-                elseif(DNNL_USE_CLANG_TIDY STREQUAL "CHECK_ALL")
                     set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY})
                     message(STATUS "Using clang-tidy to run checks for source and headers")
                 elseif(DNNL_USE_CLANG_TIDY STREQUAL "FIX")

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -225,7 +225,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
         const auto inp_offset = n * src_d_sz + id * src_h_sz + ih * src_w_sz
                 + iw * jcp.ngroups * jcp.ic_without_padding + g_ic;
         auto p = jit_sve_core_brgemm_conv_trans_kernel::
-                jit_brgemm_conv_trans_kernel_call_s();
+                jit_brgemm_conv_trans_kernel_args_t();
         p.h_count = nh;
         p.owb = nw;
         p.src = src + src_dt_size * inp_offset;

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -1311,7 +1311,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
                     + ocb * _pd->wei_ocb_stride + kd_b * _pd->wei_kd_stride
                     + kh_b * _pd->wei_kh_stride + kw_b * _pd->wei_kw_stride;
 
-            jit_brgemm_conv_comp_pad_call_s p;
+            jit_brgemm_conv_comp_pad_args_t p;
 
             p.kd_l = kd_e - kd_b;
             p.kh_l = kh_e - kh_b;
@@ -1489,7 +1489,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(int ithr,
         if (bmask(icb, odb, ohb, owb)) return;
     }
 
-    auto cp = jit_brgemm_conv_trans_kernel_call_s();
+    auto cp = jit_brgemm_conv_trans_kernel_args_t();
 
     const auto prev_odb = (jcp.copy_block_only || odb == 0
                                   || bmask(icb, odb - 1, ohb, owb) == 0)

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -30,7 +30,7 @@ using namespace Xbyak_aarch64;
 
 namespace jit_uni_brgemm_conv_comp_pad_kernel {
 
-#define GET_OFF(field) offsetof(jit_brgemm_conv_comp_pad_call_s, field)
+#define GET_OFF(field) offsetof(jit_brgemm_conv_comp_pad_args_t, field)
 
 template <cpu_isa_t isa>
 jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -28,7 +28,7 @@ namespace cpu {
 namespace aarch64 {
 
 namespace jit_uni_brgemm_conv_comp_pad_kernel {
-struct jit_brgemm_conv_comp_pad_call_s {
+struct jit_brgemm_conv_comp_pad_args_t {
     const void *ptr_in;
     void *ptr_zp_out;
     void *ptr_cp_out;

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
@@ -31,7 +31,7 @@ using namespace data_type;
 
 namespace jit_sve_core_brgemm_conv_trans_kernel {
 
-#define GET_OFF(field) offsetof(jit_brgemm_conv_trans_kernel_call_s, field)
+#define GET_OFF(field) offsetof(jit_brgemm_conv_trans_kernel_args_t, field)
 
 jit_sve_core_brgemm_conv_trans_kernel_t::
         jit_sve_core_brgemm_conv_trans_kernel_t(

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
@@ -29,7 +29,7 @@ namespace cpu {
 namespace aarch64 {
 
 namespace jit_sve_core_brgemm_conv_trans_kernel {
-struct jit_brgemm_conv_trans_kernel_call_s {
+struct jit_brgemm_conv_trans_kernel_args_t {
     const void *src;
     const void *dst;
     size_t owb;

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -219,7 +219,7 @@ inline status_t init_tag(format_tag_t &tag, const memory_desc_wrapper &mdw,
     return tag == tag_value ? status::success : status::unimplemented;
 }
 
-struct jit_conv_call_s {
+struct jit_conv_args_t {
     const void *src; /* hack, non-const for backward_data */
     const void *dst; /* hack, non-const for forward */
     const void *filt; /* hack, non-const for backward_weights */
@@ -289,7 +289,7 @@ struct jit_conv_call_s {
     int oc_flag;
 };
 
-struct jit_deconv_call_s {
+struct jit_deconv_args_t {
     const void *src; /* hack, non-const for backward_data */
     const void *dst; /* hack, non-const for forward */
     const void *filt; /* hack, non-const for backward_weights */
@@ -321,7 +321,7 @@ struct jit_deconv_call_s {
     size_t oc_blocks;
 };
 
-struct jit_dw_conv_call_s {
+struct jit_dw_conv_args_t {
     const void *input;
     const void *output;
     const void *filter;
@@ -399,7 +399,7 @@ struct jit_1x1_conv_conf_t {
     bool uses_permw_transposition;
 };
 
-struct jit_1x1_conv_call_s {
+struct jit_1x1_conv_args_t {
     const void *bcast_data;
     const void *load_data;
     const void *output_data;
@@ -471,7 +471,7 @@ struct jit_pool_conf_t {
     memory_desc_t tmp_md;
 };
 
-struct jit_pool_call_s {
+struct jit_uni_pooling_args_t {
     const void *src;
     const void *dst;
     const void *indices;
@@ -518,7 +518,7 @@ struct jit_shuffle_conf_t {
     cpu_isa_t isa = isa_undef;
 };
 
-struct jit_shuffle_call_s {
+struct jit_uni_shuffle_args_t {
     const void *src = nullptr;
     void *dst = nullptr;
     const void *input_off_ptr = nullptr;
@@ -732,7 +732,7 @@ struct jit_binary_conf_t {
     data_type_t dst_type = data_type::undef;
 };
 
-struct jit_binary_call_s {
+struct jit_uni_binary_args_t {
     // keep all sizes at 8 bytes -- jit code expects this
     const void *src0, *src1, *dst, *indices;
     const float *scales_src0, *scales_src1;

--- a/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_conv_kernel.cpp
@@ -36,7 +36,7 @@
 #include "cpu/aarch64/jit_uni_1x1_conv_utils.hpp"
 
 #define GET_OFF(field) \
-    static_cast<int32_t>(offsetof(jit_1x1_conv_call_s, field))
+    static_cast<int32_t>(offsetof(jit_1x1_conv_args_t, field))
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
@@ -113,7 +113,7 @@ void jit_sve_1x1_convolution_fwd_t<src_type, wei_type, dst_type,
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
     auto rp = typename rtus_driver_t<isa_>::call_params_t();
     const int nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
@@ -343,7 +343,7 @@ void jit_sve_1x1_convolution_fwd_t<src_type, wei_type, dst_type,
             const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            jit_conv_call_s par_conv_dw;
+            jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
@@ -484,7 +484,7 @@ void jit_sve_1x1_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
     };
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
-        auto p = jit_1x1_conv_call_s();
+        auto p = jit_1x1_conv_args_t();
         auto rp = typename rtus_driver_t<isa_>::call_params_t();
 
         int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
@@ -796,7 +796,7 @@ void jit_sve_1x1_convolution_bwd_weights_t<diff_dst_type, wei_type,
                                 img, oc_off_idx)];
                         const data_t *local_src = diff_src;
 
-                        auto p = jit_1x1_conv_call_s();
+                        auto p = jit_1x1_conv_args_t();
                         auto rp = typename rtus_driver_t<isa_>::call_params_t();
                         p.output_stride = utils::rnd_up(jcp.ic, jcp.ic_block)
                                 * jcp.oc_block * jcp.typesize_out;

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -311,7 +311,7 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
                     dw_conv_buffer_size_,
                     types::data_type_size(dw_conv_pd_->src_md()->data_type));
 
-            jit_uni_dw_conv_fwd_kernel<isa_, data_type::f32>::init_scratchpad(
+            jit_uni_dw_conv_fwd_kernel_t<isa_, data_type::f32>::init_scratchpad(
                     dw_scratchpad, jcp_dw);
 
             return status::success;
@@ -360,7 +360,7 @@ private:
 
     std::unique_ptr<jit_sve_1x1_conv_kernel<isa_>> kernel_;
     std::unique_ptr<rtus_driver_t<isa_>> rtus_driver_;
-    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32<isa_>;
+    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32_t<isa_>;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
 };
 

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.cpp
@@ -22,7 +22,7 @@
 
 #include "cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp"
 
-#define GET_OFF(field) offsetof(jit_deconv_call_s, field)
+#define GET_OFF(field) offsetof(jit_deconv_args_t, field)
 #define LD_MUL_VL(mn, op, mask, addr, off, size) \
     { \
         const int mul_vl_len = (cpu_sveLen / 4) * size; \
@@ -1430,7 +1430,7 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
         int work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         int n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
@@ -1529,7 +1529,7 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
         int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         /*loop order = cgn*/
         int n {0}, g {0}, occ {0}, oh_s {0};
@@ -1691,7 +1691,7 @@ status_t jit_sve_512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
         int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         /*loop order = cgn*/
         int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -250,7 +250,7 @@ struct _jit_sve_512_core_x8s8s32x_deconv_fwd_kernel {
 
     ~_jit_sve_512_core_x8s8s32x_deconv_fwd_kernel() = default;
 
-    void operator()(const jit_deconv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_deconv_args_t *p) const { (*kernel_)(p); }
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const deconvolution_desc_t &cd, memory_desc_t &src_md,

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.cpp
@@ -24,7 +24,7 @@
 
 #include "cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp"
 
-#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_call_s, field))
+#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_args_t, field))
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.cpp
@@ -79,7 +79,7 @@ jit_sve_512_x8s8s32x_convolution_fwd_t<src_type, dst_type>::execute_forward_1d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         int n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
@@ -192,7 +192,7 @@ jit_sve_512_x8s8s32x_convolution_fwd_t<src_type, dst_type>::execute_forward_2d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -334,7 +334,7 @@ status_t jit_sve_512_x8s8s32x_convolution_fwd_t<src_type,
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [&](int n, int oh_s, int owb, int gg) {
-                auto p = jit_conv_call_s();
+                auto p = jit_conv_args_t();
 
                 size_t src_h_stride = src_d.blk_off(0, 0, 1);
                 size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
@@ -428,7 +428,7 @@ jit_sve_512_x8s8s32x_convolution_fwd_t<src_type, dst_type>::execute_forward_3d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         size_t src_d_stride = src_d.blk_off(0, 0, 1);
         size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);

--- a/src/cpu/aarch64/jit_sve_conv_kernel.cpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.cpp
@@ -26,7 +26,7 @@
 #include "cpu/aarch64/jit_sve_conv_kernel.hpp"
 #include "cpu/platform.hpp"
 
-#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_call_s, field))
+#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_args_t, field))
 #define A64FX_L2_EFFECTIVE_CAPACITY ((666 - 128) * 1024)
 
 namespace dnnl {

--- a/src/cpu/aarch64/jit_sve_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.hpp
@@ -230,7 +230,7 @@ struct jit_sve_conv_bwd_data_kernel_f32 : public jit_generator {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_conv_bwd_data_kernel_f32)
     jit_conv_conf_t jcp;
-    void (*jit_ker_)(jit_conv_call_s *);
+    void (*jit_ker_)(jit_conv_args_t *);
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &diff_src_d,

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -627,7 +627,7 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
                     }
 
                     start *= simd_w;
-                    jit_binary_call_s p;
+                    jit_uni_binary_args_t p;
                     p.spat_offt_count = (n_simd_to_do + tail_to_do) * outer_dims
                             * dst_type_size;
                     p.src0 = src0 + (start + batch_off) * src0_type_size;
@@ -664,7 +664,7 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
             const dim_t n_simd_to_do = (end - start - ithr_does_tail) * simd_w;
             const dim_t tail_to_do = ithr_does_tail * nelems0_tail;
 
-            jit_binary_call_s p;
+            jit_uni_binary_args_t p;
             p.spat_offt_count = (n_simd_to_do + tail_to_do) * dst_type_size;
             p.src0 = src0 + start * simd_w * src0_type_size;
             p.src1 = src1
@@ -714,7 +714,7 @@ void jit_uni_binary_t::execute_bcast_per_batch_strategy(const data_t *src0,
         const dim_t n_simd_to_do = (end - start - ithr_does_tail) * simd_w;
         const dim_t tail_to_do = ithr_does_tail * nelems0_tail;
 
-        jit_binary_call_s p;
+        jit_uni_binary_args_t p;
         p.spat_offt_count = (n_simd_to_do + tail_to_do) * dst_type_size;
         const dim_t off = start * simd_w;
         p.src0 = src0 + (off + b * nelems0_per_b) * src0_type_size;
@@ -766,16 +766,17 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
         // Compute strategy:
         // Each block is individual - parallel over MB and C_blocks safely.
 
-        const std::function<void(jit_binary_call_s *, dim_t)>
+        const std::function<void(jit_uni_binary_args_t *, dim_t)>
                 kernel_blocked_no_tail
-                = [&](jit_binary_call_s *p, dim_t C_blk) { (*kernel)(p); };
-        const std::function<void(jit_binary_call_s *, dim_t)>
-                kernel_blocked_tail = [&](jit_binary_call_s *p, dim_t C_blk) {
-                    if (C_blk == (C_blocks - 1))
-                        (*kernel_tail)(p);
-                    else
-                        (*kernel)(p);
-                };
+                = [&](jit_uni_binary_args_t *p, dim_t C_blk) { (*kernel)(p); };
+        const std::function<void(jit_uni_binary_args_t *, dim_t)>
+                kernel_blocked_tail
+                = [&](jit_uni_binary_args_t *p, dim_t C_blk) {
+                      if (C_blk == (C_blocks - 1))
+                          (*kernel_tail)(p);
+                      else
+                          (*kernel)(p);
+                  };
         const auto &kernel_blocked = blocked_oc_tail ? kernel_blocked_tail
                                                      : kernel_blocked_no_tail;
         const auto src1_off = [&](dim_t mb, dim_t C_blk, dim_t off) -> dim_t {
@@ -788,7 +789,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
         };
 
         parallel_nd(MB, C_blocks, [&](dim_t mb, dim_t C_blk) {
-            jit_binary_call_s p;
+            jit_uni_binary_args_t p;
             p.spat_offt_count = SP * simd_w * dst_type_size;
             const dim_t off = mb * nelems_slice_src0 + C_blk * SP * simd_w;
             p.dst = dst + off * dst_type_size;
@@ -812,7 +813,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
         // Compute strategy:
         // Each line of channels is individual, parallel over MB and spatial.
         parallel_nd(MB, SP, [&](dim_t mb, dim_t sp) {
-            jit_binary_call_s p;
+            jit_uni_binary_args_t p;
             p.spat_offt_count = C * dst_type_size;
             const auto off = mb * nelems_slice_src0 + sp * C;
             p.dst = dst + off * dst_type_size;
@@ -837,7 +838,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
         // Compute strategy:
         // Each line of spatial is individual, parallel over MB and C.
         parallel_nd(MB, C, [&](dim_t mb, dim_t c) {
-            jit_binary_call_s p;
+            jit_uni_binary_args_t p;
             p.spat_offt_count = SP * dst_type_size;
             const auto off = mb * nelems_slice_src0 + c * SP;
             p.dst = dst + off * dst_type_size;
@@ -894,22 +895,23 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
         // and spatial (broadcasted and not broadcasted spatial dims
         // separately).
 
-        const std::function<void(jit_binary_call_s *, dim_t)>
+        const std::function<void(jit_uni_binary_args_t *, dim_t)>
                 kernel_blocked_no_tail
-                = [&](jit_binary_call_s *p, dim_t C_blk) { (*kernel)(p); };
-        const std::function<void(jit_binary_call_s *, dim_t)>
-                kernel_blocked_tail = [&](jit_binary_call_s *p, dim_t C_blk) {
-                    if (C_blk == (C_blocks - 1))
-                        (*kernel_tail)(p);
-                    else
-                        (*kernel)(p);
-                };
+                = [&](jit_uni_binary_args_t *p, dim_t C_blk) { (*kernel)(p); };
+        const std::function<void(jit_uni_binary_args_t *, dim_t)>
+                kernel_blocked_tail
+                = [&](jit_uni_binary_args_t *p, dim_t C_blk) {
+                      if (C_blk == (C_blocks - 1))
+                          (*kernel_tail)(p);
+                      else
+                          (*kernel)(p);
+                  };
         const auto &kernel_blocked = blocked_oc_tail ? kernel_blocked_tail
                                                      : kernel_blocked_no_tail;
 
         parallel_nd(MB, C_blocks, N, SP_no_bcast,
                 [&](dim_t mb, dim_t C_blk, dim_t n, dim_t sp) {
-                    jit_binary_call_s p;
+                    jit_uni_binary_args_t p;
                     p.spat_offt_count = simd_w * dst_type_size;
                     const auto off = mb * nelems_slice_src0
                             + simd_w * (C_blk * SP + n * SP_no_bcast + sp);
@@ -933,7 +935,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
         // (broadcasted and not broadcasted spatial dims separately).
 
         parallel_nd(MB, N, SP_no_bcast, [&](dim_t mb, dim_t n, dim_t sp) {
-            jit_binary_call_s p;
+            jit_uni_binary_args_t p;
             p.spat_offt_count = C * dst_type_size;
             const auto off
                     = mb * nelems_slice_src0 + n * SP_no_bcast * C + sp * C;
@@ -955,7 +957,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
         // value into a vector register.
 
         parallel_nd(MB, C, N, [&](dim_t mb, dim_t c, dim_t n) {
-            jit_binary_call_s p;
+            jit_uni_binary_args_t p;
             p.spat_offt_count = SP_no_bcast * dst_type_size;
             const auto off = mb * nelems_slice_src0 + c * N * SP_no_bcast
                     + n * SP_no_bcast;

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -24,7 +24,7 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-#define PARAM_OFF(x) ((int32_t)offsetof(jit_binary_call_s, x))
+#define PARAM_OFF(x) ((int32_t)offsetof(jit_uni_binary_args_t, x))
 
 static bcast_set_t get_supported_postops_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
@@ -189,7 +189,7 @@ void jit_uni_binary_kernel_t<isa>::load_kernel_params() {
     mov(W_TMP_0, float2int(conf_.sum_scale));
     dup(vreg_sum_scale_.s, W_TMP_0);
 
-    assert(sizeof(jit_binary_call_s) <= 255);
+    assert(sizeof(jit_uni_binary_args_t) <= 255);
 
     if (is_src1_outer_dims_tail_)
         ldr(reg_outer_dims_range_, ptr(reg_param_, PARAM_OFF(spat_offt_count)));

--- a/src/cpu/aarch64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.hpp
@@ -47,7 +47,7 @@ struct binary_kernel_t : public jit_generator {
             const jit_binary_conf_t conf, bool tail_kernel = false);
     ~binary_kernel_t() override = default;
 
-    void operator()(jit_binary_call_s *p) { jit_generator::operator()(p); }
+    void operator()(jit_uni_binary_args_t *p) { jit_generator::operator()(p); }
 
     size_t simd_w() const noexcept { return simd_w_; }
     size_t vlen() const noexcept { return vlen_; }

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
@@ -38,7 +38,8 @@ using namespace dnnl::impl::utils;
 using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::load_src(int ur_ch_blocks, int ur_w) {
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
+        int ur_ch_blocks, int ur_w) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
     const auto ch_blk = jcp.ch_block;
@@ -68,7 +69,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::load_src(int ur_ch_blocks, int ur_w) {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r) {
     int ch_blk = jcp.ch_block;
     int dilate_h = jcp.dilate_h + 1;
@@ -143,14 +144,14 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_activation(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_activation(
         int ur_ch_blocks, int ur_w) {
     if (this->jcp.with_eltwise) {
         eltwise_injector_->compute_vector_range(4, ur_w * ur_ch_blocks + 4);
     }
 }
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::store_dst(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
         int ur_ch_blocks, int ur_w) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -172,7 +173,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::store_dst(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::compute_loop(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
         int ur_w, int ur_ch_blocks, int pad_l, int pad_r) {
 
     const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
@@ -249,7 +250,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::compute_loop(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::ow_loop(int ur_ch_blocks) {
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
 
     int iw = jcp.iw;
     int ow = jcp.ow;
@@ -319,7 +320,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::ow_loop(int ur_ch_blocks) {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::generate() {
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
     const int simd_w_ = cpu_isa_traits<isa>::vlen / sizeof(float);
     this->preamble();
     //TO DO : renaming predicate register (P_ALL_ONE)
@@ -366,11 +367,11 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::generate() {
     if (jcp.with_eltwise) { eltwise_injector_->prepare_table(); }
 }
 
-template struct jit_uni_dw_conv_fwd_kernel_f32<sve_512>;
-template struct jit_uni_dw_conv_fwd_kernel_f32<sve_256>;
+template struct jit_uni_dw_conv_fwd_kernel_f32_t<sve_512>;
+template struct jit_uni_dw_conv_fwd_kernel_f32_t<sve_256>;
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::load_ddst(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_ddst(
         int ur_ch_blocks, int ur_str_w) {
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         for (int w = 0; w < ur_str_w; w++) {
@@ -381,7 +382,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::load_ddst(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::apply_filter(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
         int ur_ch_blocks, int ur_str_w) {
     int kw = jcp.kw;
     int kh = jcp.kh;
@@ -455,7 +456,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::apply_filter(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::store_dsrc(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
         int ur_ch_blocks, int ur_str_w) {
     int ch_blk = jcp.ch_block;
     int iw = jcp.iw;
@@ -475,7 +476,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::store_dsrc(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::loop_body(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::loop_body(
         int ur_ch_blocks) {
     Label unrolled_w_label;
     Label tail_w_label;
@@ -533,7 +534,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::loop_body(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::generate() {
+void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
     preamble();
 
     ldr(reg_dsrc, ptr(abi_param1, GET_OFF(src)));
@@ -568,11 +569,11 @@ void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::generate() {
     this->postamble();
 }
 
-template struct jit_uni_dw_conv_bwd_data_kernel_f32<sve_512>;
-template struct jit_uni_dw_conv_bwd_data_kernel_f32<sve_256>;
+template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<sve_512>;
+template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<sve_256>;
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter() {
     for (int i = 0; i < jcp.kw; ++i) {
         ZRegS zregs_acc = get_acc_reg_s(i);
         fmov(zregs_acc); // zero clear
@@ -580,7 +581,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_filter() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_filter() {
     for (int i = 0; i < jcp.kw; ++i) {
         int off_filter = i * simd_w;
         add_imm(reg_tmp_addr, reg_tmp_filter, off_filter * sizeof(float),
@@ -598,12 +599,12 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_filter() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_bias() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_bias() {
     ZRegS zregs_bias = get_bias_reg_s(0);
     fmov(zregs_bias); // zero clear
 }
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_bias() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_bias() {
     if (simd_w == 16) {
         ZReg zreg_bias = get_bias_reg(0);
         ldr(zreg_bias, ptr(reg_bias_baddr));
@@ -616,7 +617,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_bias() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_step_unroll(
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_step_unroll(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     const int iw_block = ow_block * jcp.stride_w;
@@ -714,7 +716,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_step_unroll(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_step_unroll(
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_step_unroll(
         const int unroll_w) {
     for (int i = 0; i < unroll_w; ++i) {
         ZRegS zregs_bias = get_bias_reg_s(0);
@@ -733,7 +735,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_step_unroll(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_filter() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_filter() {
     for (int i = 0; i < jcp.kw; ++i) {
         int off_filter = i * simd_w;
         add_imm(reg_tmp_addr, reg_tmp_filter, off_filter * sizeof(float),
@@ -751,7 +753,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_filter() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_bias() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_bias() {
     if (simd_w == 16) {
         ZReg zreg_bias = get_bias_reg(0);
         str(zreg_bias, ptr(reg_bias_baddr));
@@ -764,7 +766,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_bias() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_loop(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_loop(
         const int block_size) {
     Label oh_label;
     Label ow_blk_label;
@@ -814,7 +816,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_loop(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_zero_filter() {
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_zero_filter() {
 
     const int ch_offset = jcp.ch_block;
 
@@ -851,7 +854,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_zero_filter() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_step(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     const int ch_offset = jcp.ch_block;
@@ -895,7 +898,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_step(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_loop(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     // last index of output that is not influenced by right padding
@@ -978,7 +981,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_loop(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_block_unroll() {
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     const int ch_offset = jcp.ch_block;
     int ow = jcp.ow;
@@ -1096,7 +1099,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_block_unroll() {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::generate() {
+void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::generate() {
     const int simd_w_ = cpu_isa_traits<isa>::vlen / sizeof(float);
     preamble();
     //TO DO : renaming predicate register (P_ALL_ONE)
@@ -1125,8 +1128,8 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::generate() {
     this->postamble();
 }
 
-template struct jit_uni_dw_conv_bwd_weights_kernel_f32<sve_512>;
-template struct jit_uni_dw_conv_bwd_weights_kernel_f32<sve_256>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_f32_t<sve_512>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_f32_t<sve_256>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.cpp
@@ -24,7 +24,7 @@
 
 #include "cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp"
 
-#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_call_s, field))
+#define GET_OFF(field) static_cast<int32_t>(offsetof(jit_conv_args_t, field))
 
 namespace dnnl {
 namespace impl {
@@ -780,11 +780,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_loop(
     ldr(reg_oh,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, oh_index))));
+                            offsetof(jit_dw_conv_args_t, oh_index))));
     ldr(reg_oh_worksize,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, oh_count))));
+                            offsetof(jit_dw_conv_args_t, oh_count))));
 
     mov(reg_tmp_output, reg_output_baddr);
     L(oh_label);
@@ -826,7 +826,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_zero_filter() {
     ldr(reg_exec_flags,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, exec_flags))));
+                            offsetof(jit_dw_conv_args_t, exec_flags))));
     and_(reg_exec_flags, reg_exec_flags, FLAG_ZERO_FILTER);
     tst(reg_exec_flags, reg_exec_flags);
     b(EQ, skip_zeroing_label);
@@ -914,15 +914,15 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     ldr(reg_oh,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, oh_index))));
+                            offsetof(jit_dw_conv_args_t, oh_index))));
     ldr(reg_oh_worksize,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, oh_count))));
+                            offsetof(jit_dw_conv_args_t, oh_count))));
     ldr(reg_kh_count,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, kh_count))));
+                            offsetof(jit_dw_conv_args_t, kh_count))));
 
     mov(reg_tmp_output, reg_output_baddr);
     mov(reg_tmp_input, reg_input_baddr);
@@ -1025,14 +1025,14 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
         ldr(reg_bias_baddr,
                 ptr(abi_param1,
                         static_cast<int32_t>(
-                                offsetof(jit_dw_conv_call_s, bias))));
+                                offsetof(jit_dw_conv_args_t, bias))));
 
         zero_bias();
 
         ldr(reg_exec_flags,
                 ptr(abi_param1,
                         static_cast<int32_t>(
-                                offsetof(jit_dw_conv_call_s, exec_flags))));
+                                offsetof(jit_dw_conv_args_t, exec_flags))));
 
         and_(reg_exec_flags, reg_exec_flags, FLAG_ZERO_BIAS);
         tst(reg_exec_flags, reg_exec_flags);
@@ -1051,7 +1051,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     ldr(reg_kh_offset,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, filter_pad_off))));
+                            offsetof(jit_dw_conv_args_t, filter_pad_off))));
     add(reg_filter_baddr, reg_filter_baddr, reg_kh_offset);
 
     /* compute left padded block */
@@ -1113,15 +1113,15 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::generate() {
 
     ldr(reg_input_baddr,
             ptr(abi_param1,
-                    static_cast<int32_t>(offsetof(jit_dw_conv_call_s, input))));
+                    static_cast<int32_t>(offsetof(jit_dw_conv_args_t, input))));
     ldr(reg_output_baddr,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, output))));
+                            offsetof(jit_dw_conv_args_t, output))));
     ldr(reg_filter_baddr,
             ptr(abi_param1,
                     static_cast<int32_t>(
-                            offsetof(jit_dw_conv_call_s, filter))));
+                            offsetof(jit_dw_conv_args_t, filter))));
 
     compute_ow_block_unroll();
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -35,10 +35,10 @@ namespace cpu {
 namespace aarch64 {
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_fwd_kernel_f32 : public jit_generator {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_fwd_kernel_f32)
+struct jit_uni_dw_conv_fwd_kernel_f32_t : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_fwd_kernel_f32_t)
 
-    jit_uni_dw_conv_fwd_kernel_f32(jit_conv_conf_t ajcp)
+    jit_uni_dw_conv_fwd_kernel_f32_t(jit_conv_conf_t ajcp)
         : jcp(ajcp), eltwise_injector_(nullptr) {
         if (jcp.with_eltwise)
             eltwise_injector_
@@ -46,7 +46,7 @@ struct jit_uni_dw_conv_fwd_kernel_f32 : public jit_generator {
                             this, jcp.eltwise);
     }
 
-    ~jit_uni_dw_conv_fwd_kernel_f32() = default;
+    ~jit_uni_dw_conv_fwd_kernel_f32_t() = default;
 
     jit_conv_conf_t jcp;
 
@@ -136,15 +136,15 @@ private:
     }
 
     std::unique_ptr<jit_uni_eltwise_injector_f32<isa>> eltwise_injector_;
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_f32)
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_f32_t)
     void generate() override;
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_bwd_data_kernel_f32 : public jit_generator {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32)
+struct jit_uni_dw_conv_bwd_data_kernel_f32_t : public jit_generator {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32_t)
 
-    jit_uni_dw_conv_bwd_data_kernel_f32(jit_conv_conf_t ajcp) : jcp(ajcp) {}
+    jit_uni_dw_conv_bwd_data_kernel_f32_t(jit_conv_conf_t ajcp) : jcp(ajcp) {}
     jit_conv_conf_t jcp;
 
 private:
@@ -186,11 +186,12 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_bwd_weights_kernel_f32 : public jit_generator {
+struct jit_uni_dw_conv_bwd_weights_kernel_f32_t : public jit_generator {
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32_t)
 
-    jit_uni_dw_conv_bwd_weights_kernel_f32(jit_conv_conf_t ajcp) : jcp(ajcp) {}
+    jit_uni_dw_conv_bwd_weights_kernel_f32_t(jit_conv_conf_t ajcp)
+        : jcp(ajcp) {}
 
     jit_conv_conf_t jcp;
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -38,13 +38,14 @@ namespace cpu {
 namespace aarch64 {
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-struct jit_uni_dw_conv_fwd_kernel {
+struct jit_uni_dw_conv_fwd_kernel_t {
 
-    jit_uni_dw_conv_fwd_kernel(jit_conv_conf_t ajcp)
-        : ker_(utils::make_unique<jit_uni_dw_conv_fwd_kernel_f32<isa>>(ajcp)) {}
+    jit_uni_dw_conv_fwd_kernel_t(jit_conv_conf_t ajcp)
+        : ker_(utils::make_unique<jit_uni_dw_conv_fwd_kernel_f32_t<isa>>(
+                ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
-    ~jit_uni_dw_conv_fwd_kernel() = default;
+    ~jit_uni_dw_conv_fwd_kernel_t() = default;
 
     static bool post_ops_ok(jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
@@ -60,12 +61,12 @@ struct jit_uni_dw_conv_fwd_kernel {
     void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel)
-    std::unique_ptr<jit_uni_dw_conv_fwd_kernel_f32<isa>> ker_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_t)
+    std::unique_ptr<jit_uni_dw_conv_fwd_kernel_f32_t<isa>> ker_;
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-bool jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::post_ops_ok(
+bool jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::post_ops_ok(
         jit_conv_conf_t &jcp, const primitive_attr_t &attr) {
     const auto &p = attr.post_ops_;
 
@@ -87,7 +88,7 @@ bool jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::post_ops_ok(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-status_t jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
+status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         memory_desc_t &src_md, memory_desc_t &weights_md,
         memory_desc_t &bias_md, memory_desc_t &dst_md,
@@ -276,25 +277,25 @@ status_t jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_scratchpad(
+void jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;
     if (jcp.with_bias && jcp.oc_without_padding != jcp.oc)
         scratchpad.book<float>(key_conv_padded_bias, jcp.oc);
 }
 
-template struct jit_uni_dw_conv_fwd_kernel<sve_512, data_type::f32>;
-template struct jit_uni_dw_conv_fwd_kernel<sve_256, data_type::f32>;
+template struct jit_uni_dw_conv_fwd_kernel_t<sve_512, data_type::f32>;
+template struct jit_uni_dw_conv_fwd_kernel_t<sve_256, data_type::f32>;
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-struct jit_uni_dw_conv_bwd_data_kernel {
+struct jit_uni_dw_conv_bwd_data_kernel_t {
 
-    jit_uni_dw_conv_bwd_data_kernel(jit_conv_conf_t ajcp)
-        : ker_(utils::make_unique<jit_uni_dw_conv_bwd_data_kernel_f32<isa>>(
+    jit_uni_dw_conv_bwd_data_kernel_t(jit_conv_conf_t ajcp)
+        : ker_(utils::make_unique<jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>>(
                 ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
-    ~jit_uni_dw_conv_bwd_data_kernel() = default;
+    ~jit_uni_dw_conv_bwd_data_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &diff_src_d,
@@ -307,12 +308,12 @@ struct jit_uni_dw_conv_bwd_data_kernel {
     void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel)
-    std::unique_ptr<jit_uni_dw_conv_bwd_data_kernel_f32<isa>> ker_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel_t)
+    std::unique_ptr<jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>> ker_;
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-status_t jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_conf(
+status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         const memory_desc_wrapper &diff_src_d,
         const memory_desc_wrapper &weights_d,
@@ -409,24 +410,24 @@ status_t jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_conf(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_scratchpad(
+void jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     UNUSED(scratchpad);
     UNUSED(jcp);
 }
 
-template struct jit_uni_dw_conv_bwd_data_kernel<sve_512, data_type::f32>;
-template struct jit_uni_dw_conv_bwd_data_kernel<sve_256, data_type::f32>;
+template struct jit_uni_dw_conv_bwd_data_kernel_t<sve_512, data_type::f32>;
+template struct jit_uni_dw_conv_bwd_data_kernel_t<sve_256, data_type::f32>;
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-struct jit_uni_dw_conv_bwd_weights_kernel {
+struct jit_uni_dw_conv_bwd_weights_kernel_t {
 
-    jit_uni_dw_conv_bwd_weights_kernel(jit_conv_conf_t ajcp)
-        : ker_(utils::make_unique<jit_uni_dw_conv_bwd_weights_kernel_f32<isa>>(
-                ajcp)) {}
+    jit_uni_dw_conv_bwd_weights_kernel_t(jit_conv_conf_t ajcp)
+        : ker_(utils::make_unique<
+                jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>>(ajcp)) {}
 
     status_t create_kernel() { return ker_->create_kernel(); }
-    ~jit_uni_dw_conv_bwd_weights_kernel() = default;
+    ~jit_uni_dw_conv_bwd_weights_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
@@ -441,12 +442,12 @@ struct jit_uni_dw_conv_bwd_weights_kernel {
     void operator()(const jit_dw_conv_call_s *p) const { (*ker_)(p); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_weights_kernel)
-    std::unique_ptr<jit_uni_dw_conv_bwd_weights_kernel_f32<isa>> ker_;
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_weights_kernel_t)
+    std::unique_ptr<jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>> ker_;
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-status_t jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_conf(
+status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &diff_weights_d,
@@ -544,7 +545,7 @@ status_t jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_conf(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_scratchpad(
+void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;
     /* Notes: if splitting thread work on 'mb', then a reduction has to take
@@ -568,7 +569,7 @@ void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_scratchpad(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::balance(
+void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::balance(
         jit_conv_conf_t &jcp, int nthreads) {
     jcp.nthr = nthreads;
     jcp.nthr_g = jcp.nthr_mb = 1;
@@ -588,8 +589,8 @@ void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::balance(
     jcp.nthr = jcp.nthr_g * jcp.nthr_mb;
 }
 
-template struct jit_uni_dw_conv_bwd_weights_kernel<sve_512, data_type::f32>;
-template struct jit_uni_dw_conv_bwd_weights_kernel<sve_256, data_type::f32>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_t<sve_512, data_type::f32>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_t<sve_256, data_type::f32>;
 } // namespace aarch64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -58,7 +58,7 @@ struct jit_uni_dw_conv_fwd_kernel_t {
             const jit_conv_conf_t &jcp);
 
     jit_generator *ker() const { return ker_.get(); }
-    void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*ker_)(p); }
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_t)
@@ -305,7 +305,7 @@ struct jit_uni_dw_conv_bwd_data_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*ker_)(p); }
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel_t)
@@ -439,7 +439,7 @@ struct jit_uni_dw_conv_bwd_weights_kernel_t {
 
     static void balance(jit_conv_conf_t &jcp, int nthreads);
 
-    void operator()(const jit_dw_conv_call_s *p) const { (*ker_)(p); }
+    void operator()(const jit_dw_conv_args_t *p) const { (*ker_)(p); }
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_weights_kernel_t)

--- a/src/cpu/aarch64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_convolution.hpp
@@ -59,13 +59,13 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
             if (!ok) return status::unimplemented;
 
             status_t status
-                    = jit_uni_dw_conv_fwd_kernel<isa, src_type>::init_conf(jcp_,
-                            *desc(), src_md_, weights_md_, bias_md_, dst_md_,
-                            *attr());
+                    = jit_uni_dw_conv_fwd_kernel_t<isa, src_type>::init_conf(
+                            jcp_, *desc(), src_md_, weights_md_, bias_md_,
+                            dst_md_, *attr());
             if (status != status::success) return status;
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_uni_dw_conv_fwd_kernel<isa, src_type>::init_scratchpad(
+            jit_uni_dw_conv_fwd_kernel_t<isa, src_type>::init_scratchpad(
                     scratchpad, jcp_);
 
             return status::success;
@@ -83,7 +83,7 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_uni_dw_conv_fwd_kernel<isa, src_type>(pd()->jcp_)));
+                new jit_uni_dw_conv_fwd_kernel_t<isa, src_type>(pd()->jcp_)));
         return kernel_->create_kernel();
     }
 
@@ -96,7 +96,7 @@ private:
     void execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_uni_dw_conv_fwd_kernel<isa, src_type>> kernel_;
+    std::unique_ptr<jit_uni_dw_conv_fwd_kernel_t<isa, src_type>> kernel_;
 };
 using jit_sve_512_dw_convolution_fwd_t
         = jit_uni_dw_convolution_fwd_t<sve_512, data_type::f32>;
@@ -122,13 +122,13 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
 
             if (!ok) return status::unimplemented;
 
-            status_t status = jit_uni_dw_conv_bwd_data_kernel<isa,
+            status_t status = jit_uni_dw_conv_bwd_data_kernel_t<isa,
                     diff_dst_type>::init_conf(jcp_, *desc(), *diff_src_md(),
                     *weights_md(), *diff_dst_md());
             if (status != status::success) return status;
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_uni_dw_conv_bwd_data_kernel<isa,
+            jit_uni_dw_conv_bwd_data_kernel_t<isa,
                     diff_dst_type>::init_scratchpad(scratchpad, jcp_);
 
             return status::success;
@@ -164,7 +164,7 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_uni_dw_conv_bwd_data_kernel<isa, diff_dst_type>(
+                new jit_uni_dw_conv_bwd_data_kernel_t<isa, diff_dst_type>(
                         pd()->jcp_)));
         return kernel_->create_kernel();
     }
@@ -178,7 +178,7 @@ private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_uni_dw_conv_bwd_data_kernel<isa, diff_dst_type>>
+    std::unique_ptr<jit_uni_dw_conv_bwd_data_kernel_t<isa, diff_dst_type>>
             kernel_;
 };
 
@@ -216,14 +216,14 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
             const int max_threads
                     = dnnl_in_parallel() ? 1 : dnnl_get_max_threads();
 
-            status_t status = jit_uni_dw_conv_bwd_weights_kernel<isa,
+            status_t status = jit_uni_dw_conv_bwd_weights_kernel_t<isa,
                     src_type>::init_conf(jcp_, *desc(), *src_md(),
                     *diff_weights_md(), *diff_dst_md(), max_threads);
             if (status != status::success) return status;
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_uni_dw_conv_bwd_weights_kernel<isa, src_type>::init_scratchpad(
-                    scratchpad, jcp_);
+            jit_uni_dw_conv_bwd_weights_kernel_t<isa,
+                    src_type>::init_scratchpad(scratchpad, jcp_);
 
             return status::success;
         }
@@ -260,7 +260,7 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_uni_dw_conv_bwd_weights_kernel<isa, src_type>(
+                new jit_uni_dw_conv_bwd_weights_kernel_t<isa, src_type>(
                         pd()->jcp_)));
         CHECK(kernel_->create_kernel());
 
@@ -284,7 +284,8 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32, isa>> acc_ker_;
-    std::unique_ptr<jit_uni_dw_conv_bwd_weights_kernel<isa, src_type>> kernel_;
+    std::unique_ptr<jit_uni_dw_conv_bwd_weights_kernel_t<isa, src_type>>
+            kernel_;
 };
 
 using jit_sve_512_dw_convolution_bwd_weights_t

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -43,8 +43,8 @@ struct jit_args_t {
     size_t work_amount;
 };
 
-struct jit_uni_eltwise_kernel : public jit_generator {
-    jit_uni_eltwise_kernel(const eltwise_pd_t *pd) : pd_(pd) {}
+struct jit_uni_eltwise_kernel_t : public jit_generator {
+    jit_uni_eltwise_kernel_t(const eltwise_pd_t *pd) : pd_(pd) {}
 
     void operator()(jit_args_t *p) { jit_generator::operator()(p); }
 
@@ -63,10 +63,10 @@ protected:
 namespace {
 
 template <cpu_isa_t isa>
-struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
+struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_kernel)
 
-    jit_uni_kernel_t(const eltwise_pd_t *pd) : jit_uni_eltwise_kernel(pd) {
+    jit_uni_kernel_t(const eltwise_pd_t *pd) : jit_uni_eltwise_kernel_t(pd) {
         const auto &desc = *pd_->desc();
         // there's no auxiliary vregs on fwd path
         const bool is_fwd = pd_->is_fwd();

--- a/src/cpu/aarch64/jit_uni_eltwise.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.hpp
@@ -34,7 +34,7 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-struct jit_uni_eltwise_kernel;
+struct jit_uni_eltwise_kernel_t;
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
 struct jit_uni_eltwise_fwd_t : public primitive_t {
@@ -58,7 +58,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_uni_eltwise_kernel> kernel_;
+    std::unique_ptr<jit_uni_eltwise_kernel_t> kernel_;
 };
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
@@ -83,7 +83,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_uni_eltwise_kernel> kernel_;
+    std::unique_ptr<jit_uni_eltwise_kernel_t> kernel_;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.cpp
@@ -38,8 +38,8 @@ struct jit_args_t {
     size_t work_amount;
 };
 
-struct jit_uni_eltwise_int_kernel : public jit_generator {
-    jit_uni_eltwise_int_kernel(const eltwise_desc_t &desc) : desc_(desc) {}
+struct jit_uni_eltwise_int_kernel_t : public jit_generator {
+    jit_uni_eltwise_int_kernel_t(const eltwise_desc_t &desc) : desc_(desc) {}
 
     void operator()(jit_args_t *p) { jit_generator::operator()(p); }
 
@@ -58,11 +58,11 @@ namespace {
 using namespace Xbyak_aarch64;
 
 template <cpu_isa_t isa>
-struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel {
+struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_subkernel_int)
 
     jit_uni_subkernel_int_t(const eltwise_desc_t &desc)
-        : jit_uni_eltwise_int_kernel(desc) {
+        : jit_uni_eltwise_int_kernel_t(desc) {
         using namespace data_type;
 
         // Relu and linear for int types: s32, s8, u8; Only forward direction

--- a/src/cpu/aarch64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.hpp
@@ -34,7 +34,7 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
-struct jit_uni_eltwise_int_kernel;
+struct jit_uni_eltwise_int_kernel_t;
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
 struct jit_uni_eltwise_int_fwd_t : public primitive_t {
@@ -61,7 +61,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    jit_uni_eltwise_int_kernel *kernel_ = nullptr;
+    jit_uni_eltwise_int_kernel_t *kernel_ = nullptr;
 };
 
 } // namespace aarch64

--- a/src/cpu/aarch64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.cpp
@@ -32,7 +32,8 @@ namespace aarch64 {
 using namespace Xbyak_aarch64;
 using namespace alg_kind;
 
-#define GET_OFF(field) static_cast<uint32_t>(offsetof(jit_pool_call_s, field))
+#define GET_OFF(field) \
+    static_cast<uint32_t>(offsetof(jit_uni_pooling_args_t, field))
 
 static bcast_set_t get_supported_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,

--- a/src/cpu/aarch64/jit_uni_pooling.cpp
+++ b/src/cpu/aarch64/jit_uni_pooling.cpp
@@ -573,7 +573,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(const data_t *src,
 
     const auto ker = [&](std::size_t ithr, int n, int b_c, int oh, int ur_bc) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
-        auto arg = jit_pool_call_s();
+        auto arg = jit_uni_pooling_args_t();
 
         const int ij = oh * jpp.stride_h;
         const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
@@ -703,7 +703,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(const data_t *src,
     auto ker = [&](int n, int b_c, int od, int oh, int id, int d_t_overflow,
                        int d_b_overflow, int ur_bc, int ithr) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
-        auto arg = jit_pool_call_s();
+        auto arg = jit_uni_pooling_args_t();
 
         const int ij = oh * jpp.stride_h;
         const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
@@ -916,7 +916,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
                 nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
     };
     const auto ker = [&](int ithr, int n, int b_c, int oh, int ur_bc) {
-        auto arg = jit_pool_call_s();
+        auto arg = jit_uni_pooling_args_t();
 
         const int ih = get_first_ih(oh);
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
@@ -1043,7 +1043,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
     auto ker = [&](int n, int b_c, int od, int oh, int id, int d_t_overflow,
                        int d_b_overflow, bool zero_inp, int kd, int ur_bc,
                        int ithr) {
-        auto arg = jit_pool_call_s();
+        auto arg = jit_uni_pooling_args_t();
 
         const int ij = oh * jpp.stride_h;
         const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
@@ -196,7 +196,7 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
             const dim_t sp_curr = spb * sp_work;
             const dim_t off = mb * stride_mb + sp_curr * conf.blk_size;
 
-            jit_shuffle_call_s args;
+            jit_uni_shuffle_args_t args;
             args.src = input + off * data_type_size;
             args.dst = output + (off + SP * c_curr) * data_type_size;
 

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -30,7 +30,7 @@ namespace aarch64 {
 
 using namespace Xbyak_aarch64;
 
-#define GET_OFF(field) offsetof(jit_shuffle_call_s, field)
+#define GET_OFF(field) offsetof(jit_uni_shuffle_args_t, field)
 
 static size_t get_padding_size(const jit_shuffle_conf_t &conf) {
     const auto padding_tail_size = conf.c % conf.blk_size;

--- a/src/cpu/gemm/bf16/ref_gemm_bf16.cpp
+++ b/src/cpu/gemm/bf16/ref_gemm_bf16.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -123,9 +123,9 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
         const bfloat16_t *A, const dim_t lda, const bfloat16_t *B,
         const dim_t ldb, const float beta, float *C, const dim_t ldc,
         bool do_copy, bfloat16_t *ws) {
-    constexpr dim_t BM = gemm_traits<bfloat16_t, isTransA, isTransB>::BM;
-    constexpr dim_t BN = gemm_traits<bfloat16_t, isTransA, isTransB>::BN;
-    constexpr dim_t BK = gemm_traits<bfloat16_t, isTransA, isTransB>::BK;
+    constexpr dim_t BM = gemm_traits_t<bfloat16_t, isTransA, isTransB>::BM;
+    constexpr dim_t BN = gemm_traits_t<bfloat16_t, isTransA, isTransB>::BN;
+    constexpr dim_t BK = gemm_traits_t<bfloat16_t, isTransA, isTransB>::BK;
 
     const bfloat16_t *curA;
     const bfloat16_t *curB;

--- a/src/cpu/gemm/f32/gemm_utils_f32.hpp
+++ b/src/cpu/gemm/f32/gemm_utils_f32.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2023 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ namespace cpu {
 
 namespace gemm_utils {
 template <typename T, bool isTransA, bool isTransB>
-struct gemm_traits {};
+struct gemm_traits_t {};
 
 template <bool isTransA, bool isTransB>
-struct gemm_traits<double, isTransA, isTransB> {
+struct gemm_traits_t<double, isTransA, isTransB> {
     static constexpr dim_t m = 8;
     static constexpr dim_t n = 6;
     static constexpr dim_t BM = 4032;
@@ -37,7 +37,7 @@ struct gemm_traits<double, isTransA, isTransB> {
 };
 
 template <bool isTransA, bool isTransB>
-struct gemm_traits<float, isTransA, isTransB> {
+struct gemm_traits_t<float, isTransA, isTransB> {
     static constexpr dim_t m = 16;
     static constexpr dim_t n = 6;
     static constexpr dim_t BM = 4032;
@@ -46,7 +46,7 @@ struct gemm_traits<float, isTransA, isTransB> {
 };
 
 template <bool isTransA, bool isTransB>
-struct gemm_traits<bfloat16_t, isTransA, isTransB> {
+struct gemm_traits_t<bfloat16_t, isTransA, isTransB> {
     static constexpr dim_t m = 32;
     static constexpr dim_t n = 6;
     static constexpr dim_t BM = 4032;
@@ -55,7 +55,7 @@ struct gemm_traits<bfloat16_t, isTransA, isTransB> {
 };
 
 template <typename T>
-using unroll_factor = gemm_traits<T, false, false>;
+using unroll_factor = gemm_traits_t<T, false, false>;
 
 template <typename data_t>
 void sum_two_matrices(dim_t m, dim_t n, data_t *__restrict p_src, dim_t ld_src,

--- a/src/cpu/gemm/f32/ref_gemm_f32.cpp
+++ b/src/cpu/gemm/f32/ref_gemm_f32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2021 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -127,9 +127,9 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const data_t alpha,
         const data_t *A, const dim_t lda, const data_t *B, const dim_t ldb,
         const data_t beta, data_t *C, const dim_t ldc, bool do_copy,
         data_t *ws) {
-    constexpr dim_t BM = gemm_traits<data_t, isTransA, isTransB>::BM;
-    constexpr dim_t BN = gemm_traits<data_t, isTransA, isTransB>::BN;
-    constexpr dim_t BK = gemm_traits<data_t, isTransA, isTransB>::BK;
+    constexpr dim_t BM = gemm_traits_t<data_t, isTransA, isTransB>::BM;
+    constexpr dim_t BN = gemm_traits_t<data_t, isTransA, isTransB>::BN;
+    constexpr dim_t BK = gemm_traits_t<data_t, isTransA, isTransB>::BK;
 
     const data_t *curA;
     const data_t *curB;

--- a/src/cpu/ref_fused_convolution.hpp
+++ b/src/cpu/ref_fused_convolution.hpp
@@ -375,7 +375,6 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
                 name_.append(":");
                 name_.append(op_pd->name());
             }
-            return;
         }
     };
 

--- a/src/cpu/ref_fused_convolution.hpp
+++ b/src/cpu/ref_fused_convolution.hpp
@@ -91,6 +91,7 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
             return status::success;
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *src_md(
                 int index = 0, bool user_input = false) const override {
             if (op_pds_.empty())
@@ -154,6 +155,7 @@ struct ref_fused_convolution_fwd_t : public primitive_t {
                 default: return convolution_fwd_pd_t::arg_md(arg, user_input);
             }
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -57,12 +57,14 @@ const bool reverse = false;
 const bool any = keep;
 } // namespace fmt_order
 
+// NOLINTBEGIN(readability-identifier-naming)
 namespace spec {
 struct direct_copy {};
 struct direct_copy_except_dim_0 {};
 struct reference {};
 struct conv_req_comp {}; // {s8, u8: asymmetric quantization}
 } // namespace spec
+// NOLINTEND(readability-identifier-naming)
 
 #define SIMPLE_REORDER_TEMPL_DECL \
     impl::data_type_t type_i, impl::format_tag_t tag_i, \
@@ -111,7 +113,7 @@ struct conv_req_comp {}; // {s8, u8: asymmetric quantization}
 
 /* specific reorders: common template */
 template <SIMPLE_REORDER_TEMPL_DECL, typename spec = void>
-struct simple_reorder_impl {};
+struct simple_reorder_impl_t {};
 
 namespace {
 inline bool simple_fmt_check(bool order_keep, impl::format_tag_t tag_i,
@@ -214,7 +216,7 @@ inline dim_t get_quant_off(const dims_t &input_idx, const int ndims,
 
 /* specific reorders: implementation */
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                         && utils::one_of(tag_o, format_tag::wio,
                                 format_tag::wigo, format_tag::hwio,
@@ -355,7 +357,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<
                 (utils::one_of(tag_i, format_tag::iwo, format_tag::oiw,
                          format_tag::wio)
@@ -614,7 +616,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
 /* Asymmetric Blocking */
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<(utils::one_of(tag_i, format_tag::iwo,
                                            format_tag::oiw, format_tag::wio)
                                           && utils::one_of(
@@ -764,7 +766,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
 /* Asymmetric Blocking */
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<(utils::one_of(tag_i, format_tag::iwo,
                                            format_tag::oiw, format_tag::wio)
                                           && utils::one_of(tag_o,
@@ -957,7 +959,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<
                 (utils::one_of(tag_i, format_tag::ab, format_tag::ba,
                          format_tag::abc, format_tag::acb)
@@ -1155,7 +1157,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<
                 (utils::one_of(tag_i, format_tag::goiw, format_tag::wigo)
                         && utils::one_of(tag_o, format_tag::Goiw16g,
@@ -1346,7 +1348,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
 /* bf16 reorders */
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<(
                 (tag_i == format_tag::goihw || tag_i == format_tag::oihw)
                 && (tag_o == format_tag::gOIhw16i16o
@@ -1471,7 +1473,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<(tag_i == format_tag::nchw
                                           && tag_o == format_tag::nChw16c)
                 && type_i == data_type::f32
@@ -1559,7 +1561,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 /* reorders with tail support */
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<false
                 || (utils::one_of(
                             tag_i, format_tag::nCdhw4c, format_tag::nCdhw8c)
@@ -1706,7 +1708,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
     }
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                 && (tag_traits_t<tag_o>::block_dims == bd::_A
                         || tag_traits_t<tag_o>::block_dims == bd::_B)
@@ -1857,7 +1859,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                 && (tag_traits_t<tag_o>::block_dims == bd::_AB
                         || tag_traits_t<tag_o>::block_dims == bd::_BC)
@@ -2051,7 +2053,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 /* generic and direct-copy reorders */
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                         && tag_o == format_tag::any
                         && order_keep == fmt_order::any,
@@ -2154,7 +2156,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                         && tag_o == format_tag::any && type_i == data_type::f32
                         && utils::one_of(type_o, data_type::s4, data_type::u4,
@@ -2269,7 +2271,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                         && tag_o == format_tag::any
                         && utils::one_of(type_i, data_type::s4, data_type::u4,
@@ -2422,7 +2424,7 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                         && tag_o == format_tag::any
                         && order_keep == fmt_order::any,
@@ -2526,7 +2528,7 @@ private:
 };
 
 template <SIMPLE_REORDER_TEMPL_DECL>
-struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
         typename utils::enable_if<tag_i == format_tag::any
                         && tag_o == format_tag::any
                         && order_keep == fmt_order::any
@@ -2699,7 +2701,7 @@ struct simple_reorder_t : public primitive_t {
                             | skip_mask_t::post_ops),
                     VERBOSE_UNSUPPORTED_ATTR);
 
-            auto status = simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+            auto status = simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                     spec>::is_applicable(src_md, dst_md, attr);
             if (status != status::success) return status;
 
@@ -2718,7 +2720,7 @@ struct simple_reorder_t : public primitive_t {
             CHECK(_pd->init(engine, src_engine, dst_engine));
 
             const size_t scratchpad_sz_
-                    = simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
+                    = simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                             spec>::get_scratchpad_size(src_md, dst_md);
             auto scratchpad = _pd->scratchpad_registry().registrar();
             scratchpad.book(memory_tracking::names::key_reorder_space,
@@ -2742,7 +2744,7 @@ struct simple_reorder_t : public primitive_t {
     simple_reorder_t(const pd_t *apd) : primitive_t(apd) {}
 
     status_t execute(const exec_ctx_t &ctx) const override {
-        return simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL, spec>::execute(
+        return simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL, spec>::execute(
                 pd(), ctx);
     }
 

--- a/src/cpu/reorder/simple_sparse_reorder.hpp
+++ b/src/cpu/reorder/simple_sparse_reorder.hpp
@@ -61,7 +61,7 @@ namespace cpu {
     type_i, fmt_i_t, fmt_i, type_o, fmt_o_t, fmt_o
 
 template <SIMPLE_SPARSE_REORDER_TEMPL_DECL, typename spec = void>
-struct simple_sparse_reorder_impl {};
+struct simple_sparse_reorder_impl_t {};
 
 namespace {
 template <typename T>
@@ -71,7 +71,7 @@ constexpr bool is_format_tag(T) {
 } // namespace
 
 template <SIMPLE_SPARSE_REORDER_TEMPL_DECL>
-struct simple_sparse_reorder_impl<SIMPLE_SPARSE_REORDER_TEMPL_CALL,
+struct simple_sparse_reorder_impl_t<SIMPLE_SPARSE_REORDER_TEMPL_CALL,
         typename utils::enable_if<(is_format_tag(fmt_i)
                                           && (fmt_i == format_tag::any))
                 && (is_format_tag(fmt_o)
@@ -210,7 +210,7 @@ struct simple_sparse_reorder_t : public primitive_t {
                     && dst_md->data_type == type_o;
             if (!ok) return status::invalid_arguments;
 
-            CHECK(simple_sparse_reorder_impl<
+            CHECK(simple_sparse_reorder_impl_t<
                     SIMPLE_SPARSE_REORDER_TEMPL_CALL>::is_applicable(src_md,
                     dst_md, attr));
 
@@ -230,7 +230,7 @@ struct simple_sparse_reorder_t : public primitive_t {
             CHECK(reorder_primitive_desc_create(
                     reorder_pd_, engine, src_md(), &converted_dst_md, attr()));
 
-            const size_t scratchpad_sz_ = simple_sparse_reorder_impl<
+            const size_t scratchpad_sz_ = simple_sparse_reorder_impl_t<
                     SIMPLE_SPARSE_REORDER_TEMPL_CALL>::
                     get_scratchpad_size(src_md(), dst_md());
             auto scratchpad = scratchpad_registry().registrar();
@@ -251,7 +251,7 @@ struct simple_sparse_reorder_t : public primitive_t {
     }
 
     status_t execute(const exec_ctx_t &ctx) const override {
-        return simple_sparse_reorder_impl<
+        return simple_sparse_reorder_impl_t<
                 SIMPLE_SPARSE_REORDER_TEMPL_CALL>::execute(pd(), ctx, reorder_);
     }
 

--- a/src/cpu/rnn/brgemm_cell_common.cpp
+++ b/src/cpu/rnn/brgemm_cell_common.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ using namespace dnnl::impl::cpu::x64;
 #endif
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_merged_layer_execution_sig((_ref_rnn_fwd_t<src_type, weights_type,
-        acc_type>::merged_layer_brgemm)) {
+rnn_merged_layer_execution_sig((
+        ref_rnn_fwd_t<src_type, weights_type, acc_type>::merged_layer_brgemm)) {
 #if DNNL_X64
     using brgemm_merged_layer_t = x64::brgemm_merged_layer_t<src_iter_t,
             weights_t, scratch_t, gemm_acc_t>;
@@ -65,7 +65,7 @@ template rnn_merged_layer_execution_sig(
         ref_rnn_fwd_s8s8_t::merged_layer_brgemm);
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((_ref_rnn_fwd_t<src_type, weights_type,
+rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         acc_type>::cell_execution_brgemm)) {
 #if DNNL_X64
 
@@ -273,7 +273,7 @@ template rnn_cell_execution_sig(ref_rnn_fwd_u8s8_t::cell_execution_brgemm);
 template rnn_cell_execution_sig(ref_rnn_fwd_s8s8_t::cell_execution_brgemm);
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((_ref_rnn_bwd_t<src_type, weights_type,
+rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
         acc_type>::cell_execution_brgemm)) {
 
 #if DNNL_X64

--- a/src/cpu/rnn/cell_common.cpp
+++ b/src/cpu/rnn/cell_common.cpp
@@ -30,8 +30,8 @@ using namespace rnn_utils;
 using namespace dnnl::impl::utils;
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((
-        _ref_rnn_fwd_t<src_type, weights_type, acc_type>::cell_execution_ref)) {
+rnn_cell_execution_sig(
+        (ref_rnn_fwd_t<src_type, weights_type, acc_type>::cell_execution_ref)) {
     const auto weights_scales = this->pd_->attr()->rnn_weights_qparams_.scales_;
     const auto weights_projection_scales = rnn.is_lstm_projection
             ? this->pd_->attr()->rnn_weights_projection_qparams_.scales_
@@ -119,7 +119,8 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
             types::data_type_size(rnn.src_iter_c_dt), rnn.ws_states_iter_c_nld,
             src_iter_c_ld);
 
-    const ws_gates_aoc<const scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<const scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const weights_peephole_aoc_t<float> diff_weights_peephole(
             rnn, diff_weights_peephole_);
 
@@ -238,8 +239,8 @@ dnnl_status_t common_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
 }
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((
-        _ref_rnn_bwd_t<src_type, weights_type, acc_type>::cell_execution_ref)) {
+rnn_cell_execution_sig(
+        (ref_rnn_bwd_t<src_type, weights_type, acc_type>::cell_execution_ref)) {
     const auto gemm_layer = [&](const weights_t *A, const scratch_t *B,
                                     float *C) {
         return (this->*gemm_layer_func)('N', 'N', rnn.slc, rnn.mb,
@@ -306,7 +307,7 @@ template rnn_cell_execution_sig(ref_rnn_bwd_bf16_t::cell_execution_ref);
 template rnn_cell_execution_sig(ref_rnn_bwd_f16_t::cell_execution_ref);
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_merged_layer_execution_sig((_ref_rnn_fwd_t<src_type, weights_type,
+rnn_merged_layer_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         acc_type>::merged_layer_execution_ref)) {
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
     // If we avoid copying the last iteration, the corresponding
@@ -329,7 +330,7 @@ rnn_merged_layer_execution_sig((_ref_rnn_fwd_t<src_type, weights_type,
 }
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_merged_layer_execution_sig((_ref_rnn_bwd_t<src_type, weights_type,
+rnn_merged_layer_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
         acc_type>::merged_layer_execution_ref)) {
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
     // If we avoid copying the last iteration, the corresponding

--- a/src/cpu/rnn/cell_gru.cpp
+++ b/src/cpu/rnn/cell_gru.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,10 +33,10 @@ using namespace rnn_utils;
 
 #define AOC array_offset_calculator
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((
-        _ref_rnn_fwd_t<src_type, weights_type, acc_type>::cell_execution_gru)) {
-    const ws_gates_aoc<gates_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_t> scratch_gates(rnn, scratch_gates_);
+rnn_cell_execution_sig(
+        (ref_rnn_fwd_t<src_type, weights_type, acc_type>::cell_execution_gru)) {
+    const ws_gates_aoc_t<gates_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_t> scratch_gates(rnn, scratch_gates_);
     const auto weights_scales = this->pd_->attr()->rnn_weights_qparams_.scales_;
 
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
@@ -115,16 +115,17 @@ dnnl_status_t gru_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
         acc_data_t *diff_src_iter_, acc_data_t *diff_dst_iter_,
         acc_data_t *diff_dst_layer_, acc_data_t *diff_bias_,
         scratch_data_t *scratch_cell_, src_data_t *dst_iter_) {
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
 
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
     const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
-    const ws_states_layer_aoc<src_data_t> dst_layer(rnn, dst_layer_,
+    const ws_states_layer_aoc_t<src_data_t> dst_layer(rnn, dst_layer_,
             (cell_position & last_layer) ? dst_layer_ld : dst_iter_ld);
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
     const ws_diff_w_iter_aoc_t diff_w_iter(rnn, diff_w_iter_);
 
@@ -186,8 +187,8 @@ dnnl_status_t gru_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
 }
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((
-        _ref_rnn_bwd_t<src_type, weights_type, acc_type>::cell_execution_gru)) {
+rnn_cell_execution_sig(
+        (ref_rnn_bwd_t<src_type, weights_type, acc_type>::cell_execution_gru)) {
     auto gemm_iter_f
             = [&](int m, int n, int k, const weights_t *A, const gemm_data_t *B,
                       float beta, gemm_acc_t *C) {

--- a/src/cpu/rnn/cell_gru_lbr.cpp
+++ b/src/cpu/rnn/cell_gru_lbr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ using namespace rnn_utils;
 #define AOC array_offset_calculator
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((_ref_rnn_fwd_t<src_type, weights_type,
+rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         acc_type>::cell_execution_gru_lbr)) {
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
@@ -102,7 +102,7 @@ dnnl_status_t common_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
-    const ws_gates_aoc<scratch_data_t> scratch_gates_r(rnn, scratch_cell_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates_r(rnn, scratch_cell_);
 
     rnn_postgemm->execute(rnn, cell_position, ws_gates_, scratch_gates_,
             augru_attention_, dst_layer_, nullptr, src_iter_, nullptr, nullptr,
@@ -145,7 +145,7 @@ dnnl_status_t common_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
 #undef AOC
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_cell_execution_sig((_ref_rnn_bwd_t<src_type, weights_type,
+rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
         acc_type>::cell_execution_gru_lbr)) {
     const auto gemm_layer = [&](const weights_t *A, const scratch_t *B,
                                     float *C) {

--- a/src/cpu/rnn/postgemm_dispatcher.hpp
+++ b/src/cpu/rnn/postgemm_dispatcher.hpp
@@ -50,7 +50,7 @@ float activation(alg_kind_t alg_kind, prop_kind_t prop_kind, float s,
 
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t scratch_type, impl::data_type_t acc_type>
-struct rnn_postgemm_dispatcher {
+struct rnn_postgemm_dispatcher_t {
 
     using src_layer_t = typename prec_traits_t<src_type>::type;
     using src_iter_t = typename prec_traits_t<src_type>::type;
@@ -61,11 +61,11 @@ struct rnn_postgemm_dispatcher {
     using ht_t = typename prec_traits_t<src_type>::type;
     using gates_t = typename prec_traits_t<src_type>::type;
 
-    using class_name
-            = rnn_postgemm_dispatcher<aprop, src_type, scratch_type, acc_type>;
-    typedef rnn_postgemm_sig((class_name::*postgemm_f));
+    using class_name = rnn_postgemm_dispatcher_t<aprop, src_type, scratch_type,
+            acc_type>;
+    using postgemm_f = void (class_name::*)(rnn_postgemm_sig_args) const;
 
-    rnn_postgemm_dispatcher(
+    rnn_postgemm_dispatcher_t(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
         : pd_(pd) {
         // add check if in testing mode
@@ -102,7 +102,7 @@ struct rnn_postgemm_dispatcher {
         }
     }
 
-    virtual ~rnn_postgemm_dispatcher() = default;
+    virtual ~rnn_postgemm_dispatcher_t() = default;
 
     status_t init(const rnn_utils::rnn_conf_t &rnn) {
         DNNL_X64_ONLY(CHECK(initialize_jit(rnn)));
@@ -229,11 +229,11 @@ protected:
     postgemm_f postgemm_func;
     postgemm_f postgemm_part2_func;
 
-    DNNL_DISALLOW_COPY_AND_ASSIGN(rnn_postgemm_dispatcher);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(rnn_postgemm_dispatcher_t);
 
 #if DNNL_X64
-    std::unique_ptr<x64::jit_uni_rnn_postgemm> rnn_postgemm_;
-    std::unique_ptr<x64::jit_uni_rnn_postgemm> rnn_postgemm_part2_;
+    std::unique_ptr<x64::jit_uni_rnn_postgemm_t> rnn_postgemm_;
+    std::unique_ptr<x64::jit_uni_rnn_postgemm_t> rnn_postgemm_part2_;
 
     status_t initialize_jit(const rnn_utils::rnn_conf_t &rnn) {
         using namespace dnnl::impl::cpu::x64;
@@ -298,9 +298,9 @@ protected:
 
 template <impl::data_type_t src_type, impl::data_type_t scratch_type,
         impl::data_type_t acc_type>
-struct rnn_postgemm_fwd_t : public rnn_postgemm_dispatcher<prop_kind::forward,
+struct rnn_postgemm_fwd_t : public rnn_postgemm_dispatcher_t<prop_kind::forward,
                                     src_type, scratch_type, acc_type> {
-    using base_t = rnn_postgemm_dispatcher<prop_kind::forward, src_type,
+    using base_t = rnn_postgemm_dispatcher_t<prop_kind::forward, src_type,
             scratch_type, acc_type>;
     using base_t::base_t;
     using src_layer_t = typename base_t::src_layer_t;
@@ -325,9 +325,10 @@ struct rnn_postgemm_fwd_t : public rnn_postgemm_dispatcher<prop_kind::forward,
 
 template <impl::data_type_t src_type, impl::data_type_t scratch_type,
         impl::data_type_t acc_type>
-struct rnn_postgemm_bwd_t : public rnn_postgemm_dispatcher<prop_kind::backward,
-                                    src_type, scratch_type, acc_type> {
-    using base_t = rnn_postgemm_dispatcher<prop_kind::backward, src_type,
+struct rnn_postgemm_bwd_t
+    : public rnn_postgemm_dispatcher_t<prop_kind::backward, src_type,
+              scratch_type, acc_type> {
+    using base_t = rnn_postgemm_dispatcher_t<prop_kind::backward, src_type,
             scratch_type, acc_type>;
     using base_t::base_t;
     using src_layer_t = typename base_t::src_layer_t;

--- a/src/cpu/rnn/ref_postgemm_gru.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,8 +44,9 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
         const src_data_t *src_iter_, const void *bias_, int block_step) {
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
     const auto bias = [&](int gate_id, int dhc_id) {
@@ -56,10 +57,11 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
-    const ws_states_layer_aoc<src_data_t> dst_layer(
+    const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
-    const ws_states_iter_aoc<src_data_t> dst_iter(rnn, dst_iter_, dst_iter_ld);
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    const ws_states_iter_aoc_t<src_data_t> dst_iter(
+            rnn, dst_iter_, dst_iter_ld);
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
 
     const float *scales_G1 = scales ? scales + 1 : nullptr;
@@ -106,8 +108,9 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
         const src_data_t *src_iter_, const void *bias_, int block_step) {
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
     const auto bias = [&](int gate_id, int dhc_id) {
@@ -117,12 +120,13 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
     const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
-    const augru_attention_aoc<const src_data_t> augru_attention(
+    const augru_attention_aoc_t<const src_data_t> augru_attention(
             rnn, augru_attention_);
-    const ws_states_layer_aoc<src_data_t> dst_layer(
+    const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
-    const ws_states_iter_aoc<src_data_t> dst_iter(rnn, dst_iter_, dst_iter_ld);
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    const ws_states_iter_aoc_t<src_data_t> dst_iter(
+            rnn, dst_iter_, dst_iter_ld);
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
 
     const float *scales_G2 = scales ? scales + 2 : nullptr;
@@ -332,20 +336,20 @@ void gru_bwd_part1_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
         acc_data_t *diff_augru_attention_, acc_data_t *diff_dst_layer_) {
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
-    const augru_attention_aoc<const src_data_t> augru_attention(
+    const augru_attention_aoc_t<const src_data_t> augru_attention(
             rnn, augru_attention_);
-    const augru_attention_aoc<acc_data_t> diff_augru_attention(
+    const augru_attention_aoc_t<acc_data_t> diff_augru_attention(
             rnn, diff_augru_attention_);
 
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_src_iter(
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_src_iter(
             rnn, diff_src_iter_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_dst_iter(
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
             rnn, diff_dst_iter_);
-    const ws_diff_states_layer_aoc<acc_data_t> diff_dst_layer(
+    const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(
             rnn, diff_dst_layer_);
 
     // dG2^ = dh * (1 - G0) * (1 - G2^2)
@@ -385,18 +389,18 @@ void gru_bwd_part2_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
         acc_data_t *diff_dst_layer_, scratch_data_t *scratch_cell_) {
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
     // auto dst_ld = rnn.dst_ld(cell_position);
-    // ws_states_layer_aoc<src_data_t> dst_layer(rnn, dst_layer_, dst_ld);
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    // ws_states_layer_aoc_t<src_data_t> dst_layer(rnn, dst_layer_, dst_ld);
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
-    const ws_diff_states_layer_aoc<acc_data_t> diff_dst_layer(
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(
             rnn, diff_dst_layer_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_dst_iter(
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
             rnn, diff_dst_iter_);
 
-    const ws_diff_states_layer_aoc<acc_data_t> dhG1(rnn, diff_src_layer_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_src_iter(
+    const ws_diff_states_layer_aoc_t<acc_data_t> dhG1(rnn, diff_src_layer_);
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_src_iter(
             rnn, diff_src_iter_);
     const AOC<scratch_data_t, 2> hG1(
             scratch_cell_, rnn.ws_states_layer_nld, rnn.ws_states_layer_ld);

--- a/src/cpu/rnn/ref_postgemm_gru_lbr.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru_lbr.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,25 +46,27 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
     const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
 
-    const augru_attention_aoc<const src_data_t> augru_attention(
+    const augru_attention_aoc_t<const src_data_t> augru_attention(
             rnn, augru_attention_);
-    const ws_states_layer_aoc<src_data_t> dst_layer(
+    const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
-    const ws_states_iter_aoc<src_data_t> dst_iter(rnn, dst_iter_, dst_iter_ld);
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    const ws_states_iter_aoc_t<src_data_t> dst_iter(
+            rnn, dst_iter_, dst_iter_ld);
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
 
     const auto bias = [&](int gate_id, int dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
-    const ws_gates_aoc<scratch_data_t> scratch_cell(rnn, scratch_cell_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_cell(rnn, scratch_cell_);
     // TODO: There is some inconsistency with the strides used in brgemm vs ref
     // implementation. Fix this to have a consistent post-gemm else document.
-    const scratch_gates_aoc<scratch_data_t> scratch_cell_brgemm(
+    const scratch_gates_aoc_t<scratch_data_t> scratch_cell_brgemm(
             rnn, scratch_cell_);
     const AOC<src_data_t, 2> ws_Wh_b(ws_grid_, rnn.mb, rnn.dhc);
 
@@ -188,22 +190,22 @@ void gru_lbr_bwd_postgemm_template(T1 to_src, const rnn_utils::rnn_conf_t &rnn,
         src_data_t *ws_grid_) {
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
-    const augru_attention_aoc<const src_data_t> augru_attention(
+    const augru_attention_aoc_t<const src_data_t> augru_attention(
             rnn, augru_attention_);
-    const augru_attention_aoc<acc_data_t> diff_augru_attention(
+    const augru_attention_aoc_t<acc_data_t> diff_augru_attention(
             rnn, diff_augru_attention_);
 
-    const ws_states_iter_aoc<const src_data_t> src_iter(
+    const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_src_iter(
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_src_iter(
             rnn, diff_src_iter_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_dst_iter(
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
             rnn, diff_dst_iter_);
-    const ws_diff_states_layer_aoc<acc_data_t> diff_dst_layer(
+    const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(
             rnn, diff_dst_layer_);
-    const ws_gates_aoc<scratch_data_t> scratch_gates_r(rnn, scratch_cell_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates_r(rnn, scratch_cell_);
     const AOC<src_data_t, 2> ws_Wh_b(ws_grid_, rnn.mb, rnn.dhc);
 
     // 1. calculate dG1 dG2 dG3

--- a/src/cpu/rnn/ref_postgemm_lstm.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm.cpp
@@ -43,8 +43,9 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
         src_data_t *dst_iter_, void *dst_iter_c_, const src_data_t *src_iter_,
         const void *src_iter_c_, const float *weights_peephole_,
         const void *bias_, int block_step) {
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const weights_peephole_aoc_t<const float> weights_peephole(
             rnn, weights_peephole_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
@@ -60,10 +61,11 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
     const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
     const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
-    const ws_states_layer_aoc<src_data_t> dst_layer(
+    const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
     // TODO: we use scratch and not dst_iter for lstmp
-    const ws_states_iter_aoc<src_data_t> dst_iter(rnn, dst_iter_, dst_iter_ld);
+    const ws_states_iter_aoc_t<src_data_t> dst_iter(
+            rnn, dst_iter_, dst_iter_ld);
 
     const auto dst_iter_c = rnn_utils::make_raw_aoc(dst_iter_c_,
             types::data_type_size(rnn.dst_iter_c_dt), rnn.ws_states_iter_c_nld,
@@ -269,8 +271,8 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
         acc_data_t *diff_src_iter_c_, acc_data_t *diff_dst_layer_,
         acc_data_t *diff_dst_iter_, acc_data_t *diff_dst_iter_c_,
         const float *weights_peephole_, const void *bias_) {
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
     const weights_peephole_aoc_t<const float> weights_peephole(
             rnn, weights_peephole_);
     const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
@@ -290,13 +292,13 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
                 dst_iter_c_aoc(mb_id, dhc_id), rnn.dst_iter_c_dt);
     };
 
-    const ws_diff_states_iter_c_aoc<acc_data_t> diff_src_iter_c(
+    const ws_diff_states_iter_c_aoc_t<acc_data_t> diff_src_iter_c(
             rnn, diff_src_iter_c_);
-    const ws_diff_states_layer_aoc<acc_data_t> diff_dst_layer(
+    const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(
             rnn, diff_dst_layer_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_dst_iter(
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
             rnn, diff_dst_iter_);
-    const ws_diff_states_iter_c_aoc<acc_data_t> diff_dst_iter_c(
+    const ws_diff_states_iter_c_aoc_t<acc_data_t> diff_dst_iter_c(
             rnn, diff_dst_iter_c_);
 
     parallel_nd(rnn.mb, [&](dim_t i) {

--- a/src/cpu/rnn/ref_postgemm_rnn.cpp
+++ b/src/cpu/rnn/ref_postgemm_rnn.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -68,8 +68,9 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
         src_data_t *dst_iter_, const src_data_t *src_iter_, const void *bias_,
         int block_step) {
 
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const scratch_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
     const auto bias = [&](int gate_id, int dhc_id) {
@@ -77,9 +78,10 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
     };
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
     const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
-    const ws_states_layer_aoc<src_data_t> dst_layer(
+    const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
-    const ws_states_iter_aoc<src_data_t> dst_iter(rnn, dst_iter_, dst_iter_ld);
+    const ws_states_iter_aoc_t<src_data_t> dst_iter(
+            rnn, dst_iter_, dst_iter_ld);
 
     if (scales != nullptr) alpha = scales[0];
 
@@ -144,11 +146,11 @@ void rnn_bwd_postgemm_template(T1 func1, T2 to_src, const float *scales,
         float alpha, const rnn_utils::rnn_conf_t &rnn, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, acc_data_t *diff_dst_iter_,
         acc_data_t *diff_dst_layer_) {
-    const ws_gates_aoc<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc<scratch_data_t> scratch_gates(rnn, scratch_gates_);
-    const ws_diff_states_iter_aoc<acc_data_t> diff_dst_iter(
+    const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
+    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
             rnn, diff_dst_iter_);
-    const ws_diff_states_layer_aoc<acc_data_t> diff_dst_layer(
+    const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(
             rnn, diff_dst_layer_);
     if (scales != nullptr) alpha = scales[0];
 

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -53,7 +53,7 @@ using namespace rnn_utils;
 
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
-status_t dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
+status_t dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::pd_t::init_ref(engine_t *engine) {
 
     using namespace prop_kind;
@@ -297,7 +297,7 @@ status_t dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 status_t
-_ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
+ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
         engine_t *engine) {
     using namespace prop_kind;
     using namespace utils;
@@ -541,7 +541,7 @@ _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
 
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
-status_t _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init(
+status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init(
         engine_t *engine) {
     status_t st = init_brgemm(engine);
     if (st != status::success) {
@@ -565,7 +565,7 @@ status_t _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init(
 
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
-void _ref_rnn_common_t<aprop, src_type, weights_type,
+void ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::pd_t::init_scratchpad(size_t scratchpad_sz) {
     using namespace memory_tracking::names;
     auto scratchpad = this->scratchpad_registry().registrar();
@@ -641,7 +641,7 @@ void _ref_rnn_common_t<aprop, src_type, weights_type,
 
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
-status_t dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
+status_t dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::init(engine_t *engine) {
     /// @todo set max_feature_size assuming that we limit the number of
     /// iterations and layer to one if slc != dhc and sic != dhc
@@ -745,13 +745,13 @@ status_t dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
 // GEMM functions wrapper definitions
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_gemm_sig((_ref_rnn_fwd_t<src_type, weights_type, acc_type>::gemm)) {
+rnn_gemm_sig((ref_rnn_fwd_t<src_type, weights_type, acc_type>::gemm)) {
     assert(!"non packed gemm is unavailable for this data type");
     return dnnl_unimplemented;
 }
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_gemm_sig((_ref_rnn_bwd_t<src_type, weights_type, acc_type>::gemm)) {
+rnn_gemm_sig((ref_rnn_bwd_t<src_type, weights_type, acc_type>::gemm)) {
     assert(!"non packed gemm is unavailable for this data type");
     return dnnl_unimplemented;
 }
@@ -762,7 +762,7 @@ template rnn_gemm_sig(ref_rnn_bwd_f16_t::gemm);
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 const std::shared_ptr<primitive_t> &
-dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
+dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::get_matmul_layer(cell_position_t cell_position) const {
     const auto &rnn = pd()->rnn_;
     const auto src_ld = rnn.src_layer_ld(cell_position);
@@ -783,7 +783,7 @@ dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 const std::shared_ptr<primitive_t> &
-dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
+dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::get_matmul_iter(cell_position_t cell_position) const {
     const auto &rnn = pd()->rnn_;
     const auto src_ld = rnn.src_iter_ld(cell_position);
@@ -804,7 +804,7 @@ dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
 template <prop_kind_t aprop, impl::data_type_t src_type,
         impl::data_type_t weights_type, impl::data_type_t acc_type>
 const std::shared_ptr<primitive_t> &
-dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
+dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::get_matmul_part2(cell_position_t cell_position) const {
     const auto &rnn = pd()->rnn_;
     const auto ldb = rnn.dst_iter_part2_ld(cell_position);
@@ -827,7 +827,7 @@ dnnl::impl::cpu::_ref_rnn_common_t<aprop, src_type, weights_type,
 
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-rnn_matmul_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
+rnn_matmul_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::execute_matmul)) {
 
     // Service engine is just a global classic CPU engine that is used
@@ -896,13 +896,13 @@ rnn_gemm_sig((ref_rnn_bwd_bf16_t::gemm)) {
 // packed GEMM functions wrapper definitions
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_gemm_sig((_ref_rnn_fwd_t<src_type, weights_type, acc_type>::packed_gemm)) {
+rnn_gemm_sig((ref_rnn_fwd_t<src_type, weights_type, acc_type>::packed_gemm)) {
     assert(!"packed gemm is unavailable for this datatype");
     return dnnl_unimplemented;
 }
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
-rnn_gemm_sig((_ref_rnn_bwd_t<src_type, weights_type, acc_type>::packed_gemm)) {
+rnn_gemm_sig((ref_rnn_bwd_t<src_type, weights_type, acc_type>::packed_gemm)) {
     assert(!"packed gemm is unavailable for this datatype");
     return dnnl_unimplemented;
 }
@@ -957,7 +957,7 @@ rnn_gemm_sig(ref_rnn_fwd_s8s8_t::packed_gemm) {
 //*************** Grid computations strategy: linear ***************//
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-rnn_grid_execution_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
+rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::linear_execution)) {
     const AOC<src_layer_t, 4> ws_states_layer(ws_states_layer_, rnn.n_layer + 1,
             rnn.n_dir, rnn.n_iter + 1,
@@ -1878,7 +1878,7 @@ rnn_bias_prepare_sig_templ(copy_bias_to_ws) {
 
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-rnn_bias_prepare_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
+rnn_bias_prepare_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::bias_prepare)) {
 
     if (rnn.copy_bias) {
@@ -1932,7 +1932,7 @@ static void apply_bias_compensation(const rnn_utils::rnn_conf_t &rnn,
 
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-rnn_bias_finalize_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
+rnn_bias_finalize_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::bias_finalize)) {
     if (rnn.is_unsigned_int8_conf()) {
         const float data_shift = pd()->attr()->rnn_data_qparams_.shift_;
@@ -1949,7 +1949,7 @@ rnn_bias_finalize_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
 
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-rnn_weights_assign_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
+rnn_weights_assign_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::assign_packed_weights)) {
     assert(md->format_kind == format_kind::rnn_packed);
     const auto packed_desc = md->format_desc.rnn_packed_desc;
@@ -1969,7 +1969,7 @@ rnn_weights_assign_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
 
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-rnn_weights_assign_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
+rnn_weights_assign_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         acc_type>::assign_weights)) {
     assert(md->format_kind == format_kind::blocked);
     const auto &blk = md->format_desc.blocking;
@@ -1993,7 +1993,7 @@ rnn_weights_assign_sig((_ref_rnn_common_t<aprop, src_type, weights_type,
 //********************* Execution function *********************//
 template <prop_kind_t aprop, data_type_t src_type, data_type_t weights_type,
         data_type_t acc_type>
-status_t _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
+status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
         const exec_ctx_t &ctx) const {
     const rnn_conf_t &rnn = this->pd()->rnn_;
     auto src_layer = CTX_IN_MEM(const src_layer_t *, DNNL_ARG_SRC_LAYER);
@@ -2386,24 +2386,24 @@ rnn_merged_layer_execution_sig(ref_rnn_fwd_s8s8_t::merged_layer_execution_ref);
 template <>
 rnn_merged_layer_execution_sig(ref_rnn_fwd_s8s8_t::merged_layer_brgemm);
 
-template struct _ref_rnn_common_t<prop_kind::forward, data_type::f32,
+template struct ref_rnn_common_t<prop_kind::forward, data_type::f32,
         data_type::f32, data_type::f32>;
-template struct _ref_rnn_common_t<prop_kind::backward, data_type::f32,
+template struct ref_rnn_common_t<prop_kind::backward, data_type::f32,
         data_type::f32, data_type::f32>;
 
-template struct _ref_rnn_common_t<prop_kind::forward, data_type::bf16,
+template struct ref_rnn_common_t<prop_kind::forward, data_type::bf16,
         data_type::bf16, data_type::f32>;
-template struct _ref_rnn_common_t<prop_kind::backward, data_type::bf16,
+template struct ref_rnn_common_t<prop_kind::backward, data_type::bf16,
         data_type::bf16, data_type::f32>;
 
-template struct _ref_rnn_common_t<prop_kind::forward, data_type::f16,
+template struct ref_rnn_common_t<prop_kind::forward, data_type::f16,
         data_type::f16, data_type::f32>;
-template struct _ref_rnn_common_t<prop_kind::backward, data_type::f16,
+template struct ref_rnn_common_t<prop_kind::backward, data_type::f16,
         data_type::f16, data_type::f32>;
 
-template struct _ref_rnn_common_t<prop_kind::forward, data_type::u8,
+template struct ref_rnn_common_t<prop_kind::forward, data_type::u8,
         data_type::s8, data_type::s32>;
-template struct _ref_rnn_common_t<prop_kind::forward, data_type::s8,
+template struct ref_rnn_common_t<prop_kind::forward, data_type::s8,
         data_type::s8, data_type::s32>;
 
 #undef AOC

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -313,7 +313,7 @@ template <data_type_t type_i>
 struct rnn_weights_reorder_s8_t : public primitive_t {
     struct pd_t : public cpu_reorder_pd_t {
         using cpu_reorder_pd_t::cpu_reorder_pd_t;
-        typedef dnnl_status_t (*gemm_pack_f)(const char *identifier,
+        using gemm_pack_f = dnnl_status_t (*)(const char *identifier,
                 const char *transa, const char *transb, const dim_t *M,
                 const dim_t *N, const dim_t *K, const dim_t *lda,
                 const dim_t *ldb, const void *src, void *dst);

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -33,8 +33,8 @@
 #include "cpu/x64/cpu_isa_traits.hpp"
 #endif
 
-#define rnn_postgemm_sig(f) \
-    void f(const rnn_utils::rnn_conf_t &rnn, \
+#define rnn_postgemm_sig_args \
+    const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, gates_t *ws_gates_, \
             scratch_t *scratch_gates_, const dst_layer_t *augru_attention_, \
             dst_layer_t *dst_layer_, void *dst_iter_c_, \
@@ -44,20 +44,21 @@
             gemm_acc_t *diff_dst_layer_, gemm_acc_t *diff_dst_iter_, \
             gemm_acc_t *diff_dst_iter_c_, const float *weights_peephole_, \
             const void *bias_, gates_t *ws_grid_, scratch_t *scratch_cell_, \
-            dst_iter_t *dst_iter_, float *weights_scales_, int block_step) \
-            const
+            dst_iter_t *dst_iter_, float *weights_scales_, int block_step
+
+#define rnn_postgemm_sig(f) void f(rnn_postgemm_sig_args) const
 
 #if DNNL_X64
-#define rnn_merged_layer_execution_sig(f) \
-    dnnl_status_t f(const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+#define rnn_merged_layer_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, weights_t **w_layer_, \
             const src_layer_t *src_layer_, scratch_t *scratch_gates_, \
             gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_, \
             gemm_acc_t *amx_scratchpad, \
-            x64::brgemm_batch_element_t *addr_batch_global) const
+            x64::brgemm_batch_element_t *addr_batch_global
 
-#define rnn_cell_execution_sig(f) \
-    dnnl_status_t f(const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+#define rnn_cell_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, dst_layer_t *dst_layer_, \
             void *dst_iter_c_, gemm_acc_t *diff_src_layer_, \
             gemm_acc_t *diff_augru_attention_, gemm_acc_t *diff_src_iter_, \
@@ -75,10 +76,10 @@
             scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
             scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
             dst_iter_t *dst_iter_, gemm_acc_t *amx_scratchpad, \
-            x64::brgemm_batch_element_t *addr_batch_global) const
+            x64::brgemm_batch_element_t *addr_batch_global
 
-#define rnn_grid_execution_sig(f) \
-    dnnl_status_t f(const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+#define rnn_grid_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             weights_t **weights_layer_, weights_t **weights_iter_, \
             weights_t **weights_projection_, const float *weights_peephole_, \
             const float *w_proj_comp, void **bias_, \
@@ -98,16 +99,18 @@
             gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
             float *diff_weights_projection_, float *diff_weights_peephole_, \
             float *diff_bias_, gemm_acc_t *amx_scratchpad, \
-            x64::brgemm_batch_element_t *addr_batch_global) const
+            x64::brgemm_batch_element_t *addr_batch_global
+
 #else
-#define rnn_merged_layer_execution_sig(f) \
-    dnnl_status_t f(const rnn_utils::rnn_conf_t &rnn, \
+
+#define rnn_merged_layer_execution_sig_args \
+    const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, weights_t **w_layer_, \
             const src_layer_t *src_layer_, scratch_t *scratch_gates_, \
-            gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_) const
+            gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_
 
-#define rnn_cell_execution_sig(f) \
-    dnnl_status_t f(const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+#define rnn_cell_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, dst_layer_t *dst_layer_, \
             void *dst_iter_c_, gemm_acc_t *diff_src_layer_, \
             gemm_acc_t *diff_augru_attention_, gemm_acc_t *diff_src_iter_, \
@@ -123,10 +126,10 @@
             float *diff_bias_, gates_t *ws_gates_, scratch_t *scratch_gates_, \
             ht_t *proj_ht_, gemm_acc_t *scratch_diff_ht_, gates_t *ws_grid_, \
             scratch_t *scratch_cell_, dst_iter_t *dst_iter_, \
-            gemm_acc_t *amx_scratchpad) const
+            gemm_acc_t *amx_scratchpad
 
-#define rnn_grid_execution_sig(f) \
-    dnnl_status_t f(const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+#define rnn_grid_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             weights_t **weights_layer_, weights_t **weights_iter_, \
             weights_t **weights_projection_, const float *weights_peephole_, \
             const float *w_proj_comp, void **bias_, \
@@ -143,37 +146,55 @@
             scratch_t *scratch_cell_, gemm_acc_t *diff_augru_attention_, \
             gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
             float *diff_weights_projection_, float *diff_weights_peephole_, \
-            float *diff_bias_, gemm_acc_t *amx_scratchpad) const
+            float *diff_bias_, gemm_acc_t *amx_scratchpad
+
 #endif
+
+#define rnn_cell_execution_sig(f) \
+    dnnl_status_t f(rnn_cell_execution_sig_args) const
+
+#define rnn_grid_execution_sig(f) \
+    dnnl_status_t f(rnn_grid_execution_sig_args) const
+
+#define rnn_merged_layer_execution_sig(f) \
+    dnnl_status_t f(rnn_merged_layer_execution_sig_args) const
 
 #define rnn_matmul_sig(f) \
     dnnl_status_t f(const exec_ctx_t &ctx, \
             const std::shared_ptr<dnnl::impl::primitive_t> &matmul_prim, \
             const weights_t *a_, const gemm_data_t *b_, gemm_acc_t *c_) const
 
-#define rnn_gemm_sig(f) \
-    dnnl_status_t f(const char transA, const char transB, dim_t m, dim_t n, \
-            dim_t k, const float alpha, const weights_t *a_, const dim_t ldA, \
+#define rnn_gemm_sig_args \
+    const char transA, const char transB, dim_t m, dim_t n, dim_t k, \
+            const float alpha, const weights_t *a_, const dim_t ldA, \
             const gemm_data_t *b_, const dim_t ldB, const float beta, \
-            gemm_acc_t *c_, const dim_t ldC) const
+            gemm_acc_t *c_, const dim_t ldC
 
-#define rnn_bias_prepare_sig(f) \
-    void f(const rnn_utils::rnn_conf_t &rnn, void **bias_, const void *b_, \
-            void *scratch_bias_) const
+#define rnn_gemm_sig(f) dnnl_status_t f(rnn_gemm_sig_args) const
+
+#define rnn_bias_prepare_sig_args \
+    const rnn_utils::rnn_conf_t &rnn, void **bias_, const void *b_, \
+            void *scratch_bias_
+
+#define rnn_bias_prepare_sig(f) void f(rnn_bias_prepare_sig_args) const
 
 #define rnn_bias_prepare_sig_templ(f) \
     template <typename T> \
     static void f(const rnn_utils::rnn_conf_t &rnn, T **bias_, const T *b_, \
             T *scratch_bias_)
 
-#define rnn_bias_finalize_sig(f) \
-    void f(const rnn_utils::rnn_conf_t &rnn, void *scratch_bias_, \
-            const float *w_iter_comp, const float *w_layer_comp) const
+#define rnn_bias_finalize_sig_args \
+    const rnn_utils::rnn_conf_t &rnn, void *scratch_bias_, \
+            const float *w_iter_comp, const float *w_layer_comp
 
-#define rnn_weights_assign_sig(f) \
-    void f(const rnn_utils::rnn_conf_t &rnn, const memory_desc_t *md, \
-            int n_parts, const int *gates_per_part, weights_t **weights_, \
-            const weights_t *w_) const
+#define rnn_bias_finalize_sig(f) void f(rnn_bias_finalize_sig_args) const
+
+#define rnn_weights_assign_sig_args \
+    const rnn_utils::rnn_conf_t &rnn, const memory_desc_t *md, int n_parts, \
+            const int *gates_per_part, weights_t **weights_, \
+            const weights_t *w_
+
+#define rnn_weights_assign_sig(f) void f(rnn_weights_assign_sig_args) const
 
 namespace dnnl {
 namespace impl {
@@ -1237,8 +1258,8 @@ raw_array_offset_calculator_t<sizeof...(Targs)> make_raw_aoc(
 }
 
 template <typename T>
-struct ws_gates_aoc {
-    ws_gates_aoc(const rnn_conf_t &rnn, T *data)
+struct ws_gates_aoc_t {
+    ws_gates_aoc_t(const rnn_conf_t &rnn, T *data)
         : gates_(data, rnn.ws_gates_nld, rnn.ws_gates_ld), DHC_(rnn.dhc) {}
     T &operator()(int batch, int gate, int dhc) const {
         return gates_(batch, gate * DHC_ + dhc);
@@ -1248,22 +1269,10 @@ private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> gates_;
     const int DHC_;
 };
-using ws_gates_aoc_t = ws_gates_aoc<float>;
-using ws_gates_aoc_s32_t = ws_gates_aoc<int32_t>;
 
 template <typename T>
-struct ws_ht_aoc {
-    ws_ht_aoc(const rnn_conf_t &rnn, T *data)
-        : ht_(data, rnn.ws_ht_nld, rnn.ws_ht_ld) {}
-    T &operator()(int batch, int dhc) const { return ht_(batch, dhc); }
-
-private:
-    const dnnl::impl::utils::array_offset_calculator<T, 2> ht_;
-};
-
-template <typename T>
-struct scratch_gates_aoc {
-    scratch_gates_aoc(const rnn_conf_t &rnn, T *data)
+struct scratch_gates_aoc_t {
+    scratch_gates_aoc_t(const rnn_conf_t &rnn, T *data)
         : gates_(data, rnn.scratch_gates_nld, rnn.scratch_gates_ld)
         , DHC_(rnn.dhc) {}
     T &operator()(int batch, int gate, int dhc) const {
@@ -1274,20 +1283,6 @@ private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> gates_;
     const int DHC_;
 };
-using scratch_gates_aoc_t = scratch_gates_aoc<float>;
-using scratch_gates_aoc_s32_t = scratch_gates_aoc<int32_t>;
-
-template <typename T>
-struct scratch_ht_aoc {
-    scratch_ht_aoc(const rnn_conf_t &rnn, T *data)
-        : ht_(data, rnn.scratch_ht_nld, rnn.scratch_ht_ld) {}
-    T &operator()(int batch, int dhc) const { return ht_(batch, dhc); }
-
-private:
-    const dnnl::impl::utils::array_offset_calculator<T, 2> ht_;
-};
-using scratch_ht_aoc_t = scratch_ht_aoc<float>;
-using scratch_ht_aoc_s32_t = scratch_ht_aoc<int32_t>;
 
 template <typename T>
 struct weights_peephole_aoc_t {
@@ -1368,10 +1363,10 @@ private:
 };
 
 template <typename T>
-struct ws_states_layer_aoc {
-    ws_states_layer_aoc(const rnn_conf_t &rnn, T *data, int leading_dim)
+struct ws_states_layer_aoc_t {
+    ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data, int leading_dim)
         : state_(data, rnn.ws_states_layer_nld, leading_dim) {}
-    ws_states_layer_aoc(const rnn_conf_t &rnn, T *data)
+    ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.ws_states_layer_nld, rnn.ws_states_layer_ld) {}
     T &operator()(int batch, int dhc) const { return state_(batch, dhc); }
 
@@ -1380,10 +1375,10 @@ private:
 };
 
 template <typename T>
-struct ws_states_iter_aoc {
-    ws_states_iter_aoc(const rnn_conf_t &rnn, T *data, int leading_dim)
+struct ws_states_iter_aoc_t {
+    ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data, int leading_dim)
         : state_(data, rnn.ws_states_iter_nld, leading_dim) {}
-    ws_states_iter_aoc(const rnn_conf_t &rnn, T *data)
+    ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.ws_states_iter_nld, rnn.ws_states_iter_ld) {}
     T &operator()(int batch, int dhc) const { return state_(batch, dhc); }
 
@@ -1392,8 +1387,8 @@ private:
 };
 
 template <typename T>
-struct augru_attention_aoc {
-    augru_attention_aoc(const rnn_conf_t &rnn, T *data)
+struct augru_attention_aoc_t {
+    augru_attention_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.mb) {}
     T &operator()(int batch) const { return state_(batch); }
 
@@ -1402,8 +1397,8 @@ private:
 };
 
 template <typename T>
-struct ws_diff_states_layer_aoc {
-    ws_diff_states_layer_aoc(const rnn_conf_t &rnn, T *data)
+struct ws_diff_states_layer_aoc_t {
+    ws_diff_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_layer_(data, rnn.ws_diff_states_layer_nld,
                 rnn.ws_diff_states_layer_ld) {}
     T &operator()(int batch, int dhc) const {
@@ -1415,8 +1410,8 @@ private:
 };
 
 template <typename T>
-struct ws_diff_states_iter_aoc {
-    ws_diff_states_iter_aoc(const rnn_conf_t &rnn, T *data)
+struct ws_diff_states_iter_aoc_t {
+    ws_diff_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_(data, rnn.ws_diff_states_iter_nld,
                 rnn.ws_diff_states_iter_ld) {}
     T &operator()(int batch, int dhc) const {
@@ -1428,8 +1423,8 @@ private:
 };
 
 template <typename T>
-struct ws_diff_states_iter_c_aoc {
-    ws_diff_states_iter_c_aoc(const rnn_conf_t &rnn, T *data)
+struct ws_diff_states_iter_c_aoc_t {
+    ws_diff_states_iter_c_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_c_(data, rnn.ws_diff_states_iter_c_nld,
                 rnn.ws_diff_states_iter_c_ld) {}
     T &operator()(int batch, int dhc) const {

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -27,6 +27,9 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
+// NOLINTBEGIN(modernize-use-using)
+// GCC treats using and typedef differently for enums and structs
+// https://stackoverflow.com/questions/48613758
 // The type defines organization of batch of matrices
 typedef enum {
     // Undefined brgemm batch kind
@@ -56,13 +59,6 @@ typedef enum {
     per_k = 4,
 } brgemm_broadcast_t;
 
-struct brgemm_strides_t {
-    // Stride between A matrices
-    dim_t stride_a;
-    // Stride between B matrices
-    dim_t stride_b;
-};
-
 typedef enum {
     brgemm_lo_default = 0,
     brgemm_lo_bl_1load,
@@ -88,6 +84,14 @@ typedef enum {
     brgemm_hint_nt_false,
     brgemm_hint_nt_true,
 } brgemm_kernel_hint_nt_t;
+// NOLINTEND(modernize-use-using)
+
+struct brgemm_strides_t {
+    // Stride between A matrices
+    dim_t stride_a;
+    // Stride between B matrices
+    dim_t stride_b;
+};
 
 struct brgemm_prf_t {
     int dist0 {-1};

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -88,41 +88,32 @@ gemm_info_t<a_t, b_t, c_t>::gemm_info_t(const char *transA, const char *transB,
         const float *alpha, const a_t *a, const dim_t *lda, const a_t *oa,
         const b_t *b, const dim_t *ldb, const b_t *ob, const float *beta,
         c_t *c, const dim_t *ldc, const c_t *oc, bool force_nocopy,
-        pack_type packing, gemm_pack_storage_t *pack_dst, bool measure_only) {
-
-    this->transa = decode_trans(*transA);
-    this->transb = decode_trans(*transB);
-
-    this->m = *m;
-    this->n = *n;
-    this->k = *k;
-
-    this->a = a;
-    this->b = b;
-    this->c = c;
-
-    this->lda = lda ? *lda : 0;
-    this->ldb = ldb ? *ldb : 0;
-    this->ldc = ldc ? *ldc : 0;
-
-    this->ao = 0;
-    this->bo = 0;
-    this->co = nullptr;
-
-    this->alpha = alpha ? *alpha : 1.0f;
-    this->beta = beta ? *beta : 1.0f;
-
-    this->offsetc = offset_type::none;
-
-    this->packing = packing;
-    this->pack_dst = pack_dst;
-    this->measure_only
-            = measure_only && pack_dst && (packing != pack_type::none);
+        pack_type packing, gemm_pack_storage_t *pack_dst, bool measure_only)
+    : transa(decode_trans(*transA))
+    , transb(decode_trans(*transB))
+    , offsetc(offset_type::none)
+    , m(*m)
+    , n(*n)
+    , k(*k)
+    , lda(lda ? *lda : 0)
+    , ldb(ldb ? *ldb : 0)
+    , ldc(ldc ? *ldc : 0)
+    , a(a)
+    , b(b)
+    , c(c)
+    , alpha(alpha ? *alpha : 1.0f)
+    , beta(beta ? *beta : 1.0f)
+    , ao(0)
+    , bo(0)
+    , co(nullptr)
+    , packing(packing)
+    , pack_dst(pack_dst)
+    , measure_only(measure_only && pack_dst && (packing != pack_type::none)) {
 
     if (this->transa == packed) {
         dim_t cols;
 
-        this->a_packed.reset(new gemm_pack_storage_t(a));
+        this->a_packed = std::make_shared<gemm_pack_storage_t>(a);
         if (this->a_packed->get_nocopy(this->transa, this->lda, cols)) {
             this->a = this->a_packed->template matrix<a_t>();
             this->a_packed = nullptr;
@@ -131,7 +122,7 @@ gemm_info_t<a_t, b_t, c_t>::gemm_info_t(const char *transA, const char *transB,
     if (this->transb == packed) {
         dim_t rows;
 
-        this->b_packed.reset(new gemm_pack_storage_t(b));
+        this->b_packed = std::make_shared<gemm_pack_storage_t>(b);
         if (this->b_packed->get_nocopy(this->transb, this->ldb, rows)) {
             this->b = this->b_packed->template matrix<b_t>();
             this->b_packed = nullptr;

--- a/src/cpu/x64/gemm/gemm_partition.hpp
+++ b/src/cpu/x64/gemm/gemm_partition.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2023 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -136,8 +136,6 @@ static inline void partition_2d(const int ithr, int *nthrs, const int ithr_i,
         out_m_band = 0;
         out_n_band = 0;
     }
-
-    return;
 }
 
 static inline std::tuple<int, int> partition_2d_minblk_with_primes(dim_t m,

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -87,7 +87,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 
     const auto &post_ops = jcp_.post_ops;
     if (jcp_.with_eltwise || jcp_.with_binary) {
-#define PARAM_OFF(field) offsetof(ker_args, field)
+#define PARAM_OFF(field) offsetof(ker_args_t, field)
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
         static constexpr size_t helper_vmm_idx = 31;
@@ -136,7 +136,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 template <data_type_t dst_data_type>
 void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::apply_postops(
         const bool apply_mask, const size_t out_offset, const int vmm_idx) {
-#define PARAM_OFF(x) offsetof(ker_args, x)
+#define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
             binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
@@ -163,7 +163,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
     mov(reg_param, rcx);
 #endif
 
-#define PARAM_OFF(x) offsetof(ker_args, x)
+#define PARAM_OFF(x) offsetof(ker_args_t, x)
     mov(reg_dst_base, ptr[reg_param + PARAM_OFF(dst)]);
     mov(reg_acc_base, ptr[reg_param + PARAM_OFF(acc)]);
     if (jcp_.with_bias) mov(reg_bias, ptr[reg_param + PARAM_OFF(bias)]);
@@ -304,7 +304,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::operator()(
         const void *post_ops_binary_rhs_arg_vec, const void *dst_orig,
         const size_t g_oc_offset) {
 
-    ker_args args;
+    ker_args_t args;
     args.acc = acc;
     args.dst = dst;
     args.bias = bias;
@@ -330,7 +330,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::operator()(
         const size_t g_oc_offset) {
     if (sp_len == 0) return;
 
-    ker_args args;
+    ker_args_t args;
     args.acc = acc;
     args.dst = dst;
     args.bias = bias;

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -147,19 +147,19 @@ private:
                 const size_t g_oc_offset);
 
     private:
-        struct ker_args {
-            dst_data_t *dst;
-            const acc_data_t *acc;
-            const acc_data_t *bias;
-            float sum_scale;
-            size_t dst_stride_in_bytes;
-            size_t acc_stride_in_bytes;
-            size_t spatial_length;
-            size_t oc_work;
+        struct ker_args_t {
+            dst_data_t *dst = nullptr;
+            const acc_data_t *acc = nullptr;
+            const acc_data_t *bias = nullptr;
+            float sum_scale = 0.f;
+            size_t dst_stride_in_bytes = 0;
+            size_t acc_stride_in_bytes = 0;
+            size_t spatial_length = 0;
+            size_t oc_work = 0;
 
-            size_t g_oc_offset;
-            const void *post_ops_binary_rhs_arg_vec;
-            const void *dst_orig;
+            size_t g_oc_offset = 0;
+            const void *post_ops_binary_rhs_arg_vec = nullptr;
+            const void *dst_orig = nullptr;
         };
 
         enum { default_unroll_2_pow_ = 2 };

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -45,7 +45,7 @@ using namespace dnnl::impl::utils;
 
 using namespace Xbyak;
 
-jit_avx2_1x1_conv_kernel_f32::jit_avx2_1x1_conv_kernel_f32(
+jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), avx2), jcp(ajcp), attr_(attr) {
@@ -70,7 +70,7 @@ jit_avx2_1x1_conv_kernel_f32::jit_avx2_1x1_conv_kernel_f32(
     }
 }
 
-void jit_avx2_1x1_conv_kernel_f32::generate_bcast_loop(int load_loop_blk) {
+void jit_avx2_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     mov(aux1_reg_bcast_data, ptr[rsp + reg_bcast_data_off]);
     mov(aux_reg_output_data, reg_output_data);
     mov(bcast_loop_iter, reg_bcast_loop_work);
@@ -145,7 +145,7 @@ void iterate(const int load_loop_blk, const int ur, const F &f) {
     iterate(load_loop_blk, ur, 0, f);
 }
 
-void jit_avx2_1x1_conv_kernel_f32::apply_postops(
+void jit_avx2_1x1_conv_kernel_f32_t::apply_postops(
         const int load_loop_blk, const int ur, const int load_dim_tail) {
     if (jcp.with_eltwise || jcp.with_binary) {
         assert(ur * load_loop_blk < 14);
@@ -216,7 +216,7 @@ void jit_avx2_1x1_conv_kernel_f32::apply_postops(
     }
 };
 
-void jit_avx2_1x1_conv_kernel_f32::generate_reduce_loop(
+void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         int load_loop_blk, int ur) {
     const int load_dim_tail
             = ((jcp.with_binary
@@ -507,7 +507,8 @@ void jit_avx2_1x1_conv_kernel_f32::generate_reduce_loop(
     store();
 }
 
-void jit_avx2_1x1_conv_kernel_f32::generate_diff_bias_loop(int load_loop_blk) {
+void jit_avx2_1x1_conv_kernel_f32_t::generate_diff_bias_loop(
+        int load_loop_blk) {
     if (!jcp.with_bias || jcp.prop_kind != backward_weights) return;
 
     Label diff_bias_loop, diff_bias_loop_out, diff_bias_init_out;
@@ -563,7 +564,7 @@ void jit_avx2_1x1_conv_kernel_f32::generate_diff_bias_loop(int load_loop_blk) {
     L(diff_bias_loop_out);
 }
 
-void jit_avx2_1x1_conv_kernel_f32::generate() {
+void jit_avx2_1x1_conv_kernel_f32_t::generate() {
     preamble();
 
     sub(rsp, stack_space_needed);
@@ -683,7 +684,7 @@ void jit_avx2_1x1_conv_kernel_f32::generate() {
         postops_injector_->prepare_table(/* generate = */ true);
 }
 
-status_t jit_avx2_1x1_conv_kernel_f32::init_conf(jit_1x1_conv_conf_t &jcp,
+status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &weights_d, const memory_desc_wrapper &dst_d,
         const primitive_attr_t &attr) {
@@ -1014,7 +1015,7 @@ status_t jit_avx2_1x1_conv_kernel_f32::init_conf(jit_1x1_conv_conf_t &jcp,
     return status::success;
 }
 
-void jit_avx2_1x1_conv_kernel_f32::init_scratchpad(
+void jit_avx2_1x1_conv_kernel_f32_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad,
         const jit_1x1_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -32,7 +32,7 @@
 #include "cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp"
 #include "cpu/x64/jit_uni_1x1_conv_utils.hpp"
 
-#define GET_OFF(field) offsetof(jit_1x1_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_1x1_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
@@ -30,10 +30,10 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_avx2_1x1_conv_kernel_f32 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_1x1_conv_kernel_f32)
+struct jit_avx2_1x1_conv_kernel_f32_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_1x1_conv_kernel_f32_t)
 
-    jit_avx2_1x1_conv_kernel_f32(const jit_1x1_conv_conf_t &ajcp,
+    jit_avx2_1x1_conv_kernel_f32_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -109,7 +109,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     const int nb_ic = jcp.nb_reduce;
     const int nb_ic_blocking = jcp.nb_reduce_blocking;
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
     auto rp = rtus_driver_t<avx2>::call_params_t();
 
     // override some constants for fused dw_conv
@@ -271,7 +271,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
             const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            jit_conv_call_s par_conv_dw;
+            jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
@@ -405,7 +405,7 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
     };
 
     auto ker = [&](const int ithr, const int nthr) {
-        auto p = jit_1x1_conv_call_s();
+        auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx2>::call_params_t();
 
         int start {0}, end {0};
@@ -582,7 +582,7 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                  data_t *store_to, size_t store_to_ld,
                                  const data_t *diff_dst, const data_t *src,
                                  int ithr) {
-        auto p = jit_1x1_conv_call_s();
+        auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx2>::call_params_t();
 
         p.output_stride = store_to_ld * sizeof(float);

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -493,7 +493,7 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
 
 status_t jit_avx2_1x1_convolution_bwd_weights_t::init(engine_t *engine) {
     CHECK(safe_ptr_assign(kernel_,
-            new jit_avx2_1x1_conv_kernel_f32(
+            new jit_avx2_1x1_conv_kernel_f32_t(
                     pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
     CHECK(kernel_->create_kernel());
 

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -91,6 +91,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             return cpu_convolution_fwd_pd_t::dst_md(index);
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *dst_md(
                 int index = 0, bool user_input = false) const override {
             return dw_conv_pd_ && jcp_.with_dw_conv
@@ -113,6 +114,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             }
             return convolution_fwd_pd_t::arg_md(arg, user_input);
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -75,12 +75,12 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx2_1x1_conv_kernel_f32::init_conf(
+            CHECK(jit_avx2_1x1_conv_kernel_f32_t::init_conf(
                     jcp_, *conv_d, *src_d, *weights_md(), *dst_md(), *attr()));
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx2_1x1_conv_kernel_f32::init_scratchpad(scratchpad, jcp_);
+            jit_avx2_1x1_conv_kernel_f32_t::init_scratchpad(scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
 
@@ -314,7 +314,7 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx2_1x1_conv_kernel_f32(
+                new jit_avx2_1x1_conv_kernel_f32_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_1x1_md(0))));
         CHECK(kernel_->create_kernel());
         CHECK(init_rtus_driver<avx2>(this));
@@ -354,11 +354,11 @@ private:
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx2_1x1_conv_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx2_1x1_conv_kernel_f32_t> kernel_;
     std::unique_ptr<rtus_driver_t<avx2>> rtus_driver_;
 
     template <cpu_isa_t isa>
-    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel<isa, data_type::f32>;
+    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_t<isa, data_type::f32>;
 
     std::unique_ptr<dw_conv_kernel_t<avx2>> kernel_dw_avx2;
     std::unique_ptr<dw_conv_kernel_t<sse41>> kernel_dw_sse41;
@@ -393,11 +393,11 @@ struct jit_avx2_1x1_convolution_bwd_data_t : public primitive_t {
             rtus_prepare(this, conv_d, diff_src_d, diff_dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx2_1x1_conv_kernel_f32::init_conf(jcp_, *conv_d,
+            CHECK(jit_avx2_1x1_conv_kernel_f32_t::init_conf(jcp_, *conv_d,
                     *diff_src_d, *weights_md(), *diff_dst_md(), *attr()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx2_1x1_conv_kernel_f32::init_scratchpad(scratchpad, jcp_);
+            jit_avx2_1x1_conv_kernel_f32_t::init_scratchpad(scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
 
@@ -445,7 +445,7 @@ struct jit_avx2_1x1_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx2_1x1_conv_kernel_f32(
+                new jit_avx2_1x1_conv_kernel_f32_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         CHECK(kernel_->create_kernel());
         CHECK(init_rtus_driver<avx2>(this));
@@ -461,7 +461,7 @@ private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx2_1x1_conv_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx2_1x1_conv_kernel_f32_t> kernel_;
     std::unique_ptr<rtus_driver_t<avx2>> rtus_driver_;
 };
 
@@ -494,13 +494,13 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, diff_dst_md(), diff_weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx2_1x1_conv_kernel_f32::init_conf(jcp_, *conv_d, *src_d,
-                    *diff_weights_md(), *diff_dst_md(), *attr()));
+            CHECK(jit_avx2_1x1_conv_kernel_f32_t::init_conf(jcp_, *conv_d,
+                    *src_d, *diff_weights_md(), *diff_dst_md(), *attr()));
 
             init_balancers();
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx2_1x1_conv_kernel_f32::init_scratchpad(scratchpad, jcp_);
+            jit_avx2_1x1_conv_kernel_f32_t::init_scratchpad(scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
 
@@ -601,7 +601,7 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx2_1x1_conv_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx2_1x1_conv_kernel_f32_t> kernel_;
     std::unique_ptr<cpu_reducer_2d_t<data_type::f32>> reducer_weights_;
     std::unique_ptr<cpu_reducer_t<data_type::f32>> reducer_bias_;
     std::unique_ptr<rtus_driver_t<avx2>> rtus_driver_;

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -29,7 +29,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_avx2_conv_kernel_f32.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -50,7 +50,7 @@ bool tag_is_flat(format_tag_t tag, format_tag_t ncx, format_tag_t nxc, int ic) {
 }
 } // namespace
 
-jit_avx2_conv_fwd_kernel_f32::jit_avx2_conv_fwd_kernel_f32(
+jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), avx2), jcp(ajcp), attr_(attr) {
@@ -75,7 +75,7 @@ jit_avx2_conv_fwd_kernel_f32::jit_avx2_conv_fwd_kernel_f32(
     }
 }
 
-void jit_avx2_conv_fwd_kernel_f32::oh_step_unroll_kw(
+void jit_avx2_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     int kw = jcp.kw;
     int stride_w = jcp.stride_w;
@@ -140,7 +140,7 @@ void jit_avx2_conv_fwd_kernel_f32::oh_step_unroll_kw(
     }
 }
 
-void jit_avx2_conv_fwd_kernel_f32::oh_step_nopad(
+void jit_avx2_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
@@ -206,7 +206,7 @@ void iterate(const int load_loop_blk, const int ur, const F &f) {
     iterate(load_loop_blk, ur, 0, f);
 }
 
-void jit_avx2_conv_fwd_kernel_f32::apply_postops(
+void jit_avx2_conv_fwd_kernel_f32_t::apply_postops(
         const int oc_blocks, const int ur_w, const int oc_tail) {
     if (jcp.with_eltwise || jcp.with_binary) {
         Label regular_store;
@@ -257,7 +257,7 @@ void jit_avx2_conv_fwd_kernel_f32::apply_postops(
     }
 }
 
-void jit_avx2_conv_fwd_kernel_f32::width_blk_step(
+void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     int kw = jcp.kw;
     int oc_blk = jcp.oc_block;
@@ -488,7 +488,7 @@ void jit_avx2_conv_fwd_kernel_f32::width_blk_step(
     if (oc_tail) pop(reg_oc_blocks);
 }
 
-inline void jit_avx2_conv_fwd_kernel_f32::solve_common(int oc_blocks) {
+inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
     int n_oi = jcp.ow / ur_w;
@@ -537,7 +537,7 @@ inline void jit_avx2_conv_fwd_kernel_f32::solve_common(int oc_blocks) {
         width_blk_step(ur_w_tail, 0, r_pad, oc_blocks); // "tail"
 }
 
-void jit_avx2_conv_fwd_kernel_f32::generate() {
+void jit_avx2_conv_fwd_kernel_f32_t::generate() {
     this->preamble();
 
     mov(reg_input, ptr[this->param1 + GET_OFF(src)]);
@@ -582,7 +582,7 @@ void jit_avx2_conv_fwd_kernel_f32::generate() {
         postops_injector_->prepare_table(/* generate = */ true);
 }
 
-status_t jit_avx2_conv_fwd_kernel_f32::init_conf(jit_conv_conf_t &jcp,
+status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &weights_d, const memory_desc_wrapper &dst_d,
         const primitive_attr_t &attr) {
@@ -838,13 +838,13 @@ status_t jit_avx2_conv_fwd_kernel_f32::init_conf(jit_conv_conf_t &jcp,
     return status::success;
 }
 
-void jit_avx2_conv_fwd_kernel_f32::init_scratchpad(
+void jit_avx2_conv_fwd_kernel_f32_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     if (jcp.with_bias && jcp.oc != jcp.oc_without_padding)
         scratchpad.book<float>(key_conv_padded_bias, jcp.oc);
 }
 
-void jit_avx2_conv_bwd_data_kernel_f32::compute_loop(
+void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
         int ur_w, int l_overflow, int r_overflow) {
     int kw = jcp.kw;
     int ow = jcp.ow;
@@ -1046,7 +1046,7 @@ void jit_avx2_conv_bwd_data_kernel_f32::compute_loop(
     }
 }
 
-void jit_avx2_conv_bwd_data_kernel_f32::generate() {
+void jit_avx2_conv_bwd_data_kernel_f32_t::generate() {
     preamble();
 
     mov(reg_dsrc, ptr[this->param1 + GET_OFF(src)]);
@@ -1111,7 +1111,7 @@ void jit_avx2_conv_bwd_data_kernel_f32::generate() {
     this->postamble();
 }
 
-status_t jit_avx2_conv_bwd_data_kernel_f32::init_conf(jit_conv_conf_t &jcp,
+status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &diff_src_d,
         const memory_desc_wrapper &weights_d,
         const memory_desc_wrapper &diff_dst_d) {
@@ -1321,13 +1321,13 @@ status_t jit_avx2_conv_bwd_data_kernel_f32::init_conf(jit_conv_conf_t &jcp,
     return status::success;
 }
 
-void jit_avx2_conv_bwd_data_kernel_f32::init_scratchpad(
+void jit_avx2_conv_bwd_data_kernel_f32_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     UNUSED(scratchpad);
     UNUSED(jcp);
 }
 
-void jit_avx2_conv_bwd_weights_kernel_f32::generate() {
+void jit_avx2_conv_bwd_weights_kernel_f32_t::generate() {
     this->preamble();
 
     mov(reg_input, ptr[this->param1 + GET_OFF(src)]);
@@ -1337,7 +1337,7 @@ void jit_avx2_conv_bwd_weights_kernel_f32::generate() {
     this->postamble();
 }
 
-status_t jit_avx2_conv_bwd_weights_kernel_f32::init_conf(jit_conv_conf_t &jcp,
+status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &diff_weights_d,
         const memory_desc_wrapper &diff_dst_d) {
@@ -1478,7 +1478,7 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32::init_conf(jit_conv_conf_t &jcp,
     return status::success;
 }
 
-void jit_avx2_conv_bwd_weights_kernel_f32::init_scratchpad(
+void jit_avx2_conv_bwd_weights_kernel_f32_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     if (jcp.with_bias && (jcp.oc_without_padding % jcp.oc_block != 0)) {
         const size_t nelems_padded_bias
@@ -1487,7 +1487,8 @@ void jit_avx2_conv_bwd_weights_kernel_f32::init_scratchpad(
     }
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::od_step_comeback_pointers() {
+inline void
+jit_avx2_conv_bwd_weights_kernel_f32_t::od_step_comeback_pointers() {
     Label kd_comeback_loop;
     mov(kj, jcp.kd); //FIXME (Anton): this works only if f_pad = back_pad = 0
     L(kd_comeback_loop);
@@ -1500,7 +1501,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32::od_step_comeback_pointers() {
     }
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::oh_step_comeback_pointers() {
+inline void
+jit_avx2_conv_bwd_weights_kernel_f32_t::oh_step_comeback_pointers() {
     mov(kj, reg_kh);
     Label kh_comeback_loop;
     L(kh_comeback_loop);
@@ -1513,7 +1515,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32::oh_step_comeback_pointers() {
     }
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_ic_block_step(
+inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
         int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
         int kernel_offset, int output_offset) {
 
@@ -1597,7 +1599,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_ic_block_step(
     if (oc_tail) pop(reg_kh);
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_step_disp() {
+inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
     int ic_block_step;
     if (one_of(jcp.src_tag, ncw, nchw, ncdhw)) {
         ic_block_step = jcp.kw >= 5 ? 1 : jcp.ic_block;
@@ -1627,7 +1629,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_step_disp() {
     }
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_step_unroll_ow(
+inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         int ic_block_step, int max_ur_w) {
     UNUSED(max_ur_w);
 
@@ -1732,7 +1734,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_step_unroll_ow(
     if (ic_tail) pop(reg_ih_count);
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_step_common(
+inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step, int max_ur_w) {
     // TODO: suppport channel tails for nxc format
 
@@ -1832,7 +1834,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_step_common(
     }
 }
 
-inline void jit_avx2_conv_bwd_weights_kernel_f32::compute_oh_loop_common() {
+inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
     const int t_pad = jcp.t_pad;
     const int stride_h = jcp.stride_h;
     int b_pad = jcp.b_pad;

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
@@ -30,11 +30,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_avx2_conv_fwd_kernel_f32 : public jit_generator_t {
-    jit_avx2_conv_fwd_kernel_f32(const jit_conv_conf_t &ajcp,
+struct jit_avx2_conv_fwd_kernel_f32_t : public jit_generator_t {
+    jit_avx2_conv_fwd_kernel_f32_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_fwd_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_fwd_kernel_f32_t)
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
@@ -146,10 +146,10 @@ private:
     void generate() override;
 };
 
-struct jit_avx2_conv_bwd_data_kernel_f32 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_bwd_data_kernel_f32)
+struct jit_avx2_conv_bwd_data_kernel_f32_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_bwd_data_kernel_f32_t)
 
-    jit_avx2_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_avx2_conv_bwd_data_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp) {}
 
     static status_t init_conf(jit_conv_conf_t &jcp,
@@ -257,10 +257,10 @@ private:
     }
 };
 
-struct jit_avx2_conv_bwd_weights_kernel_f32 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_bwd_weights_kernel_f32)
+struct jit_avx2_conv_bwd_weights_kernel_f32_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx2_conv_bwd_weights_kernel_f32_t)
 
-    jit_avx2_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_avx2_conv_bwd_weights_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp) {}
 
     static status_t init_conf(jit_conv_conf_t &jcp,

--- a/src/cpu/x64/jit_avx2_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2023 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 int ocb_num = jcp.nb_oc_blocking;
 
                 for (int icb = icbb; icb < icbb + icb_step; ++icb) {
-                    auto par_conv = jit_conv_call_s();
+                    auto par_conv = jit_conv_args_t();
 
                     const int ij = oh * jcp.stride_h;
                     const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
@@ -249,7 +249,7 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
             for (int id = 0; id < jcp.id; ++id) {
                 int cur_nb_oc = nstl::min(jcp.nb_oc - oc, jcp.nb_oc_blocking);
 
-                auto par_conv = jit_conv_call_s();
+                auto par_conv = jit_conv_args_t();
 
                 int d_t_overflow, d_b_overflow, od;
                 if (jcp.dilate_d != 0) { // stride == 1
@@ -435,7 +435,7 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                         const int id = od * jcp.stride_d;
                         if (id >= jcp.id - jcp.back_pad - jcp.kd + 1) break;
 
-                        auto par_conv = jit_conv_call_s();
+                        auto par_conv = jit_conv_args_t();
                         par_conv.src
                                 = &src[src_blk_off(src_d, img, _ic, id, 0, 0)];
                         par_conv.dst = &diff_dst[src_blk_off(

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -59,11 +59,11 @@ struct jit_avx2_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx2_conv_fwd_kernel_f32::init_conf(
+            CHECK(jit_avx2_conv_fwd_kernel_f32_t::init_conf(
                     jcp_, *desc(), src_md(), weights_md(), dst_md(), *attr()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx2_conv_fwd_kernel_f32::init_scratchpad(scratchpad, jcp_);
+            jit_avx2_conv_fwd_kernel_f32_t::init_scratchpad(scratchpad, jcp_);
 
             return status::success;
         }
@@ -113,7 +113,7 @@ struct jit_avx2_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx2_conv_fwd_kernel_f32(
+                new jit_avx2_conv_fwd_kernel_f32_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         return kernel_->create_kernel();
     }
@@ -127,7 +127,7 @@ private:
     void execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx2_conv_fwd_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx2_conv_fwd_kernel_f32_t> kernel_;
 };
 
 struct jit_avx2_convolution_bwd_data_t : public primitive_t {
@@ -153,11 +153,11 @@ struct jit_avx2_convolution_bwd_data_t : public primitive_t {
             VDISPATCH_CONV(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx2_conv_bwd_data_kernel_f32::init_conf(jcp_, *desc(),
+            CHECK(jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jcp_, *desc(),
                     *diff_src_md(), *weights_md(), *diff_dst_md()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx2_conv_bwd_data_kernel_f32::init_scratchpad(
+            jit_avx2_conv_bwd_data_kernel_f32_t::init_scratchpad(
                     scratchpad, jcp_);
 
             return status::success;
@@ -201,7 +201,7 @@ struct jit_avx2_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(
-                kernel_, new jit_avx2_conv_bwd_data_kernel_f32(pd()->jcp_)));
+                kernel_, new jit_avx2_conv_bwd_data_kernel_f32_t(pd()->jcp_)));
         return kernel_->create_kernel();
     }
 
@@ -214,7 +214,7 @@ private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx2_conv_bwd_data_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx2_conv_bwd_data_kernel_f32_t> kernel_;
 };
 
 struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
@@ -240,13 +240,13 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
             VDISPATCH_CONV(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx2_conv_bwd_weights_kernel_f32::init_conf(jcp_, *desc(),
-                    *src_md(), *diff_weights_md(), *diff_dst_md()));
+            CHECK(jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jcp_,
+                    *desc(), *src_md(), *diff_weights_md(), *diff_dst_md()));
 
             init_balancers();
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx2_conv_bwd_weights_kernel_f32::init_scratchpad(
+            jit_avx2_conv_bwd_weights_kernel_f32_t::init_scratchpad(
                     scratchpad, jcp_);
 
             auto reducer_bia_scratchpad = memory_tracking::registrar_t(
@@ -323,8 +323,8 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
     using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override {
-        CHECK(safe_ptr_assign(
-                kernel_, new jit_avx2_conv_bwd_weights_kernel_f32(pd()->jcp_)));
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_avx2_conv_bwd_weights_kernel_f32_t(pd()->jcp_)));
         CHECK(safe_ptr_assign(reducer_bias_,
                 new cpu_reducer_t<data_type::f32>(pd()->reducer_bia_conf_)));
         CHECK(safe_ptr_assign(reducer_weights_,
@@ -344,7 +344,7 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx2_conv_bwd_weights_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx2_conv_bwd_weights_kernel_f32_t> kernel_;
     std::unique_ptr<cpu_reducer_t<data_type::f32>> reducer_weights_,
             reducer_bias_;
 };

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -34,7 +34,7 @@
 #include "cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp"
 #include "cpu/x64/jit_uni_1x1_conv_utils.hpp"
 
-#define GET_OFF(field) offsetof(jit_1x1_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_1x1_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
@@ -29,11 +29,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_avx512_common_1x1_conv_kernel : public jit_generator_t {
-    jit_avx512_common_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+struct jit_avx512_common_1x1_conv_kernel_t : public jit_generator_t {
+    jit_avx512_common_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_common_1x1_conv_kernel)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_common_1x1_conv_kernel_t)
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2023 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -602,7 +602,7 @@ REG_AVX512_ISA(template struct jit_avx512_common_1x1_convolution_bwd_data_t<
 status_t jit_avx512_common_1x1_convolution_bwd_weights_t ::init(
         engine_t *engine) {
     CHECK(safe_ptr_assign(kernel_,
-            new jit_avx512_common_1x1_conv_kernel(
+            new jit_avx512_common_1x1_conv_kernel_t(
                     pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
     CHECK(safe_ptr_assign(
             acc_ker_, new cpu_accumulator_1d_t<data_type::f32>()));

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -111,7 +111,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
@@ -343,7 +343,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
             const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            jit_conv_call_s par_conv_dw;
+            jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
@@ -481,7 +481,7 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
     };
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
-        auto p = jit_1x1_conv_call_s();
+        auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
         int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
@@ -791,7 +791,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                 img, oc_off_idx)];
                         const data_t *local_src = diff_src;
 
-                        auto p = jit_1x1_conv_call_s();
+                        auto p = jit_1x1_conv_args_t();
                         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
                         p.output_stride = utils::rnd_up(jcp.ic, jcp.ic_block)

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -95,6 +95,7 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             return cpu_convolution_fwd_pd_t::dst_md(index);
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *dst_md(
                 int index = 0, bool user_input = false) const override {
             return dw_conv_pd_ && jcp_.with_dw_conv
@@ -117,6 +118,7 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             }
             return convolution_fwd_pd_t::arg_md(arg, user_input);
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -77,13 +77,13 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_common_1x1_conv_kernel::init_conf(jcp_, *conv_d,
+            CHECK(jit_avx512_common_1x1_conv_kernel_t::init_conf(jcp_, *conv_d,
                     *src_d, *weights_md(), *dst_md(), *attr(),
                     dnnl_get_max_threads(), rtus_.reduce_src_));
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_common_1x1_conv_kernel::init_scratchpad(
+            jit_avx512_common_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
@@ -298,7 +298,7 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
                     dw_conv_buffer_size_,
                     types::data_type_size(dw_conv_pd_->src_md()->data_type));
 
-            jit_uni_dw_conv_fwd_kernel<avx512_core,
+            jit_uni_dw_conv_fwd_kernel_t<avx512_core,
                     data_type::f32>::init_scratchpad(dw_scratchpad, jcp_dw);
 
             return status::success;
@@ -317,7 +317,7 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_common_1x1_conv_kernel(
+                new jit_avx512_common_1x1_conv_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_1x1_md(0))));
         CHECK(kernel_->create_kernel());
 
@@ -348,9 +348,9 @@ private:
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_common_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_common_1x1_conv_kernel_t> kernel_;
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
-    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32<avx512_core>;
+    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32_t<avx512_core>;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
 };
 
@@ -388,12 +388,12 @@ struct jit_avx512_common_1x1_convolution_bwd_data_t : public primitive_t {
             rtus_prepare(this, conv_d, diff_src_d, diff_dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_common_1x1_conv_kernel::init_conf(jcp_, *conv_d,
+            CHECK(jit_avx512_common_1x1_conv_kernel_t::init_conf(jcp_, *conv_d,
                     *diff_src_d, *weights_md(), *diff_dst_md(), *attr(),
                     dnnl_get_max_threads(), rtus_.reduce_src_));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_common_1x1_conv_kernel::init_scratchpad(
+            jit_avx512_common_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_);
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
@@ -446,7 +446,7 @@ struct jit_avx512_common_1x1_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_common_1x1_conv_kernel(
+                new jit_avx512_common_1x1_conv_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         CHECK(kernel_->create_kernel());
         CHECK(init_rtus_driver<avx512_core>(this));
@@ -462,7 +462,7 @@ private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_common_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_common_1x1_conv_kernel_t> kernel_;
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
 };
 
@@ -497,14 +497,14 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, diff_dst_md(), diff_weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_common_1x1_conv_kernel::init_conf(jcp_, *conv_d,
+            CHECK(jit_avx512_common_1x1_conv_kernel_t::init_conf(jcp_, *conv_d,
                     *src_d, *diff_weights_md(), *diff_dst_md(), *attr(),
                     dnnl_get_max_threads(), rtus_.reduce_src_));
 
             init_balancers();
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_common_1x1_conv_kernel::init_scratchpad(
+            jit_avx512_common_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_);
 
             auto reducer_bia_scratchpad = memory_tracking::registrar_t(
@@ -580,10 +580,10 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_common_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_common_1x1_conv_kernel_t> kernel_;
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_;
     std::unique_ptr<cpu_reducer_t<data_type::f32>> reducer_bias_;
-    std::unique_ptr<jit_transpose4x16_src> trans_kernel_;
+    std::unique_ptr<jit_transpose4x16_src_t> trans_kernel_;
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
 };
 

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -28,7 +28,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_avx512_common_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 #define KNx_L2_EFFECTIVE_CAPACITY ((512 - 64) * 1024)
 
 namespace dnnl {

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -31,12 +31,12 @@ namespace cpu {
 namespace x64 {
 
 template <typename Vmm>
-struct _jit_avx512_common_conv_fwd_kernel : public jit_generator_t {
+struct jit_avx512_common_conv_fwd_kernel_vmm_t : public jit_generator_t {
 
-    _jit_avx512_common_conv_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_avx512_common_conv_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_avx512_common_conv_fwd_kernel)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_common_conv_fwd_kernel_vmm_t)
 
     jit_conv_conf_t jcp;
     const primitive_attr_t &attr_;
@@ -174,25 +174,25 @@ private:
     }
 };
 
-struct jit_avx512_common_conv_fwd_kernel {
+struct jit_avx512_common_conv_fwd_kernel_t {
 
-    jit_avx512_common_conv_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_avx512_common_conv_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
         switch (ajcp.oc_block) {
             case 16:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_common_conv_fwd_kernel<Xbyak::Zmm>>(
+                        jit_avx512_common_conv_fwd_kernel_vmm_t<Xbyak::Zmm>>(
                         ajcp, attr, dst_md);
                 return;
             case 8:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_common_conv_fwd_kernel<Xbyak::Ymm>>(
+                        jit_avx512_common_conv_fwd_kernel_vmm_t<Xbyak::Ymm>>(
                         ajcp, attr, dst_md);
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_common_conv_fwd_kernel<Xbyak::Xmm>>(
+                        jit_avx512_common_conv_fwd_kernel_vmm_t<Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -204,7 +204,7 @@ struct jit_avx512_common_conv_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_common_conv_fwd_kernel() = default;
+    ~jit_avx512_common_conv_fwd_kernel_t() = default;
 
     enum { typesize = sizeof(float) };
 
@@ -220,17 +220,20 @@ struct jit_avx512_common_conv_fwd_kernel {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_common_conv_fwd_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_common_conv_fwd_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 
 template <typename Vmm>
-struct _jit_avx512_common_conv_bwd_data_kernel_f32 : public jit_generator_t {
+struct jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t
+    : public jit_generator_t {
 
-    _jit_avx512_common_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t(
+            const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp) {}
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_avx512_common_conv_bwd_data_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(
+            jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t)
     jit_conv_conf_t jcp;
 
 private:
@@ -345,24 +348,24 @@ private:
     }
 };
 
-struct jit_avx512_common_conv_bwd_data_kernel_f32 {
+struct jit_avx512_common_conv_bwd_data_kernel_f32_t {
 
-    jit_avx512_common_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_avx512_common_conv_bwd_data_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : kernel_(nullptr) {
         switch (ajcp.ic_block) {
             case 16:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_common_conv_bwd_data_kernel_f32<
+                        jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                                 Xbyak::Zmm>>(ajcp);
                 return;
             case 8:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_common_conv_bwd_data_kernel_f32<
+                        jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                                 Xbyak::Ymm>>(ajcp);
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_common_conv_bwd_data_kernel_f32<
+                        jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                                 Xbyak::Xmm>>(ajcp);
                 return;
             default: assert(!"invalid channel blocking");
@@ -374,7 +377,7 @@ struct jit_avx512_common_conv_bwd_data_kernel_f32 {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_common_conv_bwd_data_kernel_f32() = default;
+    ~jit_avx512_common_conv_bwd_data_kernel_f32_t() = default;
 
     enum { typesize = sizeof(float) };
 
@@ -388,13 +391,14 @@ struct jit_avx512_common_conv_bwd_data_kernel_f32 {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_common_conv_bwd_data_kernel_f32);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_common_conv_bwd_data_kernel_f32_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 
-struct jit_avx512_common_conv_bwd_weights_kernel_f32 : public jit_generator_t {
+struct jit_avx512_common_conv_bwd_weights_kernel_f32_t
+    : public jit_generator_t {
 
-    jit_avx512_common_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_avx512_common_conv_bwd_weights_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp) {}
 
     void generate() override {
@@ -404,7 +408,8 @@ struct jit_avx512_common_conv_bwd_weights_kernel_f32 : public jit_generator_t {
             generate_microkernel();
     }
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_common_conv_bwd_weights_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(
+            jit_avx512_common_conv_bwd_weights_kernel_f32_t)
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_md,

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -215,7 +215,7 @@ struct jit_avx512_common_conv_fwd_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    void operator()(jit_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(jit_conv_args_t *p) const { (*kernel_)(p); }
 
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
@@ -387,7 +387,7 @@ struct jit_avx512_common_conv_bwd_data_kernel_f32_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*kernel_)(p); }
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -32,9 +32,9 @@ using namespace dnnl::impl::utils;
 
 using namespace nstl;
 
-using jit_conv_ker_t = void (*)(jit_conv_call_s *);
+using jit_conv_ker_t = void (*)(jit_conv_args_t *);
 
-inline void jit_conv_ker_pipeline(const jit_conv_ker_t ker, jit_conv_call_s &p,
+inline void jit_conv_ker_pipeline(const jit_conv_ker_t ker, jit_conv_args_t &p,
         const void *src, const void *dst, const void *filt, const void *bias,
         int channel, int kh_padding, int reduce_work, int load_work) {
     p.src = src;
@@ -52,7 +52,7 @@ inline void jit_conv_ker_pipeline(const jit_conv_ker_t ker, jit_conv_call_s &p,
 }
 // The special case for the driver with iw-parallelization (BWD)
 inline void jit_conv_ker_pipeline_iw_thr(const jit_conv_ker_t ker,
-        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        jit_conv_args_t &p, const void *src, const void *dst, const void *filt,
         const void *bias, int channel, int kh_padding, int iwb, int reduce_work,
         int load_work) {
     p.iwb = iwb;
@@ -62,7 +62,7 @@ inline void jit_conv_ker_pipeline_iw_thr(const jit_conv_ker_t ker,
 }
 
 inline void jit_conv_3d_ker_pipeline(const jit_conv_ker_t ker,
-        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        jit_conv_args_t &p, const void *src, const void *dst, const void *filt,
         const void *bias, int channel, int kh_padding, int kd_padding,
         int reduce_work, int load_work) {
     p.src = src;
@@ -80,7 +80,7 @@ inline void jit_conv_3d_ker_pipeline(const jit_conv_ker_t ker,
     ker(&p);
 }
 // The special case for the driver with ow-parallelization (FWD)
-inline void jit_conv_ker_pipeline_ow_thr(jit_conv_ker_t ker, jit_conv_call_s &p,
+inline void jit_conv_ker_pipeline_ow_thr(jit_conv_ker_t ker, jit_conv_args_t &p,
         const void *src, const void *dst, const void *filt, const void *bias,
         int channel, int kh_padding, int owb, int reduce_work, int load_work,
         const void *post_ops_binary_rhs_arg_vec, const void *dst_orig,
@@ -98,7 +98,7 @@ inline void jit_conv_ker_pipeline_ow_thr(jit_conv_ker_t ker, jit_conv_call_s &p,
 // The special case for the driver with ow-parallelization (FWD)
 // TODO: implement it for BWD_D and BWD_W too
 inline void jit_conv_3d_ker_pipeline_ow_thr(const jit_conv_ker_t ker,
-        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        jit_conv_args_t &p, const void *src, const void *dst, const void *filt,
         const void *bias, int channel, int kh_padding, int kd_padding, int owb,
         int reduce_work, int load_work, const void *post_ops_binary_rhs_arg_vec,
         const void *dst_orig, int flags) {
@@ -114,7 +114,7 @@ inline void jit_conv_3d_ker_pipeline_ow_thr(const jit_conv_ker_t ker,
 }
 
 inline void jit_conv_ker_pipeline_bwd_w(const jit_conv_ker_t ker,
-        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        jit_conv_args_t &p, const void *src, const void *dst, const void *filt,
         const void *bias, int channel, int kh_padding, size_t reduce_work,
         size_t load_work) {
     jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
@@ -122,7 +122,7 @@ inline void jit_conv_ker_pipeline_bwd_w(const jit_conv_ker_t ker,
 }
 
 void jit_conv_2d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
-        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        jit_conv_args_t &p, const void *src, const void *dst, const void *filt,
         const void *bias, int channel, int os_index_begin, int os_index_end,
         int kh_padding /* kh_work_size */, size_t kh_offset, size_t reduce_work,
         size_t load_work) {
@@ -144,7 +144,7 @@ void jit_conv_2d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
 }
 
 void jit_conv_3d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
-        jit_conv_call_s &p, const void *src, const void *dst, const void *filt,
+        jit_conv_args_t &p, const void *src, const void *dst, const void *filt,
         const void *bias, int channel, int os_index_begin, int os_index_end,
         int kd_padding /* kd_work_size */, size_t kd_offset, size_t reduce_work,
         size_t load_work) {
@@ -214,7 +214,7 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -340,7 +340,7 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -500,7 +500,7 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -661,7 +661,7 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -773,7 +773,7 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -937,7 +937,7 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -1394,7 +1394,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         ic_b_step = utils::div_up(icb_work, 2);
 
     for (int img = ti->img_start; img < ti->img_end; ++img) {
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
         const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
@@ -1461,7 +1461,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
         ic_b_step = utils::div_up(icb_work, 2);
     while (img_start < img_end) {
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         int work_rem = img_end - img_start;
         const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
@@ -1549,7 +1549,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         ic_b_step = utils::div_up(icb_work, 2);
 
     while (img_start < img_end) {
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         int work_rem = img_end - img_start;
         const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1136,7 +1136,7 @@ status_t jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     nthr_ic_b_ = j.nthr_ic_b;
 
     CHECK(safe_ptr_assign(
-            kernel_, new jit_avx512_common_conv_bwd_weights_kernel_f32(j)));
+            kernel_, new jit_avx512_common_conv_bwd_weights_kernel_f32_t(j)));
     CHECK(kernel_->create_kernel());
 
     if (nthr_mb_ > 1) {

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -58,12 +58,12 @@ struct jit_avx512_common_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_ATTR);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_common_conv_fwd_kernel::init_conf(jcp_, *desc(),
+            CHECK(jit_avx512_common_conv_fwd_kernel_t::init_conf(jcp_, *desc(),
                     src_md_, weights_md_, dst_md_, bias_md_, attr_,
                     dnnl_get_max_threads()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_common_conv_fwd_kernel::init_scratchpad(
+            jit_avx512_common_conv_fwd_kernel_t::init_scratchpad(
                     scratchpad, jcp_);
 
             return status::success;
@@ -80,7 +80,7 @@ struct jit_avx512_common_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_common_conv_fwd_kernel(
+                new jit_avx512_common_conv_fwd_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         return kernel_->create_kernel();
     }
@@ -107,7 +107,7 @@ private:
     void execute_forward_3d(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_common_conv_fwd_kernel> kernel_;
+    std::unique_ptr<jit_avx512_common_conv_fwd_kernel_t> kernel_;
 };
 
 template <impl::data_type_t diff_dst_type,
@@ -134,12 +134,12 @@ struct jit_avx512_common_convolution_bwd_data_t : public primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_common_conv_bwd_data_kernel_f32::init_conf(jcp_,
+            CHECK(jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(jcp_,
                     *desc(), diff_src_md_, weights_md_, diff_dst_md_,
                     dnnl_get_max_threads()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_common_conv_bwd_data_kernel_f32::init_scratchpad(
+            jit_avx512_common_conv_bwd_data_kernel_f32_t::init_scratchpad(
                     scratchpad, jcp_);
 
             return status::success;
@@ -157,7 +157,7 @@ struct jit_avx512_common_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_common_conv_bwd_data_kernel_f32(pd()->jcp_)));
+                new jit_avx512_common_conv_bwd_data_kernel_f32_t(pd()->jcp_)));
         return kernel_->create_kernel();
     }
 
@@ -179,7 +179,7 @@ private:
     void execute_backward_data_3d(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_common_conv_bwd_data_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx512_common_conv_bwd_data_kernel_f32_t> kernel_;
 };
 
 template <impl::data_type_t src_type,
@@ -207,14 +207,14 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_common_conv_bwd_weights_kernel_f32::init_conf(jcp_,
-                    *desc(), src_md_, diff_weights_md_, diff_bias_md_,
+            CHECK(jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
+                    jcp_, *desc(), src_md_, diff_weights_md_, diff_bias_md_,
                     diff_dst_md_, dnnl_get_max_threads()));
 
             init_balancers();
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_common_conv_bwd_weights_kernel_f32::init_scratchpad(
+            jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_scratchpad(
                     scratchpad, jcp_);
 
             auto reducer_bia_scratchpad = memory_tracking::registrar_t(
@@ -269,7 +269,7 @@ private:
 
     int nthr_, nthr_mb_, nthr_g_, nthr_oc_b_, nthr_ic_b_;
 
-    std::unique_ptr<jit_avx512_common_conv_bwd_weights_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx512_common_conv_bwd_weights_kernel_f32_t> kernel_;
     std::unique_ptr<cpu_accumulator_1d_t<diff_weights_type>> acc_ker_;
     std::unique_ptr<cpu_reducer_t<diff_weights_type>> reducer_bias_;
 };

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -26,7 +26,7 @@
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
@@ -135,7 +135,7 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
         size_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
         p.tile_cfg = tcfg;
         p.tile_cfg_tail = tcfg + 64;
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -29,7 +29,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_avx512_core_amx_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -286,12 +286,12 @@ private:
     bool is_store_done_ = false;
     bool is_buffer_empty_ = true;
 
-    struct w_pad_output {
+    struct w_pad_output_t {
         int l_pad_output;
         int r_pad_output;
-        w_pad_output(int l_, int r_) : l_pad_output(l_), r_pad_output(r_) {}
+        w_pad_output_t(int l_, int r_) : l_pad_output(l_), r_pad_output(r_) {}
     };
-    std::queue<w_pad_output> w_padding;
+    std::queue<w_pad_output_t> w_padding;
 
     /* data regs */
     const Xbyak::Reg64 reg_inp_ptr = r15;

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -50,7 +50,11 @@ struct jit_avx512_core_amx_compute_zp_pbuff_t : public jit_generator_t {
 private:
     jit_conv_conf_t jcp;
 
-    typedef enum { no_last_block, last_ic_block } ic_block_t;
+    enum class ic_block_t {
+        no_last_block,
+        last_ic_block,
+    };
+
     const int ic_inner_block = 4;
 
     Xbyak::Label permb_idx_label;

--- a/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
@@ -34,9 +34,9 @@ using namespace dnnl::impl::utils;
 #define wht_blk_off(d, g, ...) \
     (with_groups ? (d).blk_off((g), __VA_ARGS__) : (d).blk_off(__VA_ARGS__))
 
-struct spatial_features_3d {
+struct spatial_features_3d_t {
 
-    spatial_features_3d(const jit_conv_conf_t &jcp)
+    spatial_features_3d_t(const jit_conv_conf_t &jcp)
         : input_size_(jcp.id)
         , filter_size_(jcp.kd)
         , dilate_(jcp.dilate_d + 1)
@@ -175,7 +175,7 @@ inline void execute_backward_convolution_body(const exec_ctx_t &ctx,
 
         auto p = jit_conv_call_s();
         amx_tile_configure(tcfg);
-        spatial_features_3d sfd(jcp);
+        spatial_features_3d_t sfd(jcp);
 
         int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,

--- a/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
@@ -173,7 +173,7 @@ inline void execute_backward_convolution_body(const exec_ctx_t &ctx,
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
         amx_tile_configure(tcfg);
         spatial_features_3d_t sfd(jcp);
 

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -1940,7 +1940,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::prepare_scratchpad_data(
     const auto &jcp = pd()->jcp_;
 
     // XXX: See the comment about tr_iw and guarding elements in
-    // jit_avx512_core_bf16_conv_bwd_weights_kernel_f32::init_conf()
+    // jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf()
     auto tr_src = scratchpad.template get<src_data_t>(key_conv_tr_src);
     // Zero out guard elements that cross a buffer boundary to prevent a
     // race condition due to buffer overflows from memory optimization where

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -42,7 +42,7 @@ using namespace dnnl::impl::utils;
 
 using namespace Xbyak;
 
-jit_avx512_core_bf16_1x1_conv_kernel::jit_avx512_core_bf16_1x1_conv_kernel(
+jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
         const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), avx512_core_bf16), jcp(ajcp), attr_(attr) {
@@ -73,7 +73,7 @@ jit_avx512_core_bf16_1x1_conv_kernel::jit_avx512_core_bf16_1x1_conv_kernel(
                 bf16_emu_reserv_4, bf16_emu_reserv_5, bf16_emu_reserv_6);
 }
 
-void jit_avx512_core_bf16_1x1_conv_kernel::bcast_loop(int load_loop_blk) {
+void jit_avx512_core_bf16_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
 
@@ -146,7 +146,7 @@ static int vreg_accum_idx(
     return idx;
 }
 
-Address jit_avx512_core_bf16_1x1_conv_kernel::output_ptr(
+Address jit_avx512_core_bf16_1x1_conv_kernel_t::output_ptr(
         const int i_load, const int i_ur) {
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
@@ -179,7 +179,7 @@ static void iterate(const int load_loop_blk, const int ur, const F &f) {
     iterate(load_loop_blk, ur, false, f);
 }
 
-void jit_avx512_core_bf16_1x1_conv_kernel::apply_postops(
+void jit_avx512_core_bf16_1x1_conv_kernel_t::apply_postops(
         const int load_loop_blk, const int ur) {
     if (jcp.with_eltwise || jcp.with_binary) {
         injector_utils::vmm_index_set_t vmm_idxs;
@@ -251,7 +251,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel::apply_postops(
     }
 }
 
-void jit_avx512_core_bf16_1x1_conv_kernel::reduce_loop(
+void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
         int load_loop_blk, int ur, int substep, bool wraparound) {
     const bool load_layout_nxc = is_load_layout_nxc();
     const bool bcast_layout_nxc = is_bcast_layout_nxc();
@@ -878,7 +878,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel::reduce_loop(
     store();
 }
 
-void jit_avx512_core_bf16_1x1_conv_kernel::compute_diff_bias(
+void jit_avx512_core_bf16_1x1_conv_kernel_t::compute_diff_bias(
         int load_loop_blk) {
     if (IMPLICATION(jcp.with_bias, jcp.prop_kind != backward_weights)) return;
     Label skip_diff_bias;
@@ -990,7 +990,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel::compute_diff_bias(
     L(skip_diff_bias);
 }
 
-void jit_avx512_core_bf16_1x1_conv_kernel::generate() {
+void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
     preamble();
 
     sub(rsp, stack_space_needed);
@@ -1187,7 +1187,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel::generate() {
     }
 }
 
-status_t jit_avx512_core_bf16_1x1_conv_kernel::init_conf(
+status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jit_1x1_conv_conf_t &jcp, const convolution_desc_t &cd,
         const memory_desc_wrapper &src_d, const memory_desc_wrapper &weights_d,
         const memory_desc_wrapper &dst_d, primitive_attr_t &attr, int nthreads,
@@ -1747,7 +1747,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel::init_conf(
     return status::success;
 }
 
-status_t jit_avx512_core_bf16_1x1_conv_kernel::init_scratchpad(
+status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad,
         const jit_1x1_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;
@@ -1828,7 +1828,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel::init_scratchpad(
     return status::success;
 }
 
-void jit_avx512_core_bf16_1x1_conv_kernel::balance(
+void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         jit_1x1_conv_conf_t &jcp, int nthreads) {
     // initialize jcp reduction threading properties
     jcp.nthr = jcp.nthr_mb = jcp.nthr_g = jcp.nthr_oc_b = jcp.nthr_ic_b = 1;

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -30,7 +30,7 @@
 #include "cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp"
 #include "cpu/x64/jit_uni_1x1_conv_utils.hpp"
 
-#define GET_OFF(field) offsetof(jit_1x1_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_1x1_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
@@ -29,11 +29,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_avx512_core_bf16_1x1_conv_kernel : public jit_generator_t {
-    jit_avx512_core_bf16_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+struct jit_avx512_core_bf16_1x1_conv_kernel_t : public jit_generator_t {
+    jit_avx512_core_bf16_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_bf16_1x1_conv_kernel)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_bf16_1x1_conv_kernel_t)
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -149,7 +149,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
     const int stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
@@ -356,7 +356,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
             const int ow = 0;
             const int kw = 0;
-            jit_conv_call_s par_conv_dw;
+            jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
@@ -502,7 +502,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
     const int nb_ic = jcp.nb_load;
@@ -842,7 +842,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                         img, oc_off_idx)];
                         const src_data_t *local_src = diff_src;
 
-                        auto p = jit_1x1_conv_call_s();
+                        auto p = jit_1x1_conv_args_t();
                         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
                         p.output_stride = utils::rnd_up(jcp.ic, jcp.oc_block)

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -633,7 +633,7 @@ status_t
 jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::init(
         engine_t *engine) {
     CHECK(safe_ptr_assign(kernel_,
-            new jit_avx512_core_bf16_1x1_conv_kernel(
+            new jit_avx512_core_bf16_1x1_conv_kernel_t(
                     pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
 
     CHECK(safe_ptr_assign(

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -103,6 +103,7 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             return cpu_convolution_fwd_pd_t::dst_md(index);
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *dst_md(
                 int index = 0, bool user_input = false) const override {
             return dw_conv_pd_ && jcp_.with_dw_conv
@@ -125,6 +126,7 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             }
             return convolution_fwd_pd_t::arg_md(arg, user_input);
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -84,14 +84,14 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_bf16_1x1_conv_kernel::init_conf(jcp_, *conv_d,
-                    *src_d, *weights_md(), *dst_md(), attr_,
+            CHECK(jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(jcp_,
+                    *conv_d, *src_d, *weights_md(), *dst_md(), attr_,
                     dnnl_get_max_threads(), rtus_.reduce_src_));
 
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
 
             auto scratchpad = scratchpad_registry().registrar();
-            CHECK(jit_avx512_core_bf16_1x1_conv_kernel::init_scratchpad(
+            CHECK(jit_avx512_core_bf16_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_));
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
@@ -331,7 +331,7 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_core_bf16_1x1_conv_kernel(
+                new jit_avx512_core_bf16_1x1_conv_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_1x1_md(0))));
         CHECK(kernel_->create_kernel());
 
@@ -360,10 +360,10 @@ private:
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_core_bf16_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_bf16_1x1_conv_kernel_t> kernel_;
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
     using dw_conv_kernel_t
-            = jit_uni_dw_conv_fwd_kernel<avx512_core, data_type::bf16>;
+            = jit_uni_dw_conv_fwd_kernel_t<avx512_core, data_type::bf16>;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
 };
 
@@ -397,12 +397,12 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_data_t : public primitive_t {
             rtus_prepare(this, conv_d, diff_src_d, diff_dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_bf16_1x1_conv_kernel::init_conf(jcp_, *conv_d,
-                    *diff_src_d, *weights_md(), *diff_dst_md(), attr_,
+            CHECK(jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(jcp_,
+                    *conv_d, *diff_src_d, *weights_md(), *diff_dst_md(), attr_,
                     dnnl_get_max_threads(), rtus_.reduce_src_));
 
             auto scratchpad = scratchpad_registry().registrar();
-            CHECK(jit_avx512_core_bf16_1x1_conv_kernel::init_scratchpad(
+            CHECK(jit_avx512_core_bf16_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_));
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
 
@@ -454,7 +454,7 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_data_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_core_bf16_1x1_conv_kernel(
+                new jit_avx512_core_bf16_1x1_conv_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         CHECK(kernel_->create_kernel());
         CHECK(init_rtus_driver<avx512_core>(this));
@@ -473,7 +473,7 @@ private:
             const memory_tracking::grantor_t &scratchpad) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_core_bf16_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_bf16_1x1_conv_kernel_t> kernel_;
     /* reduction to unit stride */
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
 };
@@ -516,12 +516,12 @@ struct jit_avx512_core_bf16_1x1_convolution_bwd_weights_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, diff_dst_md(), diff_weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_bf16_1x1_conv_kernel::init_conf(jcp_, *conv_d,
-                    *src_d, *diff_weights_md(0), *diff_dst_md(), attr_,
+            CHECK(jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(jcp_,
+                    *conv_d, *src_d, *diff_weights_md(0), *diff_dst_md(), attr_,
                     dnnl_get_max_threads(), rtus_.reduce_src_));
 
             auto scratchpad = scratchpad_registry().registrar();
-            CHECK(jit_avx512_core_bf16_1x1_conv_kernel::init_scratchpad(
+            CHECK(jit_avx512_core_bf16_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_));
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
@@ -585,7 +585,7 @@ private:
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_core_bf16_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_bf16_1x1_conv_kernel_t> kernel_;
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_;
 
     /* reduction to unit stride */

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -30,7 +30,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -32,11 +32,11 @@ namespace cpu {
 namespace x64 {
 
 template <typename Vmm>
-struct _jit_avx512_core_bf16_fwd_kernel : public jit_generator_t {
-    _jit_avx512_core_bf16_fwd_kernel(const jit_conv_conf_t &ajcp,
+struct jit_avx512_core_bf16_fwd_kernel_vmm_t : public jit_generator_t {
+    jit_avx512_core_bf16_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_avx512_core_bf16_fwd_kernel)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_core_bf16_fwd_kernel_vmm_t)
 
     const jit_conv_conf_t &jcp;
     const primitive_attr_t &attr_;
@@ -213,24 +213,24 @@ private:
     }
 };
 
-struct jit_avx512_core_bf16_fwd_kernel {
-    jit_avx512_core_bf16_fwd_kernel(const jit_conv_conf_t &ajcp,
+struct jit_avx512_core_bf16_fwd_kernel_t {
+    jit_avx512_core_bf16_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
         switch (ajcp.oc_block) {
             case 16:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_bf16_fwd_kernel<Xbyak::Zmm>>(
+                        jit_avx512_core_bf16_fwd_kernel_vmm_t<Xbyak::Zmm>>(
                         ajcp, attr, dst_md);
                 return;
             case 8:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_bf16_fwd_kernel<Xbyak::Ymm>>(
+                        jit_avx512_core_bf16_fwd_kernel_vmm_t<Xbyak::Ymm>>(
                         ajcp, attr, dst_md);
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_bf16_fwd_kernel<Xbyak::Xmm>>(
+                        jit_avx512_core_bf16_fwd_kernel_vmm_t<Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -242,7 +242,7 @@ struct jit_avx512_core_bf16_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_bf16_fwd_kernel() = default;
+    ~jit_avx512_core_bf16_fwd_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_pd,
@@ -255,14 +255,14 @@ struct jit_avx512_core_bf16_fwd_kernel {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_bf16_fwd_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_bf16_fwd_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 
 template <typename Vmm>
-struct _jit_avx512_core_bf16_bwd_data_kernel : public jit_generator_t {
+struct jit_avx512_core_bf16_bwd_data_kernel_vmm_t : public jit_generator_t {
 
-    _jit_avx512_core_bf16_bwd_data_kernel(const jit_conv_conf_t &ajcp)
+    jit_avx512_core_bf16_bwd_data_kernel_vmm_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name(), avx512_core_bf16)
         , jcp(ajcp)
         , bf16_emu_(nullptr) {
@@ -429,24 +429,24 @@ private:
     }
 };
 
-struct jit_avx512_core_bf16_bwd_data_kernel {
+struct jit_avx512_core_bf16_bwd_data_kernel_t {
 
-    jit_avx512_core_bf16_bwd_data_kernel(const jit_conv_conf_t &ajcp)
+    jit_avx512_core_bf16_bwd_data_kernel_t(const jit_conv_conf_t &ajcp)
         : kernel_(nullptr) {
         switch (ajcp.ic_block) {
             case 16:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Zmm>>(
+                        jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Xbyak::Zmm>>(
                         ajcp);
                 return;
             case 8:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Ymm>>(
+                        jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Xbyak::Ymm>>(
                         ajcp);
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_bf16_bwd_data_kernel<Xbyak::Xmm>>(
+                        jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Xbyak::Xmm>>(
                         ajcp);
                 return;
             default: assert(!"invalid channel blocking");
@@ -458,7 +458,7 @@ struct jit_avx512_core_bf16_bwd_data_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_bf16_bwd_data_kernel() = default;
+    ~jit_avx512_core_bf16_bwd_data_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &diff_src_md,
@@ -468,14 +468,14 @@ struct jit_avx512_core_bf16_bwd_data_kernel {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_bf16_bwd_data_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_bf16_bwd_data_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 
-struct jit_avx512_core_bf16_conv_bwd_weights_kernel_f32
+struct jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t
     : public jit_generator_t {
 
-    jit_avx512_core_bf16_conv_bwd_weights_kernel_f32(
+    jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t(
             const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name(), avx512_core_bf16)
         , jcp(ajcp)
@@ -486,10 +486,10 @@ struct jit_avx512_core_bf16_conv_bwd_weights_kernel_f32
         }
     }
 
-    ~jit_avx512_core_bf16_conv_bwd_weights_kernel_f32() override = default;
+    ~jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t() override = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(
-            jit_avx512_core_bf16_conv_bwd_weights_kernel_f32)
+            jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t)
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_md,

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -251,7 +251,7 @@ struct jit_avx512_core_bf16_fwd_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*kernel_)(p); }
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
@@ -464,7 +464,7 @@ struct jit_avx512_core_bf16_bwd_data_kernel_t {
             const convolution_desc_t &cd, memory_desc_t &diff_src_md,
             memory_desc_t &weights_md, memory_desc_t &diff_dst_md,
             int nthreads);
-    void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*kernel_)(p); }
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -735,8 +735,8 @@ status_t jit_avx512_core_bf16_convolution_bwd_weights_t ::init(
     nthr_oc_b_ = j.nthr_oc_b;
     nthr_ic_b_ = j.nthr_ic_b;
 
-    CHECK(safe_ptr_assign(
-            kernel_, new jit_avx512_core_bf16_conv_bwd_weights_kernel_f32(j)));
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t(j)));
     CHECK(kernel_->create_kernel());
 
     if (j.transpose_src) {
@@ -1919,7 +1919,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::prepare_scratchpad_data(
 
     if (jcp.transpose_src) {
         // XXX: See the comment about tr_iw and guarding elements in
-        // jit_avx512_core_bf16_conv_bwd_weights_kernel_f32::init_conf()
+        // jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf()
         auto tr_src = scratchpad.template get<src_data_t>(key_conv_tr_src);
         // Zero out guard elements that cross a buffer boundary to prevent a
         // race condition due to buffer overflows from memory optimization where

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -82,7 +82,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
     parallel(nthr, [&](const int ithr, const int nthr) {
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         int n {0}, gg {0}, occ {0}, owb {0};
 
@@ -183,7 +183,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
     parallel(nthr, [&](const int ithr, const int nthr) {
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -309,7 +309,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
     parallel(nthr, [&](const int ithr, const int nthr) {
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -438,7 +438,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
         int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -606,7 +606,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
         int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
 
         // The second arg in template means sub_offset0 = true
         // See `blk_off` method definition.
@@ -1055,7 +1055,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
         int work_rem = end - start;
         const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
         int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
@@ -1287,7 +1287,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
         int work_rem = end - start;
         const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
         int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
@@ -1691,7 +1691,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
     };
 
     for (int img = ti->img_start; img < ti->img_end; ++img) {
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
         if (jcp.global_transpose) {
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -67,12 +67,13 @@ struct jit_avx512_core_bf16_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_BIAS_CFG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_bf16_fwd_kernel::init_conf(jcp_, *desc(),
+            CHECK(jit_avx512_core_bf16_fwd_kernel_t::init_conf(jcp_, *desc(),
                     src_md_, weights_md_, dst_md_, bias_md_, attr_,
                     dnnl_get_max_threads()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_core_bf16_fwd_kernel::init_scratchpad(scratchpad, jcp_);
+            jit_avx512_core_bf16_fwd_kernel_t::init_scratchpad(
+                    scratchpad, jcp_);
 
             return status::success;
         }
@@ -88,7 +89,7 @@ struct jit_avx512_core_bf16_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_core_bf16_fwd_kernel(
+                new jit_avx512_core_bf16_fwd_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         return kernel_->create_kernel();
     }
@@ -115,7 +116,7 @@ private:
     void execute_forward_3d(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_avx512_core_bf16_fwd_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_bf16_fwd_kernel_t> kernel_;
 };
 
 struct jit_avx512_core_bf16_convolution_bwd_data_t : public primitive_t {
@@ -145,8 +146,8 @@ struct jit_avx512_core_bf16_convolution_bwd_data_t : public primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_bf16_bwd_data_kernel::init_conf(jcp_, *desc(),
-                    diff_src_md_, weights_md_, diff_dst_md_,
+            CHECK(jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jcp_,
+                    *desc(), diff_src_md_, weights_md_, diff_dst_md_,
                     dnnl_get_max_threads()));
             return status::success;
         }
@@ -161,8 +162,8 @@ struct jit_avx512_core_bf16_convolution_bwd_data_t : public primitive_t {
     using wei_data_t = typename prec_traits_t<data_type::bf16>::type;
 
     status_t init(engine_t *engine) override {
-        CHECK(safe_ptr_assign(
-                kernel_, new jit_avx512_core_bf16_bwd_data_kernel(pd()->jcp_)));
+        CHECK(safe_ptr_assign(kernel_,
+                new jit_avx512_core_bf16_bwd_data_kernel_t(pd()->jcp_)));
         return kernel_->create_kernel();
     }
 
@@ -181,7 +182,7 @@ private:
     void execute_backward_data(const exec_ctx_t &ctx) const;
     void execute_backward_data_3d(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_avx512_core_bf16_bwd_data_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_bf16_bwd_data_kernel_t> kernel_;
 };
 
 struct jit_avx512_core_bf16_convolution_bwd_weights_t : public primitive_t {
@@ -215,12 +216,12 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t : public primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_bf16_conv_bwd_weights_kernel_f32::init_conf(
+            CHECK(jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
                     jcp_, *desc(), src_md_, diff_weights_md_, diff_bias_md_,
                     diff_dst_md_, dnnl_get_max_threads()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_core_bf16_conv_bwd_weights_kernel_f32::init_scratchpad(
+            jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_scratchpad(
                     scratchpad, jcp_);
 
             return status::success;
@@ -269,7 +270,7 @@ private:
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 
-    std::unique_ptr<jit_avx512_core_bf16_conv_bwd_weights_kernel_f32> kernel_;
+    std::unique_ptr<jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t> kernel_;
 
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -33,7 +33,7 @@ namespace x64 {
 using namespace Xbyak;
 using namespace dnnl::impl::utils;
 
-jit_avx512_dw_conv_fwd_kernel_bf16::jit_avx512_dw_conv_fwd_kernel_bf16(
+jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name()), jcp(ajcp) {
     if (jcp.with_eltwise || jcp.with_binary) {
@@ -63,16 +63,16 @@ jit_avx512_dw_conv_fwd_kernel_bf16::jit_avx512_dw_conv_fwd_kernel_bf16(
                 bf16_emu_reserv_4, bf16_emu_reserv_5, bf16_emu_reserv_6);
 }
 
-int jit_avx512_dw_conv_fwd_kernel_bf16::get_acc_reg_idx(int idx) const {
+int jit_avx512_dw_conv_fwd_kernel_bf16_t::get_acc_reg_idx(int idx) const {
     assert(idx + acc_idx_start <= get_max_regs());
     return idx + acc_idx_start;
 }
 
-Xbyak::Zmm jit_avx512_dw_conv_fwd_kernel_bf16::get_acc_reg(int idx) {
+Xbyak::Zmm jit_avx512_dw_conv_fwd_kernel_bf16_t::get_acc_reg(int idx) {
     return Xbyak::Zmm(get_acc_reg_idx(idx));
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::load_src(
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
         int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -113,8 +113,9 @@ void jit_avx512_dw_conv_fwd_kernel_bf16::load_src(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::apply_filter_unrolled(int ur_ch_blocks,
-        int ur_w, int pad_l, int pad_r, bool last_ch_block_flag) {
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
+        int ur_ch_blocks, int ur_w, int pad_l, int pad_r,
+        bool last_ch_block_flag) {
     int ch_blk = jcp.ch_block;
     int dilate_h = jcp.dilate_h + 1;
     int dilate_w = jcp.dilate_w + 1;
@@ -200,7 +201,7 @@ static void iterate(const int ur_ch_blocks, const int ur_w, const F &f) {
     iterate(ur_ch_blocks, ur_w, false, f);
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::apply_postops(
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_postops(
         int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
     if (this->jcp.with_eltwise || this->jcp.with_binary) {
 
@@ -262,7 +263,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16::apply_postops(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::store_dst(
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
         int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -371,7 +372,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16::store_dst(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::compute_loop(
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
         int ur_w, int ur_ch_blocks, int pad_l, int pad_r) {
 
     // ch_loop currently happen only when data layout is nxc. The strides are
@@ -455,7 +456,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16::compute_loop(
     pop(reg_ch_blocks);
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::loop_ow(int ur_ch_blocks) {
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
 
     int iw = jcp.iw;
     int ow = jcp.ow;
@@ -524,7 +525,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16::loop_ow(int ur_ch_blocks) {
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_bf16::generate() {
+void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     this->preamble();
 
     assert(mayiuse(avx512_core));
@@ -614,7 +615,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16::generate() {
         postops_injector_->prepare_table(/* generate = */ true);
 }
 
-inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::load_ddst(
+inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::load_ddst(
         int ur_ch_blocks, int ur_str_w) {
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         for (int w = 0; w < ur_str_w; w++) {
@@ -624,7 +625,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::load_ddst(
     }
 }
 
-inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::apply_filter(
+inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
     int kw = jcp.kw;
     int kh = jcp.kh;
@@ -705,7 +706,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::apply_filter(
     L(iter_exit_label);
 }
 
-inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::store_dsrc(
+inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
     int ch_blk = jcp.ch_block;
     int iw = jcp.iw;
@@ -752,7 +753,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::store_dsrc(
      * registers, changes are needed in both JIT-kernel and Driver code. */
 }
 
-inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::ch_loop_body(
+inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
         int ur_ch_blocks, int unroll_w) {
 
     auto call_compute_body
@@ -822,7 +823,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::ch_loop_body(
     }
 }
 
-inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::unroll_width_body(
+inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::unroll_width_body(
         int ur_ch_blocks) {
 
     auto unroll_width_loop = [&](int unroll_w) {
@@ -850,7 +851,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16::unroll_width_body(
     unroll_width_loop(1);
 }
 
-void jit_avx512_dw_conv_bwd_data_kernel_bf16::generate() {
+void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
     assert(is_dsrc_layout_nxc() == is_ddst_layout_nxc());
 
     preamble();
@@ -897,14 +898,15 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16::generate() {
 #undef GET_OFF
 
 #define GET_OFF(field) offsetof(jit_dw_conv_call_s, field)
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::zero_filter() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter() {
     for (int i = 0; i < jcp.kw; ++i) {
         Zmm zmm_acc = get_acc_reg(i);
         uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::load_filter(bool is_last_ch) {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::load_filter(
+        bool is_last_ch) {
     for (int i = 0; i < jcp.kw; ++i) {
         int off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
@@ -914,17 +916,17 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::load_filter(bool is_last_ch) {
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::zero_bias() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_bias() {
     uni_vpxor(zmm_bias_reg, zmm_bias_reg, zmm_bias_reg);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::load_bias(bool is_last_ch) {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::load_bias(bool is_last_ch) {
     Zmm m_zmm_bias_reg
             = is_last_ch ? zmm_bias_reg | k_ch_tail_mask | T_z : zmm_bias_reg;
     vmovups(m_zmm_bias_reg, vmmword[reg_bias_baddr]);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ow_step_unroll(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         bool is_last_ch) {
 
@@ -1004,7 +1006,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ow_step_unroll(
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_bias_step_unroll(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_bias_step_unroll(
         const int unroll_w, bool is_last_ch) {
 
     const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1019,7 +1021,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_bias_step_unroll(
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::store_filter(bool is_last_ch) {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::store_filter(
+        bool is_last_ch) {
 
     /* bf16: all data is stored as f32. Down-convert to bf16 happens at the
      * reduction phase. */
@@ -1032,13 +1035,13 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::store_filter(bool is_last_ch) {
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::store_bias(bool is_last_ch) {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::store_bias(bool is_last_ch) {
     Zmm m_zmm_bias_reg
             = is_last_ch ? zmm_bias_reg | k_ch_tail_mask : zmm_bias_reg;
     vmovups(vmmword[reg_bias_baddr], m_zmm_bias_reg);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_spatial_loop_bias(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
         bool is_last_ch) {
     Label oh_label;
     Label ow_blk_label;
@@ -1079,7 +1082,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_spatial_loop_bias(
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::
         compute_single_ch_block_bias() {
 
     auto write_compute_bias = [&](bool masked_ch_tail) {
@@ -1121,7 +1124,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::
     L(done_bias_label);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ch_loop_bias(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ch_loop_bias(
         bool do_load_bias) {
 
     assert(is_ddst_layout_nxc());
@@ -1161,7 +1164,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ch_loop_bias(
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::deploy_ch_loop_bias() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::deploy_ch_loop_bias() {
 
     Label ch_loop_label, zero_bias_label, load_bias_done_label;
 
@@ -1179,7 +1182,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::deploy_ch_loop_bias() {
     L(load_bias_done_label);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_bias() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_bias() {
 
     mov(reg_bias_baddr, ptr[this->param1 + GET_OFF(bias)]);
 
@@ -1189,7 +1192,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_bias() {
         compute_single_ch_block_bias();
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::zero_filter_kh_loop() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter_kh_loop() {
 
     const size_t filter_offset_kw = jcp.kw * jcp.ch_block * jcp.typesize_out;
     const size_t filter_offset_kh = jcp.kh * filter_offset_kw;
@@ -1211,7 +1214,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::zero_filter_kh_loop() {
     sub(reg_tmp_filter, filter_offset_kh);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::deploy_zero_filter() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::deploy_zero_filter() {
 
     Label skip_zeroing_label;
 
@@ -1228,7 +1231,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::deploy_zero_filter() {
     L(skip_zeroing_label);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_kh_step(int unroll_w,
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
         int l_pad, int pad_offset, int ow_block, bool is_last_ch) {
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1270,7 +1273,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_kh_step(int unroll_w,
     L(skip_loop_label);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ch_loop(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ch_loop(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     const bool masked_ch_tail = is_layout_nxc() && jcp.ch_tail > 0;
@@ -1298,7 +1301,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ch_loop(
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_h_loop(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     mov(reg_tmp_output, reg_output_baddr);
@@ -1406,7 +1409,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_h_loop(
     L(loop_end_label);
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::calculate_w_unrolling(
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
         int &unroll_trips, int &unroll_w, int &unroll_w_tail) {
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
@@ -1432,7 +1435,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::calculate_w_unrolling(
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ow_block_unroll() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for compute middle block
     int pad_offset = 0;
@@ -1489,7 +1492,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16::compute_ow_block_unroll() {
     }
 }
 
-void jit_avx512_dw_conv_bwd_weights_kernel_bf16::generate() {
+void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::generate() {
     assert(is_src_layout_nxc() == is_ddst_layout_nxc());
 
     preamble();

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -23,7 +23,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {
@@ -897,7 +897,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
 }
 #undef GET_OFF
 
-#define GET_OFF(field) offsetof(jit_dw_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_dw_conv_args_t, field)
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter() {
     for (int i = 0; i < jcp.kw; ++i) {
         Zmm zmm_acc = get_acc_reg(i);

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -32,10 +32,10 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_avx512_dw_conv_fwd_kernel_bf16 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_fwd_kernel_bf16)
+struct jit_avx512_dw_conv_fwd_kernel_bf16_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_fwd_kernel_bf16_t)
 
-    jit_avx512_dw_conv_fwd_kernel_bf16(
+    jit_avx512_dw_conv_fwd_kernel_bf16_t(
             const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md);
 
     jit_conv_conf_t jcp;
@@ -127,10 +127,10 @@ private:
     void generate() override;
 };
 
-struct jit_avx512_dw_conv_bwd_data_kernel_bf16 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_bwd_data_kernel_bf16)
+struct jit_avx512_dw_conv_bwd_data_kernel_bf16_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_bwd_data_kernel_bf16_t)
 
-    jit_avx512_dw_conv_bwd_data_kernel_bf16(const jit_conv_conf_t &ajcp)
+    jit_avx512_dw_conv_bwd_data_kernel_bf16_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp), bf16_emu_(nullptr) {
 
         if (!isa_has_bf16(jcp.isa))
@@ -139,7 +139,7 @@ struct jit_avx512_dw_conv_bwd_data_kernel_bf16 : public jit_generator_t {
                     bf16_emu_reserv_4, bf16_emu_reserv_5, bf16_emu_reserv_6);
     }
 
-    ~jit_avx512_dw_conv_bwd_data_kernel_bf16() override = default;
+    ~jit_avx512_dw_conv_bwd_data_kernel_bf16_t() override = default;
 
     jit_conv_conf_t jcp;
 
@@ -202,14 +202,14 @@ private:
                 format_tag::nwc);
     }
 
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_dw_conv_bwd_data_kernel_bf16);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_dw_conv_bwd_data_kernel_bf16_t);
 };
 
-struct jit_avx512_dw_conv_bwd_weights_kernel_bf16 : public jit_generator_t {
+struct jit_avx512_dw_conv_bwd_weights_kernel_bf16_t : public jit_generator_t {
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_bwd_weights_kernel_bf16)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_bwd_weights_kernel_bf16_t)
 
-    jit_avx512_dw_conv_bwd_weights_kernel_bf16(const jit_conv_conf_t &ajcp)
+    jit_avx512_dw_conv_bwd_weights_kernel_bf16_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp), bf16_emu_(nullptr) {
 
         if (!isa_has_bf16(jcp.isa))
@@ -218,7 +218,7 @@ struct jit_avx512_dw_conv_bwd_weights_kernel_bf16 : public jit_generator_t {
                     bf16_emu_reserv_4, bf16_emu_reserv_5, bf16_emu_reserv_6);
     }
 
-    ~jit_avx512_dw_conv_bwd_weights_kernel_bf16() override = default;
+    ~jit_avx512_dw_conv_bwd_weights_kernel_bf16_t() override = default;
 
     jit_conv_conf_t jcp;
 
@@ -280,7 +280,7 @@ private:
 
     std::unique_ptr<bf16_emulation_t> bf16_emu_;
 
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_dw_conv_bwd_weights_kernel_bf16)
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_dw_conv_bwd_weights_kernel_bf16_t)
 
     /* Micro-kernel JIT'ing, fusing 'kw' and 'ow_block' loops into unrolled FMAs
      */

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -152,7 +152,7 @@ private:
     Xbyak::Zmm zmm_ker_reg = Xbyak::Zmm(0);
     Xbyak::Zmm zmm_dst_reg = Xbyak::Zmm(1);
 
-    inline Xbyak::Zmm get_acc_reg(int idx) {
+    inline Xbyak::Zmm get_acc_reg(int idx) const {
         assert(idx + acc_idx_start <= get_max_regs());
         return Xbyak::Zmm(idx + acc_idx_start);
     }
@@ -237,11 +237,11 @@ private:
     Xbyak::Zmm zmm_bias_reg = Xbyak::Zmm(0);
     Xbyak::Zmm zmm_out_reg = Xbyak::Zmm(1);
 
-    inline Xbyak::Zmm get_acc_reg(int idx) {
+    inline Xbyak::Zmm get_acc_reg(int idx) const {
         assert(idx + idx_start <= get_max_regs());
         return Xbyak::Zmm(idx + idx_start);
     }
-    inline Xbyak::Zmm get_input_reg(int idx) {
+    inline Xbyak::Zmm get_input_reg(int idx) const {
         const int i_idx = idx_start + jcp.kw + idx % jcp.kw;
         assert(i_idx <= get_max_regs());
         return Xbyak::Zmm(i_idx);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -22,7 +22,7 @@
 
 #include "cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -35,7 +35,7 @@ using namespace dnnl::impl::utils;
 
 using namespace Xbyak;
 
-jit_avx512_dw_conv_fwd_kernel_f16::jit_avx512_dw_conv_fwd_kernel_f16(
+jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name()), jcp(ajcp) {
     const auto simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
@@ -70,7 +70,7 @@ static bool check_if_tail(const bool is_ch_tail, const int c_tail, const int ch,
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && simd_w > c_tail;
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::load_src(
+void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
         int ur_ch_blocks, int ur_w, bool is_ch_tail) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -110,7 +110,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16::load_src(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::apply_filter_unrolled(
+void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
     int ch_blk = jcp.ch_block;
     int dilate_h = jcp.dilate_h + 1;
@@ -238,7 +238,7 @@ void iterate(const int ur_ch_blocks, const int ur_w, const F &f) {
     iterate(ur_ch_blocks, ur_w, false, f);
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::apply_postops(
+void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_postops(
         const int ur_ch_blocks, const int ur_w, const bool is_ch_tail) {
     if (this->jcp.with_eltwise || this->jcp.with_binary) {
         injector_utils::vmm_index_set_t zmm_idxs;
@@ -309,7 +309,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16::apply_postops(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::store_dst(
+void jit_avx512_dw_conv_fwd_kernel_f16_t::store_dst(
         int ur_ch_blocks, int ur_w, bool is_ch_tail) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -333,7 +333,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16::store_dst(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::compute_loop(
+void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
         int ur_w, int ur_ch_blocks, int pad_l, int pad_r) {
 
     const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
@@ -412,7 +412,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16::compute_loop(
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::ow_loop(int ur_ch_blocks) {
+void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
 
     int iw = jcp.iw;
     int ow = jcp.ow;
@@ -481,7 +481,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16::ow_loop(int ur_ch_blocks) {
     }
 }
 
-void jit_avx512_dw_conv_fwd_kernel_f16::generate() {
+void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     this->preamble();
 
     if (jcp.is_fused_conv) {

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
@@ -76,20 +76,20 @@ private:
 
     inline Xbyak::Zmm get_ker_reg(int idx) { return Xbyak::Zmm(idx + 0); }
     inline Xbyak::Zmm get_src_reg(int idx) { return Xbyak::Zmm(idx + 1); }
-    inline int get_acc_reg_idx(int idx) {
+    inline int get_acc_reg_idx(int idx) const {
         const int max_regs = 32;
         return idx + (max_regs - jcp.ur_w * jcp.nb_ch_blocking);
     }
-    inline Xbyak::Zmm get_acc_reg(int idx) {
+    inline Xbyak::Zmm get_acc_reg(int idx) const {
         return Xbyak::Zmm(get_acc_reg_idx(idx));
     }
 
-    int get_ow_start(int ki, int pad_l) {
+    int get_ow_start(int ki, int pad_l) const {
         return nstl::max(0,
                 utils::div_up(pad_l - ki * (jcp.dilate_w + 1), jcp.stride_w));
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
                 - nstl::max(0,
                         utils::div_up(
@@ -97,11 +97,11 @@ private:
                                 jcp.stride_w));
     }
 
-    inline bool is_src_layout_nxc() {
+    inline bool is_src_layout_nxc() const {
         return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
                 format_tag::nwc);
     }
-    inline bool is_dst_layout_nxc() {
+    inline bool is_dst_layout_nxc() const {
         return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
                 format_tag::nwc);
     }

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
@@ -32,10 +32,10 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_avx512_dw_conv_fwd_kernel_f16 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_fwd_kernel_f16)
+struct jit_avx512_dw_conv_fwd_kernel_f16_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_avx512_dw_conv_fwd_kernel_f16_t)
 
-    jit_avx512_dw_conv_fwd_kernel_f16(
+    jit_avx512_dw_conv_fwd_kernel_f16_t(
             const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md);
 
     jit_conv_conf_t jcp;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -32,7 +32,7 @@
 #include "cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp"
 #include "cpu/x64/jit_uni_1x1_conv_utils.hpp"
 
-#define GET_OFF(field) offsetof(jit_1x1_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_1x1_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -32,10 +32,11 @@ namespace cpu {
 namespace x64 {
 
 template <typename Vmm>
-struct _jit_avx512_core_x8s8s32x_1x1_conv_kernel : public jit_generator_t {
+struct jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_avx512_core_x8s8s32x_1x1_conv_fwd_ker_t)
-    _jit_avx512_core_x8s8s32x_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
-            const primitive_attr_t &attr, const memory_desc_t &dst_md);
+    jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t(
+            const jit_1x1_conv_conf_t &ajcp, const primitive_attr_t &attr,
+            const memory_desc_t &dst_md);
 
     jit_1x1_conv_conf_t jcp;
     const primitive_attr_t &attr_;
@@ -148,26 +149,26 @@ private:
             bool mask_flag);
 };
 
-struct jit_avx512_core_x8s8s32x_1x1_conv_kernel {
-    jit_avx512_core_x8s8s32x_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+struct jit_avx512_core_x8s8s32x_1x1_conv_kernel_t {
+    jit_avx512_core_x8s8s32x_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
         int ch_block = ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Xbyak::Zmm>>(
-                        ajcp, attr, dst_md);
+                        jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<
+                                Xbyak::Zmm>>(ajcp, attr, dst_md);
                 return;
             case 8:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Xbyak::Ymm>>(
-                        ajcp, attr, dst_md);
+                        jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<
+                                Xbyak::Ymm>>(ajcp, attr, dst_md);
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Xbyak::Xmm>>(
-                        ajcp, attr, dst_md);
+                        jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<
+                                Xbyak::Xmm>>(ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
         }
@@ -178,7 +179,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_x8s8s32x_1x1_conv_kernel() = default;
+    ~jit_avx512_core_x8s8s32x_1x1_conv_kernel_t() = default;
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_t *&src_md,
@@ -193,7 +194,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_x8s8s32x_1x1_conv_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_x8s8s32x_1x1_conv_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -190,7 +190,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr);
 
-    void operator()(const jit_1x1_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_1x1_conv_args_t *p) const { (*kernel_)(p); }
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -174,7 +174,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
     const int nb_oc = jcp.nb_load;
@@ -395,7 +395,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
         const auto ocb_end = ocb_start + load_step;
         const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
-        auto par_conv_dw = jit_conv_call_s();
+        auto par_conv_dw = jit_conv_args_t();
 
         par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
         par_conv_dw.b_overflow = nstl::min(

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -105,13 +105,13 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_x8s8s32x_1x1_conv_kernel::init_conf(jcp_,
+            CHECK(jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(jcp_,
                     *conv_d, src_d, weights_md_, dst_md_, bias_md_, *attr(),
                     dnnl_get_max_threads(), rtus_.reduce_src_));
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_core_x8s8s32x_1x1_conv_kernel::init_scratchpad(
+            jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_scratchpad(
                     scratchpad, jcp_, *attr());
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
@@ -315,7 +315,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_core_x8s8s32x_1x1_conv_kernel(
+                new jit_avx512_core_x8s8s32x_1x1_conv_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_1x1_md(0))));
         CHECK(kernel_->create_kernel());
 
@@ -352,9 +352,9 @@ private:
             const memory_tracking::grantor_t &scratchpad,
             const float *dst_scales, const float *dw_wei_scales) const;
 
-    std::unique_ptr<jit_avx512_core_x8s8s32x_1x1_conv_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_x8s8s32x_1x1_conv_kernel_t> kernel_;
     std::unique_ptr<rtus_driver_t<avx512_core>> rtus_driver_;
-    using dw_conv_kernel_t = jit_avx512_core_x8s8s32x_fwd_kernel;
+    using dw_conv_kernel_t = jit_avx512_core_x8s8s32x_fwd_kernel_t;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
 };
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -123,6 +123,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             return cpu_convolution_fwd_pd_t::dst_md(index);
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *dst_md(
                 int index = 0, bool user_input = false) const override {
             return dw_conv_pd_ && jcp_.with_dw_conv
@@ -145,6 +146,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             }
             return convolution_fwd_pd_t::arg_md(arg, user_input);
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -28,7 +28,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -278,7 +278,7 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel_t {
             memory_desc_t &bias_pd, primitive_attr_t &attr, int nthreads);
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp, const primitive_attr_t &attr);
-    void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*kernel_)(p); }
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -59,11 +59,11 @@ private:
         ker_dw_reg_base_idx = 30,
         ker_zp_reg_base_idx = 26,
     };
-    typedef enum {
+    enum class ic_block_t {
         no_last_block,
         last_ic_block,
         last_sp_block,
-    } ic_block_t;
+    };
 
     /* data regs */
     const Xbyak::Reg64 reg_ptr_scales = rax;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -32,12 +32,12 @@ namespace cpu {
 namespace x64 {
 
 template <typename Vmm>
-struct _jit_avx512_core_x8s8s32x_fwd_kernel : public jit_generator_t {
+struct jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_avx512_core_x8s8s32x_conv_fwd_ker_t)
 
     enum { STATE_FIRST_DST_LOAD = 0x1U };
 
-    _jit_avx512_core_x8s8s32x_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     jit_conv_conf_t jcp;
@@ -239,26 +239,26 @@ private:
     Vmm vmm_mask(const Vmm vmm_in, bool mask_flag, bool store = false);
 };
 
-struct jit_avx512_core_x8s8s32x_fwd_kernel {
+struct jit_avx512_core_x8s8s32x_fwd_kernel_t {
 
-    jit_avx512_core_x8s8s32x_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_avx512_core_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
         int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Zmm>>(
+                        jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Xbyak::Zmm>>(
                         ajcp, attr, dst_md);
                 return;
             case 8:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Ymm>>(
+                        jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Xbyak::Ymm>>(
                         ajcp, attr, dst_md);
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_avx512_core_x8s8s32x_fwd_kernel<Xbyak::Xmm>>(
+                        jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -270,7 +270,7 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_avx512_core_x8s8s32x_fwd_kernel() = default;
+    ~jit_avx512_core_x8s8s32x_fwd_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_pd,
@@ -282,7 +282,7 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel {
     const Xbyak::uint8 *jit_ker() const { return kernel_->jit_ker(); }
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_x8s8s32x_fwd_kernel)
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_avx512_core_x8s8s32x_fwd_kernel_t)
     std::unique_ptr<jit_generator_t> kernel_;
 };
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -113,7 +113,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         int n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
@@ -243,7 +243,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -409,7 +409,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [&](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
-                auto p = jit_conv_call_s();
+                auto p = jit_conv_args_t();
 
                 size_t src_h_stride = src_d.blk_off(0, 0, 1);
                 size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
@@ -527,7 +527,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         size_t src_d_stride = src_d.blk_off(0, 0, 1);
         size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
@@ -77,12 +77,12 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_avx512_core_x8s8s32x_fwd_kernel::init_conf(jcp_, *desc(),
-                    src_md_, weights_md_, dst_md_, bias_md_, attr_,
+            CHECK(jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jcp_,
+                    *desc(), src_md_, weights_md_, dst_md_, bias_md_, attr_,
                     dnnl_get_max_threads()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_avx512_core_x8s8s32x_fwd_kernel::init_scratchpad(
+            jit_avx512_core_x8s8s32x_fwd_kernel_t::init_scratchpad(
                     scratchpad, jcp_, *attr());
 
             return status::success;
@@ -114,7 +114,7 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_avx512_core_x8s8s32x_fwd_kernel(
+                new jit_avx512_core_x8s8s32x_fwd_kernel_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         return kernel_->create_kernel();
     }
@@ -142,7 +142,7 @@ private:
     const float *adjust_oscales(const memory_tracking::grantor_t &scratchpad,
             const float *src_scales, const float *wei_scales) const;
 
-    std::unique_ptr<jit_avx512_core_x8s8s32x_fwd_kernel> kernel_;
+    std::unique_ptr<jit_avx512_core_x8s8s32x_fwd_kernel_t> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -21,7 +21,7 @@
 
 #include "cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp"
 
-#define GET_OFF(field) offsetof(jit_deconv_call_s, field)
+#define GET_OFF(field) offsetof(jit_deconv_args_t, field)
 
 namespace dnnl {
 namespace impl {
@@ -1465,7 +1465,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
         int work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         int n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
@@ -1572,7 +1572,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
         int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         /*loop order = cgn*/
         int n {0}, g {0}, occ {0}, oh_s {0};
@@ -1743,7 +1743,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
         int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         /*loop order = cgn*/
         int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -40,11 +40,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-typedef enum {
+enum ker_block_t {
     no_last_block = 0x1U,
     last_ic_block = 0x2U,
     last_sp_block = 0x4U,
-} ker_block_t;
+};
 
 struct ur_w_blks_params_t {
     struct single_ur_w_blk_params_t {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -226,7 +226,7 @@ struct jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t {
 
     ~jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t() = default;
 
-    void operator()(const jit_deconv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_deconv_args_t *p) const { (*kernel_)(p); }
 
     static bool post_ops_ok(jit_conv_conf_t &jcp, primitive_attr_t &attr,
             const memory_desc_wrapper &dst_d);

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -357,7 +357,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
                 + ih * src_w_sz + iw * jcp.ngroups * jcp.ic_without_padding
                 + g_ic;
         auto p = jit_avx512_core_brgemm_conv_trans_kernel::
-                jit_brgemm_conv_trans_kernel_call_s();
+                jit_brgemm_conv_trans_kernel_args_t();
         p.h_count = nh;
         p.owb = nw;
         p.src = src + src_dt_size * inp_offset;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1541,7 +1541,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
                 std::memset(&s8s8_comp_buffer[buffer_offs], 0,
                         sizeof(int32_t) * comp_kw_sz);
 
-            jit_brgemm_conv_comp_pad_call_s p;
+            jit_brgemm_conv_comp_pad_args_t p;
 
             p.kd_l = kd_e - kd_b;
             p.kh_l = kh_e - kh_b;
@@ -1779,7 +1779,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
         if (bmask(icb, btc.odb, btc.ohb, btc.owb)) return;
     }
 
-    auto cp = jit_brgemm_conv_trans_kernel_call_s();
+    auto cp = jit_brgemm_conv_trans_kernel_args_t();
 
     const auto prev_odb
             = (jcp.copy_block_only || btc.odb == 0
@@ -1859,7 +1859,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                 + iw_buf * jcp.inp_ic_block * (jcp.is_relo_whi() ? KH : 1);
 
         // for relo_whi we copy top and bottom padded lines
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         bool has_inp_buffer_overlap = true && last_btc.g == btc.g
                 && last_btc.n == btc.n && last_btc.owb == btc.owb;

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -78,7 +78,7 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         int bs_c;
         // need custom hasher to use array as key in unordered_map
         template <int asize>
-        struct ahasher {
+        struct hasher_t {
             size_t operator()(const std::array<int, asize> &a) const {
                 size_t seed = 0;
                 for (auto e : a)
@@ -88,7 +88,7 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         };
         template <int asize>
         using Arrmap = std::unordered_map<std::array<int, asize>, int,
-                ahasher<asize>>;
+                hasher_t<asize>>;
 
         Arrmap<4> batchsizes;
         int brg_indices_c {0};

--- a/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
@@ -28,7 +28,7 @@ using namespace data_type;
 
 namespace jit_avx512_core_brgemm_conv_bwd_copy_kernel {
 
-#define GET_OFF(field) offsetof(jit_brgemm_conv_bwd_copy_kernel_call_s, field)
+#define GET_OFF(field) offsetof(jit_brgemm_conv_bwd_copy_kernel_args_t, field)
 
 template <typename Vmm>
 jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::

--- a/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.hpp
@@ -26,10 +26,10 @@ namespace cpu {
 namespace x64 {
 
 namespace jit_avx512_core_brgemm_conv_bwd_copy_kernel {
-struct jit_brgemm_conv_bwd_copy_kernel_call_s {
-    const void *src;
-    const void *dst;
-    size_t num_ic;
+struct jit_brgemm_conv_bwd_copy_kernel_args_t {
+    const void *src = nullptr;
+    const void *dst = nullptr;
+    size_t num_ic = 0;
 };
 
 template <typename Vmm>

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -900,7 +900,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                     const int ic_size
                             = is_ic_tail ? jcp.ic % jcp.ic_block : jcp.ic_block;
 
-                    auto cp = jit_brgemm_conv_bwd_copy_kernel_call_s();
+                    auto cp = jit_brgemm_conv_bwd_copy_kernel_args_t();
                     cp.src = btc.out_buffer;
                     cp.dst = diff_src
                             + data_blk_off(diff_src_d, n,
@@ -970,7 +970,7 @@ void brgemm_convolution_bwd_strided_t<isa>::cal_compensation(
             if (!everyone_is(0, kd_e, kd_b, kh_e, kh_b, kw_e, kw_b)) {
                 assert(kd_e > kd_b && kh_e > kh_b && kw_e > kw_b);
 
-                jit_brgemm_conv_comp_pad_call_s p;
+                jit_brgemm_conv_comp_pad_args_t p;
 
                 p.kd_l = div_up(kd_e - kd_b, SD);
                 p.kh_l = div_up(kh_e - kh_b, SH);
@@ -1150,7 +1150,7 @@ void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
             && last_ihb == ihb && last_iwb == iwb)
         return;
 
-    auto cp = jit_brgemm_conv_bwd_trans_kernel_call_s();
+    auto cp = jit_brgemm_conv_bwd_trans_kernel_args_t();
 
     const auto oc = ocb * jcp.oc_block;
     const auto g_oc = g * jcp.oc + oc;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
@@ -60,7 +60,7 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
 
         // need custom hasher to use array as key in unordered_map
         template <int asize>
-        struct ahasher {
+        struct hasher_t {
             size_t operator()(const std::array<int, asize> &a) const {
                 size_t seed = 0;
                 for (auto e : a)
@@ -70,7 +70,7 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
         };
         template <int asize>
         using Arrmap = std::unordered_map<std::array<int, asize>, int,
-                ahasher<asize>>;
+                hasher_t<asize>>;
 
         int brg_indices_c {0};
         Arrmap<4> brg_indices;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
@@ -28,7 +28,7 @@ using namespace data_type;
 
 namespace jit_avx512_core_brgemm_conv_bwd_trans_kernel {
 
-#define GET_OFF(field) offsetof(jit_brgemm_conv_bwd_trans_kernel_call_s, field)
+#define GET_OFF(field) offsetof(jit_brgemm_conv_bwd_trans_kernel_args_t, field)
 
 template <typename Vmm>
 jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.hpp
@@ -26,14 +26,14 @@ namespace cpu {
 namespace x64 {
 
 namespace jit_avx512_core_brgemm_conv_bwd_trans_kernel {
-struct jit_brgemm_conv_bwd_trans_kernel_call_s {
-    const void *src;
-    const void *dst;
-    size_t iwb;
-    size_t oc;
-    size_t t_pad;
-    size_t h_count;
-    size_t b_pad;
+struct jit_brgemm_conv_bwd_trans_kernel_args_t {
+    const void *src = nullptr;
+    const void *dst = nullptr;
+    size_t iwb = 0;
+    size_t oc = 0;
+    size_t t_pad = 0;
+    size_t h_count = 0;
+    size_t b_pad = 0;
 };
 
 template <typename Vmm>

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -981,7 +981,7 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
                             0, 0, 1, oh_s, ohb_s, ohb_e);
 
                     if (jcp.with_bias && ic_b == 0) {
-                        auto bp = jit_conv_call_s();
+                        auto bp = jit_conv_args_t();
 
                         bp.bias = diff_bias + g * rnd_up(jcp.oc, jcp.oc_block)
                                 + oc_b * jcp.oc_block;
@@ -1170,7 +1170,7 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
 
                         if (jcp.with_bias && ic_b == 0) {
                             for (int iodb = odb_s; iodb < odb_e; iodb++) {
-                                auto bp = jit_conv_call_s();
+                                auto bp = jit_conv_args_t();
 
                                 bp.bias = diff_bias
                                         + g * rnd_up(jcp.oc, jcp.oc_block)
@@ -1263,7 +1263,7 @@ void brgemm_convolution_bwd_weights_t::store_in_vnni_format(
         const int g = ti->g_start + sub_g_start;
         const int oc_b = ti->oc_b_start + sub_oc_b_start;
         const int ic_b = ti->ic_b_start + vnni_granularity * sub_icb2_start;
-        jit_conv_call_s p = jit_conv_call_s();
+        jit_conv_args_t p = jit_conv_args_t();
 
         float *input = ti->wei_bia_reduction + wei_offset_int(g, oc_b, ic_b, 0);
         char *output = (char *)ti->diff_weights

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -29,7 +29,7 @@ using namespace prop_kind;
 
 namespace jit_uni_brgemm_conv_comp_pad_kernel {
 
-#define GET_OFF(field) offsetof(jit_brgemm_conv_comp_pad_call_s, field)
+#define GET_OFF(field) offsetof(jit_brgemm_conv_comp_pad_args_t, field)
 
 template <typename Vmm>
 jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -26,16 +26,16 @@ namespace cpu {
 namespace x64 {
 
 namespace jit_uni_brgemm_conv_comp_pad_kernel {
-struct jit_brgemm_conv_comp_pad_call_s {
-    const void *ptr_in;
-    void *ptr_zp_out;
-    void *ptr_cp_out;
-    size_t use_inversion;
-    size_t kw_l;
-    size_t kh_l;
-    size_t kd_l;
-    size_t ker_l {1};
-    size_t last_ocb {1};
+struct jit_brgemm_conv_comp_pad_args_t {
+    const void *ptr_in = nullptr;
+    void *ptr_zp_out = nullptr;
+    void *ptr_cp_out = nullptr;
+    size_t use_inversion = 0;
+    size_t kw_l = 0;
+    size_t kh_l = 0;
+    size_t kd_l = 0;
+    size_t ker_l = 1;
+    size_t last_ocb = 1;
 };
 
 // Kernel is unified to work with fwd and bwd_d conv

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
@@ -28,7 +28,7 @@ using namespace data_type;
 
 namespace jit_avx512_core_brgemm_conv_trans_kernel {
 
-#define GET_OFF(field) offsetof(jit_brgemm_conv_trans_kernel_call_s, field)
+#define GET_OFF(field) offsetof(jit_brgemm_conv_trans_kernel_args_t, field)
 
 jit_avx512_core_brgemm_conv_trans_kernel_t::
         jit_avx512_core_brgemm_conv_trans_kernel_t(

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.hpp
@@ -26,14 +26,14 @@ namespace cpu {
 namespace x64 {
 
 namespace jit_avx512_core_brgemm_conv_trans_kernel {
-struct jit_brgemm_conv_trans_kernel_call_s {
-    const void *src;
-    const void *dst;
-    size_t owb;
-    size_t ic;
-    size_t t_pad;
-    size_t h_count;
-    size_t b_pad;
+struct jit_brgemm_conv_trans_kernel_args_t {
+    const void *src = nullptr;
+    const void *dst = nullptr;
+    size_t owb = 0;
+    size_t ic = 0;
+    size_t t_pad = 0;
+    size_t h_count = 0;
+    size_t b_pad = 0;
 };
 
 struct jit_avx512_core_brgemm_conv_trans_kernel_t : public jit_generator_t {

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -1237,7 +1237,7 @@ void brgemm_inner_product_bwd_weights_t<isa>::transpose_matrix_c_chunk(
     const auto &jbgp = pd()->jbgp_;
 
     if (jbgp.is_amx) {
-        auto p = jit_amx_ip_trans_diff_wei::ctx_t();
+        auto p = jit_amx_ip_trans_diff_wei_t::ctx_t();
 
         // Note: This assumes AxB{inner_blocking} weights memory format.
         const dim_t ext_nb_ic = div_up(jbgp.ic, ext_ic_block_);

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -603,12 +603,13 @@ struct brgemm_inner_product_bwd_weights_t : public primitive_t {
 
         if (jbgp.use_buffer_b)
             CHECK(create_brgemm_trans_to_vnni(trans_B_kernel_, &pd()->jbgp_,
-                    jit_brgemm_trans_to_vnni_t::matrix_to_transform::matrix_B));
+                    jit_brgemm_trans_to_vnni_t::matrix_to_transform_t::
+                            matrix_B));
 
         if (!jbgp.is_amx) {
             if (jbgp.wei_dt != jbgp.acc_dt)
                 CHECK(create_brgemm_trans_to_vnni(trans_C_kernel_, &pd()->jbgp_,
-                        jit_brgemm_trans_to_vnni_t::matrix_to_transform::
+                        jit_brgemm_trans_to_vnni_t::matrix_to_transform_t::
                                 matrix_C));
         } else if (utils::one_of(jbgp.wei_dt, data_type::bf16, data_type::f16,
                            data_type::f8_e5m2, data_type::f8_e4m3)) {

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -640,7 +640,7 @@ private:
     std::unique_ptr<jit_brgemm_trans_to_vnni_t> trans_B_kernel_;
     std::unique_ptr<jit_brgemm_trans_to_vnni_t> trans_C_kernel_;
     std::unique_ptr<cpu_accumulator_1d_t<data_type::f32>> acc_ker_;
-    std::unique_ptr<jit_amx_ip_trans_diff_wei> diff_wei_trans_kernel_;
+    std::unique_ptr<jit_amx_ip_trans_diff_wei_t> diff_wei_trans_kernel_;
 
     void execute_backward_weights(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -2914,13 +2914,13 @@ void jit_brgemm_trans_wei_f16_t::generate() {
     postamble();
 }
 
-struct jit_amx_ip_trans_diff_wei_to_vnni_t : public jit_amx_ip_trans_diff_wei,
+struct jit_amx_ip_trans_diff_wei_to_vnni_t : public jit_amx_ip_trans_diff_wei_t,
                                              public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_amx_ip_trans_diff_wei_to_vnni)
 
     jit_amx_ip_trans_diff_wei_to_vnni_t(const jit_brgemm_primitive_conf_t *jbgp,
             const int ext_ic_block, const int ext_oc_block)
-        : jit_amx_ip_trans_diff_wei(jbgp, ext_ic_block, ext_oc_block)
+        : jit_amx_ip_trans_diff_wei_t(jbgp, ext_ic_block, ext_oc_block)
         , jit_generator_t(jit_name()) {}
 
     void operator()(ctx_t *ctx) override { jit_generator_t::operator()(ctx); }
@@ -3222,7 +3222,7 @@ status_t create_brgemm_trans_wei(
 }
 
 status_t create_brgemm_amx_ip_trans_wei(
-        std::unique_ptr<jit_amx_ip_trans_diff_wei> &trans_ker,
+        std::unique_ptr<jit_amx_ip_trans_diff_wei_t> &trans_ker,
         const jit_brgemm_primitive_conf_t *conf, const int ext_ic_block,
         const int ext_oc_block) {
     if (conf->prop_kind == dnnl_backward_weights

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -2116,7 +2116,7 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
     if (!is_f32) {
         const uint8_t no = 16; // 16o
         for (uint8_t o = 0; o < no; ++o) {
-            for (uint8_t r = 0; r < vnni_width; r++) {
+            for (uint8_t r = 0; r < static_cast<uint8_t>(vnni_width); r++) {
                 const uint8_t index = o + r * no;
                 if (is_xf16)
                     dw(index);

--- a/src/cpu/x64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.hpp
@@ -225,7 +225,7 @@ private:
     void generate() override;
 };
 
-struct jit_amx_ip_trans_diff_wei {
+struct jit_amx_ip_trans_diff_wei_t {
     struct ctx_t {
         const void *src;
         const void *dst;
@@ -237,13 +237,13 @@ struct jit_amx_ip_trans_diff_wei {
     virtual void operator()(ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;
 
-    jit_amx_ip_trans_diff_wei(const jit_brgemm_primitive_conf_t *jbgp,
+    jit_amx_ip_trans_diff_wei_t(const jit_brgemm_primitive_conf_t *jbgp,
             const int ext_ic_block, const int ext_oc_block)
         : jbgp_(jbgp)
         , ext_ic_block_(ext_ic_block)
         , ext_oc_block_(ext_oc_block) {}
 
-    virtual ~jit_amx_ip_trans_diff_wei() = default;
+    virtual ~jit_amx_ip_trans_diff_wei_t() = default;
 
     const jit_brgemm_primitive_conf_t *jbgp_;
 
@@ -265,7 +265,7 @@ status_t create_brgemm_trans_wei(
         std::unique_ptr<jit_brgemm_trans_wei_t> &trans_ker,
         const jit_brgemm_primitive_conf_t *conf);
 status_t create_brgemm_amx_ip_trans_wei(
-        std::unique_ptr<jit_amx_ip_trans_diff_wei> &trans_ker,
+        std::unique_ptr<jit_amx_ip_trans_diff_wei_t> &trans_ker,
         const jit_brgemm_primitive_conf_t *conf, const int ext_ic_block,
         const int ext_oc_block);
 } // namespace x64

--- a/src/cpu/x64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.hpp
@@ -145,10 +145,10 @@ struct jit_brgemm_trans_to_vnni_t {
         dim_t current_col_size, current_row_size;
     };
 
-    typedef enum matrix_to_transform {
+    enum class matrix_to_transform_t {
         matrix_B,
-        matrix_C
-    } matrix_to_transform_t;
+        matrix_C,
+    };
 
     virtual void operator()(ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;

--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
@@ -25,7 +25,7 @@ namespace cpu {
 namespace x64 {
 namespace gemm_x8s8s32x_convolution_utils {
 
-jit_gemm_x8s8s32x_zp_pad_comp_helper::jit_gemm_x8s8s32x_zp_pad_comp_helper(
+jit_gemm_x8s8s32x_zp_pad_comp_helper_t::jit_gemm_x8s8s32x_zp_pad_comp_helper_t(
         jit_generator_t *host, const conv_gemm_conf_t &jcp,
         const Xbyak::Reg64 &reg_zp_pad_comp,
         const Xbyak::Reg64 &reg_zp_pad_comp_temp,
@@ -62,7 +62,7 @@ jit_gemm_x8s8s32x_zp_pad_comp_helper::jit_gemm_x8s8s32x_zp_pad_comp_helper(
     , reg_zp_pad_comp_(reg_zp_pad_comp)
     , reg_zp_pad_comp_tmp_(reg_zp_pad_comp_temp) {}
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::init(const dim_t off_w,
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::init(const dim_t off_w,
         const dim_t off_h, const dim_t off_w_size, const dim_t off_w_off,
         const dim_t off_zp_pad_com_base_off,
         const dim_t off_g_oc_offset_prologue, const dim_t off_g_oc_offset,
@@ -76,14 +76,14 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::init(const dim_t off_w,
     load_zp_src_comp_pad_addr_if_needed(g_oc_offset_prologue_);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::
         load_next_point_zp_src_comp_pad_addr() {
     next_point();
     should_apply_zp_src_pad();
     load_zp_src_comp_pad_addr_if_needed(g_oc_offset_);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::zp_src_comp_pad_operation(
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::zp_src_comp_pad_operation(
         const std::function<void(const Xbyak::Reg64 &)> &op) {
     if (op) {
         Xbyak::Label end;
@@ -94,8 +94,8 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::zp_src_comp_pad_operation(
     }
 }
 
-jit_gemm_x8s8s32x_zp_pad_comp_helper::zp_src_pad_com_d
-jit_gemm_x8s8s32x_zp_pad_comp_helper::calculate_zp_src_pad_com_d(
+jit_gemm_x8s8s32x_zp_pad_comp_helper_t::zp_src_pad_com_d
+jit_gemm_x8s8s32x_zp_pad_comp_helper_t::calculate_zp_src_pad_com_d(
         const dim_t d_off) const {
 
     dim_t zp_src_pad_com_d_off = 0;
@@ -124,21 +124,21 @@ jit_gemm_x8s8s32x_zp_pad_comp_helper::calculate_zp_src_pad_com_d(
     return {should_apply_zp_src_pad_comp_d, zp_src_pad_com_d_off};
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::fin() {
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::fin() {
     host_->add(host_->rsp, reserved_stack_size_);
 }
 
-dim_t jit_gemm_x8s8s32x_zp_pad_comp_helper::calculate_lower_bound_dim(
+dim_t jit_gemm_x8s8s32x_zp_pad_comp_helper_t::calculate_lower_bound_dim(
         const dim_t begin_comp_pad) const noexcept {
     return begin_comp_pad;
 }
 
-dim_t jit_gemm_x8s8s32x_zp_pad_comp_helper::calculate_upper_bound_dim(
+dim_t jit_gemm_x8s8s32x_zp_pad_comp_helper_t::calculate_upper_bound_dim(
         const dim_t output_size, const dim_t end_comp_pad) const noexcept {
     return output_size - end_comp_pad;
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::set_up_initial_args(
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::set_up_initial_args(
         const dim_t off_w, const dim_t off_h, const dim_t off_w_size,
         const dim_t off_w_off, const dim_t off_zp_pad_com_base_off,
         const dim_t off_g_oc_offset_prologue, const dim_t off_g_oc_offset,
@@ -180,7 +180,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::set_up_initial_args(
     host_->mov(should_apply_zp_src_pad_comp_d_, reg_zp_pad_comp_tmp_i8);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::check_bound(
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::check_bound(
         const Xbyak::Reg64 &reg_dim, const Xbyak::Address &result_addr,
         const dim_t bound_value, const bound bound_kind) {
 
@@ -191,8 +191,8 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::check_bound(
         host_->setge(result_addr);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::load_zp_src_comp_pad_addr_if_needed(
-        const Xbyak::Address &g_oc_offset) {
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::
+        load_zp_src_comp_pad_addr_if_needed(const Xbyak::Address &g_oc_offset) {
     Xbyak::Label calc_zp_src_comp_pad_addr, end;
     host_->cmp(should_apply_zp_src_pad_, 0);
     host_->je(end, jit_generator_t::T_NEAR);
@@ -214,7 +214,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::load_zp_src_comp_pad_addr_if_needed(
     host_->L(end);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::
         calculate_zp_src_comp_pad_effective_addr(
                 const Xbyak::Address &g_oc_offset) {
     // Calculation steps:
@@ -240,7 +240,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::
     host_->add(reg_zp_pad_comp_, reg_zp_pad_comp_tmp_);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::get_zp_pad_com_dim(
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::get_zp_pad_com_dim(
         const Xbyak::Address &dim_under_lower_bound,
         const Xbyak::Address &dim_over_eq_upper_bound, const dim_t begin_pad,
         dim_t mid_pad, const dim_t end_pad, const dim_t out_dim_size,
@@ -272,7 +272,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::get_zp_pad_com_dim(
     host_->L(end);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::should_apply_zp_src_pad() {
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::should_apply_zp_src_pad() {
     const Xbyak::Reg8 &reg_tmp8 = reg_zp_pad_comp_tmp_.cvt8();
     host_->mov(reg_tmp8, w_under_lower_bound_);
     host_->or_(reg_tmp8, w_over_eq_upper_bound_);
@@ -285,7 +285,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper::should_apply_zp_src_pad() {
     host_->setne(should_apply_zp_src_pad_);
 }
 
-void jit_gemm_x8s8s32x_zp_pad_comp_helper::next_point() {
+void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::next_point() {
 
     Xbyak::Label inc_h, inc_w, row_begin, store_w;
 

--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
@@ -94,7 +94,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::zp_src_comp_pad_operation(
     }
 }
 
-jit_gemm_x8s8s32x_zp_pad_comp_helper_t::zp_src_pad_com_d
+jit_gemm_x8s8s32x_zp_pad_comp_helper_t::zp_src_pad_comp_d_dim_t
 jit_gemm_x8s8s32x_zp_pad_comp_helper_t::calculate_zp_src_pad_com_d(
         const dim_t d_off) const {
 
@@ -107,18 +107,18 @@ jit_gemm_x8s8s32x_zp_pad_comp_helper_t::calculate_zp_src_pad_com_d(
     const bool should_apply_zp_src_pad_comp_d
             = d_under_lower_bound || d_over_eq_upper_bound;
 
-    dim_t zp_src_pad_com_d = 0;
+    dim_t zp_src_pad_comp_d_dim_t = 0;
     if (d_under_lower_bound) {
-        zp_src_pad_com_d = d_off;
+        zp_src_pad_comp_d_dim_t = d_off;
     } else if (d_over_eq_upper_bound) {
-        zp_src_pad_com_d = jcp_.zp.src_pad_comp.front_pad
+        zp_src_pad_comp_d_dim_t = jcp_.zp.src_pad_comp.front_pad
                 + jcp_.zp.src_pad_comp.mid_d
                 + (jcp_.zp.src_pad_comp.back_pad - (jcp_.od - d_off));
     } else {
-        zp_src_pad_com_d = jcp_.zp.src_pad_comp.front_pad;
+        zp_src_pad_comp_d_dim_t = jcp_.zp.src_pad_comp.front_pad;
     }
 
-    zp_src_pad_com_d_off = zp_src_pad_com_d * jcp_.zp.src_pad_comp.h
+    zp_src_pad_com_d_off = zp_src_pad_comp_d_dim_t * jcp_.zp.src_pad_comp.h
             * jcp_.zp.src_pad_comp.w;
 
     return {should_apply_zp_src_pad_comp_d, zp_src_pad_com_d_off};

--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp
@@ -50,12 +50,19 @@ public:
     void load_next_point_zp_src_comp_pad_addr();
     void zp_src_comp_pad_operation(
             const std::function<void(const Xbyak::Reg64 &)> &op);
-    struct zp_src_pad_com_d {
-        bool should_apply_pad_comp_d;
-        dim_t offset;
+
+    // `d` dim in `dhw` spatial.
+    struct zp_src_pad_comp_d_dim_t {
+        zp_src_pad_comp_d_dim_t() = default;
+        zp_src_pad_comp_d_dim_t(bool should_apply_pad_comp_d, dim_t offset)
+            : should_apply_pad_comp_d(should_apply_pad_comp_d)
+            , offset(offset) {}
+
+        bool should_apply_pad_comp_d = false;
+        dim_t offset = 0;
     };
 
-    zp_src_pad_com_d calculate_zp_src_pad_com_d(const dim_t d_off) const;
+    zp_src_pad_comp_d_dim_t calculate_zp_src_pad_com_d(const dim_t d_off) const;
 
 private:
     enum bound { upper, lower };

--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.hpp
@@ -34,8 +34,8 @@ class jit_generator_t;
 
 namespace gemm_x8s8s32x_convolution_utils {
 
-struct jit_gemm_x8s8s32x_zp_pad_comp_helper {
-    jit_gemm_x8s8s32x_zp_pad_comp_helper(jit_generator_t *host,
+struct jit_gemm_x8s8s32x_zp_pad_comp_helper_t {
+    jit_gemm_x8s8s32x_zp_pad_comp_helper_t(jit_generator_t *host,
             const conv_gemm_conf_t &jcp, const Xbyak::Reg64 &reg_zp_pad_comp,
             const Xbyak::Reg64 &reg_zp_pad_comp_temp,
             const Xbyak::Reg8 &should_apply_zp_src_pad, const dim_t ndims);

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -136,7 +136,7 @@ private:
     const size_t sum_step_factor_;
     const size_t max_unroll_;
 
-    std::unique_ptr<jit_gemm_x8s8s32x_zp_pad_comp_helper> zp_pad_comp_helper_;
+    std::unique_ptr<jit_gemm_x8s8s32x_zp_pad_comp_helper_t> zp_pad_comp_helper_;
 };
 
 jit_pp_ker_t::jit_pp_ker_t(
@@ -168,8 +168,8 @@ jit_pp_ker_t::jit_pp_ker_t(
     , zp_pad_comp_helper_(jit_gemm_convolution_utils::padding_exists(jcp)
                               && jcp.zp.src_exists
                       ? utils::make_unique<
-                              jit_gemm_x8s8s32x_zp_pad_comp_helper>(this, jcp_,
-                              reg_zp_pad_comp_, reg_zp_pad_comp_temp_,
+                              jit_gemm_x8s8s32x_zp_pad_comp_helper_t>(this,
+                              jcp_, reg_zp_pad_comp_, reg_zp_pad_comp_temp_,
                               reg_should_apply_src_pad_comp_,
                               pd->src_md()->ndims)
                       : nullptr)

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -251,12 +251,12 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
         args.w_size = chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_off = chunk_desc.w_off_;
         args.zp_src_pad_comp = zp.src_pad_comp;
-        const auto zp_src_pad_com_d
+        const auto zp_src_pad_comp_d_dim_t
                 = zp_pad_comp_helper_->calculate_zp_src_pad_com_d(
                         chunk_desc.d_off_);
-        args.zp_src_pad_com_d_offset = zp_src_pad_com_d.offset;
+        args.zp_src_pad_com_d_offset = zp_src_pad_comp_d_dim_t.offset;
         args.should_apply_zp_src_pad_comp_d
-                = zp_src_pad_com_d.should_apply_pad_comp_d;
+                = zp_src_pad_comp_d_dim_t.should_apply_pad_comp_d;
     }
 
     jit_generator_t::operator()(&args);

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -302,117 +302,117 @@ inline bool has_large_size(const convolution_desc_t &cd,
     return false;
 }
 
-struct jit_conv_call_s {
-    const void *src; /* hack, non-const for backward_data */
-    const void *dst; /* hack, non-const for forward */
-    const void *filt; /* hack, non-const for backward_weights */
-    const void *bias; /* hack, non-const for backward_bias */
-    const void *src_prf;
-    const void *dst_prf;
-    const void *filt_prf;
-    const void *bias_prf;
-    const void *scales;
-    const void *acc_s32;
-    const void *compensation;
-    const int32_t *zp_compensation;
-    const int32_t *src_zero_point;
-    const int32_t *zero_point_pbuff;
-    const int32_t *dst_zero_point;
-    const void *tile_cfg;
-    const void *tile_cfg_tail;
-    const void *dst_scale;
+struct jit_conv_args_t {
+    const void *src = nullptr; /* hack, non-const for backward_data */
+    const void *dst = nullptr; /* hack, non-const for forward */
+    const void *filt = nullptr; /* hack, non-const for backward_weights */
+    const void *bias = nullptr; /* hack, non-const for backward_bias */
+    const void *src_prf = nullptr;
+    const void *dst_prf = nullptr;
+    const void *filt_prf = nullptr;
+    const void *bias_prf = nullptr;
+    const void *scales = nullptr;
+    const void *acc_s32 = nullptr;
+    const void *compensation = nullptr;
+    const int32_t *zp_compensation = nullptr;
+    const int32_t *src_zero_point = nullptr;
+    const int32_t *zero_point_pbuff = nullptr;
+    const int32_t *dst_zero_point = nullptr;
+    const void *tile_cfg = nullptr;
+    const void *tile_cfg_tail = nullptr;
+    const void *dst_scale = nullptr;
 
     // ptr to table of void * elements that are pointers to
     // post_op binary src1 tensors
-    const void *post_ops_binary_rhs_arg_vec;
-    const void *dst_orig; // pointer to dst memory (no offset)
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    const void *dst_orig = nullptr; // pointer to dst memory (no offset)
 
-    size_t kd_offset;
-    size_t kd_offset_prf;
-    size_t kh_offset;
-    size_t kh_offset_prf;
-    size_t os_index_begin;
-    size_t os_index_begin_prf;
-    size_t os_index_end;
-    size_t os_index_end_prf;
-    size_t kd_padding;
-    size_t kd_padding_prf;
-    size_t kh_padding;
-    size_t kh_padding_prf;
-    size_t iwb;
-    size_t iwb_prf;
-    size_t owb;
-    size_t owb_prf;
-    size_t ohb;
-    size_t kw_padding;
-    size_t channel;
-    size_t channel_prf;
-    size_t ic_blocks;
-    size_t oc_blocks;
-    size_t ur_w;
-    size_t ur_str_w;
-    size_t ch_blocks;
-    size_t ch_blocks_prf;
-    size_t reduce_work;
-    size_t reduce_work_prf;
-    size_t load_work;
-    size_t load_work_prf;
-    size_t l_overflow;
-    size_t r_overflow;
-    size_t t_overflow;
-    size_t b_overflow;
-    size_t f_overflow;
-    size_t back_overflow;
-    size_t last_h;
-    size_t tail;
-    size_t current_iw;
-    size_t is_osb;
-    int flags;
-    int flags_prf;
-    int oc_flag;
-    size_t last_ic_block;
-    size_t last_oc_block;
+    size_t kd_offset = 0;
+    size_t kd_offset_prf = 0;
+    size_t kh_offset = 0;
+    size_t kh_offset_prf = 0;
+    size_t os_index_begin = 0;
+    size_t os_index_begin_prf = 0;
+    size_t os_index_end = 0;
+    size_t os_index_end_prf = 0;
+    size_t kd_padding = 0;
+    size_t kd_padding_prf = 0;
+    size_t kh_padding = 0;
+    size_t kh_padding_prf = 0;
+    size_t iwb = 0;
+    size_t iwb_prf = 0;
+    size_t owb = 0;
+    size_t owb_prf = 0;
+    size_t ohb = 0;
+    size_t kw_padding = 0;
+    size_t channel = 0;
+    size_t channel_prf = 0;
+    size_t ic_blocks = 0;
+    size_t oc_blocks = 0;
+    size_t ur_w = 0;
+    size_t ur_str_w = 0;
+    size_t ch_blocks = 0;
+    size_t ch_blocks_prf = 0;
+    size_t reduce_work = 0;
+    size_t reduce_work_prf = 0;
+    size_t load_work = 0;
+    size_t load_work_prf = 0;
+    size_t l_overflow = 0;
+    size_t r_overflow = 0;
+    size_t t_overflow = 0;
+    size_t b_overflow = 0;
+    size_t f_overflow = 0;
+    size_t back_overflow = 0;
+    size_t last_h = 0;
+    size_t tail = 0;
+    size_t current_iw = 0;
+    size_t is_osb = 0;
+    int flags = 0;
+    int flags_prf = 0;
+    int oc_flag = 0;
+    size_t last_ic_block = 0;
+    size_t last_oc_block = 0;
 };
 
-struct jit_deconv_call_s {
-    const void *src; /* hack, non-const for backward_data */
-    const void *dst; /* hack, non-const for forward */
-    const void *filt; /* hack, non-const for backward_weights */
-    const void *bias; /* hack, non-const for backward_bias */
-    const void *scales;
-    const void *dst_scale;
-    const void *compensation;
-    const int32_t *zp_src_pad_str_compensation;
-    const int32_t *zp_compensation;
-    const int32_t *src_zero_point;
-    const int32_t *dst_zero_point;
+struct jit_deconv_args_t {
+    const void *src = nullptr; /* hack, non-const for backward_data */
+    const void *dst = nullptr; /* hack, non-const for forward */
+    const void *filt = nullptr; /* hack, non-const for backward_weights */
+    const void *bias = nullptr; /* hack, non-const for backward_bias */
+    const void *scales = nullptr;
+    const void *dst_scale = nullptr;
+    const void *compensation = nullptr;
+    const int32_t *zp_src_pad_str_compensation = nullptr;
+    const int32_t *zp_compensation = nullptr;
+    const int32_t *src_zero_point = nullptr;
+    const int32_t *dst_zero_point = nullptr;
 
     /*
      * ptr to table of void * elements that are pointers to post_op binary
      * src1 tensors
      */
-    const void *post_ops_binary_rhs_arg_vec;
-    const void *dst_orig; /* pointer to dst memory (no offset) */
-    size_t t_overflow;
-    size_t b_overflow;
-    size_t f_overflow;
-    size_t back_overflow;
-    size_t kh_padding;
-    size_t kd_padding;
-    size_t oc_blocks;
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    const void *dst_orig = nullptr; /* pointer to dst memory (no offset) */
+    size_t t_overflow = 0;
+    size_t b_overflow = 0;
+    size_t f_overflow = 0;
+    size_t back_overflow = 0;
+    size_t kh_padding = 0;
+    size_t kd_padding = 0;
+    size_t oc_blocks = 0;
 };
 
-struct jit_dw_conv_call_s {
-    const void *input;
-    const void *output;
-    const void *filter;
-    const void *bias;
-    size_t kh_count;
-    size_t oh_count;
-    size_t oh_index;
-    size_t filter_pad_off;
-    unsigned char
-            exec_flags; /* Flags passed by driver execution to inner kernel */
+struct jit_dw_conv_args_t {
+    const void *input = nullptr;
+    const void *output = nullptr;
+    const void *filter = nullptr;
+    const void *bias = nullptr;
+    size_t kh_count = 0;
+    size_t oh_count = 0;
+    size_t oh_index = 0;
+    size_t filter_pad_off = 0;
+    // Flags passed by driver execution to inner kernel
+    unsigned char exec_flags = 0;
 };
 
 struct jit_1x1_conv_conf_t {
@@ -483,32 +483,33 @@ struct jit_1x1_conv_conf_t {
     bool uses_permw_transposition;
 };
 
-struct jit_1x1_conv_call_s {
-    const void *bcast_data;
-    const void *load_data;
-    const void *output_data;
-    const void *bias_data; // used in forward and backward_weights only
-    const void *acc_s32;
-    const void *scales;
-    const void *compensation;
-    const void *store_buffer;
-    const int32_t *zp_compensation;
-    const int32_t *src_zero_point;
-    const int32_t *dst_zero_point;
-    const void *dst_scale;
+struct jit_1x1_conv_args_t {
+    const void *bcast_data = nullptr;
+    const void *load_data = nullptr;
+    const void *output_data = nullptr;
+    // Used in forward and backward_weights only
+    const void *bias_data = nullptr;
+    const void *acc_s32 = nullptr;
+    const void *scales = nullptr;
+    const void *compensation = nullptr;
+    const void *store_buffer = nullptr;
+    const int32_t *zp_compensation = nullptr;
+    const int32_t *src_zero_point = nullptr;
+    const int32_t *dst_zero_point = nullptr;
+    const void *dst_scale = nullptr;
 
     // ptr to table of void * elements that are pointers to
     // post_op binary src1 tensors
-    const void *post_ops_binary_rhs_arg_vec;
-    const void *dst_orig; // pointer to dst memory (no offset)
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    const void *dst_orig = nullptr; // pointer to dst memory (no offset)
 
-    size_t load_dim;
-    size_t bcast_dim;
-    size_t reduce_dim;
+    size_t load_dim = 0;
+    size_t bcast_dim = 0;
+    size_t reduce_dim = 0;
 
-    size_t output_stride; // used in backward_weights only
+    size_t output_stride = 0; // used in backward_weights only
 
-    size_t first_last_flag;
+    size_t first_last_flag = 0;
 };
 
 struct jit_pool_conf_t {
@@ -556,28 +557,28 @@ struct jit_pool_conf_t {
     dim_t f32_accum_block_size;
 };
 
-struct jit_pool_call_s {
-    const void *src;
-    const void *dst;
-    const void *indices;
-    const void *src_prf;
-    const void *dst_prf;
-    const void *indices_prf;
-    const void *post_ops_binary_rhs_arg_vec;
-    const void *dst_orig;
-    const void *dst_po_helper;
-    size_t zero_ih;
-    size_t zero_id;
-    const void *zero_ptr;
-    size_t kd_padding;
-    size_t kh_padding;
-    size_t kh_padding_shift;
-    size_t kd_padding_shift;
-    size_t kw_padding;
-    const void *init_value;
-    float ker_area_h;
-    size_t ur_bc; // contains number of channel blocks to processing
-    size_t b_c; // contains number of channel blocks already processed
+struct jit_uni_pooling_args_t {
+    const void *src = nullptr;
+    const void *dst = nullptr;
+    const void *indices = nullptr;
+    const void *src_prf = nullptr;
+    const void *dst_prf = nullptr;
+    const void *indices_prf = nullptr;
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    const void *dst_orig = nullptr;
+    const void *dst_po_helper = nullptr;
+    size_t zero_ih = 0;
+    size_t zero_id = 0;
+    const void *zero_ptr = nullptr;
+    size_t kd_padding = 0;
+    size_t kh_padding = 0;
+    size_t kh_padding_shift = 0;
+    size_t kd_padding_shift = 0;
+    size_t kw_padding = 0;
+    const void *init_value = nullptr;
+    float ker_area_h = 0.f;
+    size_t ur_bc = 0; // contains number of channel blocks to processing
+    size_t b_c = 0; // contains number of channel blocks already processed
 };
 
 struct jit_resampling_conf_t {
@@ -624,7 +625,7 @@ struct jit_resampling_conf_t {
     std::queue<float> sum_scales;
 };
 
-struct jit_resampling_call_s {
+struct jit_uni_resampling_args_t {
     size_t batch_of_sp_points_to_process = 0;
 
     const void *src = nullptr;
@@ -874,13 +875,13 @@ struct jit_shuffle_conf_t {
     cpu_isa_t isa = isa_undef;
 };
 
-struct jit_shuffle_call_s {
+struct jit_uni_shuffle_args_t {
     const void *src = nullptr;
     void *dst = nullptr;
     const void *input_off_ptr = nullptr;
 
-    dim_t cb_loop_size
-            = 0; // number of loop iterations over corresponding C batches
+    // Number of loop iterations over corresponding C batches.
+    dim_t cb_loop_size = 0;
     bool is_padded_block = false;
 };
 
@@ -924,14 +925,19 @@ struct jit_binary_conf_t {
     data_type_t dst_type = data_type::undef;
 };
 
-struct jit_binary_call_s {
+struct jit_uni_binary_args_t {
     // keep all sizes at 8 bytes -- jit code expects this
-    const void *src0, *src1, *src2, *dst, *indices;
-    const float *scales_src0, *scales_src1;
-    size_t spat_offt_count;
-    const void *post_ops_binary_rhs_arg_vec;
-    size_t src1_stride_range;
-    const void *dst_orig;
+    const void *src0 = nullptr;
+    const void *src1 = nullptr;
+    const void *src2 = nullptr;
+    const void *dst = nullptr;
+    const void *indices = nullptr;
+    const float *scales_src0 = nullptr;
+    const float *scales_src1 = nullptr;
+    size_t spat_offt_count = 0;
+    const void *post_ops_binary_rhs_arg_vec = nullptr;
+    size_t src1_stride_range = 0;
+    const void *dst_orig = nullptr;
 };
 
 struct jit_reduction_conf_t {
@@ -959,7 +965,7 @@ struct jit_reduction_conf_t {
     std::queue<float> sum_scales;
 };
 
-struct jit_reduction_call_s {
+struct jit_uni_reduction_args_t {
     const void *src = nullptr;
     void *dst = nullptr;
     const void *post_ops_binary_rhs_arg_vec = nullptr;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -26,7 +26,7 @@
 #include "cpu/x64/jit_sse41_1x1_conv_kernel_f32.hpp"
 #include "cpu/x64/jit_uni_1x1_conv_utils.hpp"
 
-#define GET_OFF(field) offsetof(jit_1x1_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_1x1_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.hpp
@@ -29,8 +29,8 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_sse41_1x1_conv_kernel_f32 : public jit_generator_t {
-    jit_sse41_1x1_conv_kernel_f32(const jit_1x1_conv_conf_t &ajcp,
+struct jit_sse41_1x1_conv_kernel_f32_t : public jit_generator_t {
+    jit_sse41_1x1_conv_kernel_f32_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
@@ -39,7 +39,7 @@ struct jit_sse41_1x1_conv_kernel_f32 : public jit_generator_t {
             const memory_desc_wrapper &dst_d, const primitive_attr_t &attr,
             int nthreads);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sse41_1x1_conv_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sse41_1x1_conv_kernel_f32_t)
 
     jit_1x1_conv_conf_t jcp;
     const primitive_attr_t &attr_;

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2023 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    auto par_conv = jit_1x1_conv_call_s();
+    auto par_conv = jit_1x1_conv_args_t();
 
     const int nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
@@ -227,7 +227,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
             const int ow = 0;
             const int kw = 0;
-            jit_conv_call_s par_conv_dw;
+            jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 

--- a/src/cpu/x64/jit_sse41_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.hpp
@@ -66,7 +66,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_sse41_1x1_conv_kernel_f32::init_conf(jcp_, *desc(),
+            CHECK(jit_sse41_1x1_conv_kernel_f32_t::init_conf(jcp_, *desc(),
                     *src_md(), *weights_md(), *dst_md(), *attr(),
                     dnnl_get_max_threads()));
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
@@ -279,8 +279,8 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
                     dw_conv_buffer_size_,
                     types::data_type_size(dw_conv_pd_->src_md()->data_type));
 
-            jit_uni_dw_conv_fwd_kernel<sse41, data_type::f32>::init_scratchpad(
-                    dw_scratchpad, jcp_dw);
+            jit_uni_dw_conv_fwd_kernel_t<sse41,
+                    data_type::f32>::init_scratchpad(dw_scratchpad, jcp_dw);
 
             return status::success;
         }
@@ -292,7 +292,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_sse41_1x1_conv_kernel_f32(
+                new jit_sse41_1x1_conv_kernel_f32_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_1x1_md(0))));
         CHECK(kernel_->create_kernel());
         if (pd()->jcp_.with_dw_conv) {
@@ -319,8 +319,8 @@ private:
             const void *post_ops_binary_rhs_arg_vec,
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_sse41_1x1_conv_kernel_f32> kernel_;
-    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32<sse41>;
+    std::unique_ptr<jit_sse41_1x1_conv_kernel_f32_t> kernel_;
+    using dw_conv_kernel_t = jit_uni_dw_conv_fwd_kernel_f32_t<sse41>;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
 };
 

--- a/src/cpu/x64/jit_sse41_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.hpp
@@ -78,6 +78,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
             return cpu_convolution_fwd_pd_t::dst_md(index);
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *dst_md(
                 int index = 0, bool user_input = false) const override {
             return dw_conv_pd_ && jcp_.with_dw_conv
@@ -100,6 +101,7 @@ struct jit_sse41_1x1_convolution_fwd_t : public primitive_t {
             }
             return convolution_fwd_pd_t::arg_md(arg, user_input);
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -25,7 +25,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_sse41_conv_kernel_f32.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -38,7 +38,7 @@ using namespace dnnl::impl::utils;
 
 using namespace Xbyak;
 
-jit_sse41_conv_fwd_kernel_f32::jit_sse41_conv_fwd_kernel_f32(
+jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), sse41), jcp(ajcp), attr_(attr) {
@@ -63,7 +63,7 @@ jit_sse41_conv_fwd_kernel_f32::jit_sse41_conv_fwd_kernel_f32(
     }
 }
 
-void jit_sse41_conv_fwd_kernel_f32::oh_step_unroll_kw(
+void jit_sse41_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     int kw = jcp.kw;
     int stride_w = jcp.stride_w;
@@ -99,7 +99,7 @@ void jit_sse41_conv_fwd_kernel_f32::oh_step_unroll_kw(
     }
 }
 
-void jit_sse41_conv_fwd_kernel_f32::oh_step_nopad(
+void jit_sse41_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
@@ -155,7 +155,7 @@ static void iterate(const int oc_blocks, const int ur_w, const F &f) {
             f(mask_flag, i, j);
     }
 }
-void jit_sse41_conv_fwd_kernel_f32::apply_postops(
+void jit_sse41_conv_fwd_kernel_f32_t::apply_postops(
         const int oc_blocks, const int ur_w) {
     injector_utils::vmm_index_set_t vmm_idxs;
     if (jcp.with_binary) {
@@ -183,7 +183,7 @@ void jit_sse41_conv_fwd_kernel_f32::apply_postops(
     }
 }
 
-void jit_sse41_conv_fwd_kernel_f32::width_blk_step(
+void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     int kw = jcp.kw;
     int oc_blk = jcp.oc_block;
@@ -295,7 +295,7 @@ void jit_sse41_conv_fwd_kernel_f32::width_blk_step(
     sub(reg_bias, sizeof(float) * 8);
 }
 
-inline void jit_sse41_conv_fwd_kernel_f32::solve_common(int oc_blocks) {
+inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
     int n_oi = jcp.ow / ur_w;
@@ -344,7 +344,7 @@ inline void jit_sse41_conv_fwd_kernel_f32::solve_common(int oc_blocks) {
         width_blk_step(ur_w_tail, 0, r_pad, oc_blocks); // "tail"
 }
 
-void jit_sse41_conv_fwd_kernel_f32::generate() {
+void jit_sse41_conv_fwd_kernel_f32_t::generate() {
     this->preamble();
 
     mov(reg_input, ptr[this->param1 + GET_OFF(src)]);
@@ -379,7 +379,7 @@ void jit_sse41_conv_fwd_kernel_f32::generate() {
         postops_injector_->prepare_table(/* generate = */ true);
 }
 
-status_t jit_sse41_conv_fwd_kernel_f32::init_conf(jit_conv_conf_t &jcp,
+status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, const memory_desc_wrapper &src_d,
         const memory_desc_wrapper &weights_d, const memory_desc_wrapper &dst_d,
         const primitive_attr_t &attr, int nthreads) {

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
@@ -29,8 +29,8 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_sse41_conv_fwd_kernel_f32 : public jit_generator_t {
-    jit_sse41_conv_fwd_kernel_f32(const jit_conv_conf_t &ajcp,
+struct jit_sse41_conv_fwd_kernel_f32_t : public jit_generator_t {
+    jit_sse41_conv_fwd_kernel_f32_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     static status_t init_conf(jit_conv_conf_t &jcp,
@@ -39,7 +39,7 @@ struct jit_sse41_conv_fwd_kernel_f32 : public jit_generator_t {
             const memory_desc_wrapper &dst_d, const primitive_attr_t &attr,
             int nthreads);
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sse41_conv_fwd_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sse41_conv_fwd_kernel_f32_t)
     jit_conv_conf_t jcp;
     const primitive_attr_t &attr_;
 

--- a/src/cpu/x64/jit_sse41_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2023 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 int ocb_num = jcp.nb_oc_blocking;
 
                 for (int icb = icbb; icb < icbb + icb_step; ++icb) {
-                    auto par_conv = jit_conv_call_s();
+                    auto par_conv = jit_conv_args_t();
 
                     const int ij = oh * jcp.stride_h;
                     const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -57,7 +57,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_sse41_conv_fwd_kernel_f32::init_conf(jcp_, *desc(),
+            CHECK(jit_sse41_conv_fwd_kernel_f32_t::init_conf(jcp_, *desc(),
                     *src_md(), *weights_md(), *dst_md(), *attr(),
                     dnnl_get_max_threads()));
 
@@ -108,7 +108,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_sse41_conv_fwd_kernel_f32(
+                new jit_sse41_conv_fwd_kernel_f32_t(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md(0))));
         return kernel_->create_kernel();
     }
@@ -121,7 +121,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
 private:
     void execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_sse41_conv_fwd_kernel_f32> kernel_;
+    std::unique_ptr<jit_sse41_conv_fwd_kernel_f32_t> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -1067,11 +1067,11 @@ void jit_trans_ow_oc_t::generate() {
 
 /*
 // -------------------------------------------------
-// jit_transpose4x16_src
+// jit_transpose4x16_src_t
 // -------------------------------------------------
 */
 
-void jit_transpose4x16_src::transpose(int nrows) {
+void jit_transpose4x16_src_t::transpose(int nrows) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 4, "Unsupported transpose size");
     if (!nrows) return;
@@ -1191,7 +1191,7 @@ alignas(64) static constexpr const int64_t idx1[8] = {2, 3, 0, 1, 6, 7, 4, 5};
 alignas(64) static constexpr const int32_t idxP[16]
         = {0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15};
 
-void jit_transpose4x16_src::generate() {
+void jit_transpose4x16_src_t::generate() {
     preamble();
 
     const int ic_block = params->ic_block;

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -1205,7 +1205,7 @@ void jit_transpose4x16_src_t::generate() {
     const int src_step = ic_block * transpose_size * typesize;
     const int tr_src_step = ic_block * transpose_size * typesize;
 
-#define GET_TR_OFF(x) offsetof(jit_src_transpose_s, x)
+#define GET_TR_OFF(x) offsetof(jit_transpose_src_args_t, x)
     mov(reg_loop, ptr[param1 + GET_TR_OFF(size)]);
     mov(reg_src, ptr[param1 + GET_TR_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_TR_OFF(tr_src)]);
@@ -1263,7 +1263,7 @@ void jit_transpose4x16_src_t::generate() {
 
 #undef GET_OFF
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 void jit_diff_wei_trans_to_vnni_t::generate() {
     /* Reorder part of F32 weights tensor

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -68,22 +68,22 @@ struct jit_trans_dst_t {
     const jit_conv_conf_t *conf_;
 };
 
-struct jit_transpose4x16_src_t {
+struct jit_transpose4x16_src_params_t {
     int src_pf0_distance;
     int tr_src_pf0_distance;
     bool src_pf1;
     bool tr_src_pf1;
 };
 
-struct jit_transpose4x16_src : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_transpose4x16_src)
+struct jit_transpose4x16_src_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_transpose4x16_src_t)
 
-    jit_transpose4x16_src(const jit_1x1_conv_conf_t *aparams,
-            jit_transpose4x16_src_t *tparams_)
+    jit_transpose4x16_src_t(const jit_1x1_conv_conf_t *aparams,
+            jit_transpose4x16_src_params_t *tparams_)
         : jit_generator_t(jit_name()), params(aparams), tparams(tparams_) {}
 
     const jit_1x1_conv_conf_t *params;
-    const jit_transpose4x16_src_t *tparams;
+    const jit_transpose4x16_src_params_t *tparams;
 
     static const int transpose_size = 4;
 

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -43,12 +43,12 @@ struct jit_trans_src_t {
     const jit_conv_conf_t *conf_;
 };
 
-struct jit_src_transpose_s {
-    size_t size;
-    const void *src;
-    const void *tr_src;
-    const void *src_prf;
-    const void *tr_src_prf;
+struct jit_transpose_src_args_t {
+    size_t size = 0;
+    const void *src = nullptr;
+    const void *tr_src = nullptr;
+    const void *src_prf = nullptr;
+    const void *tr_src_prf = nullptr;
 };
 
 struct jit_trans_dst_t {

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -733,12 +733,11 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
     const bool is_src_different_layouts = conf.is_src_different_layouts;
 
     if (is_src_different_layouts) {
-        std::vector<unsigned> indices;
+        std::vector<unsigned> indices(simd_w);
 
         const dim_t src1_different_layout_stride = conf.src1_stride;
         for (size_t i = 0; i < simd_w; i++)
-            indices.push_back(
-                    i * src1_different_layout_stride * src1_type_size);
+            indices[i] = i * src1_different_layout_stride * src1_type_size;
 
         const dim_t batch = src0_d.dims()[0];
         const dim_t batch_stride = src1_d.blocking_desc().strides[0];

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -24,7 +24,7 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-#define PARAM_OFF(x) offsetof(jit_binary_call_s, x)
+#define PARAM_OFF(x) offsetof(jit_uni_binary_args_t, x)
 
 static bcast_set_t get_supported_postops_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -47,7 +47,9 @@ struct binary_kernel_t : public jit_generator_t {
             bool tail_kernel = false);
     ~binary_kernel_t() override = default;
 
-    void operator()(jit_binary_call_s *p) { jit_generator_t::operator()(p); }
+    void operator()(jit_uni_binary_args_t *p) {
+        jit_generator_t::operator()(p);
+    }
 
     size_t simd_w() const noexcept { return simd_w_; }
     size_t vlen() const noexcept { return vlen_; }

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -36,7 +36,7 @@ using namespace dnnl::impl::utils;
 using namespace Xbyak;
 
 template <cpu_isa_t isa>
-jit_uni_dw_conv_fwd_kernel_f32<isa>::jit_uni_dw_conv_fwd_kernel_f32(
+jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), isa), jcp(ajcp) {
     if (jcp.with_eltwise || jcp.with_binary) {
@@ -66,7 +66,7 @@ bool check_if_tail_load(const bool is_ch_tail, const int c_tail, const int ch,
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::load_src(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
         int ur_ch_blocks, int ur_w, bool is_ch_tail) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -127,7 +127,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::load_src(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
     int ch_blk = jcp.ch_block;
     int dilate_h = jcp.dilate_h + 1;
@@ -270,7 +270,7 @@ void iterate(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_postops(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_postops(
         const int ur_ch_blocks, const int ur_w, const bool is_ch_tail) {
     if (this->jcp.with_eltwise || this->jcp.with_binary) {
         const int repeats = max_repeats();
@@ -345,63 +345,63 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::apply_postops(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::load_tail(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_tail(
         Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
     uni_vmovups(vmm | k_oc_tail_mask | T_z, ptr[reg + offset]);
 }
 
 template <>
-void jit_uni_dw_conv_fwd_kernel_f32<avx2>::load_tail(
+void jit_uni_dw_conv_fwd_kernel_f32_t<avx2>::load_tail(
         Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
     load_bytes(vmm, reg, offset, load_size);
 }
 
 template <>
-void jit_uni_dw_conv_fwd_kernel_f32<sse41>::load_tail(
+void jit_uni_dw_conv_fwd_kernel_f32_t<sse41>::load_tail(
         Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
     load_bytes(vmm, reg, offset, load_size);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::add_tail_from_mem(Vmm &vmm_acc,
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::add_tail_from_mem(Vmm &vmm_acc,
         Vmm &vmm_tmp, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
     uni_vaddps(vmm_acc | k_oc_tail_mask | T_z, vmm_acc, ptr[reg + offset]);
 }
 
 template <>
-void jit_uni_dw_conv_fwd_kernel_f32<avx2>::add_tail_from_mem(Vmm &vmm_acc,
+void jit_uni_dw_conv_fwd_kernel_f32_t<avx2>::add_tail_from_mem(Vmm &vmm_acc,
         Vmm &vmm_tmp, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
     load_bytes(vmm_tmp, reg, offset, load_size);
     uni_vaddps(vmm_acc, vmm_acc, vmm_tmp);
 }
 
 template <>
-void jit_uni_dw_conv_fwd_kernel_f32<sse41>::add_tail_from_mem(Vmm &vmm_acc,
+void jit_uni_dw_conv_fwd_kernel_f32_t<sse41>::add_tail_from_mem(Vmm &vmm_acc,
         Vmm &vmm_tmp, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
     load_bytes(vmm_tmp, reg, offset, load_size);
     uni_vaddps(vmm_acc, vmm_acc, vmm_tmp);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::store_tail(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_tail(
         Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
     uni_vmovups(vmmword[reg + offset], vmm | k_oc_tail_mask);
 }
 
 template <>
-void jit_uni_dw_conv_fwd_kernel_f32<avx2>::store_tail(
+void jit_uni_dw_conv_fwd_kernel_f32_t<avx2>::store_tail(
         Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
     store_bytes(vmm, reg, offset, store_size);
 }
 
 template <>
-void jit_uni_dw_conv_fwd_kernel_f32<sse41>::store_tail(
+void jit_uni_dw_conv_fwd_kernel_f32_t<sse41>::store_tail(
         Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
     store_bytes(vmm, reg, offset, store_size);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::store_dst(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
         int ur_ch_blocks, int ur_w, bool is_ch_tail) {
 
     const auto dst_layout_nxc = is_dst_layout_nxc();
@@ -434,7 +434,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::store_dst(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::compute_loop(
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
         int ur_w, int ur_ch_blocks, int pad_l, int pad_r) {
 
     const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
@@ -514,7 +514,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::compute_loop(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::ow_loop(int ur_ch_blocks) {
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
 
     int iw = jcp.iw;
     int ow = jcp.ow;
@@ -584,7 +584,7 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::ow_loop(int ur_ch_blocks) {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_fwd_kernel_f32<isa>::generate() {
+void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
     this->preamble();
 
     if (jcp.is_fused_conv) {
@@ -653,52 +653,52 @@ void jit_uni_dw_conv_fwd_kernel_f32<isa>::generate() {
         postops_injector_->prepare_table(/* generate = */ true);
 }
 
-template struct jit_uni_dw_conv_fwd_kernel_f32<avx512_core>;
-template struct jit_uni_dw_conv_fwd_kernel_f32<avx2>;
-template struct jit_uni_dw_conv_fwd_kernel_f32<sse41>;
+template struct jit_uni_dw_conv_fwd_kernel_f32_t<avx512_core>;
+template struct jit_uni_dw_conv_fwd_kernel_f32_t<avx2>;
+template struct jit_uni_dw_conv_fwd_kernel_f32_t<sse41>;
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::load_vmm(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
     int ch_tail = jcp.oc_without_padding % simd_w_; // special case for SSE41
     int bytes = (tail && ch_tail > 0 ? ch_tail : simd_w_) * sizeof(float);
     load_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<avx2>::load_vmm(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::load_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
     int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
     load_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<avx512_core>::load_vmm(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx512_core>::load_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
     Zmm masked_vmm = tail ? vmm | k_ch_tail_mask | T_z : vmm;
     vmovups(masked_vmm, addr);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::store_vmm(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
     int ch_tail = jcp.oc_without_padding % simd_w_; // special case for SSE41
     int bytes = (tail && ch_tail > 0 ? ch_tail : simd_w_) * sizeof(float);
     store_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<avx2>::store_vmm(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::store_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
     int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
     store_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<avx512_core>::store_vmm(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx512_core>::store_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
     Zmm masked_vmm = tail ? vmm | k_ch_tail_mask : vmm;
     vmovups(addr, masked_vmm);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::load_ddst(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_ddst(
         int ur_ch_blocks, int ur_str_w) {
     for (int i = 0; i < reg_repeats_; i++) {
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
@@ -712,7 +712,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::load_ddst(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::apply_filter(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
     int kw = jcp.kw;
     int kh = jcp.kh;
@@ -801,7 +801,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::apply_filter(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::store_dsrc(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
     int ch_block = jcp.ch_block;
     int iw = jcp.iw;
@@ -837,7 +837,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::store_dsrc(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::ch_loop_body(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
         int ur_ch_blocks, int unroll_w) {
 
     auto call_compute_body
@@ -909,7 +909,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::ch_loop_body(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::unroll_width_body(
+inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::unroll_width_body(
         int ur_ch_blocks) {
     assert(is_dsrc_layout_nxc() == is_ddst_layout_nxc());
     const size_t ch_step = sizeof(float)
@@ -939,7 +939,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::unroll_width_body(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::generate() {
+void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
     preamble();
 
     mov(reg_dsrc, ptr[this->param1 + GET_OFF(src)]);
@@ -986,14 +986,14 @@ void jit_uni_dw_conv_bwd_data_kernel_f32<isa>::generate() {
 }
 #undef GET_OFF
 
-template struct jit_uni_dw_conv_bwd_data_kernel_f32<avx512_core>;
-template struct jit_uni_dw_conv_bwd_data_kernel_f32<avx2>;
-template struct jit_uni_dw_conv_bwd_data_kernel_f32<sse41>;
+template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<avx512_core>;
+template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>;
+template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<sse41>;
 
 #define GET_OFF(field) offsetof(jit_dw_conv_call_s, field)
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
     int ch_tail = jcp.oc_without_padding % simd_w_; // special case for SSE41
     int bytes
@@ -1001,20 +1001,20 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_xmm(
     load_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx2>::load_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::load_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
     int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
     load_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx512_core>::load_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx512_core>::load_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
     Zmm masked_vmm = compute_tail ? vmm | k_ch_tail_mask | T_z : vmm;
     vmovups(masked_vmm, addr);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
     int ch_tail = jcp.oc_without_padding % simd_w_; // special case for SSE41
     int bytes
@@ -1022,26 +1022,27 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_xmm(
     store_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx2>::store_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::store_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
     int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
     store_bytes(vmm, addr, bytes);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx512_core>::store_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx512_core>::store_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
     Zmm masked_vmm = compute_tail ? vmm | k_ch_tail_mask : vmm;
     vmovups(addr, masked_vmm);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::addps_xmm(Vmm &vmm_dst,
-        Vmm &vmm_src, const Xbyak::Address &addr, bool compute_tail) {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::addps_xmm(
+        Vmm &vmm_dst, Vmm &vmm_src, const Xbyak::Address &addr,
+        bool compute_tail) {
     load_xmm(vmm_src, addr, compute_tail);
     uni_vaddps(vmm_dst, vmm_dst, vmm_src);
 }
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx2>::addps_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::addps_xmm(
         Vmm &vmm_dst, Vmm &vmm_src, const Xbyak::Address &addr,
         bool compute_tail) {
     if (compute_tail) {
@@ -1053,7 +1054,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx2>::addps_xmm(
     }
 }
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx512_core>::addps_xmm(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx512_core>::addps_xmm(
         Vmm &vmm_dst, Vmm &vmm_src, const Xbyak::Address &addr,
         bool compute_tail) {
     Zmm masked_vmm = compute_tail ? vmm_src | k_ch_tail_mask | T_z : vmm_src;
@@ -1061,7 +1062,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<avx512_core>::addps_xmm(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter() {
     for (int ch = 0; ch < jcp.nb_ch_blocking; ++ch) {
         for (int r = 0; r < reg_repeats_; ++r) {
             for (int i = 0; i < jcp.kw; ++i) {
@@ -1074,7 +1075,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter() {
 }
 
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::load_filter(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::load_filter(
         int nb_ch_blocking, bool is_last_ch) {
     assert(nb_ch_blocking == 1);
     for (int r = 0; r < reg_repeats_; ++r) {
@@ -1093,7 +1094,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::load_filter(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_filter(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_filter(
         int nb_ch_blocking, bool is_last_ch) {
     const size_t filter_step = jcp.kh * jcp.kw;
     for (int ch = 0; ch < nb_ch_blocking; ++ch) {
@@ -1109,7 +1110,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_filter(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_bias() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_bias() {
     for (int ch = 0; ch < jcp.nb_ch_blocking; ++ch) {
         for (int r = 0; r < reg_repeats_; ++r) {
             Vmm vmm_bias = get_bias_reg(r * jcp.nb_ch_blocking + ch);
@@ -1119,7 +1120,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_bias() {
 }
 
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::load_bias(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::load_bias(
         int nb_ch_blocking, bool is_last_ch) {
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
@@ -1134,7 +1135,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::load_bias(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_bias(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_bias(
         int nb_ch_blocking, bool is_last_ch) {
     for (int ch = 0; ch < nb_ch_blocking; ++ch) {
         bool masked_load = is_last_ch && (ch == nb_ch_blocking - 1);
@@ -1147,7 +1148,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::load_bias(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_unroll_ow_step_nxc(
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         int nb_ch_blocking, bool is_last_ch) {
 
@@ -1245,7 +1246,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_unroll_ow_step_nxc(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_unroll_ow_step(
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         bool is_last_ch) {
 
@@ -1344,7 +1346,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_unroll_ow_step(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::dispatch_ow_step_unroll(
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::dispatch_ow_step_unroll(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         int nb_ch_blocking, bool is_last_ch) {
     if (jcp.is_fast_depthwise) {
@@ -1359,7 +1361,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::dispatch_ow_step_unroll(
 
 template <>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::compute_bias_step_unroll(
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
     const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
     for (int r = 0; r < reg_repeats_; ++r) {
@@ -1381,7 +1383,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::compute_bias_step_unroll(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_step_unroll(
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
     const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
     for (int i = 0; i < unroll_w; ++i) {
@@ -1400,7 +1402,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias_step_unroll(
 }
 
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::store_filter(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::store_filter(
         int nb_ch_blocking, bool is_last_ch) {
     assert(nb_ch_blocking == 1);
     for (int r = 0; r < reg_repeats_; ++r) {
@@ -1419,7 +1421,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::store_filter(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_filter(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_filter(
         int nb_ch_blocking, bool is_last_ch) {
     size_t filter_step = jcp.kh * jcp.kw;
     for (int ch = 0; ch < nb_ch_blocking; ++ch) {
@@ -1435,7 +1437,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_filter(
 }
 
 template <>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::store_bias(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::store_bias(
         int nb_ch_blocking, bool is_last_ch) {
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
@@ -1450,7 +1452,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>::store_bias(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_bias(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_bias(
         int nb_ch_blocking, bool is_last_ch) {
     for (int ch = 0; ch < nb_ch_blocking; ++ch) {
         bool masked_store = is_last_ch && ch == nb_ch_blocking - 1;
@@ -1463,7 +1465,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::store_bias(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_spatial_loop_bias(
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
         int nb_ch_blocking, bool is_last_ch) {
     Label oh_label;
     Label ow_blk_label;
@@ -1505,7 +1507,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_spatial_loop_bias(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_weights_kernel_f32<
+void jit_uni_dw_conv_bwd_weights_kernel_f32_t<
         isa>::compute_single_ch_block_bias() {
 
     auto write_compute_bias = [&](bool is_last_ch) {
@@ -1549,7 +1551,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32<
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ch_loop_bias(
+void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ch_loop_bias(
         bool do_load_bias) {
 
     assert(is_ddst_layout_nxc());
@@ -1602,7 +1604,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ch_loop_bias(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::deploy_ch_loop_bias() {
+void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::deploy_ch_loop_bias() {
 
     Label ch_loop_label, zero_bias_label, load_bias_done_label;
 
@@ -1621,7 +1623,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::deploy_ch_loop_bias() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias() {
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias() {
 
     mov(reg_bias_baddr, ptr[this->param1 + GET_OFF(bias)]);
 
@@ -1632,7 +1634,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_bias() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter_kh_loop(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter_kh_loop(
         int nb_ch_blocking) {
 
     const size_t filter_offset_kw = jcp.kw * jcp.ch_block * sizeof(float);
@@ -1656,7 +1658,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter_kh_loop(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter_ch_loop() {
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter_ch_loop() {
 
     bool write_ch_blocking_unroll
             = is_layout_nxc() && jcp.nb_ch > jcp.nb_ch_blocking;
@@ -1687,7 +1690,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::zero_filter_ch_loop() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::deploy_zero_filter() {
+inline void
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::deploy_zero_filter() {
 
     Label skip_zeroing_label;
 
@@ -1705,7 +1709,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::deploy_zero_filter() {
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_kh_step(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         int nb_ch_blocking, bool is_last_ch) {
 
@@ -1749,7 +1753,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_kh_step(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ch_loop(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ch_loop(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     bool write_ch_blocking_unroll
@@ -1790,7 +1794,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ch_loop(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_loop(
+inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         int unroll_w, int l_pad, int pad_offset, int ow_block) {
 
     mov(reg_tmp_output, reg_output_baddr);
@@ -1899,7 +1903,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_h_loop(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::calculate_w_unrolling(
+void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
         int &unroll_trips, int &unroll_w, int &unroll_w_tail) {
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
@@ -1927,7 +1931,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::calculate_w_unrolling(
 
 template <cpu_isa_t isa>
 inline void
-jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_block_unroll() {
+jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for computing 'ow middle' block
     int pad_offset = 0;
@@ -1985,7 +1989,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::compute_ow_block_unroll() {
 }
 
 template <cpu_isa_t isa>
-void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::generate() {
+void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::generate() {
     assert(is_src_layout_nxc() == is_ddst_layout_nxc());
 
     preamble();
@@ -2009,9 +2013,9 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32<isa>::generate() {
 }
 #undef GET_OFF
 
-template struct jit_uni_dw_conv_bwd_weights_kernel_f32<avx512_core>;
-template struct jit_uni_dw_conv_bwd_weights_kernel_f32<avx2>;
-template struct jit_uni_dw_conv_bwd_weights_kernel_f32<sse41>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx512_core>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>;
+template struct jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -22,7 +22,7 @@
 
 #include "cpu/x64/jit_uni_dw_conv_kernel_f32.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {
@@ -990,7 +990,7 @@ template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<avx512_core>;
 template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>;
 template struct jit_uni_dw_conv_bwd_data_kernel_f32_t<sse41>;
 
-#define GET_OFF(field) offsetof(jit_dw_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_dw_conv_args_t, field)
 
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_xmm(

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -32,10 +32,10 @@ namespace cpu {
 namespace x64 {
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_fwd_kernel_f32 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_fwd_kernel_f32)
+struct jit_uni_dw_conv_fwd_kernel_f32_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_fwd_kernel_f32_t)
 
-    jit_uni_dw_conv_fwd_kernel_f32(
+    jit_uni_dw_conv_fwd_kernel_f32_t(
             const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md);
 
     jit_conv_conf_t jcp;
@@ -126,10 +126,10 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_bwd_data_kernel_f32 : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32)
+struct jit_uni_dw_conv_bwd_data_kernel_f32_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_data_kernel_f32_t)
 
-    jit_uni_dw_conv_bwd_data_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_uni_dw_conv_bwd_data_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp) {}
     jit_conv_conf_t jcp;
 
@@ -190,11 +190,11 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_dw_conv_bwd_weights_kernel_f32 : public jit_generator_t {
+struct jit_uni_dw_conv_bwd_weights_kernel_f32_t : public jit_generator_t {
 
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32)
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_dw_conv_bwd_weights_kernel_f32_t)
 
-    jit_uni_dw_conv_bwd_weights_kernel_f32(const jit_conv_conf_t &ajcp)
+    jit_uni_dw_conv_bwd_weights_kernel_f32_t(const jit_conv_conf_t &ajcp)
         : jit_generator_t(jit_name()), jcp(ajcp) {}
 
     jit_conv_conf_t jcp;

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -26,7 +26,7 @@ namespace x64 {
 using namespace data_type;
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-status_t jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
+status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         memory_desc_t &src_md, memory_desc_t &weights_md,
         memory_desc_t &bias_md, memory_desc_t &dst_md, primitive_attr_t &attr) {
@@ -270,7 +270,7 @@ status_t jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_scratchpad(
+void jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;
     if (jcp.bia_dt == data_type::bf16)
@@ -282,7 +282,7 @@ void jit_uni_dw_conv_fwd_kernel<isa, kernel_dt>::init_scratchpad(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-status_t jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_conf(
+status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         memory_desc_t &diff_src_md, memory_desc_t &weights_md,
         memory_desc_t &diff_dst_md) {
@@ -452,14 +452,14 @@ status_t jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_conf(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_data_kernel<isa, kernel_dt>::init_scratchpad(
+void jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     UNUSED(scratchpad);
     UNUSED(jcp);
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-status_t jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_conf(
+status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
         jit_conv_conf_t &jcp, const convolution_desc_t &cd,
         memory_desc_t &src_md, memory_desc_t &diff_weights_md,
         memory_desc_t &diff_bias_md, memory_desc_t &diff_dst_md, int nthreads) {
@@ -644,7 +644,7 @@ status_t jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_conf(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_scratchpad(
+void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;
 
@@ -693,7 +693,7 @@ void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::init_scratchpad(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::balance(
+void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::balance(
         jit_conv_conf_t &jcp, int nthreads) {
     jcp.nthr_oh = jcp.nthr_g = jcp.nthr_mb = 1;
     if (jcp.harness == harness_mb_reduction) {
@@ -723,7 +723,7 @@ void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::balance(
 }
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::partition_nthr_nxc(
+void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
         jit_conv_conf_t &jcp, int nthreads, bool prioritize_threading) {
 
     /* Explore thread partitioning space across 'nb_ch', 'mb' and 'nb_oh'
@@ -840,25 +840,25 @@ void jit_uni_dw_conv_bwd_weights_kernel<isa, kernel_dt>::partition_nthr_nxc(
 }
 
 REG_AVX512_ISA(
-        template struct jit_uni_dw_conv_fwd_kernel<avx512_core_fp16, f16>);
-REG_AVX512_ISA(template struct jit_uni_dw_conv_fwd_kernel<avx512_core, bf16>);
-REG_AVX512_ISA(template struct jit_uni_dw_conv_fwd_kernel<avx512_core, f32>);
-REG_AVX2_ISA(template struct jit_uni_dw_conv_fwd_kernel<avx2, f32>);
-REG_SSE41_ISA(template struct jit_uni_dw_conv_fwd_kernel<sse41, f32>);
+        template struct jit_uni_dw_conv_fwd_kernel_t<avx512_core_fp16, f16>);
+REG_AVX512_ISA(template struct jit_uni_dw_conv_fwd_kernel_t<avx512_core, bf16>);
+REG_AVX512_ISA(template struct jit_uni_dw_conv_fwd_kernel_t<avx512_core, f32>);
+REG_AVX2_ISA(template struct jit_uni_dw_conv_fwd_kernel_t<avx2, f32>);
+REG_SSE41_ISA(template struct jit_uni_dw_conv_fwd_kernel_t<sse41, f32>);
 
 REG_AVX512_ISA(
-        template struct jit_uni_dw_conv_bwd_data_kernel<avx512_core, bf16>);
+        template struct jit_uni_dw_conv_bwd_data_kernel_t<avx512_core, bf16>);
 REG_AVX512_ISA(
-        template struct jit_uni_dw_conv_bwd_data_kernel<avx512_core, f32>);
-REG_AVX2_ISA(template struct jit_uni_dw_conv_bwd_data_kernel<avx2, f32>);
-REG_SSE41_ISA(template struct jit_uni_dw_conv_bwd_data_kernel<sse41, f32>);
+        template struct jit_uni_dw_conv_bwd_data_kernel_t<avx512_core, f32>);
+REG_AVX2_ISA(template struct jit_uni_dw_conv_bwd_data_kernel_t<avx2, f32>);
+REG_SSE41_ISA(template struct jit_uni_dw_conv_bwd_data_kernel_t<sse41, f32>);
 
+REG_AVX512_ISA(template struct jit_uni_dw_conv_bwd_weights_kernel_t<avx512_core,
+        bf16>);
 REG_AVX512_ISA(
-        template struct jit_uni_dw_conv_bwd_weights_kernel<avx512_core, bf16>);
-REG_AVX512_ISA(
-        template struct jit_uni_dw_conv_bwd_weights_kernel<avx512_core, f32>);
-REG_AVX2_ISA(template struct jit_uni_dw_conv_bwd_weights_kernel<avx2, f32>);
-REG_SSE41_ISA(template struct jit_uni_dw_conv_bwd_weights_kernel<sse41, f32>);
+        template struct jit_uni_dw_conv_bwd_weights_kernel_t<avx512_core, f32>);
+REG_AVX2_ISA(template struct jit_uni_dw_conv_bwd_weights_kernel_t<avx2, f32>);
+REG_SSE41_ISA(template struct jit_uni_dw_conv_bwd_weights_kernel_t<sse41, f32>);
 } // namespace x64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.hpp
@@ -58,7 +58,7 @@ struct jit_uni_dw_conv_fwd_kernel_t {
             const jit_conv_conf_t &jcp);
 
     jit_generator_t *ker() const { return ker_.get(); }
-    void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*ker_)(p); }
 
 private:
     constexpr static bool ker_condition_
@@ -92,7 +92,7 @@ struct jit_uni_dw_conv_bwd_data_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp);
 
-    void operator()(const jit_conv_call_s *p) const { (*ker_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*ker_)(p); }
 
 private:
     using jit_kernel_t = typename utils::conditional<isa == avx512_core
@@ -127,7 +127,7 @@ struct jit_uni_dw_conv_bwd_weights_kernel_t {
             jit_conv_conf_t &jcp, int nthreads, bool prioritize_threading);
     static void balance(jit_conv_conf_t &jcp, int nthreads);
 
-    void operator()(const jit_dw_conv_call_s *p) const { (*ker_)(p); }
+    void operator()(const jit_dw_conv_args_t *p) const { (*ker_)(p); }
 
 private:
     using jit_kernel_t = typename utils::conditional<isa == avx512_core

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.hpp
@@ -37,9 +37,9 @@ namespace cpu {
 namespace x64 {
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-struct jit_uni_dw_conv_fwd_kernel {
+struct jit_uni_dw_conv_fwd_kernel_t {
 
-    jit_uni_dw_conv_fwd_kernel(
+    jit_uni_dw_conv_fwd_kernel_t(
             const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
         : ker_(utils::make_unique<jit_kernel_t>(ajcp, dst_md)) {}
 
@@ -47,7 +47,7 @@ struct jit_uni_dw_conv_fwd_kernel {
         if (ker_) return ker_->create_kernel();
         return status::out_of_memory;
     }
-    ~jit_uni_dw_conv_fwd_kernel() = default;
+    ~jit_uni_dw_conv_fwd_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_md,
@@ -66,24 +66,24 @@ private:
             || (isa == avx512_core_fp16 && kernel_dt == data_type::f16);
     using jit_kernel_t = typename utils::conditional<ker_condition_,
             typename utils::conditional<kernel_dt == data_type::bf16,
-                    jit_avx512_dw_conv_fwd_kernel_bf16,
-                    jit_avx512_dw_conv_fwd_kernel_f16>::type,
-            jit_uni_dw_conv_fwd_kernel_f32<isa>>::type;
+                    jit_avx512_dw_conv_fwd_kernel_bf16_t,
+                    jit_avx512_dw_conv_fwd_kernel_f16_t>::type,
+            jit_uni_dw_conv_fwd_kernel_f32_t<isa>>::type;
     std::unique_ptr<jit_kernel_t> ker_;
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel)
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_fwd_kernel_t)
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-struct jit_uni_dw_conv_bwd_data_kernel {
+struct jit_uni_dw_conv_bwd_data_kernel_t {
 
-    jit_uni_dw_conv_bwd_data_kernel(const jit_conv_conf_t &ajcp)
+    jit_uni_dw_conv_bwd_data_kernel_t(const jit_conv_conf_t &ajcp)
         : ker_(utils::make_unique<jit_kernel_t>(ajcp)) {}
 
     status_t create_kernel() {
         if (ker_) return ker_->create_kernel();
         return status::out_of_memory;
     }
-    ~jit_uni_dw_conv_bwd_data_kernel() = default;
+    ~jit_uni_dw_conv_bwd_data_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &diff_src_md,
@@ -97,23 +97,23 @@ struct jit_uni_dw_conv_bwd_data_kernel {
 private:
     using jit_kernel_t = typename utils::conditional<isa == avx512_core
                     && kernel_dt == data_type::bf16,
-            jit_avx512_dw_conv_bwd_data_kernel_bf16,
-            jit_uni_dw_conv_bwd_data_kernel_f32<isa>>::type;
+            jit_avx512_dw_conv_bwd_data_kernel_bf16_t,
+            jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>>::type;
     std::unique_ptr<jit_kernel_t> ker_;
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel)
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_data_kernel_t)
 };
 
 template <cpu_isa_t isa, data_type_t kernel_dt>
-struct jit_uni_dw_conv_bwd_weights_kernel {
+struct jit_uni_dw_conv_bwd_weights_kernel_t {
 
-    jit_uni_dw_conv_bwd_weights_kernel(const jit_conv_conf_t &ajcp)
+    jit_uni_dw_conv_bwd_weights_kernel_t(const jit_conv_conf_t &ajcp)
         : ker_(utils::make_unique<jit_kernel_t>(ajcp)) {}
 
     status_t create_kernel() {
         if (ker_) return ker_->create_kernel();
         return status::out_of_memory;
     }
-    ~jit_uni_dw_conv_bwd_weights_kernel() = default;
+    ~jit_uni_dw_conv_bwd_weights_kernel_t() = default;
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_md,
@@ -132,10 +132,10 @@ struct jit_uni_dw_conv_bwd_weights_kernel {
 private:
     using jit_kernel_t = typename utils::conditional<isa == avx512_core
                     && kernel_dt == data_type::bf16,
-            jit_avx512_dw_conv_bwd_weights_kernel_bf16,
-            jit_uni_dw_conv_bwd_weights_kernel_f32<isa>>::type;
+            jit_avx512_dw_conv_bwd_weights_kernel_bf16_t,
+            jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>>::type;
     std::unique_ptr<jit_kernel_t> ker_;
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_weights_kernel)
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_dw_conv_bwd_weights_kernel_t)
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.cpp
@@ -128,7 +128,7 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             const auto ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
             const auto oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
 
-            auto par_conv = jit_conv_call_s();
+            auto par_conv = jit_conv_args_t();
             par_conv.src = jcp.is_fused_conv
                     ? src
                     : &src[src_d.blk_off(n, ic_off_idx, ih, iw)];
@@ -195,7 +195,7 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
                                  int i_t_overflow, int i_b_overflow,
                                  int stride_off_h, int ch, int n,
                                  int work_remaining) {
-        auto par_conv = jit_conv_call_s();
+        auto par_conv = jit_conv_args_t();
         const bool is_dsrc_layout_nxc
                 = utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc);
         const bool is_ddst_layout_nxc
@@ -273,7 +273,7 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
                 int l_border = nstl::min(jcp.kw - 1 - jcp.l_pad, jcp.iw);
                 int ur_str_w = 1;
                 for (; iw < l_border; iw += jcp.stride_w) {
-                    jit_conv_call_s par_conv = kernel_params(ur_str_w, iw, oh,
+                    jit_conv_args_t par_conv = kernel_params(ur_str_w, iw, oh,
                             ih, i_t_overflow, i_b_overflow, stride_off_h, ch, n,
                             work_rem);
 
@@ -283,7 +283,7 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
                 // main loop
                 ur_str_w = (aux_w - iw) / jcp.stride_w;
                 if (ur_str_w > 0) {
-                    jit_conv_call_s par_conv = kernel_params(ur_str_w, iw, oh,
+                    jit_conv_args_t par_conv = kernel_params(ur_str_w, iw, oh,
                             ih, i_t_overflow, i_b_overflow, stride_off_h, ch, n,
                             work_rem);
 
@@ -295,7 +295,7 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
                 // right border
                 ur_str_w = 1;
                 for (; iw < jcp.iw; iw += jcp.stride_w) {
-                    jit_conv_call_s par_conv = kernel_params(ur_str_w, iw, oh,
+                    jit_conv_args_t par_conv = kernel_params(ur_str_w, iw, oh,
                             ih, i_t_overflow, i_b_overflow, stride_off_h, ch, n,
                             work_rem);
 
@@ -355,7 +355,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
     const int ch_block = jcp.ch_block;
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
-        auto conv_params = jit_dw_conv_call_s();
+        auto conv_params = jit_dw_conv_args_t();
         const int h_block_size = jcp.oh_blk_size;
 
         const int ch_outer_blocks
@@ -481,7 +481,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
     const int ch_block = jcp.ch_block;
 
     auto set_kernel_params
-            = [&](jit_dw_conv_call_s *conv_params, const int batch,
+            = [&](jit_dw_conv_args_t *conv_params, const int batch,
                       const int group, const int oh_start, const int work_size,
                       const unsigned char exec_flag, const size_t kh_padding,
                       const size_t filter_off) {
@@ -516,7 +516,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         assert(nthr == jcp.nthr);
 
-        auto conv_params = jit_dw_conv_call_s();
+        auto conv_params = jit_dw_conv_args_t();
         const int h_block_size = jcp.oh_blk_size;
         const int nb_ch = jcp.nb_ch;
 

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -43,8 +43,8 @@ struct jit_args_t {
     size_t work_amount;
 };
 
-struct jit_uni_eltwise_kernel : public jit_generator_t {
-    jit_uni_eltwise_kernel(
+struct jit_uni_eltwise_kernel_t : public jit_generator_t {
+    jit_uni_eltwise_kernel_t(
             const eltwise_pd_t *pd, const char *name, cpu_isa_t isa)
         : jit_generator_t(name, isa), pd_(pd) {}
 
@@ -76,11 +76,11 @@ protected:
 // jit kernels
 namespace {
 template <cpu_isa_t isa>
-struct jit_uni_kernel_t : public jit_uni_eltwise_kernel {
+struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_kernel)
 
     jit_uni_kernel_t(const eltwise_pd_t *pd)
-        : jit_uni_eltwise_kernel(pd, jit_name(), isa)
+        : jit_uni_eltwise_kernel_t(pd, jit_name(), isa)
         , vlen_(is_bf16() || is_f16() ? cpu_isa_traits_t<isa>::vlen / 2
                           : is_f8()   ? cpu_isa_traits_t<isa>::vlen / 4
                                       : cpu_isa_traits_t<isa>::vlen)

--- a/src/cpu/x64/jit_uni_eltwise.hpp
+++ b/src/cpu/x64/jit_uni_eltwise.hpp
@@ -33,7 +33,7 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_uni_eltwise_kernel;
+struct jit_uni_eltwise_kernel_t;
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
 struct jit_uni_eltwise_fwd_t : public primitive_t {
@@ -63,7 +63,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_uni_eltwise_kernel> kernel_;
+    std::unique_ptr<jit_uni_eltwise_kernel_t> kernel_;
 };
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
@@ -94,7 +94,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_uni_eltwise_kernel> kernel_;
+    std::unique_ptr<jit_uni_eltwise_kernel_t> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -37,8 +37,8 @@ struct jit_args_int8_t {
     size_t work_amount;
 };
 
-struct jit_uni_eltwise_int_kernel : public jit_generator_t {
-    jit_uni_eltwise_int_kernel(
+struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
+    jit_uni_eltwise_int_kernel_t(
             const eltwise_pd_t *pd, const cpu_isa_t isa, const char *name)
         : jit_generator_t(name, isa), pd_(pd) {}
 
@@ -59,11 +59,11 @@ namespace {
 using namespace Xbyak;
 
 template <cpu_isa_t isa>
-struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel {
+struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_subkernel_int)
 
     jit_uni_subkernel_int_t(const eltwise_pd_t *pd)
-        : jit_uni_eltwise_int_kernel(pd, isa, jit_name()) {
+        : jit_uni_eltwise_int_kernel_t(pd, isa, jit_name()) {
         using namespace data_type;
 
         // Relu and linear for int types: s32, s8, u8; Only forward direction

--- a/src/cpu/x64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.hpp
@@ -33,7 +33,7 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-struct jit_uni_eltwise_int_kernel;
+struct jit_uni_eltwise_int_kernel_t;
 
 template <cpu_isa_t isa, impl::data_type_t d_type>
 struct jit_uni_eltwise_int_fwd_t : public primitive_t {
@@ -61,7 +61,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
 private:
     status_t execute_forward(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    jit_uni_eltwise_int_kernel *kernel_ = nullptr;
+    jit_uni_eltwise_int_kernel_t *kernel_ = nullptr;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -32,7 +32,7 @@ namespace x64 {
 using namespace Xbyak;
 using namespace alg_kind;
 
-#define GET_OFF(field) offsetof(jit_pool_call_s, field)
+#define GET_OFF(field) offsetof(jit_uni_pooling_args_t, field)
 
 constexpr int sse41_single_block_size
         = cpu_isa_traits_t<sse41>::vlen / sizeof(float);

--- a/src/cpu/x64/jit_uni_reduction.cpp
+++ b/src/cpu/x64/jit_uni_reduction.cpp
@@ -183,7 +183,7 @@ status_t jit_uni_reduction_t::execute(const exec_ctx_t &ctx) const {
         const dim_t src_off = i * reduce_size * src_dt_size;
         const dim_t dst_off = i * dst_dt_size;
 
-        jit_reduction_call_s args = jit_reduction_call_s();
+        jit_uni_reduction_args_t args;
         args.src = src + src_off;
         args.dst = dst + dst_off;
         args.dst_orig = dst;

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ namespace cpu {
 namespace x64 {
 
 using namespace Xbyak;
-#define GET_OFF(field) offsetof(jit_reduction_call_s, field)
+#define GET_OFF(field) offsetof(jit_uni_reduction_args_t, field)
 
 static const bcast_set_t &get_supported_postops_bcast_strategies() {
     static const bcast_set_t supported_strategies

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -458,7 +458,7 @@ status_t jit_uni_resampling_fwd_t::interpolate_nearest(const uint8_t *src,
             const dim_t dst_off = ((mb * C + c) * OD * OH * OW + od * OH * OW)
                     * dst_dt_size;
 
-            jit_resampling_call_s args = jit_resampling_call_s();
+            jit_uni_resampling_args_t args;
             args.src = src + src_off;
             args.dst = dst + dst_off;
             args.dst_orig = dst;
@@ -479,7 +479,7 @@ status_t jit_uni_resampling_fwd_t::interpolate_nearest(const uint8_t *src,
 
             const size_t cb = std::div(nsp, CB).rem;
 
-            jit_resampling_call_s args = jit_resampling_call_s();
+            jit_uni_resampling_args_t args;
             args.batch_of_sp_points_to_process = OW;
             args.src = src + src_off;
             args.dst = dst + dst_off;
@@ -520,7 +520,7 @@ status_t jit_uni_resampling_fwd_t::interpolate_linear(const uint8_t *src,
             const dim_t src_off = (mb * C + c) * ID * IH * IW * src_dt_size;
             const dim_t dst_off = (mb * C + c) * OD * OH * OW * dst_dt_size;
 
-            jit_resampling_call_s args = jit_resampling_call_s();
+            jit_uni_resampling_args_t args;
             args.batch_of_sp_points_to_process = OW * OH * OD;
             args.src = src + src_off;
             args.dst = dst + dst_off;
@@ -551,7 +551,7 @@ status_t jit_uni_resampling_fwd_t::interpolate_linear(const uint8_t *src,
 
             const size_t cb = std::div(nsp, CB).rem;
 
-            jit_resampling_call_s args = jit_resampling_call_s();
+            jit_uni_resampling_args_t args;
             args.batch_of_sp_points_to_process = OW;
             args.src = src + src_off;
             args.dst = dst + dst_off;

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ using namespace Xbyak;
 using namespace format_tag;
 using tag_kind = jit_memory_tag_kind_t;
 
-#define GET_OFF(field) offsetof(jit_resampling_call_s, field)
+#define GET_OFF(field) offsetof(jit_uni_resampling_args_t, field)
 
 template <cpu_isa_t isa, typename Vmm>
 jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -32,7 +32,7 @@
 #include "cpu/x64/jit_uni_1x1_conv_utils.hpp"
 #include "cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_1x1_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_1x1_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -31,9 +31,9 @@ namespace cpu {
 namespace x64 {
 
 template <cpu_isa_t isa, typename Vmm>
-struct _jit_uni_x8s8s32x_1x1_conv_kernel : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_uni_x8s8s32x_1x1_conv_kernel)
-    _jit_uni_x8s8s32x_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+struct jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t)
+    jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     int get_tail_size() { return jcp.oc_without_padding % jcp.oc_block; }
@@ -128,9 +128,9 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_x8s8s32x_1x1_conv_kernel {
+struct jit_uni_x8s8s32x_1x1_conv_kernel_t {
 
-    jit_uni_x8s8s32x_1x1_conv_kernel(const jit_1x1_conv_conf_t &ajcp,
+    jit_uni_x8s8s32x_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
 
@@ -152,7 +152,7 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_uni_x8s8s32x_1x1_conv_kernel() = default;
+    ~jit_uni_x8s8s32x_1x1_conv_kernel_t() = default;
 
     void operator()(const jit_1x1_conv_call_s *p) const { (*kernel_)(p); }
 
@@ -166,14 +166,14 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel {
             const jit_1x1_conv_conf_t &jcp, const primitive_attr_t &attr);
 
     using jit_sse41_x8s8s32x_1x1_conv_kernel
-            = _jit_uni_x8s8s32x_1x1_conv_kernel<sse41, Xbyak::Xmm>;
+            = jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<sse41, Xbyak::Xmm>;
     using jit_avx2_x8s8s32x_1x1_conv_kernel
-            = _jit_uni_x8s8s32x_1x1_conv_kernel<avx2, Xbyak::Ymm>;
+            = jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<avx2, Xbyak::Ymm>;
 
     constexpr static int simd_w = isa == avx2 ? 8 : 4;
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_1x1_conv_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_1x1_conv_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -154,7 +154,7 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel_t {
 
     ~jit_uni_x8s8s32x_1x1_conv_kernel_t() = default;
 
-    void operator()(const jit_1x1_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_1x1_conv_args_t *p) const { (*kernel_)(p); }
 
     static status_t init_conf(jit_1x1_conv_conf_t &jcp,
             const convolution_desc_t &cd, const memory_desc_wrapper &src_d,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -163,7 +163,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
 
-    auto p = jit_1x1_conv_call_s();
+    auto p = jit_1x1_conv_args_t();
 
     auto rp = typename rtus_driver_t<isa>::call_params_t();
     const int nb_oc = jcp.nb_load;
@@ -382,7 +382,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
         const auto ocb_end = ocb_start + load_step;
         const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
-        auto par_conv_dw = jit_conv_call_s();
+        auto par_conv_dw = jit_conv_args_t();
 
         par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
         par_conv_dw.b_overflow = nstl::min(

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -123,6 +123,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             return cpu_convolution_fwd_pd_t::dst_md(index);
         }
 
+        // NOLINTBEGIN(google-default-arguments)
         const memory_desc_t *dst_md(
                 int index = 0, bool user_input = false) const override {
             return dw_conv_pd_ && jcp_.with_dw_conv
@@ -145,6 +146,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             }
             return convolution_fwd_pd_t::arg_md(arg, user_input);
         }
+        // NOLINTEND(google-default-arguments)
 
         arg_usage_t arg_usage(int arg) const override {
             if (arg == (DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS))

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -104,14 +104,14 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             rtus_prepare(this, conv_d, src_d, dst_md(), weights_md());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_uni_x8s8s32x_1x1_conv_kernel<isa>::init_conf(jcp_,
+            CHECK(jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(jcp_,
                     *conv_d, *src_d, *weights_md(), *dst_md(),
                     with_bias() ? *weights_md(1) : types::zero_md(), attr_,
                     dnnl_get_max_threads(), rtus_.reduce_src_));
             if (jcp_.with_dw_conv) CHECK(depthwise_po_init(engine));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_uni_x8s8s32x_1x1_conv_kernel<isa>::init_scratchpad(
+            jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_scratchpad(
                     scratchpad, jcp_, *attr());
 
             rtus_prepare_space_info(this, scratchpad, jcp_.nthr);
@@ -369,7 +369,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_uni_x8s8s32x_1x1_conv_kernel<isa>(
+                new jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_1x1_md())));
         CHECK(kernel_->create_kernel());
 
@@ -402,9 +402,9 @@ private:
             const void *post_ops_binary_rhs_arg_vec_dw) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    std::unique_ptr<jit_uni_x8s8s32x_1x1_conv_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>> kernel_;
     std::unique_ptr<rtus_driver_t<isa>> rtus_driver_;
-    using dw_conv_kernel_t = jit_uni_x8s8s32x_fwd_kernel<isa>;
+    using dw_conv_kernel_t = jit_uni_x8s8s32x_fwd_kernel_t<isa>;
     std::unique_ptr<dw_conv_kernel_t> kernel_dw_;
 };
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -54,7 +54,7 @@ void pick_loop_order(jit_conv_conf_t &jcp) {
 } // namespace
 
 template <cpu_isa_t isa, typename Vmm>
-_jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::_jit_uni_x8s8s32x_fwd_kernel(
+jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
         const jit_conv_conf_t &ajcp, const primitive_attr_t &attr,
         const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), isa), jcp(ajcp), attr_(attr) {
@@ -85,7 +85,7 @@ _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::_jit_uni_x8s8s32x_fwd_kernel(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::prepare_output(int ur_w) {
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(int ur_w) {
     int nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
     for (int k = 0; k < nb_oc_block; ++k)
@@ -105,7 +105,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::prepare_output(int ur_w) {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::cvt2ps(data_type_t type_in,
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::cvt2ps(data_type_t type_in,
         const Vmm &vmm_in, const Reg64 &reg, int offset, int load_size) {
 
     load_data(type_in, vmm_in, reg, offset, load_size);
@@ -133,9 +133,9 @@ void iterate(const int nb_oc_block, const int ur_w, const F &f) {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::apply_sum(const int nb_oc_block,
-        const int ur_w, const bool last_oc_block_flag, const int oc_block,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_sum(
+        const int nb_oc_block, const int ur_w, const bool last_oc_block_flag,
+        const int oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_sum) {
         assert(!utils::any_null(p_sum_scale, p_sum_zp)
                 && "p_sum_scale or p_sum_zp = nullptr");
@@ -177,7 +177,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::apply_sum(const int nb_oc_block,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::apply_postops(
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
         const int nb_oc_block, const int ur_w, const bool last_oc_block_flag,
         const int oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
@@ -221,7 +221,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::apply_postops(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::store_output(
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         int ur_w, bool last_oc_block_flag) {
     int nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
@@ -373,8 +373,8 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::store_output(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::compute_ker_dw(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
+        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
 
     if (!(utils::one_of(isa, avx2) && std::is_same<Vmm, Xbyak::Ymm>::value)
             && !(utils::one_of(isa, sse41)
@@ -514,8 +514,8 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::compute_ker_dw(int ur_w, int pad_l,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::compute_ker(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
+        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
@@ -659,7 +659,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::compute_ker(int ur_w, int pad_l,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::kh_loop(
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
         int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
 
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
@@ -816,7 +816,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::kh_loop(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::icb_loop(
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
         int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
     prepare_output(ur_w);
 
@@ -888,7 +888,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::icb_loop(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::generate() {
+void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     Label permute_index_table;
     int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
                                         : jcp.ic_without_padding * jcp.ngroups;
@@ -1236,7 +1236,7 @@ void _jit_uni_x8s8s32x_fwd_kernel<isa, Vmm>::generate() {
 }
 
 template <cpu_isa_t isa>
-status_t jit_uni_x8s8s32x_fwd_kernel<isa>::init_conf(jit_conv_conf_t &jcp,
+status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
@@ -1615,7 +1615,7 @@ status_t jit_uni_x8s8s32x_fwd_kernel<isa>::init_conf(jit_conv_conf_t &jcp,
 }
 
 template <cpu_isa_t isa>
-void jit_uni_x8s8s32x_fwd_kernel<isa>::init_scratchpad(
+void jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp,
         const primitive_attr_t &attr) {
     dim_t count = 8;
@@ -1626,11 +1626,11 @@ void jit_uni_x8s8s32x_fwd_kernel<isa>::init_scratchpad(
     scratchpad.book<float>(key_conv_adjusted_scales, count);
 }
 
-template struct _jit_uni_x8s8s32x_fwd_kernel<avx2, Ymm>;
-template struct _jit_uni_x8s8s32x_fwd_kernel<avx2, Xmm>;
-template struct _jit_uni_x8s8s32x_fwd_kernel<sse41, Xmm>;
-template struct jit_uni_x8s8s32x_fwd_kernel<avx2>;
-template struct jit_uni_x8s8s32x_fwd_kernel<sse41>;
+template struct jit_uni_x8s8s32x_fwd_kernel_vmm_t<avx2, Ymm>;
+template struct jit_uni_x8s8s32x_fwd_kernel_vmm_t<avx2, Xmm>;
+template struct jit_uni_x8s8s32x_fwd_kernel_vmm_t<sse41, Xmm>;
+template struct jit_uni_x8s8s32x_fwd_kernel_t<avx2>;
+template struct jit_uni_x8s8s32x_fwd_kernel_t<sse41>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -28,7 +28,7 @@
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
 #include "cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp"
 
-#define GET_OFF(field) offsetof(jit_conv_call_s, field)
+#define GET_OFF(field) offsetof(jit_conv_args_t, field)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -31,10 +31,10 @@ namespace cpu {
 namespace x64 {
 
 template <cpu_isa_t isa, typename Vmm>
-struct _jit_uni_x8s8s32x_fwd_kernel : public jit_generator_t {
+struct jit_uni_x8s8s32x_fwd_kernel_vmm_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_uni_x8s8s32x_conv_fwd_ker_t_)
 
-    _jit_uni_x8s8s32x_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_uni_x8s8s32x_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
     jit_conv_conf_t jcp;
@@ -188,9 +188,9 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_x8s8s32x_fwd_kernel {
+struct jit_uni_x8s8s32x_fwd_kernel_t {
 
-    jit_uni_x8s8s32x_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_uni_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
         int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
@@ -198,14 +198,14 @@ struct jit_uni_x8s8s32x_fwd_kernel {
             case 8:
                 if (utils::one_of(isa, avx2)) {
                     kernel_ = utils::make_unique<
-                            _jit_uni_x8s8s32x_fwd_kernel<isa, Xbyak::Ymm>>(
+                            jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Xbyak::Ymm>>(
                             ajcp, attr, dst_md);
                 } else
                     assert(!"invalid channel blocking for current ISA");
                 return;
             case 4:
                 kernel_ = utils::make_unique<
-                        _jit_uni_x8s8s32x_fwd_kernel<isa, Xbyak::Xmm>>(
+                        jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Xbyak::Xmm>>(
                         ajcp, attr, dst_md);
                 return;
             default: assert(!"invalid channel blocking");
@@ -217,7 +217,7 @@ struct jit_uni_x8s8s32x_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_uni_x8s8s32x_fwd_kernel() = default;
+    ~jit_uni_x8s8s32x_fwd_kernel_t() = default;
 
     void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
 
@@ -231,7 +231,7 @@ struct jit_uni_x8s8s32x_fwd_kernel {
     void (*jit_ker)(jit_conv_call_s *);
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -219,7 +219,7 @@ struct jit_uni_x8s8s32x_fwd_kernel_t {
 
     ~jit_uni_x8s8s32x_fwd_kernel_t() = default;
 
-    void operator()(const jit_conv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_conv_args_t *p) const { (*kernel_)(p); }
 
     static status_t init_conf(jit_conv_conf_t &jcp,
             const convolution_desc_t &cd, memory_desc_t &src_pd,
@@ -228,7 +228,7 @@ struct jit_uni_x8s8s32x_fwd_kernel_t {
     static void init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
-    void (*jit_ker)(jit_conv_call_s *);
+    void (*jit_ker)(jit_conv_args_t *);
 
 private:
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_fwd_kernel_t);

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -111,7 +111,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -282,7 +282,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         int n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
@@ -412,7 +412,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [&](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
-                auto p = jit_conv_call_s();
+                auto p = jit_conv_args_t();
 
                 size_t src_h_stride = src_d.blk_off(0, 0, 1);
                 size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
@@ -531,7 +531,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_conv_call_s();
+        auto p = jit_conv_args_t();
 
         size_t src_d_stride = src_d.blk_off(0, 0, 1);
         size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
@@ -75,12 +75,12 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
-            CHECK(jit_uni_x8s8s32x_fwd_kernel<isa>::init_conf(jcp_, *desc(),
+            CHECK(jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jcp_, *desc(),
                     src_md_, weights_md_, dst_md_, bias_md_, attr_,
                     dnnl_get_max_threads()));
 
             auto scratchpad = scratchpad_registry().registrar();
-            jit_uni_x8s8s32x_fwd_kernel<isa>::init_scratchpad(
+            jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_scratchpad(
                     scratchpad, jcp_, *attr());
 
             return attr_.set_default_formats(dst_md(0));
@@ -111,7 +111,7 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
-                new jit_uni_x8s8s32x_fwd_kernel<isa>(
+                new jit_uni_x8s8s32x_fwd_kernel_t<isa>(
                         pd()->jcp_, *pd()->attr(), *pd()->dst_md())));
         return kernel_->create_kernel();
     }
@@ -142,7 +142,7 @@ private:
     const float *adjust_oscales(const memory_tracking::grantor_t &scratchpad,
             const float *src_scales, const float *wei_scales) const;
 
-    std::unique_ptr<jit_uni_x8s8s32x_fwd_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_x8s8s32x_fwd_kernel_t<isa>> kernel_;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -25,7 +25,7 @@
 #include "cpu/x64/jit_uni_deconv_zp_pad_str_kernel.hpp"
 #include "cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp"
 
-#define GET_OFF(field) offsetof(jit_deconv_call_s, field)
+#define GET_OFF(field) offsetof(jit_deconv_args_t, field)
 
 namespace dnnl {
 namespace impl {
@@ -1546,7 +1546,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
         const int work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         int n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
@@ -1657,7 +1657,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
         const int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         /*loop order = cgn*/
         int n {0}, g {0}, occ {0}, oh_s {0};
@@ -1832,7 +1832,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
         int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
-        auto p = jit_deconv_call_s();
+        auto p = jit_deconv_args_t();
 
         /*loop order = cgn*/
         int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -161,7 +161,7 @@ struct jit_uni_x8s8s32x_deconv_fwd_kernel_t {
 
     ~jit_uni_x8s8s32x_deconv_fwd_kernel_t();
 
-    void operator()(const jit_deconv_call_s *p) const { (*kernel_)(p); }
+    void operator()(const jit_deconv_args_t *p) const { (*kernel_)(p); }
 
     static bool post_ops_ok(jit_conv_conf_t &jcp,
             const memory_desc_wrapper &dst_d, const primitive_attr_t &attr);

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -45,13 +45,13 @@ class jit_uni_postops_injector_t;
 using namespace Xbyak;
 
 template <cpu_isa_t isa, typename Vmm>
-struct _jit_uni_x8s8s32x_deconv_fwd_kernel : public jit_generator_t {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(_jit_uni_x8s8s32x_deconv_fwd_kernel);
+struct jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t : public jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t);
 
-    _jit_uni_x8s8s32x_deconv_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_wrapper &dst_d);
 
-    ~_jit_uni_x8s8s32x_deconv_fwd_kernel() override;
+    ~jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t() override;
 
     const jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
@@ -149,9 +149,9 @@ private:
 };
 
 template <cpu_isa_t isa>
-struct jit_uni_x8s8s32x_deconv_fwd_kernel {
+struct jit_uni_x8s8s32x_deconv_fwd_kernel_t {
 
-    jit_uni_x8s8s32x_deconv_fwd_kernel(const jit_conv_conf_t &ajcp,
+    jit_uni_x8s8s32x_deconv_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_wrapper &dst_d);
 
     status_t create_kernel() {
@@ -159,7 +159,7 @@ struct jit_uni_x8s8s32x_deconv_fwd_kernel {
         return status::out_of_memory;
     }
 
-    ~jit_uni_x8s8s32x_deconv_fwd_kernel();
+    ~jit_uni_x8s8s32x_deconv_fwd_kernel_t();
 
     void operator()(const jit_deconv_call_s *p) const { (*kernel_)(p); }
 
@@ -176,10 +176,10 @@ struct jit_uni_x8s8s32x_deconv_fwd_kernel {
             const jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
     using _jit_avx2_x8s8s32x_deconv_fwd_kernel
-            = _jit_uni_x8s8s32x_deconv_fwd_kernel<avx2, Xbyak::Ymm>;
+            = jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<avx2, Xbyak::Ymm>;
 
 private:
-    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_deconv_fwd_kernel);
+    DNNL_DISALLOW_COPY_AND_ASSIGN(jit_uni_x8s8s32x_deconv_fwd_kernel_t);
     std::unique_ptr<jit_generator_t> kernel_;
 };
 
@@ -211,7 +211,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     const float *adjust_oscales(const memory_tracking::grantor_t &scratchpad,
             const float *src_scales, const float *wei_scales) const;
-    std::unique_ptr<jit_uni_x8s8s32x_deconv_fwd_kernel<isa>> kernel_;
+    std::unique_ptr<jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>> kernel_;
     std::unique_ptr<zp::jit_uni_deconv_zp_pad_str_kernel_base_t>
             zp_src_pad_comp_kernel_;
 };

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
@@ -124,16 +124,20 @@ void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::load_data_to_stack(
             = tail_proc == tail_mode::NextTail ? this->vlen_ : 0;
     this->load_tail(C_tail, this->diffdst_, tail_src_mem_offset,
             get_stack_offset(this->diffdst_, tail_mode::CurrentTail),
-            this->tmp_load_to_stack_idx_tail_);
+            jit_avx512_common_lrn_kernel_bwd_nhwc_t<
+                    d_type>::tmp_load_to_stack_idx_tail_);
     this->load_tail(C_tail, this->workspace0_, tail_src_mem_offset,
             get_stack_offset(this->workspace0_, tail_mode::CurrentTail),
-            this->tmp_load_to_stack_idx_tail_);
+            jit_avx512_common_lrn_kernel_bwd_nhwc_t<
+                    d_type>::tmp_load_to_stack_idx_tail_);
     this->load_tail(C_tail, this->workspace1_, tail_src_mem_offset,
             get_stack_offset(this->workspace1_, tail_mode::CurrentTail),
-            this->tmp_load_to_stack_idx_tail_);
+            jit_avx512_common_lrn_kernel_bwd_nhwc_t<
+                    d_type>::tmp_load_to_stack_idx_tail_);
     this->load_tail(C_tail, this->src_, tail_src_mem_offset,
             get_stack_offset(this->src_, tail_mode::CurrentTail),
-            this->tmp_load_to_stack_idx_tail_);
+            jit_avx512_common_lrn_kernel_bwd_nhwc_t<
+                    d_type>::tmp_load_to_stack_idx_tail_);
 }
 
 template <data_type_t d_type>

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
@@ -202,7 +202,9 @@ void jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>::load_data_to_stack(
             = tail_proc == tail_mode::NextTail ? this->vlen_ : 0;
     static constexpr int tail_dst_stack_offset = zmm_size;
     this->load_tail(C_tail, this->src_, tail_src_mem_offset,
-            tail_dst_stack_offset, this->tmp_load_to_stack_idx_tail_);
+            tail_dst_stack_offset,
+            jit_avx512_common_lrn_kernel_fwd_nhwc_t<
+                    d_type>::tmp_load_to_stack_idx_tail_);
 }
 
 template <data_type_t d_type>

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_utils.hpp
@@ -32,12 +32,14 @@ enum class direction { forward, backward };
 
 enum class across_version : char { First, Middle, Last, Single };
 
+// NOLINTBEGIN(readability-identifier-naming)
 struct nChw16c_across_t {
     int H, W;
     across_version version;
     constexpr nChw16c_across_t(int h, int w, across_version version)
         : H(h), W(w), version(version) {}
 };
+// NOLINTEND(readability-identifier-naming)
 
 enum class tail_mode { NoTail, NextTail, CurrentTail };
 

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
@@ -128,7 +128,7 @@ void jit_uni_lrn_kernel_t<Derived<isa, d_type>>::within_loop(
 
     this->dec(h_);
     this->cmp(h_, 0);
-    this->jne(lrn_loop_h, this->T_NEAR);
+    this->jne(lrn_loop_h, T_NEAR);
 
     for (int i = config.H - upper_bound; i < config.H; ++i) {
         pixel_count = 0;
@@ -169,7 +169,7 @@ void jit_uni_lrn_kernel_t<Derived<isa, d_type>>::within_body_reg_blocked(
         derived_ptr->move_data_pointers(max_reg_blocks, pk);
         this->dec(this->w_);
         this->cmp(this->w_, 0);
-        this->jne(reg_block_compute_loop, this->T_NEAR);
+        this->jne(reg_block_compute_loop, T_NEAR);
     }
     if (res.rem) {
         derived_ptr->within_body(

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -169,7 +169,7 @@ private:
 
 class bw_map_t {
 public:
-    bw_map_t() {}
+    bw_map_t() = default;
 
     float get_bw(int x) const { return linear_interpolation(multicore_bw, x); }
 

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
@@ -900,7 +900,7 @@ void brgemm_diff_wei_peep_t<scratch_t>::kernel(
             types::data_type_size(rnn_.src_iter_c_dt),
             rnn_.ws_states_iter_c_nld, src_iter_c_ld_);
 
-    const rnn_utils::ws_gates_aoc<const scratch_t> scratch_gates(
+    const rnn_utils::ws_gates_aoc_t<const scratch_t> scratch_gates(
             rnn_, scratch_gates_);
     const rnn_utils::weights_peephole_aoc_t<float> diff_weights_peephole(
             rnn_, diff_weights_peephole_);

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
@@ -26,17 +26,17 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_gru_cell_postgemm_part1_bwd : public jit_uni_rnn_postgemm {
+struct jit_uni_gru_cell_postgemm_part1_bwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part1_bwd)
 
     jit_uni_gru_cell_postgemm_part1_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     ~jit_uni_gru_cell_postgemm_part1_bwd() override = default;
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         return create_kernel();
     }
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -27,7 +27,7 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_gru_cell_postgemm_part1_fwd : public jit_uni_rnn_postgemm {
+struct jit_uni_gru_cell_postgemm_part1_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part1_fwd)
 
     using injector_t = typename utils::conditional<isa == avx512_core,
@@ -36,10 +36,10 @@ struct jit_uni_gru_cell_postgemm_part1_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_cell_postgemm_part1_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         // no need to save state of registers
         // (unless emulating bf16 support)
         const bool save_state

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
@@ -26,17 +26,17 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_gru_cell_postgemm_part2_bwd : public jit_uni_rnn_postgemm {
+struct jit_uni_gru_cell_postgemm_part2_bwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part2_bwd)
 
     jit_uni_gru_cell_postgemm_part2_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     ~jit_uni_gru_cell_postgemm_part2_bwd() override = default;
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         return create_kernel();
     }
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -26,7 +26,7 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_gru_cell_postgemm_part2_fwd : public jit_uni_rnn_postgemm {
+struct jit_uni_gru_cell_postgemm_part2_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_cell_postgemm_part2_fwd)
 
     using injector_t = typename utils::conditional<isa == avx512_core,
@@ -35,10 +35,10 @@ struct jit_uni_gru_cell_postgemm_part2_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_cell_postgemm_part2_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         // no need to save state of registers
         // (unless emulating bf16 support or using pre-avx2 isa)
         const bool save_state = (isa == sse41 || isa == avx)

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
@@ -26,17 +26,17 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_gru_lbr_cell_postgemm_bwd : public jit_uni_rnn_postgemm {
+struct jit_uni_gru_lbr_cell_postgemm_bwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_lbr_cell_postgemm_bwd)
 
     jit_uni_gru_lbr_cell_postgemm_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     ~jit_uni_gru_lbr_cell_postgemm_bwd() override = default;
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         return create_kernel();
     }
 

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
@@ -27,7 +27,7 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_gru_lbr_cell_postgemm_fwd : public jit_uni_rnn_postgemm {
+struct jit_uni_gru_lbr_cell_postgemm_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_gru_lbr_cell_postgemm_fwd)
 
     using injector_t = typename utils::conditional<isa == avx512_core,
@@ -36,10 +36,10 @@ struct jit_uni_gru_lbr_cell_postgemm_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_gru_lbr_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         // we use rax for both constant tables and load correspondent label
         // into it when calling correspondent injector.
         sigmoid_injector_ = utils::make_unique<injector_t>(this,

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
@@ -30,18 +30,18 @@ namespace x64 {
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
 struct jit_uni_lstm_cell_postgemm_bwd
-    : public jit_uni_rnn_postgemm,
+    : public jit_uni_rnn_postgemm_t,
       public jit_uni_lstm_cell_postgemm_t<isa> {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_lstm_cell_postgemm_bwd)
 
     jit_uni_lstm_cell_postgemm_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name())
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name())
         , jit_uni_lstm_cell_postgemm_t<isa>(this, 11 /*tmp_id_begin*/,
-                  // usage of jit_uni_rnn_postgemm::bf16_emu_ to identify bf16
+                  // usage of jit_uni_rnn_postgemm_t::bf16_emu_ to identify bf16
                   // emulation case is illegal here, it's created in
-                  // jit_uni_rnn_postgemm::init(), not in constructor, so
-                  // jit_uni_rnn_postgemm::bf16_emu_ = nullptr always on this
+                  // jit_uni_rnn_postgemm_t::init(), not in constructor, so
+                  // jit_uni_rnn_postgemm_t::bf16_emu_ = nullptr always on this
                   // stage
                   src_data_t == data_type::bf16 && !mayiuse(avx512_core_bf16)) {
     }
@@ -49,7 +49,7 @@ struct jit_uni_lstm_cell_postgemm_bwd
     ~jit_uni_lstm_cell_postgemm_bwd() override = default;
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         // we use rax for both constant tables as they use the same table
         tanh_injector_
                 = utils::make_unique<injector_t>(this, alg_kind::eltwise_tanh,

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
@@ -29,19 +29,19 @@ namespace x64 {
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
 struct jit_uni_lstm_cell_postgemm_fwd
-    : public jit_uni_rnn_postgemm,
+    : public jit_uni_rnn_postgemm_t,
       public jit_uni_lstm_cell_postgemm_t<isa> {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_lstm_cell_postgemm_fwd)
 
     jit_uni_lstm_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name())
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name())
         , jit_uni_lstm_cell_postgemm_t<isa>(this,
                   get_last_preserved_vmm_idx(1) + 1,
-                  // usage of jit_uni_rnn_postgemm::bf16_emu_ to identify bf16
+                  // usage of jit_uni_rnn_postgemm_t::bf16_emu_ to identify bf16
                   // emulation case is illegal here, it's created in
-                  // jit_uni_rnn_postgemm::init(), not in constructor, so
-                  // jit_uni_rnn_postgemm::bf16_emu_ = nullptr always on this
+                  // jit_uni_rnn_postgemm_t::init(), not in constructor, so
+                  // jit_uni_rnn_postgemm_t::bf16_emu_ = nullptr always on this
                   // stage
                   src_data_t == data_type::bf16 && !mayiuse(avx512_core_bf16)) {
     }
@@ -49,7 +49,7 @@ struct jit_uni_lstm_cell_postgemm_fwd
     ~jit_uni_lstm_cell_postgemm_fwd() override = default;
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         // we use rax for both constant tables and load correspondent label
         // into it when calling correspondent injector.
         sigmoid_injector_ = utils::make_unique<injector_t>(this,

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_projection_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_projection_postgemm_fwd.hpp
@@ -26,17 +26,18 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_lstm_cell_projection_postgemm_fwd : public jit_uni_rnn_postgemm {
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_lstm_cell_projection_postgemm_fwd)
+struct jit_uni_lstm_cell_projection_postgemm_fwd_t
+    : public jit_uni_rnn_postgemm_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_lstm_cell_projection_postgemm_fwd_t)
 
-    jit_uni_lstm_cell_projection_postgemm_fwd(
+    jit_uni_lstm_cell_projection_postgemm_fwd_t(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
-    ~jit_uni_lstm_cell_projection_postgemm_fwd() override = default;
+    ~jit_uni_lstm_cell_projection_postgemm_fwd_t() override = default;
 
     status_t init(data_type_t sdt) override {
-        jit_uni_rnn_postgemm::init(src_data_t);
+        jit_uni_rnn_postgemm_t::init(src_data_t);
         projection_ = true;
         return create_kernel();
     }

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
@@ -26,17 +26,17 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_rnn_cell_postgemm_bwd : public jit_uni_rnn_postgemm {
+struct jit_uni_rnn_cell_postgemm_bwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_rnn_cell_postgemm_bwd)
 
     jit_uni_rnn_cell_postgemm_bwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     ~jit_uni_rnn_cell_postgemm_bwd() override = default;
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         return create_kernel();
     }
 

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -27,7 +27,7 @@ namespace x64 {
 
 template <cpu_isa_t isa, impl::data_type_t src_data_t,
         impl::data_type_t scratch_data_t>
-struct jit_uni_rnn_cell_postgemm_fwd : public jit_uni_rnn_postgemm {
+struct jit_uni_rnn_cell_postgemm_fwd : public jit_uni_rnn_postgemm_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_rnn_cell_postgemm_fwd)
 
     using injector_t = typename utils::conditional<isa == avx512_core,
@@ -36,10 +36,10 @@ struct jit_uni_rnn_cell_postgemm_fwd : public jit_uni_rnn_postgemm {
 
     jit_uni_rnn_cell_postgemm_fwd(
             const rnn_utils::rnn_conf_t &rnn, const rnn_pd_t *pd)
-        : jit_uni_rnn_postgemm(rnn, pd, jit_name()) {}
+        : jit_uni_rnn_postgemm_t(rnn, pd, jit_name()) {}
 
     status_t init(data_type_t sdt) override {
-        CHECK(jit_uni_rnn_postgemm::init(src_data_t));
+        CHECK(jit_uni_rnn_postgemm_t::init(src_data_t));
         // we use rax for constant tables
         injector_ = utils::make_unique<injector_t>(this, pd_->activation_kind(),
                 pd_->desc()->alpha, pd_->desc()->beta, 1.0f, data_type::f32,

--- a/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
@@ -212,7 +212,7 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
             const dim_t sp_curr = spb * sp_work;
             const dim_t off = mb * stride_mb + sp_curr * conf.blk_size;
 
-            jit_shuffle_call_s args;
+            jit_uni_shuffle_args_t args;
             args.src = input + off * data_type_size;
             args.dst = output + (off + SP * c_curr) * data_type_size;
 

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -29,7 +29,7 @@ namespace x64 {
 
 using namespace Xbyak;
 
-#define GET_OFF(field) offsetof(jit_shuffle_call_s, field)
+#define GET_OFF(field) offsetof(jit_uni_shuffle_args_t, field)
 
 static size_t get_padding_size(const jit_shuffle_conf_t &conf) {
     const auto padding_tail_size = conf.c % conf.blk_size;

--- a/src/gpu/intel/compute/dispatch_reusable.hpp
+++ b/src/gpu/intel/compute/dispatch_reusable.hpp
@@ -537,7 +537,7 @@ public:
             }
 
             // Copy buffer terms into params
-            std::vector<size_t> buf_terms = buffer_term_map[buf_idx];
+            const std::vector<size_t> &buf_terms = buffer_term_map[buf_idx];
             compile_params.buffer_num_terms[buf_idx] = buf_terms.size();
             for (size_t j = 0; j < buf_terms.size(); j++) {
                 compile_params.buffer_term_index[buf_idx][j] = buf_terms[j];

--- a/src/gpu/intel/jit/config/gemmstone_config.hpp
+++ b/src/gpu/intel/jit/config/gemmstone_config.hpp
@@ -70,6 +70,7 @@ using SerializationStream = dnnl::impl::serialization_stream_t;
 
 enum class BinaryOp;
 using PostOps = dnnl::impl::gpu::intel::gpu_post_ops_t;
+// NOLINTBEGIN(readability-identifier-naming)
 struct PostOpsProblem {
     PostOpsProblem() = default;
     PostOpsProblem(PostOps &&ops) : ops(std::move(ops)) {};
@@ -158,6 +159,7 @@ struct PostOpsProblem {
         injector.compute(C_grfs, C_ngrf, seed.getBase(), seed.getOffset(), t);
     }
 };
+// NOLINTEND(readability-identifier-naming)
 
 } // namespace gemmstone
 #endif

--- a/src/gpu/intel/jit/utils/utils.hpp
+++ b/src/gpu/intel/jit/utils/utils.hpp
@@ -1228,6 +1228,7 @@ void deserialize_from_hex(T &t, const std::string &s_hex) {
     d.pop(t);
 }
 
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define GPU_DEFINE_BIT_MASK_ENUM_OPS(E) \
     constexpr E operator&(E a, E b) { \
         using backing_t = typename std::underlying_type<E>::type; \
@@ -1244,6 +1245,7 @@ void deserialize_from_hex(T &t, const std::string &s_hex) {
         return static_cast<E>(~static_cast<backing_t>(a)); \
     } \
     constexpr bool any(E a) { return a != static_cast<E>(0); }
+// NOLINTEND(bugprone-macro-parentheses)
 
 } // namespace jit
 } // namespace intel

--- a/src/gpu/intel/ocl/convolution_inner_product.cpp
+++ b/src/gpu/intel/ocl/convolution_inner_product.cpp
@@ -105,13 +105,13 @@ status_t convolution_inner_product_fwd_t::pd_t::init_conf(
     if (dst_conv != ip_dst_md
             && dst_conv.format_desc.blocking.inner_nblks > 0) {
         conf.reorder_dst = true;
-        primitive_attr_t r_attr(default_attr());
+        const primitive_attr_t &r_attr = default_attr();
         if (!r_attr.is_initialized()) return status::out_of_memory;
         CHECK(reorder_primitive_desc_create(
                 rpd_dst_, engine, &dst_conv, &ip_dst_md, &r_attr));
 
         if (conf.attr_info.with_sum) {
-            primitive_attr_t r_attr(default_attr());
+            const primitive_attr_t &r_attr = default_attr();
             if (!r_attr.is_initialized()) return status::out_of_memory;
             CHECK(reorder_primitive_desc_create(
                     rpd_postop_, engine, &ip_dst_md, &dst_conv, &r_attr));

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -451,8 +451,7 @@ struct host_scalar_executable_t : public op_executable_t {
 
         auto prim = dnnl::reorder(src_mem, dst_mem);
 
-        auto sycl_deps = deps;
-        auto e = dnnl::sycl_interop::execute(prim, stream, args, sycl_deps);
+        auto e = dnnl::sycl_interop::execute(prim, stream, args, deps);
         if (stream.get_engine().get_kind() == engine::kind::cpu) e.wait();
         return e;
     }
@@ -475,8 +474,7 @@ struct host_scalar_executable_t : public op_executable_t {
 
         auto prim = dnnl::reorder(src_mem, dst_mem);
 
-        auto ocl_deps = deps;
-        auto e = dnnl::ocl_interop::execute(prim, stream, args, ocl_deps);
+        auto e = dnnl::ocl_interop::execute(prim, stream, args, deps);
         return e;
     }
 #endif

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -4200,7 +4200,7 @@ status_t fuse_sdpa(std::shared_ptr<subgraph_t> &sg) {
 
     size_t input_idx = 3;
     for (size_t i = 1; i < candidates.size(); ++i) {
-        auto op = candidates[i];
+        const auto &op = candidates[i];
         if (op->get_kind() == op_kind::dnnl_binary) {
             auto alg = static_cast<dnnl::algorithm>(
                     op->get_attr<int64_t>(op_attr::alg_kind));

--- a/tests/benchdnn/graph/input_displacer.hpp
+++ b/tests/benchdnn/graph/input_displacer.hpp
@@ -38,7 +38,7 @@ public:
     displace_args_t() = default;
     displace_args_t(const deserialized_op_t &op, size_t offset,
             const deserialized_lt_t &lt, filling_type_t type,
-            fill_cfg_t cfg = {})
+            const fill_cfg_t &cfg = {})
         : main_op_(op)
         , main_op_offset_(offset)
         , tensor_(lt)

--- a/tests/benchdnn/graph/ref_primitive.hpp
+++ b/tests/benchdnn/graph/ref_primitive.hpp
@@ -38,7 +38,7 @@ public:
 template <typename prb_t>
 class prb_wrapper_t : public prb_wrapper_base_t {
 public:
-    prb_wrapper_t(const std::shared_ptr<prb_t> prb) : prb_(prb) {}
+    prb_wrapper_t(const std::shared_ptr<prb_t> &prb) : prb_(prb) {}
     // get raw pointer of prb object
     const prb_t *get() const { return prb_.get(); }
 

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -242,6 +242,7 @@ int measure_perf(timer::timer_t &t,
         const std::vector<std::vector<dnnl::graph::tensor>> &outputs_v,
         res_t *res) {
     std::vector<perf_function_t> perf_func_v;
+    perf_func_v.reserve(cp_v.size());
     for (size_t i = 0; i < cp_v.size(); i++) {
         perf_func_v.emplace_back(std::bind(&compiled_partition_executor,
                 cp_v[i], std::placeholders::_1, std::placeholders::_2,

--- a/tests/gtests/graph/unit/backend/dnnl/dnnl_test_common.hpp
+++ b/tests/gtests/graph/unit/backend/dnnl/dnnl_test_common.hpp
@@ -259,7 +259,7 @@ static inline bool allclose(const test_tensor_t &a, const test_tensor_t &b,
 #pragma GCC diagnostic pop
 #endif
 
-static inline size_t product(std::vector<int64_t> &in) {
+static inline size_t product(const std::vector<int64_t> &in) {
     if (in.empty()) return 0;
     int64_t prod = std::accumulate(in.begin(), in.end(),
             static_cast<int64_t>(1), std::multiplies<int64_t>());

--- a/tests/gtests/graph/unit/backend/dnnl/test_binary_op.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_binary_op.cpp
@@ -643,6 +643,7 @@ TEST(test_binary_op_execute_subgraph_fp32, Binary3Postops) {
             {graph::op_kind::Multiply, graph::op_kind::HardSwish}};
 
     std::vector<graph::logical_tensor_t> lt_vec;
+    lt_vec.reserve(9);
     for (size_t i = 0; i < 9; ++i)
         lt_vec.emplace_back(utils::logical_tensor_init(
                 i, binary_src_shape, graph::data_type::f32));
@@ -659,7 +660,8 @@ TEST(test_binary_op_execute_subgraph_fp32, Binary3Postops) {
         input_lts.push_back(lt_idx);
         binary_op.add_output(lt_vec[++lt_idx]);
 
-        std::vector<graph::op_t> post_ops {};
+        std::vector<graph::op_t> post_ops;
+        post_ops.reserve(pop_ts.size());
         for (size_t i = 0; i < pop_ts.size(); ++i) {
             auto pop_t = pop_ts[i];
             post_ops.emplace_back(i + 1, pop_t, "post op");
@@ -691,7 +693,8 @@ TEST(test_binary_op_execute_subgraph_fp32, Binary3Postops) {
 
         test_tensor_t binary_src0_ts(lt_vec[0], engine, src_datas[0]);
         test_tensor_t binary_src1_ts(lt_vec[1], engine, src_datas[1]);
-        std::vector<test_tensor_t> src_tss {};
+        std::vector<test_tensor_t> src_tss;
+        src_tss.reserve(input_lts.size());
         for (size_t i = 0; i < input_lts.size(); ++i)
             src_tss.emplace_back(lt_vec[input_lts[i]], engine, src_datas[i]);
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_concat.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_concat.cpp
@@ -196,9 +196,9 @@ TEST(test_concat_compile, ConcatWithMoreInputs) {
 
     graph::compiled_partition_t cp(p);
 
-    std::vector<const graph::logical_tensor_t *> inputs;
+    std::vector<const graph::logical_tensor_t *> inputs(num_inputs);
     for (size_t i = 0; i < num_inputs; ++i) {
-        inputs.push_back(&input_lts[i]);
+        inputs[i] = &input_lts[i];
     }
     std::vector<const graph::logical_tensor_t *> outputs {&dst_lt};
     auto ret = p.compile(&cp, inputs, outputs, eng);

--- a/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
@@ -6849,8 +6849,8 @@ TEST(test_convolution_execute_subgraph_int8, ShareCachedWeights) {
     std::vector<std::shared_ptr<graph::compiled_partition_t>> cps;
     for (size_t i = 0; i < src_shapes.size(); ++i) {
         std::cout << "---------------\n";
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         src_u8 = utils::logical_tensor_init(1, src_shape, graph::data_type::u8);
         dst_f32 = utils::logical_tensor_init(

--- a/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
@@ -2531,7 +2531,7 @@ TEST(test_convtranspose_execute_subgraph_int8,
                 ? std::vector<int64_t> {1, out_channel, 14}
                 : nd == 2 ? std::vector<int64_t> {1, out_channel, 14, 14}
                           : std::vector<int64_t> {1, out_channel, 14, 14, 14};
-        std::vector<int64_t> other_shape = dst_shape;
+        const std::vector<int64_t> &other_shape = dst_shape;
 
         std::vector<uint8_t> src_u8_data(product(src_shape));
         std::vector<int8_t> weight_s8_data(product(weight_shape));

--- a/tests/gtests/graph/unit/backend/dnnl/test_matmul.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_matmul.cpp
@@ -352,8 +352,8 @@ TEST(test_matmul_execute, MatmulNdx1d) {
 
     for (size_t w_idx = 0; w_idx < weight_shapes.size(); ++w_idx) {
         for (size_t idx = 0; idx < src_shapes.size(); idx++) {
-            auto src_shape = src_shapes[idx];
-            auto dst_shape = dst_shapes[idx + w_idx * src_shapes.size()];
+            const auto &src_shape = src_shapes[idx];
+            const auto &dst_shape = dst_shapes[idx + w_idx * src_shapes.size()];
 
             std::vector<float> src_data(product(src_shape));
             std::vector<float> weight_data(product(weight_shapes[w_idx]));
@@ -448,8 +448,9 @@ TEST(test_matmul_execute, Matmul1dxNd) {
 
     for (size_t idx = 0; idx < src_shapes.size(); ++idx) {
         for (size_t w_idx = 0; w_idx < weight_shapes.size(); w_idx++) {
-            auto src_shape = src_shapes[idx];
-            auto dst_shape = dst_shapes[w_idx + idx * weight_shapes.size()];
+            const auto &src_shape = src_shapes[idx];
+            const auto &dst_shape
+                    = dst_shapes[w_idx + idx * weight_shapes.size()];
 
             std::vector<float> src_data(product(src_shape));
             std::vector<float> weight_data(product(weight_shapes[w_idx]));
@@ -973,10 +974,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2d) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -1133,10 +1134,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulU8U8) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<uint8_t> weight_data(product(weight_shape));
@@ -1272,9 +1273,9 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx1d) {
     for (size_t i = 0; i < weight_shapes.size(); ++i) {
         for (size_t j = 0; j < src_shapes.size(); ++j) {
             // prepare fp32 data
-            std::vector<int64_t> src_shape = src_shapes[j];
-            std::vector<int64_t> weight_shape = weight_shapes[i];
-            std::vector<int64_t> dst_shape
+            const std::vector<int64_t> &src_shape = src_shapes[j];
+            const std::vector<int64_t> &weight_shape = weight_shapes[i];
+            const std::vector<int64_t> &dst_shape
                     = dst_shapes[j + i * src_shapes.size()];
 
             std::vector<uint8_t> src_data(product(src_shape));
@@ -1427,10 +1428,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2dWithTranspose) {
     for (size_t i = 0; i < src_shapes.size(); ++i) {
         for (size_t j = 0; j < weight_shapes.size(); ++j) {
             // prepare fp32 data
-            std::vector<int64_t> src_shape = src_shapes[i];
-            std::vector<int64_t> weight_shape = weight_shapes[j];
-            std::vector<int64_t> bias_shape {1};
-            std::vector<int64_t> dst_shape = dst_shapes[i];
+            const std::vector<int64_t> &src_shape = src_shapes[i];
+            const std::vector<int64_t> &weight_shape = weight_shapes[j];
+            const std::vector<int64_t> bias_shape {1};
+            const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
             std::vector<uint8_t> src_data(product(src_shape));
             std::vector<int8_t> weight_data(product(weight_shape));
@@ -1601,10 +1602,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasSumNdx2d) {
     for_(const auto &other_qtype : other_qtypes)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -1808,10 +1809,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasBinary) {
     for_(size_t j = 0; j < weight_shapes.size(); ++j)
     for (const auto &binary_kind : binary_kinds) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -1995,10 +1996,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasAddMul) {
         if (engine->kind() == graph::engine_kind::gpu && qtype == "per_channel")
             continue;
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -2208,10 +2209,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasNdx2dX8s8f32) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -2348,9 +2349,9 @@ TEST(test_matmul_execute_subgraph_int8, MatmulNdx2dX8s8f32) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -2478,10 +2479,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasGeluNdx2dX8s8f32) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -2697,10 +2698,10 @@ TEST(test_matmul_execute_subgraph_int8, Matmul2dx3dWithTranspose) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {1};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {1};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<int8_t> weight_data(product(weight_shape));
@@ -2852,10 +2853,10 @@ TEST(test_matmul_execute_subgraph_int8, MatmulBiasSumGetInplacePair_CPU) {
     for_(const auto &other_qtype : other_qtypes)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         float scale_src = 1 / 255.f; // map to 0~255
         float scale_other = 1 / 127.f;
@@ -4754,10 +4755,10 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasSumNdx2d) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<float> weight_data(product(weight_shape));
@@ -4978,9 +4979,9 @@ TEST(test_matmul_execute_subgraph_int8, U8S8U8MatmulAddF32) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<float> weight_data(product(weight_shape));
@@ -5155,10 +5156,10 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasNdx2dWithTranspose) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         std::vector<uint8_t> src_data(product(src_shape));
         std::vector<float> weight_data(product(weight_shape));
@@ -5338,10 +5339,10 @@ TEST(test_matmul_execute_subgraph_int8, QuantWeiMatmulBiasReluNdx2d) {
     for_(size_t i = 0; i < src_shapes.size(); ++i)
     for (size_t j = 0; j < weight_shapes.size(); ++j) {
         // prepare fp32 data
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> weight_shape = weight_shapes[j];
-        std::vector<int64_t> bias_shape {2};
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &weight_shape = weight_shapes[j];
+        const std::vector<int64_t> bias_shape {2};
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         float scale_src = 1 / 255.f; // map to 0~255
         float scale_out = 1;
@@ -7984,8 +7985,8 @@ TEST(test_matmul_execute_subgraph_int8, ShareCachedWeight) {
     dnnl::graph::set_constant_tensor_cache_capacity(
             static_cast<engine::kind>(engine->kind()), 1024);
     for (size_t i = 0; i < src_shapes.size(); ++i) {
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         src_u8 = utils::logical_tensor_init(1, src_shape, graph::data_type::u8);
         dst_s8 = utils::logical_tensor_init(8, dst_shape, graph::data_type::s8);
@@ -8131,8 +8132,8 @@ TEST(test_matmul_execute_subgraph_int8, NoShareCachedWeight) {
     }
 
     for (size_t i = 0; i < src_shapes.size(); ++i) {
-        std::vector<int64_t> src_shape = src_shapes[i];
-        std::vector<int64_t> dst_shape = dst_shapes[i];
+        const std::vector<int64_t> &src_shape = src_shapes[i];
+        const std::vector<int64_t> &dst_shape = dst_shapes[i];
 
         src_u8 = utils::logical_tensor_init(1, src_shape, graph::data_type::u8);
         dst_s8 = utils::logical_tensor_init(8, dst_shape, graph::data_type::s8);

--- a/tests/gtests/graph/unit/backend/dnnl/test_op_schema_cpu.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_op_schema_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ TEST(test_op_schema, InferSqueezeOutputShape) {
 
         const std::vector<int64_t> inferred_out_shape
                 = logical_tensor_wrapper_t(lt_out).vdims();
-        const std::vector<int64_t> expected_out_shape = dst_shapes[i];
+        const std::vector<int64_t> &expected_out_shape = dst_shapes[i];
         EXPECT_EQ(inferred_out_shape, expected_out_shape);
     }
 }

--- a/tests/gtests/graph/unit/backend/dnnl/test_pool.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_pool.cpp
@@ -224,7 +224,8 @@ TEST(test_pool_execute_subgraph_fp32, Pool3Postops) {
     std::vector<int64_t> pool_src_shape {2, 2, 4, 4};
     std::vector<int64_t> pool_dst_shape {2, 2, 2, 2};
 
-    std::vector<std::vector<float>> src_datas {};
+    std::vector<std::vector<float>> src_datas;
+    src_datas.reserve(1 + 3);
     src_datas.emplace_back(product(pool_src_shape));
     // at most 3 additional input tensors
     for (size_t i = 0; i < 3; ++i)
@@ -237,6 +238,7 @@ TEST(test_pool_execute_subgraph_fp32, Pool3Postops) {
                 [&]() { return f32_distribution(generator); });
 
     std::vector<graph::logical_tensor_t> lt_vec;
+    lt_vec.reserve(1 + 7);
     lt_vec.emplace_back(utils::logical_tensor_init(
             0, pool_src_shape, graph::data_type::f32));
     // at most 7 tensors in the whole graph
@@ -281,7 +283,8 @@ TEST(test_pool_execute_subgraph_fp32, Pool3Postops) {
         input_lts.push_back(lt_idx);
         pool_op.add_output(lt_vec[++lt_idx]);
 
-        std::vector<graph::op_t> post_ops {};
+        std::vector<graph::op_t> post_ops;
+        post_ops.reserve(post_op_ts.size());
         for (size_t i = 0; i < post_op_ts.size(); ++i) {
             auto pop_t = post_op_ts[i];
             post_ops.emplace_back(i + 1, pop_t, "post op");
@@ -303,7 +306,8 @@ TEST(test_pool_execute_subgraph_fp32, Pool3Postops) {
             g.add_op(&pop);
         g.finalize();
 
-        std::vector<test_tensor_t> src_tss {};
+        std::vector<test_tensor_t> src_tss;
+        src_tss.reserve(input_lts.size());
         for (size_t i = 0; i < input_lts.size(); ++i)
             src_tss.emplace_back(lt_vec[input_lts[i]], engine, src_datas[i]);
 

--- a/tests/gtests/test_concat.cpp
+++ b/tests/gtests/test_concat.cpp
@@ -156,6 +156,7 @@ protected:
         memory::data_type data_type = data_traits_t<data_t>::data_type;
 
         std::vector<memory::desc> srcs_md;
+        srcs_md.reserve(p.srcs_cds.size());
         std::vector<memory> srcs;
         for (size_t i = 0; i < p.srcs_cds.size(); i++)
             srcs_md.emplace_back(p.srcs_cds[i], data_type, p.srcs_format[i]);

--- a/tests/gtests/test_sum.cpp
+++ b/tests/gtests/test_sum.cpp
@@ -203,6 +203,7 @@ protected:
         auto strm = make_stream(eng);
 
         std::vector<memory::desc> srcs_md;
+        srcs_md.reserve(num_srcs);
         std::vector<memory> srcs;
 
         for (size_t i = 0; i < num_srcs; i++)


### PR DESCRIPTION
This PR addresses leftover clang-tidy hits obtained with Clang 19.1.6.
With that, it should be possible to enable the mandatory linter check.

Commits are scoped for each team to simplify the review.

For CPU:
* Commits 2, 3 and 4 are doing renaming.
  * Commit 2 applies minor changes to RNN w.r.t. macro handling.
  * Commit 3 just updates names with `_t`.
  * Commit 4 changes the name for arguments passed into the kernel, adds zero initialization of structs.
* Commits 5+ do some changes, please check them.