### PR TITLE
benchdnn: graph: support validation through select primitive

### DIFF
--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -2465,12 +2465,13 @@ status_t binary_canonicalization(std::shared_ptr<subgraph_t> &sg) {
         int32_t target_ndims = std::max(src0_ndims, src1_ndims);
         std::vector<int32_t> in_ndims {src0_ndims, src1_ndims};
         for (size_t i = 0; i < cur_op->num_inputs(); ++i) {
-            // For binary select op, broadcast for the third input is
-            // unsupported.
-            if (i == 2) { continue; }
-            if (in_ndims[i] == target_ndims) { continue; }
+            // broadcast for the condition input of Select op.
+            int current_ndims = i == 2
+                    ? cur_op->get_input_value(2)->get_logical_tensor().ndims
+                    : in_ndims[i];
+            if (current_ndims == target_ndims) { continue; }
 
-            std::vector<int64_t> axes(target_ndims - in_ndims[i]);
+            std::vector<int64_t> axes(target_ndims - current_ndims);
             std::iota(axes.begin(), axes.end(), 0);
 
             // Only for NCX format BiasAdd, we need to unsqueeze the 1D bias to

--- a/tests/benchdnn/graph/custom_driver.hpp
+++ b/tests/benchdnn/graph/custom_driver.hpp
@@ -29,7 +29,6 @@ namespace custom {
 
 enum alg_t {
     GENINDEX,
-    SELECT,
     TRANSPOSE,
     RESHAPE,
     ALG_UNKNOWN,

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -543,7 +543,7 @@ dnnl_driver_t opkind2driver(const dnnl::graph::op::kind &kind) {
                             dnnl_driver_t::eltwise},
                     {dnnl::graph::op::kind::Reorder, dnnl_driver_t::reorder},
                     {dnnl::graph::op::kind::Round, dnnl_driver_t::eltwise},
-                    {dnnl::graph::op::kind::Select, dnnl_driver_t::custom},
+                    {dnnl::graph::op::kind::Select, dnnl_driver_t::binary},
                     {dnnl::graph::op::kind::Sigmoid, dnnl_driver_t::eltwise},
                     {dnnl::graph::op::kind::SigmoidBackward,
                             dnnl_driver_t::eltwise},
@@ -1164,7 +1164,7 @@ int get_prim_arg_name_from_graph_op_input_offset(
         } break;
         case dnnl::graph::op::kind::Select: {
             if (input_offset == 0)
-                return DNNL_ARG_WEIGHTS;
+                return DNNL_ARG_SRC_2;
             else if (input_offset == 1)
                 return DNNL_ARG_SRC_0;
             else if (input_offset == 2)

--- a/tests/benchdnn/utils/data_kind.cpp
+++ b/tests/benchdnn/utils/data_kind.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ static data_kind_entry_t data_kind_table[] = {
         // is the one that corresponts to the argument expected in comparison.
         {SRC, {DNNL_ARG_DIFF_SRC, DNNL_ARG_SRC}},
         {SRC_1, {DNNL_ARG_DIFF_SRC_1, DNNL_ARG_SRC_1}},
+        {SRC_2, {DNNL_ARG_DIFF_SRC_2, DNNL_ARG_SRC_2}},
         {SRC_ITER, {DNNL_ARG_DIFF_SRC_ITER, DNNL_ARG_SRC_ITER}},
         {SRC_ITER_C, {DNNL_ARG_DIFF_SRC_ITER_C, DNNL_ARG_SRC_ITER_C}},
         {WEI, {DNNL_ARG_DIFF_WEIGHTS, DNNL_ARG_WEIGHTS}},
@@ -97,6 +98,7 @@ const char *data_kind2str(data_kind_t kind) {
     switch (kind) {
         case SRC: return "SRC";
         case SRC_1: return "SRC_ADD";
+        case SRC_2: return "SRC_2";
         case WEI: return "WEI";
         case BIA: return "BIA";
         case DST: return "DST";

--- a/tests/benchdnn/utils/data_kind.hpp
+++ b/tests/benchdnn/utils/data_kind.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ enum data_kind_t {
     ACC,
     // bnorm, lnorm
     SRC_1,
+    // select
+    SRC_2,
     MEAN,
     VAR,
     SC,


### PR DESCRIPTION
## General

With the recent support of select primitive, benchdnn graph also needs to enable validation with select primitive as the reference and remove the customized driver as well as its reference implementation for select.
