### PR TITLE
rfcs: extend layer norm to support root mean square normalization

### DIFF
--- a/rfcs/20251004-rms-norm/README.md
+++ b/rfcs/20251004-rms-norm/README.md
@@ -110,9 +110,10 @@ explciitly indicate what is happening with the variance.
 
 #### Compatibility with Existing Flags
 
-The combination of `dnnl_use_global_stats` and `dnnl_rms_norm` would be supported,
-but users must only provide pre-computed RMS norm statistics
-(instead of both mean and variance as required for Layer normalization).
+The combination of `dnnl_use_global_stats` and `dnnl_rms_norm` will be supported.
+However, users must provide pre-computed RMS norm statistics
+(instead of both mean and variance as required for Layer Normalization)
+using the `DNNL_ARG_VARIANCE` index.
 
 Since RMSNorm is a simplified version of LayerNorm, it works with `dnnl_use_scale`
 and `dnnl_use_shift` flags in the same manner.

--- a/rfcs/20251004-rms-norm/README.md
+++ b/rfcs/20251004-rms-norm/README.md
@@ -51,6 +51,9 @@ using frameworks like TensorFlow and PyTorch.
 Additionally, consider [Keras RMS Normalization Layer](https://github.com/keras-team/keras/blob/v3.9.2/keras/src/layers/normalization/rms_normalization.py)
 and [PyTorch RMSNorm](https://pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html) APIs.
 
+Note that this proposal currently does not cover the [Keras Layer Normalization](https://keras.io/api/layers/normalization_layers/layer_normalization/)
+with the `rms_scaling=True` option, see [keras#21234 Issue](https://github.com/keras-team/keras/issues/21234).
+
 ## Proposal
 
 The proposal is to extend the LayerNorm primitive to support RMSNorm

--- a/rfcs/20251004-rms-norm/README.md
+++ b/rfcs/20251004-rms-norm/README.md
@@ -149,17 +149,8 @@ An additional flag for LayerNorm to enable RMSNorm will be added to the `--flags
 
 Note: If the flag is named `dnnl_{use_zero, no}_mean`, the option will be updated to `--flags=[|G|C|H|Z]`.
 
-Other internal changes would be captured in work-in-progress [PR 3068](https://github.com/uxlfoundation/oneDNN/pull/3068).
+Other internal changes would be captured in [PR 3068](https://github.com/uxlfoundation/oneDNN/pull/3068).
 
 ## Open Questions
 
-- Should the flag be named `dnnl_rms_norm` or `dnnl_{use_zero, no}_mean`?
-
-  Pros and Cons:
-  - (Preferred) `dnnl_rms_norm`:
-    - Pros: Explicitly indicates that RMS normalization is used.
-    - Cons: May not be immediately clear to those unfamiliar with the term.
-  - `dnnl_{use_zero, no}_mean`:
-    - Pros: Clearly indicates that the mean is assumed to be zero.
-    - Cons: Somewhat misleading as it doesn't explicitly indicate what is happening with
-      the variance (e.g, do we compute and use true variance or `RMS^2`?).
+N/A, everything was discussed and agreed upon.

--- a/rfcs/20251004-rms-norm/README.md
+++ b/rfcs/20251004-rms-norm/README.md
@@ -48,9 +48,8 @@ refer to the article by [Biao Zhang and Rico Sennrich](https://arxiv.org/abs/191
 This article provides more details regarding the method and showcases some experiments
 using frameworks like TensorFlow and PyTorch.
 
-Additionally, consider TensorFlow
-[LayerNorm with RMS parameter](https://www.tensorflow.org/api_docs/python/tf/keras/layers/LayerNormalization)
-and PyTorch [RMSNorm](https://pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html) APIs.
+Additionally, consider [Keras RMS Normalization Layer](https://github.com/keras-team/keras/blob/v3.9.2/keras/src/layers/normalization/rms_normalization.py)
+and [PyTorch RMSNorm](https://pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html) APIs.
 
 ## Proposal
 

--- a/rfcs/20251004-rms-norm/README.md
+++ b/rfcs/20251004-rms-norm/README.md
@@ -139,14 +139,13 @@ as they wouldn't need to adjust how outputs are handled in case of LayerNorm and
 An additional flag for LayerNorm to enable RMSNorm will be added to the `--flags` option.
 
 ```
-`--flags=[|G|C|H|R]` -- layer normalization flags, default `none`; where
+`--flags=[|G|C|H|M]` -- layer normalization flags, default `none`; where
             multiple simultaneous flags are supported.
             `G` is dnnl_use_global_stats;
             `C` is dnnl_use_scale;
             `H` is dnnl_use_shift;
-            `R` is dnnl_use_rms_norm;
-            Refer to [layer normalization primitive](https://uxlfoundation.github.io/oneDNN/dev_guide_layer_normalization.html)
-            for details.
+            `M` is dnnl_use_rms_norm;
+            ...
 ```
 
 Note: If the flag is named `dnnl_{use, force}_zero_mean`, the option will be updated to `--flags=[|G|C|H|Z]`.

--- a/rfcs/20251004-rms-norm/README.md
+++ b/rfcs/20251004-rms-norm/README.md
@@ -27,15 +27,16 @@ input data, which helps improve stability and convergence.
 RMSNorm, on the other hand, skips the re-centering step and normalizes using only
 the root mean square statistic (`RMS`):
 ```math
-RMS(t, n) = \sqrt{\frac{1}{C} \sum_{c} src(t, n, c)^2 + \epsilon}
+RMS(t, n) = \sqrt{\frac{1}{C} \sum_{c} src(t, n, c)^2 }
 ```
-The `epsilon` is added to avoid further dividing by zero.
-Note that it is not always the part of the definition for `RMS` statistics.
 
 This results in a simpler normalization formula:
 ```math
-dst(t, n, c) = \frac{src(t, n, c)}{RMS(t, n)} * \gamma(c) + \beta(c)
+dst(t, n, c) = \frac{src(t, n, c)}{\sqrt{\frac{1}{C} \sum_{c} src(t, n, c)^2 + \epsilon}} * \gamma(c) + \beta(c)
 ```
+
+The `epsilon` is added to avoid further dividing by zero.
+Note that it is not always the part of the definition for `RMS` statistics.
 
 TLDR; RMSNorm could be considered a simplified version of
 LayerNorm where the mean is assumed to be zero. As a result, the variance is


### PR DESCRIPTION
Proposal to extend current Layer Normalization primitive to support RMS normalization via new flag.
Note "open questions" section for providing your opinion on better naming.
[Read here](https://github.com/uxlfoundation/oneDNN/blob/mzhukova/rfcs/20251004-rms-norm/rfcs/20251004-rms-norm/README.md)

Draft of implementation: https://github.com/uxlfoundation/oneDNN/pull/3068
JIRA: https://jira.devtools.intel.com/browse/MFDNN-13287

// Note: Current proposal is aligned with keras RMS normalization, but not Layer Normalization with rms_scaling due to https://github.com/keras-team/keras/issues/21234.
