### PR TITLE
cpu: x64: matmul: AMX blocking heuristics fixes

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -113,6 +113,8 @@ private:
     dim_t m_per_thread, k_per_thread, n_per_thread, b_per_thread;
     bool need_prefetch;
     bool is_horizontal;
+    dim_t min_m_elem, min_k_elem, min_n_elem;
+    dim_t k_threshold_write_bound_layer_elem, min_n_dim_write_bound_layer_elem;
 
     size_t m_tmul, n_tmul, k_tmul;
     bool set_blocking_parameters();


### PR DESCRIPTION
## Description
This PR fixes 
https://jira.devtools.intel.com/browse/MFDNN-13324
https://jira.devtools.intel.com/browse/MFDNN-13503
Matmul performance issues related to blocking strategies.


SPR-E2 56c@2.2GHz | BF16 | INT8
-- | -- | -- 
3D-UNet Inference | 99% | 100%
3D-UNet Inference RT | 101% | 104%
MaskRCNN Inference | 99% | 101%
MaskRCNN Inference RT | 101% | 108%
MaskRCNN Training | 100% | N/A
ResNeXt-101 Inference | 100% | 100%
ResNeXt-101 Inference RT | 100% | 101%
ResNet-50 v1.5 Inference | 100% | 100%
ResNet-50 v1.5 Inference RT | 99% | 100%
ResNet-50 v1.5 Training | 100% | N/A
SSD-ResNet-34 Inference | 99% | 100%
SSD-ResNet-34 Inference RT | 101% | 104%
SSD-ResNet-34 Training | 100% | N/A
Vision Transformer Inference | 100% | 100%
Vision Transformer Inference RT | 99% | 100%
MaskRCNN Inference | 100% | 100%
MaskRCNN Inference RT | 99% | 100%
MaskRCNN Training | 100% | N/A
GEMM (inner product) BERT Large Inference | 101% | 99%
BERT Large Inference RT | 99% | 101%
BERT Large Training | 100% | N/A
DIEN Inference RT | 99% | 98%
DLRM Inference | 102% | 101%
DLRM Inference RT | 99% | 101%
DLRM Training | 99% | N/A
DLRM-v2 Inference | 100% | 101%
DLRM-v2 Inference RT | 97% | 99%
DLRM-v2 Training | 100% | N/A
DistilBERT Inference | 100% | 101%
DistilBERT Inference RT | 100% | 99%
GPT-J 2016/32 Inference | 100% | 99%
GPT-J 2016/32 Inference RT | 100% | 101%
GPT-J 32/32 Inference | 100% | 100%
GPT-J 32/32 Inference RT | 101% | 100%
LLaMA2 7B 2016/32 Inference RT | 100% | 100%
LLaMA2 7B 32/32 Inference RT | 99% | 102%
MaskRCNN Inference | 100% | 100%
MaskRCNN Inference RT | 99% | 106%
MaskRCNN Training | 99% | N/A
RGAT Inference | 100% | 100%
RGAT Inference RT | 100% | 100%
Transformer LT Inference | 101% | 99%
Transformer LT Inference RT | 99% | 107%
Transformer LT Training | 101% | N/A
Vision Transformer Inference | 97% | 100%
Vision Transformer Inference RT | 99% | 100%
GEMM (matmul) BERT Large Inference | 100% | 100%
BERT Large Inference RT | 102% | 105%
BERT Large Training | 100% | N/A
DIEN Inference RT | 96% | 99%
DLRM Inference | 98% | 99%
DLRM Inference RT | 100% | 99%
DLRM Training | 100% | N/A
DLRM-v2 Inference | 100% | 100%
DLRM-v2 Inference RT | 104% | 101%
DLRM-v2 Training | 100% | N/A
DistilBERT Inference | 100% | 103%
DistilBERT Inference RT | 101% | 100%
GPT-J 2016/32 Inference | 100% | 100%
GPT-J 2016/32 Inference RT | 100% | 102%
GPT-J 32/32 Inference | 100% | 100%
GPT-J 32/32 Inference RT | 100% | 100%
LLaMA2 7B 2016/32 Inference RT | 100% | 99%
LLaMA2 7B 32/32 Inference RT | 99% | 100%
RGAT Inference | 100% | 99%
RGAT Inference RT | 99% | 99%
Transformer LT Inference | 100% | 101%
Transformer LT Inference RT | 102% | 98%
Transformer LT Training | 100% | N/A
Vision Transformer Inference | 99% | 101%
Vision Transformer Inference RT | 99% | 100%
