### PR TITLE
x64: matmul: Fix buffer B chunk size / Buffer B per thread size

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1793,18 +1793,20 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
 
     bgmmc.buffer_a_per_thread_sz = bgmmc.buffer_a_m_stride * bgmmc.M_chunk_size;
 
-    bgmmc.buffer_b_gb_stride = bgmmc.tr_b_dt_sz * bgmmc.LDB * bgmmc.K_blk;
+    bgmmc.buffer_b_gb_stride = bgmmc.tr_b_dt_sz * rnd_up(bgmmc.LDB, bgmmc.N_blk)
+            * bgmmc.wei_k_blk;
     bgmmc.buffer_b_k_brg_stride
-            = bgmmc.buffer_b_gb_stride * bgmmc.brgemm_batch_size;
+            = bgmmc.buffer_b_gb_stride * bgmmc.K_chunk_size * bgmmc.K_blk;
 
+    // TODO: (Refactoring) the only usage of `buffer_b_chunk_sz`
+    // and `buffer_b_n_blk_stride` is here. Remove it if not needed.
     bgmmc.buffer_b_n_blk_stride = bgmmc.tr_b_dt_sz
             * ((bgmmc.N_blk / bgmmc.LDB) * bgmmc.LDB2
                     + (bgmmc.N_blk % bgmmc.LDB)
                             * data_type_vnni_granularity(bgmmc.wei_dt));
 
-    bgmmc.buffer_b_chunk_sz = bgmmc.tr_b_dt_sz * rnd_up(bgmmc.N_blk, bgmmc.LDB)
-            * rnd_up(bgmmc.K_chunk_elems, bgmmc.wei_k_blk);
-
+    bgmmc.buffer_b_chunk_sz
+            = bgmmc.buffer_b_k_brg_stride * bgmmc.brgemm_batch_size;
     bgmmc.buffer_b_per_thread_sz = bgmmc.buffer_b_chunk_sz;
 
     bgmmc.buffer_reduce_per_thread_sz = 0;


### PR DESCRIPTION
# Description
It fixes [MFDNN-13311](https://jira.devtools.intel.com/browse/MFDNN-13311). 
`buffer_b_chunk_sz` should be aligned with 
`char *get_buf_B_ptr(int ithr, int k_blk_idx, int n_blk_idx, int gb)` logic implemented here:
https://github.com/uxlfoundation/oneDNN/blob/main/src/cpu/x64/matmul/brgemm_matmul.cpp#L1688
The issue accidentally observed on the big number of threads (>193).
