### PR TITLE
[rls-v3.8]graph: backend: dnnl: insert reorder for block input of genindex

### DIFF
--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -1650,6 +1650,13 @@ status_t layout_propagator_for_gen_index(std::shared_ptr<op_t> &op,
     UNUSED(rewriter);
     auto src_md = make_dnnl_memory_desc(
             op->get_input_value(0)->get_logical_tensor());
+    if (!is_plain(src_md)) {
+        auto plain_src_md = dnnl::memory::desc(src_md.get_dims(),
+                src_md.get_data_type(), dnnl::memory::format_tag::abcd);
+        insert_reorder_before(
+                op, 0, plain_src_md, p_engine, mgr, pd_cache, rewriter);
+        src_md = plain_src_md;
+    }
     value_ptr dst_val = op->get_output_value(0);
     status_t status = fill_layout_info(dst_val, src_md);
     return status;


### PR DESCRIPTION
# Description

Backport #3173. Fix the layout propagation for genindex. Force the genindex input to be plain.
