### PR TITLE
Backport: cpu: x64: matmul: AMX blocking heuristics fixes (backport v3.8)

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -113,6 +113,8 @@ private:
     dim_t m_per_thread, k_per_thread, n_per_thread, b_per_thread;
     bool need_prefetch;
     bool is_horizontal;
+    dim_t min_m_elem, min_k_elem, min_n_elem;
+    dim_t k_threshold_write_bound_layer_elem, min_n_dim_write_bound_layer_elem;
 
     size_t m_tmul, n_tmul, k_tmul;
     bool set_blocking_parameters();


### PR DESCRIPTION
The backport of [#3145](https://github.com/uxlfoundation/oneDNN/pull/3145).