### PR TITLE
src: cpu: aarch64: Enable JIT fp16 -> fp16 reorder

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -172,7 +172,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
 
         bool is_f16 = (p.itype == f16 || p.otype == f16);
         bool f16_ok = (p.itype == f32 && p.otype == f16 && p.beta == 0.f)
-                || (p.itype == f16 && p.otype == f32 && p.beta == 0.f);
+                || (p.itype == f16 && p.otype == f32 && p.beta == 0.f)
+                || (p.itype == f16 && p.otype == f16 && p.beta == 0.f);
 
         bool ok = true && p.ndims > 0
                 && utils::one_of(

--- a/tests/benchdnn/inputs/reorder/test_reorder_float16
+++ b/tests/benchdnn/inputs/reorder/test_reorder_float16
@@ -11,7 +11,7 @@
 --dtag=gOIhw4i8o2i 4x16x16x3x3 2x16x6x3x2 2x2x10x2x3
 --dtag=gOIhw4o8i2o 4x16x16x3x3 2x16x6x3x2 2x2x10x2x3
 
---sdt=f16 --ddt=f16,f32,bf16,s8,u8,f8_e5m2,f8_e4m3
+--sdt=f16 --ddt=f32,bf16,s8,u8,f8_e5m2,f8_e4m3
 --dtag=abx,axb
 --stag=aBx16b 2x64x14x14 2x56x14x14
 --stag=gOIhw16i16o 2x64x64x3x3 2x56x56x3x3

--- a/tests/benchdnn/inputs/reorder/test_reorder_float16
+++ b/tests/benchdnn/inputs/reorder/test_reorder_float16
@@ -1,6 +1,6 @@
 # f32, s8, u8 <--> f16
 --reset
---sdt=f32,bf16,s8,u8,f8_e5m2,f8_e4m3 --ddt=f16
+--sdt=f16,f32,bf16,s8,u8,f8_e5m2,f8_e4m3 --ddt=f16
 --stag=abx,axb
 --dtag=aBx16b 2x64x14x14 2x56x14x14
 --dtag=gOIhw16i16o 2x64x64x3x3 2x56x56x3x3
@@ -11,7 +11,7 @@
 --dtag=gOIhw4i8o2i 4x16x16x3x3 2x16x6x3x2 2x2x10x2x3
 --dtag=gOIhw4o8i2o 4x16x16x3x3 2x16x6x3x2 2x2x10x2x3
 
---sdt=f16 --ddt=f32,bf16,s8,u8,f8_e5m2,f8_e4m3
+--sdt=f16 --ddt=f16,f32,bf16,s8,u8,f8_e5m2,f8_e4m3
 --dtag=abx,axb
 --stag=aBx16b 2x64x14x14 2x56x14x14
 --stag=gOIhw16i16o 2x64x64x3x3 2x56x56x3x3
@@ -26,3 +26,4 @@
 --attr-scales=src:per_dim_1,dst:per_dim_1
 --sdt=f32 --ddt=f16 3x5x7x11
 --sdt=f16 --ddt=f32 3x5x7x11
+--sdt=f16 --ddt=f16 3x5x7x11


### PR DESCRIPTION
# Description

This PR adds support for fp16 JIT reorder for data type f16->f16. 
## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
- [x] Have you submitted performance data that demonstrates performance improvements?

## Performance improvements

Below are small test case logs that demonstrate performance numbers before and after.

`./tests/benchdnn/benchdnn --reorder --sdt=f16 --ddt=f16 --stag=abc --dtag=aBc8b --mode=p 1x4096x4096`

**(new) jit:uni**: `total perf: min(ms):0.564941 avg(ms):1.01874`
**(old) simple:any**: `total perf: min(ms):25.6047 avg(ms):27.257`