### PR TITLE
common: remove DNNL_EXPERIMENTAL_SPARSE remnants

### DIFF
--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -67,9 +67,7 @@ void serialize(serialization_stream_t &sstream, const memory_desc_t &md) {
     sstream.append(md.format_kind);
     // format desc
     switch ((int)md.format_kind) {
-#ifdef DNNL_EXPERIMENTAL_SPARSE
         case format_kind::sparse:
-#endif
         case format_kind::undef:
         case format_kind::any: break;
         case format_kind::blocked:

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -220,11 +220,7 @@ size_t dnn_mem_t::size() const {
 }
 
 bool dnn_mem_t::is_sparse_md() const {
-#ifdef DNNL_EXPERIMENTAL_SPARSE
     return query_md_sparse_encoding(md_) != dnnl_sparse_encoding_undef;
-#else
-    return false;
-#endif
 }
 
 size_t dnn_mem_t::sizeof_dt() const {
@@ -476,11 +472,7 @@ void dnn_mem_t::memset(int value, size_t size, int buffer_index) const {
     bool is_sycl = is_sycl_engine(engine_);
     auto mem = m_padded_ ? m_padded_ : m_;
     void *mem_handle;
-#ifdef DNNL_EXPERIMENTAL_SPARSE
     DNN_SAFE_V(dnnl_memory_get_data_handle_v2(mem, &mem_handle, buffer_index));
-#else
-    DNN_SAFE_V(dnnl_memory_get_data_handle(mem, &mem_handle));
-#endif
 
     if (is_opencl) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL


### PR DESCRIPTION
Removing some `#ifdef DNNL_EXPERIMENTAL_SPARSE` cases left after sparse promotion, most likely due to complex rebases.