### PR TITLE
benchdnn: utils: cfg: consolidate adjustment logic under one umbrella

### DIFF
--- a/tests/benchdnn/conv/cfg.cpp
+++ b/tests/benchdnn/conv/cfg.cpp
@@ -30,24 +30,6 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
 
-    adjust_ranges_for_safe_n_acc();
-
-    // Use wider dst to test proper u8 loads.
-    const bool is_int8_and_wide_dst = this->get_dt(SRC) == dnnl_u8
-            && dnnl_data_type_size(this->get_dt(WEI)) == 1
-            && dnnl_data_type_size(this->get_dt(DST)) >= 4;
-    if (is_int8_and_wide_dst) { set_range_max(SRC, 160); }
-
-    // For s8s8 weights have to be even to comply with adjust_scale of 0.5f.
-    // Divide the range by factor of two here, and multiply values by factor
-    // of two when do filling.
-    const bool is_s8s8
-            = this->get_dt(SRC) == dnnl_s8 && this->get_dt(WEI) == dnnl_s8;
-    if (is_s8s8) {
-        set_range_min(WEI, -2);
-        set_range_max(WEI, 2);
-    }
-
     // Keep legacy filling for Wino.
     if (prb->alg == WINO) {
         if (prb->dt[0] == dnnl_f32) {
@@ -65,11 +47,8 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
         }
     }
 
-    BENCHDNN_PRINT(6,
-            "[FILL_CFG] SRC_%s=[%d;%d]; WEI_%s=[%d;%d]; DST_%s=[%d;%d];\n",
-            dt2str(this->get_dt(SRC)), get_range_min(SRC), get_range_max(SRC),
-            dt2str(this->get_dt(WEI)), get_range_min(WEI), get_range_max(WEI),
-            dt2str(this->get_dt(DST)), get_range_min(DST), get_range_max(DST));
+    adjust_ranges();
+    print_fill_cfg_verbose();
 }
 
 // Adjust density based on accumulation chain.
@@ -82,7 +61,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
 
     if (density_args.data_kind == allowed_non_dense_kind) {
         int64_t safe_n_acc = get_safe_n_acc();
-        assert(safe_n_acc > 0);
         safe_n_acc_str = std::to_string(safe_n_acc);
 
         // Bump density for some empiric value for int8 validation to hit

--- a/tests/benchdnn/deconv/cfg.cpp
+++ b/tests/benchdnn/deconv/cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2017-2024 Intel Corporation
+* Copyright 2017-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,29 +30,8 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
 
-    adjust_ranges_for_safe_n_acc();
-
-    // Use wider dst to test proper u8 loads.
-    const bool is_int8_and_wide_dst
-            = dnnl_data_type_size(this->get_dt(WEI)) == 1
-            && dnnl_data_type_size(this->get_dt(DST)) >= 4;
-    if (is_int8_and_wide_dst) { this->set_range_max(SRC, 160); }
-
-    // For s8s8 weights have to be even to comply with adjust_scale of 0.5f.
-    // Divide the range by factor of two here, and multiply values by factor
-    // of two when do filling.
-    const bool is_s8s8
-            = this->get_dt(SRC) == dnnl_s8 && this->get_dt(WEI) == dnnl_s8;
-    if (is_s8s8) {
-        this->set_range_min(WEI, -2);
-        this->set_range_max(WEI, 2);
-    }
-
-    BENCHDNN_PRINT(6,
-            "[FILL_CFG] SRC_%s=[%d;%d]; WEI_%s=[%d;%d]; DST_%s=[%d;%d];\n",
-            dt2str(this->get_dt(SRC)), get_range_min(SRC), get_range_max(SRC),
-            dt2str(this->get_dt(WEI)), get_range_min(WEI), get_range_max(WEI),
-            dt2str(this->get_dt(DST)), get_range_min(DST), get_range_max(DST));
+    adjust_ranges();
+    print_fill_cfg_verbose();
 }
 
 // Adjust density based on accumulation chain.
@@ -65,7 +44,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
 
     if (density_args.data_kind == allowed_non_dense_kind) {
         int64_t safe_n_acc = get_safe_n_acc();
-        assert(safe_n_acc > 0);
         safe_n_acc_str = std::to_string(safe_n_acc);
 
         // Bump density for some empiric value for int8 validation to hit

--- a/tests/benchdnn/ip/cfg.cpp
+++ b/tests/benchdnn/ip/cfg.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2018-2024 Intel Corporation
+* Copyright 2018-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,11 +30,7 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
                         kind, orig_data_type, data_type, get_cfg_map(kind)});
     }
 
-    // Use wider dst to test proper u8 loads.
-    const bool is_int8_and_wide_dst = this->get_dt(SRC) == dnnl_u8
-            && dnnl_data_type_size(this->get_dt(WEI)) == 1
-            && dnnl_data_type_size(this->get_dt(DST)) >= 4;
-    if (is_int8_and_wide_dst) { set_range_max(SRC, 160); }
+    adjust_ranges();
 
     // Wider ranges make Nvidia/AMD bf16/f16 test cases to fail by accuracy,
     // likely due to internal dispatch into lower precision accumulation code.
@@ -49,11 +45,7 @@ cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds) {
         set_range_max(DST, 2);
     }
 
-    BENCHDNN_PRINT(6,
-            "[FILL_CFG] SRC_%s=[%d;%d]; WEI_%s=[%d;%d]; DST_%s=[%d;%d];\n",
-            dt2str(this->get_dt(SRC)), get_range_min(SRC), get_range_max(SRC),
-            dt2str(this->get_dt(WEI)), get_range_min(WEI), get_range_max(WEI),
-            dt2str(this->get_dt(DST)), get_range_min(DST), get_range_max(DST));
+    print_fill_cfg_verbose();
 }
 
 // Adjust density based on accumulation chain.
@@ -65,7 +57,6 @@ float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
     if (density_args.data_kind != SRC) return density;
 
     const auto safe_n_acc = get_safe_n_acc();
-    assert(safe_n_acc > 0);
 
     // Bump density for some empiric value for int8 validation to hit saturation
     // bound.

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -117,8 +117,9 @@ cold_cache_t::cold_cache_t(
             smart_bytes(hot_args_size).c_str(),
             smart_bytes(cold_args_size).c_str());
 
-    const size_t cold_mem_pool_size
-            = MAX2(cache_size_upper_bound - hot_args_size, 0);
+    const size_t cold_mem_pool_size = cache_size_upper_bound > hot_args_size
+            ? cache_size_upper_bound - hot_args_size
+            : 0;
 
     size_t n_mem_pool_buffers = 0;
     // If `cold_args_size` are greater then allowed pool_size, it means there's


### PR DESCRIPTION
* Update safe_n_acc to return fixed number of elements for very low precision dt.
* Move all logic spread across configs under a base config.
* Utilize a single call across cfgs to re-use the filling logic.

A better version of https://github.com/uxlfoundation/oneDNN/pull/3101 (the commit was reverted on main) which was exposed to the issue after matmul driver coverage was updated between the validation and promotion. Besides, the issue was caught on Nightly coverage which was not validated.

And a fix for cold-cache variable overflow.