### PR TITLE
sycl: address SYCL build clang-tidy hits

### DIFF
--- a/examples/graph/graph_example_utils.hpp
+++ b/examples/graph/graph_example_utils.hpp
@@ -117,7 +117,7 @@ struct sycl_deletor_t {
     sycl_deletor_t() = delete;
     ::sycl::context ctx_;
     sycl_deletor_t(const ::sycl::context &ctx) : ctx_(ctx) {}
-    void operator()(void *ptr) {
+    void operator()(void *ptr) const {
         if (ptr) ::sycl::free(ptr, ctx_);
     }
 };
@@ -578,7 +578,6 @@ public:
         // executed in the order in which they are submitted. Don't need to wait
         // event.
         is_free_ptr_[ptr] = true;
-        return;
     }
 #endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -93,6 +93,7 @@ struct brgemm_strides_t {
     dim_t stride_b;
 };
 
+// NOLINTBEGIN(modernize-use-using)
 // memory advice feature heuristic is based on the performance tests done
 // on simulator and lets the tile loading snoop for other cores caches if
 // the A/B matrices are shared. thus, if already shared, no need to fetch
@@ -122,6 +123,7 @@ typedef enum {
     // between threads
     brgemm_hint_mem_advice_A_B,
 } brgemm_kernel_hint_mem_advice_t;
+// NOLINTEND(modernize-use-using)
 
 struct brgemm_prf_t {
     int dist0 {-1};

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -2760,7 +2760,7 @@ public:
         return (jit_ker_) ? status::success : status::runtime_error;
     }
 
-    inline const cpu_isa_t max_cpu_isa() const noexcept { return max_cpu_isa_; }
+    inline cpu_isa_t max_cpu_isa() const noexcept { return max_cpu_isa_; }
 
 private:
     const cpu_isa_t max_cpu_isa_;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -155,16 +155,13 @@ bool matmul_amx_blocking_params_macro_t::find_best_blocking(
     matmul_amx_blocking_params_macro_t current_blocking(bgmmc);
     assert(bgmmc.tr_a_dt_sz == bgmmc.tr_b_dt_sz);
     current_blocking.gemm_dt_sz = bgmmc.tr_a_dt_sz;
-    current_blocking.min_m_elem = current_blocking.min_m_dim;
-    current_blocking.min_k_elem
-            = current_blocking.min_k_dim / current_blocking.gemm_dt_sz;
-    current_blocking.min_n_elem = current_blocking.min_n_dim / bgmmc.c_dt_sz;
+    current_blocking.min_m_elem = min_m_dim;
+    current_blocking.min_k_elem = min_k_dim / current_blocking.gemm_dt_sz;
+    current_blocking.min_n_elem = min_n_dim / bgmmc.c_dt_sz;
     current_blocking.k_threshold_write_bound_layer_elem
-            = current_blocking.k_threshold_write_bound_layer
-            / current_blocking.gemm_dt_sz;
+            = k_threshold_write_bound_layer / current_blocking.gemm_dt_sz;
     current_blocking.min_n_dim_write_bound_layer_elem
-            = current_blocking.min_n_dim_write_bound_layer
-            / current_blocking.gemm_dt_sz;
+            = min_n_dim_write_bound_layer / current_blocking.gemm_dt_sz;
 
     for (size_t nthr_to_check = bgmmc.nthr; nthr_to_check > 0;
             nthr_to_check--) {

--- a/src/gpu/intel/compute/zero_pool.cpp
+++ b/src/gpu/intel/compute/zero_pool.cpp
@@ -34,14 +34,14 @@ static std::mutex zero_pool_cache_mutex;
 #ifdef DNNL_WITH_SYCL
 // Unfortunately, weak_ptrs cannot be hashed, so unordered_map not possible here.
 // SYCL is currently missing owner_less for command graphs, so define it ourselves.
-struct weak_graph_owner_less {
+struct weak_graph_owner_less_t {
     bool operator()(const sycl::stream_t::weak_graph_t &lhs,
             const sycl::stream_t::weak_graph_t &rhs) const noexcept {
         return lhs.owner_before(rhs);
     }
 };
 static std::map<sycl::stream_t::weak_graph_t, zero_pool_t *,
-        weak_graph_owner_less>
+        weak_graph_owner_less_t>
         recorded_zero_pool_cache;
 #endif
 

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -202,7 +202,7 @@ public:
 
     template <typename... ngen_generator_args>
     ir_kernel_base_t(const exec_config_t &exec_cfg,
-            const kernel_iface_t &kernel_iface, ngen_generator_args... args)
+            const kernel_iface_t &kernel_iface, ngen_generator_args &&...args)
         : ngen_generator_t(std::forward<ngen_generator_args>(args)...)
         , kernel_iface_(kernel_iface)
         , exec_cfg_(exec_cfg)

--- a/src/gpu/intel/jit/codegen/reduce.hpp
+++ b/src/gpu/intel/jit/codegen/reduce.hpp
@@ -54,7 +54,7 @@ public:
         tensor_t tile = find_1d_tile(src_layout_, dst_layout_);
         int tile_elems = (int)tile.elems();
         auto src_tile_layout = src_layout_.map(tile);
-        auto src_tile_blocks = src_tile_layout.blocks();
+        const auto &src_tile_blocks = src_tile_layout.blocks();
         gpu_assert(src_tile_blocks.size() <= 1);
         ngen_register_scope_t block_scope(scope.register_allocator());
         int src_stride

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1662,7 +1662,7 @@ walk_order_t compute_walk_order(const conv_config_t &cfg) {
 
     // Add M/N blocks until the full footprint fits L3 cache.
     pvar_tile_t grid_inner;
-    pvar_tile_t rem_tile = grid_tile;
+    const pvar_tile_t &rem_tile = grid_tile;
     ab_bytes = inner_bytes;
     mn_walker_t mn_walker(rem_tile, cfg.prb());
     while (mn_walker.has_next()) {

--- a/src/gpu/intel/jit/conv/conv_kernel.hpp
+++ b/src/gpu/intel/jit/conv/conv_kernel.hpp
@@ -71,7 +71,7 @@ conv_kernel_t<hw>::conv_kernel_t(const conv_config_t &cfg,
     ir_utils::debug_profiler_t profile("Conv Kernel Construction Profile");
     // Build IR for the kernel.
     conv_ir_builder_t builder(cfg, kernel_info, zp_dst);
-    stmt_t body = builder.stmt();
+    const stmt_t &body = builder.stmt();
     profile.stamp("Kernel Builder");
 
     alloc_manager_t alloc_mgr(body);

--- a/src/gpu/intel/jit/conv/gen_convolution.cpp
+++ b/src/gpu/intel/jit/conv/gen_convolution.cpp
@@ -507,7 +507,7 @@ status_t gen_convolution_fwd_t::pd_t::init(impl::engine_t *engine) {
 }
 
 status_t gen_convolution_fwd_t::init(impl::engine_t *engine) {
-    impl_.reset(new gen_convolution_t());
+    impl_ = std::make_shared<gen_convolution_t>();
     return impl_->init(this, engine);
 }
 
@@ -528,7 +528,7 @@ status_t gen_convolution_bwd_weights_t::pd_t::init(impl::engine_t *engine) {
 }
 
 status_t gen_convolution_bwd_data_t::init(impl::engine_t *engine) {
-    impl_.reset(new gen_convolution_t());
+    impl_ = std::make_shared<gen_convolution_t>();
     return impl_->init(this, engine);
 }
 
@@ -537,7 +537,7 @@ status_t gen_convolution_bwd_data_t::execute(const exec_ctx_t &ctx) const {
 }
 
 status_t gen_convolution_bwd_weights_t::init(impl::engine_t *engine) {
-    impl_.reset(new gen_convolution_t());
+    impl_ = std::make_shared<gen_convolution_t>();
     return impl_->init(this, engine);
 }
 

--- a/src/gpu/intel/jit/conv/pipeline.cpp
+++ b/src/gpu/intel/jit/conv/pipeline.cpp
@@ -1041,7 +1041,7 @@ public:
         auto compute_loop_stmt
                 = find_stmt_group(root_, stmt_label_t::compute_loop());
         if (!compute_loop_stmt.has_value()) return root_;
-        auto compute_loop = compute_loop_stmt.value();
+        const auto &compute_loop = compute_loop_stmt.value();
         auto loop_nest = compute_loop_nest_t(compute_loop, ir_ctx_);
         auto &loops = loop_nest.loops();
 

--- a/src/gpu/intel/jit/ir/message_patterns.hpp
+++ b/src/gpu/intel/jit/ir/message_patterns.hpp
@@ -142,7 +142,7 @@ struct send_hint_t {
     enum send_dim_idx { block = 0, w = 1, h = 2 };
     using slayout_t = stride_layout_t<dim_type_t>;
     using hint_t = send_hint_t<dim_type_t>;
-    dim_t operator[](dim_type_t i) const {
+    dim_t operator[](const dim_type_t &i) const {
         return (hint_.count(i) == 0 ? 0 : hint_.at(i));
     }
     dim_t &operator[](dim_type_t i) { return hint_[i]; }
@@ -188,12 +188,12 @@ struct send_hint_t {
         hint_[i.dim] = (hint_.count(i.dim) == 0) ? base : hint_[i.dim] * base;
     }
 
-    void set_dim(dim_type_t idx, send_dim_idx i) { w_dims_[idx] |= i; }
-    bool is_w_dim(dim_type_t idx) const {
+    void set_dim(const dim_type_t &idx, send_dim_idx i) { w_dims_[idx] |= i; }
+    bool is_w_dim(const dim_type_t &idx) const {
         if (w_dims_.count(idx) == 0) return false;
         return (w_dims_.at(idx)) & send_dim_idx::w;
     }
-    bool is_h_dim(dim_type_t idx) const {
+    bool is_h_dim(const dim_type_t &idx) const {
         if (w_dims_.count(idx) == 0) return false;
         return w_dims_.at(idx) & send_dim_idx::h;
     }

--- a/src/gpu/intel/jit/pass/shuffle_splitter.cpp
+++ b/src/gpu/intel/jit/pass/shuffle_splitter.cpp
@@ -172,6 +172,7 @@ public:
         }
 
         vec_bcast = make_add(base_args);
+        vec_off.reserve(args.size());
         for (auto &a : args)
             vec_off.emplace_back(make_add(difference(a, base_args)));
 

--- a/src/gpu/intel/jit/pooling/pooling_kernel.hpp
+++ b/src/gpu/intel/jit/pooling/pooling_kernel.hpp
@@ -45,7 +45,7 @@ public:
                 {GENERATOR_NAME, GENERATOR_LINE}) {
         set_kernel_iface(kernel_info.iface());
         pooling_ir_builder_t builder(cfg, kernel_info, pd);
-        stmt_t body = builder.stmt();
+        const stmt_t &body = builder.stmt();
         setup_interface(body);
 
         // Generate assembly from IR.

--- a/src/gpu/intel/jit/utils/utils.hpp
+++ b/src/gpu/intel/jit/utils/utils.hpp
@@ -1062,7 +1062,7 @@ public:
     }
 
 private:
-    int find_entry_index(const std::string name) const {
+    int find_entry_index(const std::string &name) const {
         for (int i = 0; i < (int)entries_.size(); i++) {
             if (entries_[i].matches_relaxed(name)) return i;
         }

--- a/src/gpu/intel/jit/v2/conv/model.cpp
+++ b/src/gpu/intel/jit/v2/conv/model.cpp
@@ -32,10 +32,11 @@ struct hw_config_t {
     int regs = 0;
 
     hw_config_t() = default;
-    hw_config_t(const hw_t &hw, fma_kind_t fma) : hw(hw), fma(fma) {
-        regs = (utils::one_of(fma, fma_kind_t::dpas, fma_kind_t::dpasw) ? 256
-                                                                        : 128);
-    }
+    hw_config_t(const hw_t &hw, fma_kind_t fma)
+        : hw(hw)
+        , fma(fma)
+        , regs(utils::one_of(fma, fma_kind_t::dpas, fma_kind_t::dpasw) ? 256
+                                                                       : 128) {}
 
     int max_tgs_per_gpu(dim_t tg_size) const {
         int tgs_per_ss
@@ -108,10 +109,11 @@ struct bmnk_helper_t {
         to_bmnk(prb.prop(), desc.iter_tile, bi, mi, ni, ki);
         bl = ml = nl = 1;
         kl = ir_utils::safe_div(k, kt * ki);
-        tiles = 1;
+        tiles = 1; // NOLINT(cppcoreguidelines-prefer-member-initializer)
         tiles *= ir_utils::safe_div(b, bl * bt * bi);
         tiles *= ir_utils::safe_div(m, ml * mt * mi);
         tiles *= ir_utils::safe_div(n, nl * nt * ni);
+        // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         iters = tiles * kl;
         gpu_assert(tmp_iters == iters);
     }

--- a/src/gpu/intel/jit/v2/ir/builder.cpp
+++ b/src/gpu/intel/jit/v2/ir/builder.cpp
@@ -81,7 +81,7 @@ offset_t offset_scope_t::get_offset(int version, const expr_t &base0,
         const expr_t &base, const std::vector<expr_t> &_shift_vec,
         const expr_t &_shift, const offset_params_t &_params,
         const loop_nest_t &loop_nest) {
-    auto params = _params;
+    const auto &params = _params;
     expr_t _base_init;
     std::vector<expr_t> _loop_incs;
     split_to_linear(base, loop_nest.indices(), loop_nest.init_exprs(),

--- a/src/gpu/intel/jit/v2/ir/reqs.cpp
+++ b/src/gpu/intel/jit/v2/ir/reqs.cpp
@@ -180,7 +180,7 @@ public:
         auto parts = gpu_utils::split(s, "*");
         std::vector<expr_t> args;
         for (auto &p : parts) {
-            pvars_.push_back(pvar_t(p));
+            pvars_.emplace_back(p);
         }
     }
 
@@ -214,27 +214,24 @@ private:
 class req_rhs_entry_t {
 public:
     req_rhs_entry_t() = default;
-    explicit req_rhs_entry_t(dim_t value) : value_(value) { is_undef_ = false; }
-    explicit req_rhs_entry_t(const pvar_t &pvar) : pvar_(pvar) {
-        is_undef_ = false;
-    }
-    explicit req_rhs_entry_t(const expr_t &e) {
+    explicit req_rhs_entry_t(dim_t value) : is_undef_(false), value_(value) {}
+    explicit req_rhs_entry_t(const pvar_t &pvar)
+        : is_undef_(false), pvar_(pvar) {}
+    explicit req_rhs_entry_t(const expr_t &e) : is_undef_(false) {
         if (is_const(e)) {
             value_ = to_cpp<int>(e);
         } else {
             pvar_ = pvar_t::from_var(e);
             gpu_assert(!pvar_.is_undef()) << e;
         }
-        is_undef_ = false;
     }
-    explicit req_rhs_entry_t(const std::string &s) {
+    explicit req_rhs_entry_t(const std::string &s) : is_undef_(false) {
         if (!s.empty() && std::isdigit(s[0])) {
             value_ = std::stoi(s);
         } else {
             pvar_ = pvar_t(s);
             gpu_assert(!pvar_.is_undef()) << s;
         }
-        is_undef_ = false;
     }
     bool is_undef() const { return is_undef_; }
     bool is_pvar() const { return !is_undef_ && !pvar_.is_undef(); }

--- a/src/gpu/intel/sycl/engine.cpp
+++ b/src/gpu/intel/sycl/engine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ status_t engine_t::create_stream(
 }
 
 status_t engine_t::init_device_info() {
-    device_info_.reset(new gpu::intel::sycl::device_info_t());
+    device_info_ = std::make_shared<gpu::intel::sycl::device_info_t>();
     CHECK(device_info_->init(this));
     return status::success;
 }

--- a/src/gpu/intel/sycl/interop_kernel.cpp
+++ b/src/gpu/intel/sycl/interop_kernel.cpp
@@ -155,7 +155,7 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
             } else if (arg.is_local()) {
                 auto acc = xpu::sycl::compat::local_accessor<uint8_t, 1>(
                         ::sycl::range<1>(arg.size()), cgh);
-                cgh.set_arg((int)i, std::move(acc));
+                cgh.set_arg((int)i, acc);
             } else {
                 set_scalar_arg(cgh, (int)i, arg.scalar_type(), arg.value());
             }

--- a/src/gpu/intel/sycl/utils.cpp
+++ b/src/gpu/intel/sycl/utils.cpp
@@ -200,7 +200,7 @@ status_t create_ocl_engine(
         std::unique_ptr<gpu::intel::ocl::engine_t, engine_deleter_t>
                 *ocl_engine,
         const gpu::intel::sycl::engine_t *engine) {
-    const auto sycl_ctx = engine->context();
+    const auto &sycl_ctx = engine->context();
     return create_ocl_engine(ocl_engine, engine->device(), &sycl_ctx);
 }
 

--- a/src/graph/backend/dnnl/scratchpad.hpp
+++ b/src/graph/backend/dnnl/scratchpad.hpp
@@ -52,9 +52,6 @@ public:
         , size_(size)
         , eng_(&eng)
         , alloc_(&alloc)
-#ifdef DNNL_WITH_SYCL
-        , e_(::sycl::event())
-#endif
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
         , ocl_e_(nullptr)
 #endif
@@ -94,7 +91,7 @@ public:
     size_t size() const override { return size_; }
 
 #ifdef DNNL_WITH_SYCL
-    void set_deps(::sycl::event event) { e_ = event; }
+    void set_deps(::sycl::event event) { e_ = std::move(event); }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL

--- a/src/xpu/sycl/buffer_memory_storage.hpp
+++ b/src/xpu/sycl/buffer_memory_storage.hpp
@@ -51,7 +51,7 @@ public:
         if (!handle) return status::success;
 
         auto *buf_u8_ptr = static_cast<xpu::sycl::buffer_u8_t *>(handle);
-        buffer_.reset(new xpu::sycl::buffer_u8_t(*buf_u8_ptr));
+        buffer_ = std::make_shared<xpu::sycl::buffer_u8_t>(*buf_u8_ptr);
         return status::success;
     }
 

--- a/src/xpu/sycl/capi/capi_memory.cpp
+++ b/src/xpu/sycl/capi/capi_memory.cpp
@@ -32,7 +32,6 @@ using dnnl::impl::engine_t;
 using dnnl::impl::memory_desc_t;
 using dnnl::impl::memory_t;
 using dnnl::impl::status_t;
-using ::sycl::context;
 using ::sycl::get_pointer_type;
 
 status_t dnnl_sycl_interop_memory_create_v2(memory_t **memory,

--- a/src/xpu/sycl/context.hpp
+++ b/src/xpu/sycl/context.hpp
@@ -32,6 +32,10 @@ struct event_t : public xpu::event_t {
     event_t(const std::vector<::sycl::event> &event) : events(event) {}
     event_t(std::vector<::sycl::event> &&event) : events(std::move(event)) {}
     event_t(const event_t &) = default;
+    event_t &operator=(event_t &&other) {
+        std::swap(events, other.events);
+        return *this;
+    }
     event_t &operator=(const event_t &other) {
         events = other.events;
         return *this;

--- a/src/xpu/sycl/engine_impl.hpp
+++ b/src/xpu/sycl/engine_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -106,7 +106,6 @@ private:
     std::string name_;
     runtime_version_t runtime_version_;
 
-private:
     ::sycl::device device_;
     ::sycl::context context_;
 

--- a/src/xpu/sycl/stream_impl.hpp
+++ b/src/xpu/sycl/stream_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public:
     ~stream_impl_t() override = default;
 
     status_t set_queue(::sycl::queue queue) {
-        queue_.reset(new ::sycl::queue(queue));
+        queue_.reset(new ::sycl::queue(std::move(queue)));
         return status::success;
     }
 

--- a/src/xpu/sycl/types.hpp
+++ b/src/xpu/sycl/types.hpp
@@ -211,7 +211,8 @@ struct md_t {
         return phys_offset;
     }
 
-    dim_t off_v_masked(const dims_t pos, int mask, bool is_pos_padded = false) {
+    dim_t off_v_masked(
+            const dims_t pos, int mask, bool is_pos_padded = false) const {
         dims_t pos_masked;
         utils::copy_dims_with_mask(pos_masked, pos, ndims(), mask);
         return off_v(pos_masked, is_pos_padded);

--- a/src/xpu/sycl/usm_memory_storage.hpp
+++ b/src/xpu/sycl/usm_memory_storage.hpp
@@ -91,9 +91,9 @@ public:
                 ::sycl::usm::alloc::unknown);
     }
 
-    virtual std::unique_ptr<memory_storage_t> get_sub_storage(
+    std::unique_ptr<memory_storage_t> get_sub_storage(
             size_t offset, size_t size) const override {
-        void *sub_ptr = usm_ptr_.get()
+        void *sub_ptr = usm_ptr_
                 ? reinterpret_cast<uint8_t *>(usm_ptr_.get()) + offset
                 : nullptr;
         auto storage = utils::make_unique<usm_memory_storage_t>(engine());

--- a/src/xpu/sycl/utils.cpp
+++ b/src/xpu/sycl/utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -309,7 +309,7 @@ status_t get_device_index(size_t *index, const ::sycl::device &dev) {
     auto backend = get_backend(dev);
     auto devices = get_devices(dev_type, backend);
 
-    VERROR_ENGINE(devices.size() > 0, status::invalid_arguments,
+    VERROR_ENGINE(!devices.empty(), status::invalid_arguments,
             "%s devices queried but not found",
             xpu::sycl::to_string(dev_type).c_str());
 

--- a/src/xpu/sycl/verbose.hpp
+++ b/src/xpu/sycl/verbose.hpp
@@ -34,7 +34,7 @@ namespace impl {
 namespace xpu {
 namespace sycl {
 
-void print_verbose_header(engine_kind_t kind) {
+inline void print_verbose_header(engine_kind_t kind) {
     engine_factory_t factory(kind);
     auto s_engine_kind = (kind == engine_kind::cpu ? "cpu" : "gpu");
 
@@ -92,7 +92,7 @@ void print_verbose_header(engine_kind_t kind) {
     }
 }
 
-void print_verbose_header() {
+inline void print_verbose_header() {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL
     print_verbose_header(engine_kind::cpu);
 #endif

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -522,7 +522,7 @@ void dnn_mem_t::memset(int value, size_t size, int buffer_index) const {
                     ::sycl::accessor<uint8_t, 1, ::sycl::access::mode::write,
                             target_device>
                             acc(buf, cgh);
-                    cgh.fill(std::move(acc), static_cast<uint8_t>(value));
+                    cgh.fill(acc, static_cast<uint8_t>(value));
                 });
                 DNN_SAFE_V(dnnl_stream_wait(stream));
                 return;

--- a/tests/gtests/graph/api/sycl/test_cpp_api_compiled_partition.cpp
+++ b/tests/gtests/graph/api/sycl/test_cpp_api_compiled_partition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -101,20 +101,20 @@ TEST(SYCLApi, CompiledPartitionExecute) {
     outputs_ts.reserve(outputs.size());
     for (const auto &in : inputs) {
         size_t mem_size = in.get_mem_size();
-        data_buffers.push_back({});
+        data_buffers.emplace_back();
         data_buffers.back().reset(::sycl::malloc_shared(mem_size,
                                           q.get_device(), q.get_context()),
-                sycl_deletor {q.get_context()});
-        inputs_ts.push_back(tensor {in, eng, data_buffers.back().get()});
+                sycl_deletor_t {q.get_context()});
+        inputs_ts.emplace_back(in, eng, data_buffers.back().get());
     }
 
     for (const auto &out : outputs) {
         size_t mem_size = out.get_mem_size();
-        data_buffers.push_back({});
+        data_buffers.emplace_back();
         data_buffers.back().reset(::sycl::malloc_device(mem_size,
                                           q.get_device(), q.get_context()),
-                sycl_deletor {q.get_context()});
-        outputs_ts.push_back(tensor {out, eng, data_buffers.back().get()});
+                sycl_deletor_t {q.get_context()});
+        outputs_ts.emplace_back(out, eng, data_buffers.back().get());
     }
 
     cp.execute(strm, inputs_ts, outputs_ts);
@@ -164,20 +164,20 @@ TEST(SYCLApi, CompiledPartitionInteropExecute) {
     outputs_ts.reserve(outputs.size());
     for (const auto &in : inputs) {
         size_t mem_size = in.get_mem_size();
-        data_buffers.push_back({});
+        data_buffers.emplace_back();
         data_buffers.back().reset(::sycl::malloc_shared(mem_size,
                                           q.get_device(), q.get_context()),
-                sycl_deletor {q.get_context()});
-        inputs_ts.push_back(tensor {in, eng, data_buffers.back().get()});
+                sycl_deletor_t {q.get_context()});
+        inputs_ts.emplace_back(in, eng, data_buffers.back().get());
     }
 
     for (const auto &out : outputs) {
         size_t mem_size = out.get_mem_size();
-        data_buffers.push_back({});
+        data_buffers.emplace_back();
         data_buffers.back().reset(::sycl::malloc_device(mem_size,
                                           q.get_device(), q.get_context()),
-                sycl_deletor {q.get_context()});
-        outputs_ts.push_back(tensor {out, eng, data_buffers.back().get()});
+                sycl_deletor_t {q.get_context()});
+        outputs_ts.emplace_back(out, eng, data_buffers.back().get());
     }
 
     sycl_interop::execute(cp, strm, inputs_ts, outputs_ts);

--- a/tests/gtests/graph/api/test_api_common.hpp
+++ b/tests/gtests/graph/api/test_api_common.hpp
@@ -138,11 +138,11 @@ struct allocator_handle_t {
 };
 static allocator_handle_t allocator_handle;
 
-struct sycl_deletor {
-    sycl_deletor() = delete;
+struct sycl_deletor_t {
+    sycl_deletor_t() = delete;
     ::sycl::context ctx_;
-    sycl_deletor(const ::sycl::context &ctx) : ctx_(ctx) {}
-    void operator()(void *ptr) {
+    sycl_deletor_t(const ::sycl::context &ctx) : ctx_(ctx) {}
+    void operator()(void *ptr) const {
         if (ptr) ::sycl::free(ptr, ctx_);
     }
 };

--- a/tests/gtests/sycl/api/test_memory_buffer.cpp
+++ b/tests/gtests/sycl/api/test_memory_buffer.cpp
@@ -35,10 +35,10 @@ class init_kernel;
 
 namespace dnnl {
 
-class sycl_memory_buffer_test : public ::testing::TestWithParam<engine::kind> {
-};
+class sycl_memory_buffer_test_t
+    : public ::testing::TestWithParam<engine::kind> {};
 
-TEST_P(sycl_memory_buffer_test, BasicInteropCtor) {
+TEST_P(sycl_memory_buffer_test_t, BasicInteropCtor) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -76,7 +76,7 @@ TEST_P(sycl_memory_buffer_test, BasicInteropCtor) {
     }
 }
 
-TEST_P(sycl_memory_buffer_test, ConstructorNone) {
+TEST_P(sycl_memory_buffer_test_t, ConstructorNone) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -100,7 +100,7 @@ TEST_P(sycl_memory_buffer_test, ConstructorNone) {
     (void)buf;
 }
 
-TEST_P(sycl_memory_buffer_test, ConstructorAllocate) {
+TEST_P(sycl_memory_buffer_test_t, ConstructorAllocate) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -138,7 +138,7 @@ TEST_P(sycl_memory_buffer_test, ConstructorAllocate) {
     mem.unmap_data(mapped_ptr);
 }
 
-TEST_P(sycl_memory_buffer_test, BasicInteropGetSet) {
+TEST_P(sycl_memory_buffer_test_t, BasicInteropGetSet) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -178,7 +178,7 @@ TEST_P(sycl_memory_buffer_test, BasicInteropGetSet) {
     }
 }
 
-TEST_P(sycl_memory_buffer_test, InteropReorder) {
+TEST_P(sycl_memory_buffer_test_t, InteropReorder) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 #ifdef DNNL_SYCL_HIP
@@ -246,7 +246,7 @@ TEST_P(sycl_memory_buffer_test, InteropReorder) {
     }
 }
 
-TEST_P(sycl_memory_buffer_test, InteropReorderAndUserKernel) {
+TEST_P(sycl_memory_buffer_test_t, InteropReorderAndUserKernel) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -328,7 +328,7 @@ TEST_P(sycl_memory_buffer_test, InteropReorderAndUserKernel) {
     }
 }
 
-TEST_P(sycl_memory_buffer_test, EltwiseWithUserKernel) {
+TEST_P(sycl_memory_buffer_test_t, EltwiseWithUserKernel) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -388,7 +388,7 @@ TEST_P(sycl_memory_buffer_test, EltwiseWithUserKernel) {
     }
 }
 
-TEST_P(sycl_memory_buffer_test, MemoryOutOfScope) {
+TEST_P(sycl_memory_buffer_test_t, MemoryOutOfScope) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -414,7 +414,7 @@ TEST_P(sycl_memory_buffer_test, MemoryOutOfScope) {
     s.wait();
 }
 
-TEST_P(sycl_memory_buffer_test, TestSparseMemoryCreation) {
+TEST_P(sycl_memory_buffer_test_t, TestSparseMemoryCreation) {
     engine::kind eng_kind = GetParam();
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
@@ -464,7 +464,7 @@ TEST_P(sycl_memory_buffer_test, TestSparseMemoryCreation) {
     ASSERT_EQ(h3, buf_col_indices);
 }
 
-TEST_P(sycl_memory_buffer_test, TestSparseMemoryMapUnmap) {
+TEST_P(sycl_memory_buffer_test_t, TestSparseMemoryMapUnmap) {
     engine::kind eng_kind = GetParam();
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
@@ -523,7 +523,7 @@ TEST_P(sycl_memory_buffer_test, TestSparseMemoryMapUnmap) {
 }
 
 namespace {
-struct PrintToStringParamName {
+struct print_to_string_param_name_t {
     template <class ParamType>
     std::string operator()(
             const ::testing::TestParamInfo<ParamType> &info) const {
@@ -532,8 +532,8 @@ struct PrintToStringParamName {
 };
 } // namespace
 
-INSTANTIATE_TEST_SUITE_P(Simple, sycl_memory_buffer_test,
+INSTANTIATE_TEST_SUITE_P(Simple, sycl_memory_buffer_test_t,
         ::testing::Values(engine::kind::cpu, engine::kind::gpu),
-        PrintToStringParamName());
+        print_to_string_param_name_t());
 
 } // namespace dnnl

--- a/tests/gtests/sycl/api/test_memory_usm.cpp
+++ b/tests/gtests/sycl/api/test_memory_usm.cpp
@@ -29,7 +29,7 @@ namespace dnnl {
 
 class fill_kernel;
 
-class sycl_memory_usm_test : public ::testing::TestWithParam<engine::kind> {
+class sycl_memory_usm_test_t : public ::testing::TestWithParam<engine::kind> {
     using usm_unique_ptr_t = std::unique_ptr<void, std::function<void(void *)>>;
 
 protected:
@@ -57,7 +57,7 @@ protected:
     }
 };
 
-TEST_P(sycl_memory_usm_test, Constructor) {
+TEST_P(sycl_memory_usm_test_t, Constructor) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -97,7 +97,7 @@ TEST_P(sycl_memory_usm_test, Constructor) {
     }
 }
 
-TEST_P(sycl_memory_usm_test, ConstructorNone) {
+TEST_P(sycl_memory_usm_test_t, ConstructorNone) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -118,7 +118,7 @@ TEST_P(sycl_memory_usm_test, ConstructorNone) {
     ASSERT_EQ(nullptr, mem.get_data_handle());
 }
 
-TEST_P(sycl_memory_usm_test, ConstructorAllocate) {
+TEST_P(sycl_memory_usm_test_t, ConstructorAllocate) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -149,7 +149,7 @@ TEST_P(sycl_memory_usm_test, ConstructorAllocate) {
     mem.unmap_data(mapped_ptr);
 }
 
-TEST_P(sycl_memory_usm_test, DefaultConstructor) {
+TEST_P(sycl_memory_usm_test_t, DefaultConstructor) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -181,7 +181,7 @@ TEST_P(sycl_memory_usm_test, DefaultConstructor) {
 
 /// This test checks if passing system allocated memory(e.g. using malloc)
 /// will throw if passed into the make_memory
-TEST_P(sycl_memory_usm_test, ErrorMakeMemoryUsingSystemMemory) {
+TEST_P(sycl_memory_usm_test_t, ErrorMakeMemoryUsingSystemMemory) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -211,7 +211,7 @@ TEST_P(sycl_memory_usm_test, ErrorMakeMemoryUsingSystemMemory) {
 
 /// This test checks if passing system allocated memory(e.g. using malloc)
 /// will throw if passed into the make_memory
-TEST_P(sycl_memory_usm_test, ErrorMemoryConstructorUsingSystemMemory) {
+TEST_P(sycl_memory_usm_test_t, ErrorMemoryConstructorUsingSystemMemory) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -236,7 +236,7 @@ TEST_P(sycl_memory_usm_test, ErrorMemoryConstructorUsingSystemMemory) {
     }
 }
 
-TEST_P(sycl_memory_usm_test, MemoryOutOfScope) {
+TEST_P(sycl_memory_usm_test_t, MemoryOutOfScope) {
     engine::kind eng_kind = GetParam();
     SKIP_IF(engine::get_count(eng_kind) == 0, "Engine not found.");
 
@@ -266,7 +266,7 @@ TEST_P(sycl_memory_usm_test, MemoryOutOfScope) {
     s.wait();
 }
 
-TEST_P(sycl_memory_usm_test, TestSparseMemoryCreation) {
+TEST_P(sycl_memory_usm_test_t, TestSparseMemoryCreation) {
     engine::kind eng_kind = GetParam();
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
@@ -316,7 +316,7 @@ TEST_P(sycl_memory_usm_test, TestSparseMemoryCreation) {
     ASSERT_EQ(mem.get_data_handle(2), usm_col_indices.get());
 }
 
-TEST_P(sycl_memory_usm_test, TestSparseMemoryMapUnmap) {
+TEST_P(sycl_memory_usm_test_t, TestSparseMemoryMapUnmap) {
     engine::kind eng_kind = GetParam();
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_SYCL
@@ -381,7 +381,7 @@ TEST_P(sycl_memory_usm_test, TestSparseMemoryMapUnmap) {
 }
 
 namespace {
-struct PrintToStringParamName {
+struct print_to_string_param_name_t {
     template <class ParamType>
     std::string operator()(
             const ::testing::TestParamInfo<ParamType> &info) const {
@@ -390,8 +390,8 @@ struct PrintToStringParamName {
 };
 } // namespace
 
-INSTANTIATE_TEST_SUITE_P(Simple, sycl_memory_usm_test,
+INSTANTIATE_TEST_SUITE_P(Simple, sycl_memory_usm_test_t,
         ::testing::Values(engine::kind::cpu, engine::kind::gpu),
-        PrintToStringParamName());
+        print_to_string_param_name_t());
 
 } // namespace dnnl

--- a/tests/gtests/sycl/api/test_stream.cpp
+++ b/tests/gtests/sycl/api/test_stream.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@
 using namespace sycl;
 
 namespace dnnl {
-class sycl_stream_test : public ::testing::TestWithParam<engine::kind> {
+class sycl_stream_test_t : public ::testing::TestWithParam<engine::kind> {
 protected:
-    virtual void SetUp() {
+    void SetUp() override {
         if (engine::get_count(engine::kind::cpu) > 0) {
             cpu_eng = engine(engine::kind::cpu, 0);
         }
@@ -76,7 +76,7 @@ protected:
     engine gpu_eng;
 };
 
-TEST_P(sycl_stream_test, Create) {
+TEST_P(sycl_stream_test_t, Create) {
     engine::kind kind = GetParam();
     SKIP_IF(!has(kind), "Device not found.");
 
@@ -97,7 +97,7 @@ TEST_P(sycl_stream_test, Create) {
     EXPECT_EQ(get_context(kind), queue_ctx);
 }
 
-TEST_P(sycl_stream_test, BasicInterop) {
+TEST_P(sycl_stream_test_t, BasicInterop) {
     engine::kind kind = GetParam();
     SKIP_IF(!has(kind), "Device not found.");
 
@@ -114,7 +114,7 @@ TEST_P(sycl_stream_test, BasicInterop) {
     EXPECT_EQ(interop_queue, sycl_interop::get_queue(s));
 }
 
-TEST_P(sycl_stream_test, InteropIncompatibleQueue) {
+TEST_P(sycl_stream_test_t, InteropIncompatibleQueue) {
     engine::kind kind = GetParam();
     SKIP_IF(!has(engine::kind::cpu) || !has(engine::kind::gpu),
             "CPU or GPU device not found.");
@@ -136,7 +136,7 @@ TEST_P(sycl_stream_test, InteropIncompatibleQueue) {
 extern "C" dnnl_status_t dnnl_reset_profiling(dnnl_stream_t stream);
 #endif
 
-TEST_P(sycl_stream_test, TestProfilingAPIDisabledAndEnabled) {
+TEST_P(sycl_stream_test_t, TestProfilingAPIDisabledAndEnabled) {
     engine::kind kind = GetParam();
     SKIP_IF(!has(kind), "Device not found.");
     SKIP_IF(kind == engine::kind::cpu, "Test is GPU specific.");
@@ -201,7 +201,7 @@ TEST_P(sycl_stream_test, Flags) {
 #endif
 
 namespace {
-struct PrintToStringParamName {
+struct print_to_string_param_name_t {
     template <class ParamType>
     std::string operator()(
             const ::testing::TestParamInfo<ParamType> &info) const {
@@ -215,8 +215,8 @@ struct PrintToStringParamName {
 };
 } // namespace
 
-INSTANTIATE_TEST_SUITE_P(AllEngineKinds, sycl_stream_test,
+INSTANTIATE_TEST_SUITE_P(AllEngineKinds, sycl_stream_test_t,
         ::testing::Values(engine::kind::cpu, engine::kind::gpu),
-        PrintToStringParamName());
+        print_to_string_param_name_t());
 
 } // namespace dnnl


### PR DESCRIPTION
Builds off of #3142 and addresses clang-tidy hits identified using `clang-tidy` bundled with DPC++ 2025.1 compiler and command
```bash
grep "\"file\":" build/compile_commands.json | \
    cut -d" " -f4 | rev | cut -c3- | rev | cut -c2- | \
    xargs rg -il SYCL | sort -u | \
    while read file; do
        echo "Processing $file"
        clang-tidy -p build $file
    done
```
for a SYCL runtime build.
(I couldn't get this `clang-tidy` to work with cmake.)

These changes are exhaustive.