### PR TITLE
benchdnn: inputs: graph: change gpu batch file names

### DIFF
--- a/tests/benchdnn/inputs/graph/test_graph_bf16_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_bf16_gpu
@@ -1,4 +1,0 @@
---batch=op/harness_bf16_all
---batch=pattern/harness_bf16_all
---batch=op/harness_bf16_ci
---batch=pattern/harness_bf16_ci

--- a/tests/benchdnn/inputs/graph/test_graph_f16_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_f16_gpu
@@ -1,4 +1,0 @@
---batch=op/harness_f16_all
---batch=pattern/harness_f16_all
---batch=op/harness_f16_ci
---batch=pattern/harness_f16_ci

--- a/tests/benchdnn/inputs/graph/test_graph_f32_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_f32_gpu
@@ -1,4 +1,0 @@
---batch=op/harness_f32_all
---batch=pattern/harness_f32_all
---batch=op/harness_f32_ci
---batch=pattern/harness_f32_ci

--- a/tests/benchdnn/inputs/graph/test_graph_f8_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_f8_gpu
@@ -1,2 +1,0 @@
---batch=pattern/harness_f8_all
---batch=pattern/harness_f8_ci

--- a/tests/benchdnn/inputs/graph/test_graph_int8_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_int8_gpu
@@ -1,2 +1,0 @@
---batch=pattern/harness_int8_all
---batch=pattern/harness_int8_ci

--- a/tests/benchdnn/inputs/graph/test_graph_op_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_op_gpu
@@ -1,0 +1,7 @@
+--batch=op/harness_f32_ci
+--batch=op/harness_f16_ci
+--batch=op/harness_bf16_ci
+
+--batch=op/harness_f32_all
+--batch=op/harness_f16_all
+--batch=op/harness_bf16_all

--- a/tests/benchdnn/inputs/graph/test_graph_pattern_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_pattern_gpu
@@ -1,0 +1,11 @@
+--batch=pattern/harness_f32_ci
+--batch=pattern/harness_f16_ci
+--batch=pattern/harness_bf16_ci
+--batch=pattern/harness_int8_ci
+--batch=pattern/harness_f8_ci
+
+--batch=pattern/harness_f32_all
+--batch=pattern/harness_f16_all
+--batch=pattern/harness_bf16_all
+--batch=pattern/harness_int8_all
+--batch=pattern/harness_f8_all


### PR DESCRIPTION
Reorganize gpu tests and change the gpu batch file names.

Previously bf16 op/pattern cases were not tested on all gpu platforms in nightly.

Fixes MFDNN-12927