### PR TITLE
benchdnn: graph: use device usm by default

### DIFF
--- a/src/graph/utils/alloc.cpp
+++ b/src/graph/utils/alloc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ namespace utils {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 void *ocl_allocator_t::malloc(
         size_t size, size_t alignment, cl_device_id dev, cl_context ctx) {
-    return ocl::malloc_shared(dev, ctx, size, alignment);
+    return ocl::malloc_device(dev, ctx, size, alignment);
 }
 
 void ocl_allocator_t::free(
@@ -43,7 +43,7 @@ void ocl_allocator_t::free(
 void *sycl_allocator_t::malloc(
         size_t size, size_t alignment, const void *dev, const void *ctx) {
     const size_t align = alignment == 0 ? DEFAULT_ALIGNMENT : alignment;
-    return ::sycl::aligned_alloc_shared(align, size,
+    return ::sycl::aligned_alloc_device(align, size,
             *static_cast<const ::sycl::device *>(dev),
             *static_cast<const ::sycl::context *>(ctx));
 }

--- a/src/graph/utils/ocl_usm_utils.cpp
+++ b/src/graph/utils/ocl_usm_utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -95,6 +95,26 @@ void *malloc_shared(
     if (size == 0) return nullptr;
     static ext_func_t<clSharedMemAllocINTEL_func_t> ext_func(
             "clSharedMemAllocINTEL");
+
+    cl_platform_id platform;
+    UNUSED_OCL_RESULT(clGetDeviceInfo(
+            dev, CL_DEVICE_PLATFORM, sizeof(platform), &platform, nullptr));
+
+    cl_int err;
+    void *p = ext_func(platform, ctx, dev, nullptr, size,
+            static_cast<cl_uint>(alignment), &err);
+    assert(dnnl::impl::utils::one_of(err, CL_SUCCESS, CL_OUT_OF_RESOURCES,
+            CL_OUT_OF_HOST_MEMORY, CL_INVALID_BUFFER_SIZE));
+    return p;
+}
+
+void *malloc_device(
+        cl_device_id dev, cl_context ctx, size_t size, size_t alignment) {
+    using clDeviceMemAllocINTEL_func_t = void *(*)(cl_context, cl_device_id,
+            cl_ulong *, size_t, cl_uint, cl_int *);
+    if (size == 0) return nullptr;
+    static ext_func_t<clDeviceMemAllocINTEL_func_t> ext_func(
+            "clDeviceMemAllocINTEL");
 
     cl_platform_id platform;
     UNUSED_OCL_RESULT(clGetDeviceInfo(

--- a/src/graph/utils/ocl_usm_utils.hpp
+++ b/src/graph/utils/ocl_usm_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,6 +28,9 @@ namespace utils {
 namespace ocl {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 void *malloc_shared(
+        cl_device_id dev, cl_context ctx, size_t size, size_t alignment = 0);
+
+void *malloc_device(
         cl_device_id dev, cl_context ctx, size_t size, size_t alignment = 0);
 
 void free(void *ptr, cl_device_id dev, cl_context ctx);

--- a/tests/benchdnn/graph/memory_pool.hpp
+++ b/tests/benchdnn/graph/memory_pool.hpp
@@ -119,7 +119,7 @@ public:
         if (need_alloc_new_mm) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
             auto sh_ptr = std::shared_ptr<void> {
-                    malloc_shared(size, *static_cast<const sycl::device *>(dev),
+                    malloc_device(size, *static_cast<const sycl::device *>(dev),
                             *static_cast<const sycl::context *>(ctx)),
                     sycl_deletor_t {*static_cast<const sycl::context *>(ctx)}};
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL


### PR DESCRIPTION
Previously we used shared USM by default in benchdnn graph driver for gpu testing. Now changing it to device USM.

This is a follow-up work for f836db436b1327a1cc02c36841c3e9d2acac08e2 and MFDNN-4353.