### PR TITLE
src: conv: introduce an additional call to attr_scales_ok (fixes MFDNN-13563)

### DIFF
--- a/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/aarch64/jit_brdgmm_dw_conv.cpp
@@ -203,9 +203,7 @@ status_t brdgmm_dw_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             || !wei_scales.has_default_values();
     jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
-    const bool scales_ok
-            = attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});
-    if (!scales_ok) { return status::unimplemented; }
+    CHECK(attr_scales_ok());
 
     // strd is only feasible for 1D (i.e., height dim is one)
     // and if there are no tails (for calculating matrix_B strides).

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -67,9 +67,11 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     one_of(bias_md_.data_type, data_type::undef, f32, src_type))
             && attr()->has_default_values(skip_mask, dst_type)
             && attr()->post_ops_.check_sum_consistency(dst_type, is_int8)
-            && !has_zero_dim_memory() && zero_points_ok() && arg_scales_ok()
+            && !has_zero_dim_memory() && zero_points_ok()
             && impl::is_dense_format_kind({src_md(), weights_md(), dst_md()});
     if (!ok) return status::unimplemented;
+
+    CHECK(attr_scales_ok());
 
     CHECK(brgemm_convolution_utils::init_1x1_conf(jcp_, isa, *desc(), src_md_,
             weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
@@ -60,11 +60,6 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
     protected:
-        bool arg_scales_ok() const {
-            std::vector<int> supported_args
-                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-            return attr_scales_ok(supported_args);
-        }
         bool zero_points_ok() const {
             const auto &zp = attr()->zero_points_;
 

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -322,9 +322,11 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     one_of(bias_md_.data_type, data_type::undef, f32, src_type))
             && attr()->has_default_values(skip_mask, dst_type)
             && attr()->post_ops_.check_sum_consistency(dst_type, is_int8)
-            && !has_zero_dim_memory() && zero_points_ok() && arg_scales_ok()
+            && !has_zero_dim_memory() && zero_points_ok()
             && impl::is_dense_format_kind({src_md(), weights_md(), dst_md()});
     if (!ok) return status::unimplemented;
+
+    CHECK(attr_scales_ok());
 
     CHECK(brgemm_convolution_utils::init_conf(jcp_, isa, *desc(), src_md_,
             weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -137,12 +137,6 @@ struct brgemm_convolution_fwd_t : public primitive_t {
         int ndims = 0;
 
     protected:
-        bool arg_scales_ok() const {
-            std::vector<int> supported_args
-                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-            return attr_scales_ok(supported_args);
-        }
-
         bool zero_points_ok() const {
             const auto &zp = attr()->zero_points_;
 

--- a/src/cpu/cpu_convolution_pd.hpp
+++ b/src/cpu/cpu_convolution_pd.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2021 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,11 +33,6 @@ namespace cpu {
 struct cpu_convolution_fwd_pd_t : public convolution_fwd_pd_t {
     using convolution_fwd_pd_t::convolution_fwd_pd_t;
 
-    bool has_padded_dst() const {
-        memory_desc_wrapper dst_d(&dst_md_);
-        return OC() != dst_d.padded_dims()[1];
-    }
-
     bool wants_padded_bias() const {
         if (!with_bias()) return false;
         return has_padded_dst();
@@ -58,10 +53,34 @@ struct cpu_convolution_fwd_pd_t : public convolution_fwd_pd_t {
         }
         return !is_zero_preserved;
     }
+
+protected:
+    // See `convolution_pd_t::attr_scales_ok` comment.
+    status_t attr_scales_ok(
+            const std::unordered_map<int, std::vector<int>> &supported_args_map
+            = {{DNNL_ARG_SRC, {0}}, {DNNL_ARG_WEIGHTS, {0, 1}},
+                    {DNNL_ARG_DST, {0}}}) const {
+        return convolution_fwd_pd_t::attr_scales_ok(supported_args_map);
+    }
+
+private:
+    bool has_padded_dst() const {
+        memory_desc_wrapper dst_d(&dst_md_);
+        return OC() != dst_d.padded_dims()[1];
+    }
 };
 
 struct cpu_convolution_bwd_data_pd_t : public convolution_bwd_data_pd_t {
     using convolution_bwd_data_pd_t::convolution_bwd_data_pd_t;
+
+protected:
+    // See `convolution_pd_t::attr_scales_ok` comment.
+    status_t attr_scales_ok(
+            const std::unordered_map<int, std::vector<int>> &supported_args_map
+            = {{DNNL_ARG_SRC, {0}}, {DNNL_ARG_WEIGHTS, {0, 1}},
+                    {DNNL_ARG_DST, {0}}}) const {
+        return convolution_bwd_data_pd_t::attr_scales_ok(supported_args_map);
+    }
 };
 
 struct cpu_convolution_bwd_weights_pd_t : public convolution_bwd_weights_pd_t {

--- a/src/cpu/cpu_convolution_pd.hpp
+++ b/src/cpu/cpu_convolution_pd.hpp
@@ -63,6 +63,15 @@ protected:
         return convolution_fwd_pd_t::attr_scales_ok(supported_args_map);
     }
 
+    // See `convolution_pd_t::attr_zero_points_ok` comment.
+    // Put a default map relevant for most implementations. Once it's changed,
+    // update the default.
+    status_t attr_zero_points_ok(
+            const std::unordered_map<int, std::vector<int>> &supported_args_map
+            = {{DNNL_ARG_SRC, {0}}, {DNNL_ARG_DST, {0}}}) const {
+        return convolution_fwd_pd_t::attr_zero_points_ok(supported_args_map);
+    }
+
 private:
     bool has_padded_dst() const {
         memory_desc_wrapper dst_d(&dst_md_);

--- a/src/cpu/gemm_x8s8s32x_convolution.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.hpp
@@ -79,7 +79,7 @@ struct gemm_x8s8s32x_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(dst_type,
                                    /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
             VDISPATCH_CONV(zero_points_valid(attr()), VERBOSE_UNSUPPORTED_ATTR);
 
             auto scratchpad = scratchpad_registry().registrar();
@@ -158,7 +158,7 @@ struct gemm_x8s8s32x_convolution_bwd_data_t : public primitive_t {
             VDISPATCH_CONV(attr()->has_default_values(
                                    primitive_attr_t::skip_mask_t::scales),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
 
             auto scratchpad = scratchpad_registry().registrar();
 

--- a/src/cpu/gemm_x8s8s32x_convolution.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.hpp
@@ -80,7 +80,7 @@ struct gemm_x8s8s32x_convolution_fwd_t : public primitive_t {
                                    /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
             CHECK(attr_scales_ok());
-            VDISPATCH_CONV(zero_points_valid(attr()), VERBOSE_UNSUPPORTED_ATTR);
+            CHECK(attr_zero_points_ok());
 
             auto scratchpad = scratchpad_registry().registrar();
 

--- a/src/cpu/ref_convolution_int8.hpp
+++ b/src/cpu/ref_convolution_int8.hpp
@@ -68,7 +68,8 @@ struct ref_convolution_int8_fwd_t : public primitive_t {
                                    /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
             CHECK(attr_scales_ok());
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok(
+                    {{DNNL_ARG_SRC, {0, 2}}, {DNNL_ARG_DST, {0, 2}}}));
             VDISPATCH_CONV(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_CONV(
                     attr_.set_default_formats(dst_md(0)) == status::success,
@@ -84,21 +85,6 @@ struct ref_convolution_int8_fwd_t : public primitive_t {
                     ? utils::pick(ndims() - 3, goiw, goihw, goidhw)
                     : utils::pick(ndims() - 3, oiw, oihw, oidhw);
             return set_default_formats_common(dat_tag, wei_tag, dat_tag);
-        }
-
-        bool zero_points_ok() const {
-            if (!attr()->zero_points_.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = attr()->zero_points_.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0 || mask_src == (1 << 1);
-                if (!ok) return false;
-            }
-            if (!attr()->zero_points_.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = attr()->zero_points_.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0 || mask_dst == (1 << 1);
-                if (!ok) return false;
-            }
-
-            return attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS);
         }
 
         bool post_ops_ok() const {

--- a/src/cpu/ref_convolution_int8.hpp
+++ b/src/cpu/ref_convolution_int8.hpp
@@ -67,7 +67,7 @@ struct ref_convolution_int8_fwd_t : public primitive_t {
             VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(dst_type,
                                    /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_CONV(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_CONV(
@@ -151,7 +151,7 @@ struct ref_convolution_int8_bwd_data_t : public primitive_t {
             VDISPATCH_CONV(attr()->has_default_values(
                                    primitive_attr_t::skip_mask_t::scales),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
 
             return status::success;
         }

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
@@ -71,7 +71,7 @@ struct jit_avx512_core_amx_1x1_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
                     VERBOSE_BAD_ALGORITHM);
             VDISPATCH_CONV(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_ATTR);
+            CHECK(attr_scales_ok());
             VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(
                                    dst_md(0)->data_type,
                                    /* is_int8 */ is_int8_convolution),

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.hpp
@@ -76,7 +76,7 @@ struct jit_avx512_core_amx_1x1_convolution_fwd_t : public primitive_t {
                                    dst_md(0)->data_type,
                                    /* is_int8 */ is_int8_convolution),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
             CHECK(jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jcp_, *desc(),
@@ -91,24 +91,6 @@ struct jit_avx512_core_amx_1x1_convolution_fwd_t : public primitive_t {
         }
 
         jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-
-    protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
     };
 
     jit_avx512_core_amx_1x1_convolution_fwd_t(const pd_t *apd)

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -79,7 +79,7 @@ struct jit_avx512_core_amx_convolution_fwd_t : public primitive_t {
                                    /* is_int8 */ is_int8_convolution),
                     VERBOSE_UNSUPPORTED_POSTOP);
             CHECK(attr_scales_ok());
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
             CHECK(jit_avx512_core_amx_fwd_kernel_t::init_conf(jcp_, *desc(),
@@ -94,24 +94,6 @@ struct jit_avx512_core_amx_convolution_fwd_t : public primitive_t {
         }
 
         jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-
-    protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
     };
 
     jit_avx512_core_amx_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -78,7 +78,7 @@ struct jit_avx512_core_amx_convolution_fwd_t : public primitive_t {
                                    dst_md(0)->data_type,
                                    /* is_int8 */ is_int8_convolution),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -94,7 +94,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                     {DNNL_ARG_WEIGHTS, {0, 1}}, {DNNL_ARG_DST, {0}},
                     {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS, {0, 1}},
                     {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST, {0}}}));
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok());
 
             const convolution_desc_t *conv_d = desc();
             const memory_desc_t *src_d = src_md();
@@ -168,23 +168,6 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
         format_tag_t dat_tag() const {
             return utils::pick(src_md_.ndims - 3, format_tag::nwc,
                     format_tag::nhwc, format_tag::ndhwc);
-        }
-
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
         }
 
         status_t copy(const pd_t &other) {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -78,11 +78,6 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                                     | smask_t::sum_dt,
                             dst_md(0)->data_type),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_CONV(attr()->scales_.has_default_values({DNNL_ARG_SRC,
-                                   DNNL_ARG_WEIGHTS, DNNL_ARG_DST,
-                                   DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS,
-                                   DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST}),
-                    VERBOSE_UNSUPPORTED_ATTR);
 
             VDISPATCH_CONV(set_default_formats_common(
                                    dat_tag(), format_tag::any, dat_tag()),
@@ -95,7 +90,10 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                                    /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok({{DNNL_ARG_SRC, {0}},
+                    {DNNL_ARG_WEIGHTS, {0, 1}}, {DNNL_ARG_DST, {0}},
+                    {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS, {0, 1}},
+                    {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST, {0}}}));
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
 
             const convolution_desc_t *conv_d = desc();

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
@@ -74,7 +74,7 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             CHECK(attr_scales_ok());
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
             CHECK(jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jcp_,
@@ -89,24 +89,6 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
         }
 
         jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-
-    protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
     };
 
     jit_avx512_core_x8s8s32x_convolution_fwd_t(const pd_t *apd)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.hpp
@@ -73,7 +73,7 @@ struct jit_avx512_core_x8s8s32x_convolution_fwd_t : public primitive_t {
                                    dst_md(0)->data_type, /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
 
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -257,9 +257,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
             || !wei_scales.has_default_values();
     jcp.is_oc_scale = wei_scales.get_mask() > 0;
 
-    const bool scales_ok
-            = attr_scales_ok({DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST});
-    VDISPATCH_CONV(scales_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(attr_scales_ok());
 
     const auto &zp = attr()->zero_points_;
     jcp.src_zero_point = !zp.has_default_values(DNNL_ARG_SRC);

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -81,7 +81,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(dst_type, is_int8),
             VERBOSE_UNSUPPORTED_POSTOP);
     VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
-    VDISPATCH_CONV(arg_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(attr_scales_ok());
 
     CHECK(brgemm_convolution_utils::init_1x1_conf(jcp_, isa, *desc(), src_md_,
             weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -80,8 +80,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(dst_type, is_int8),
             VERBOSE_UNSUPPORTED_POSTOP);
-    VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
     CHECK(attr_scales_ok());
+    CHECK(attr_zero_points_ok());
 
     CHECK(brgemm_convolution_utils::init_1x1_conf(jcp_, isa, *desc(), src_md_,
             weights_md_, dst_md_, bias_md_, attr_, dnnl_get_max_threads()));

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -77,11 +77,6 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
     protected:
-        bool arg_scales_ok() const {
-            std::vector<int> supported_args
-                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-            return attr_scales_ok(supported_args);
-        }
         bool zero_points_ok() const {
             const auto &zp = attr()->zero_points_;
 

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -76,24 +76,6 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
 
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
-    protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
-
     private:
         status_t init_brgemm_desc();
     };

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -383,7 +383,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(dst_type, is_int8),
             VERBOSE_UNSUPPORTED_POSTOP);
     VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
-    VDISPATCH_CONV(arg_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+    CHECK(attr_scales_ok());
     VDISPATCH_CONV(
             impl::is_dense_format_kind({src_md(0), weights_md(0), dst_md(0)}),
             VERBOSE_UNSUPPORTED_SPARSE_CFG);

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -382,8 +382,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(dst_type, is_int8),
             VERBOSE_UNSUPPORTED_POSTOP);
-    VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
     CHECK(attr_scales_ok());
+    CHECK(attr_zero_points_ok());
     VDISPATCH_CONV(
             impl::is_dense_format_kind({src_md(0), weights_md(0), dst_md(0)}),
             VERBOSE_UNSUPPORTED_SPARSE_CFG);

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -129,12 +129,6 @@ struct brgemm_convolution_fwd_t : public primitive_t {
                 bool do_init, int kd_b, int kd_e, int kh_b, int kh_e);
 
     protected:
-        bool arg_scales_ok() const {
-            std::vector<int> supported_args
-                    = {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST};
-            return attr_scales_ok(supported_args);
-        }
-
         bool zero_points_ok() const {
             const auto &zp = attr()->zero_points_;
 

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -129,23 +129,6 @@ struct brgemm_convolution_fwd_t : public primitive_t {
                 bool do_init, int kd_b, int kd_e, int kh_b, int kh_e);
 
     protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
-
         int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK,
                 KW_BLOCK, KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, IDP, IHP, IWP,
                 OD, OH, OW, SD, SH, SW, FP, TP, LP, DD, DH, DW;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -87,7 +87,7 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                     {DNNL_ARG_WEIGHTS, {0, 1}}, {DNNL_ARG_DST, {0}},
                     {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS, {0, 1}},
                     {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST, {0}}}));
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok());
             VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(
                                    dst_md(0)->data_type, /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
@@ -164,23 +164,6 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
         using dw_pd_t = typename jit_uni_x8s8s32x_convolution_fwd_t<isa>::pd_t;
 
     protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
-
         status_t copy(const pd_t &other) {
             jcp_ = other.jcp_;
             rtus_ = other.rtus_;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -79,16 +79,14 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                                     | smask_t::sum_dt,
                             dst_md(0)->data_type),
                     VERBOSE_UNSUPPORTED_ATTR);
-            VDISPATCH_CONV(attr()->scales_.has_default_values({DNNL_ARG_SRC,
-                                   DNNL_ARG_WEIGHTS, DNNL_ARG_DST,
-                                   DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS,
-                                   DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST}),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_CONV(set_default_formats_common(
                                    dat_tag(), format_tag::any, dat_tag()),
                     VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_CONV(set_or_check_wei_format(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok({{DNNL_ARG_SRC, {0}},
+                    {DNNL_ARG_WEIGHTS, {0, 1}}, {DNNL_ARG_DST, {0}},
+                    {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS, {0, 1}},
+                    {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST, {0}}}));
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
             VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(
                                    dst_md(0)->data_type, /* is_int8 */ true),

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
@@ -71,7 +71,7 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
             VDISPATCH_CONV(attr()->post_ops_.check_sum_consistency(
                                    dst_md(0)->data_type, /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_CONV(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
+            CHECK(attr_scales_ok());
             VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
 
             // TODO: make `init_conf` assign initialized object to `jcp_`

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.hpp
@@ -72,7 +72,7 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
                                    dst_md(0)->data_type, /* is_int8 */ true),
                     VERBOSE_UNSUPPORTED_POSTOP);
             CHECK(attr_scales_ok());
-            VDISPATCH_CONV(zero_points_ok(), VERBOSE_UNSUPPORTED_ZP_CFG);
+            CHECK(attr_zero_points_ok());
 
             // TODO: make `init_conf` assign initialized object to `jcp_`
             CHECK(jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jcp_, *desc(),
@@ -87,24 +87,6 @@ struct jit_uni_x8s8s32x_convolution_fwd_t : public primitive_t {
         }
 
         jit_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-
-    protected:
-        bool zero_points_ok() const {
-            const auto &zp = attr()->zero_points_;
-
-            if (!zp.has_default_values(DNNL_ARG_SRC)) {
-                int mask_src = zp.get_mask(DNNL_ARG_SRC);
-                const bool ok = mask_src == 0;
-                if (!ok) return false;
-            }
-            if (!zp.has_default_values(DNNL_ARG_DST)) {
-                int mask_dst = zp.get_mask(DNNL_ARG_DST);
-                const bool ok = mask_dst == 0;
-                if (!ok) return false;
-            }
-
-            return zp.has_default_values(DNNL_ARG_WEIGHTS);
-        }
     };
 
     jit_uni_x8s8s32x_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/gpu/gpu_convolution_pd.hpp
+++ b/src/gpu/gpu_convolution_pd.hpp
@@ -30,68 +30,12 @@ namespace gpu {
 
 struct gpu_convolution_fwd_pd_t : public convolution_fwd_pd_t {
     using convolution_fwd_pd_t::convolution_fwd_pd_t;
-
-protected:
-    // TODO: consider either moving this method to primitive_conf.hpp or making
-    //       it static, or removing the 'attr' argument accessible via attr()
-    bool zero_points_ok(const primitive_attr_t *attr) const {
-        const auto &zp = attr->zero_points_;
-
-        using namespace data_type;
-        bool ok = IMPLICATION(
-                !utils::one_of(invariant_src_md()->data_type, s8, u8),
-                zp.has_default_values());
-        if (!ok) return false;
-
-        if (!zp.has_default_values(DNNL_ARG_SRC)) {
-            int mask_src = zp.get_mask(DNNL_ARG_SRC);
-            ok = utils::one_of(mask_src, 0, (1 << 1));
-            if (!ok) return false;
-        }
-        if (!zp.has_default_values(DNNL_ARG_WEIGHTS)) {
-            int mask_wei = zp.get_mask(DNNL_ARG_WEIGHTS);
-            ok = mask_wei == 0;
-            if (!ok) return false;
-        }
-        if (!zp.has_default_values(DNNL_ARG_DST)) {
-            int mask_dst = zp.get_mask(DNNL_ARG_DST);
-            ok = utils::one_of(mask_dst, 0, (1 << 1));
-            if (!ok) return false;
-        }
-
-        return true;
-    }
 };
 
 struct gpu_convolution_bwd_data_pd_t : public convolution_bwd_data_pd_t {
     using convolution_bwd_data_pd_t::convolution_bwd_data_pd_t;
 
 protected:
-    // TODO: consider either moving this method to primitive_conf.hpp or making
-    //       it static, or removing the 'attr' argument accessible via attr()
-    bool zero_points_ok(const primitive_attr_t *attr) const {
-        const auto &zp = attr->zero_points_;
-
-        using namespace data_type;
-        bool ok = IMPLICATION(
-                !utils::one_of(invariant_dst_md()->data_type, s8, u8),
-                zp.has_default_values());
-        if (!ok) return false;
-
-        if (!zp.has_default_values(DNNL_ARG_SRC)) {
-            int mask_src = zp.get_mask(DNNL_ARG_SRC);
-            ok = utils::one_of(mask_src, 0, (1 << 1));
-            if (!ok) return false;
-        }
-        if (!zp.has_default_values(DNNL_ARG_DST)) {
-            int mask_dst = zp.get_mask(DNNL_ARG_DST);
-            ok = utils::one_of(mask_dst, 0, (1 << 1));
-            if (!ok) return false;
-        }
-
-        return zp.has_default_values(DNNL_ARG_WEIGHTS);
-    }
-
     // TODO: consider either moving this method to primitive_conf.hpp or making
     //       it static, or removing the 'attr' argument accessible via attr()
     bool post_ops_ok(const primitive_attr_t *attr) const {

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -987,6 +987,9 @@ bool post_ops_ok(const conv_problem_t &prb, const hw_t &hw) {
     std::vector<int> scales(scale_args.size());
     for (int i = 0; i < (int)scale_args.size(); i++)
         scales[i] = scale_args[i].second;
+
+    // The following check could be re-used from the convolution_pd.hpp but
+    // prb doesn't inherits pd and can't use protected method.
     if (!attr->scales_.has_default_values(scales)) return false;
     for (int arg : scales) {
         if (attr->scales_.has_default_values(arg)) continue;

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -385,9 +385,13 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
         const bool is_wei_zp = !prb->attr.zero_points.is_def(DNNL_ARG_WEIGHTS);
         const bool is_non_s32_src_zp
                 = prb->attr.zero_points.get(DNNL_ARG_SRC).dt != dnnl_s32;
+        const bool is_non_unit_dst_scale
+                = !prb->attr.scales.is_def(DNNL_ARG_DST)
+                && prb->attr.scales.get_mask(DNNL_ARG_DST, dnnl_convolution)
+                        > 0;
 
         if (is_f32f32x8 || is_bf16bf16x8 || is_x8x8f16 || !is_valid_f16
-                || is_wei_zp || is_non_s32_src_zp) {
+                || is_wei_zp || is_non_s32_src_zp || is_non_unit_dst_scale) {
             res->state = SKIPPED;
             res->reason = skip_reason::case_not_supported;
             return;


### PR DESCRIPTION
MFDNN-13563

To split supported cases per engine kind/backends as the call serves a common ground for both of them.