### PR TITLE
xe: jit: gemm: dynamic quantization fixes

### DIFF
--- a/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
@@ -1563,6 +1563,9 @@ bool BLASKernelGenerator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStr
             period = outerProductCount(hw, problem, strategy);
         }
 
+        if (strategy.kInterleave)
+            period = gcd(period, strategy.kInterleaveChunk);
+
         makeUnbackedRegLayout(Tc_compute, state.Cr_layout, Cr_unrollM, Cr_unrollN, globalCM, 1, strategy.C.tileR, strategy.C.tileC, true);
     }
 

--- a/src/gpu/intel/jit/gemm/generator/pieces/matrix_multiply.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/matrix_multiply.cxx
@@ -758,14 +758,14 @@ void BLASKernelGenerator<hw>::outerProductRepackC(int x0, int xr0, int nx, int h
             if (scaleA && !doBSum) {
                 int hs = (h / problem.aqGroupK) % state.kaqLate;
                 scale[nscale] = findBlockReg(state.Ta_scaleInt, state.Ar_scaleLayout,
-                                             i, hs, state.Ar_scaleRegs, nes[0], sblock);
+                                             i, hs, state.Ar_scaleRegs, nes[nscale], sblock);
                 scaleStride[nscale] = globalCM ? 1 : 0;
                 nscale++;
             }
             if (scaleB && !doASum) {
                 int hs = (h / problem.bqGroupK) % state.kbqLate;
                 scale[nscale] = findBlockReg(state.Tb_scaleInt, state.Br_scaleLayout,
-                                             hs, j, state.Br_scaleRegs, nes[1], sblock);
+                                             hs, j, state.Br_scaleRegs, nes[nscale], sblock);
                 scaleStride[nscale] = globalCM ? 0 : 1;
                 nscale++;
             }


### PR DESCRIPTION
Addresses MFDNN-13578. Two fixes for dynamic quantization scenarios (int4/8 wei/src + f32 dst):

* C repack period could exceed the k chunk size when using interleaved k-parallelization, which is illegal because different k chunks have different scale factors.
* When only src has grouped scales, kernels could fail to generate due to an indexing glitch.