### PR TITLE
fixup: benchdnn: conv: inputs: improve GPU CI coverage

### DIFF
--- a/tests/benchdnn/inputs/conv/shapes_basic_gpu
+++ b/tests/benchdnn/inputs/conv/shapes_basic_gpu
@@ -1,0 +1,20 @@
+# basic shapes for GPU - reduced version of shapes_basic due to kernels
+# compilation overhead, one problem of a kind.
+
+# one dimensional shapes
+g1ic17oc17_iw5ow5kw3pw1_n"1d_tail_conv:3x3"
+
+# two dimensional shapes
+g1ic3oc16_ih5oh5kh3ph1_n"2d_conv:1st"
+g1ic3oc17_ih5oh5kh3ph1_n"2d_conv:1st_tail"
+g1ic17oc17_ih5oh5kh1ph0_n"2d_tail_conv:1x1"
+g1ic16oc16_ih5oh5kh3ph1_n"2d_conv:3x3"
+g4ic16oc16_ih5oh5kh3ph1_n"2d_conv:grouped"
+g4ic20oc20_ih5oh5kh3ph1_n"2d_tail_conv:grouped"
+
+# three dimensional shapes
+g1ic3oc17_id5od5kd3pd1_n"3d_tail_conv:1st"
+g1ic16oc16_id5od5kd1pd0_n"3d_conv:1x1"
+g1ic17oc17_id5od5kd3pd1_n"3d_tail_conv:3x3"
+g16ic16oc16_id5od5kd3pd1_n"3d_conv:depthwise"
+g17ic17oc17_id5od5kd3pd1_n"3d_tail_conv:depthwise"


### PR DESCRIPTION
Fixup for #3120. `shapes_basic_gpu` should be restored as it's used by `test_conv_gpu` input file.

Will replace this file by `shapes_ci_gpu` which has better coverage but need more time to confirm there are no failures with Nightly. This PR is a quick fixup.