### PR TITLE
[RFC] benchdnn: add diff based testing

### DIFF
--- a/src/common/primitive.hpp
+++ b/src/common/primitive.hpp
@@ -61,6 +61,7 @@ struct primitive_t : public c_compatible {
     const std::shared_ptr<primitive_desc_t> &pd() const { return pd_; }
     primitive_kind_t kind() const { return pd_->kind(); }
     virtual status_t execute(const exec_ctx_t &ctx) const = 0;
+    virtual uint64_t get_id() const { return 0; }
 
     virtual status_t get_cache_blob(
             engine_t *engine, cache_blob_t &cache_blob) const {

--- a/src/common/primitive_desc_iface.hpp
+++ b/src/common/primitive_desc_iface.hpp
@@ -54,6 +54,7 @@ struct dnnl_primitive_desc : public dnnl::impl::c_compatible {
 
     dnnl::impl::status_t init();
     dnnl::impl::status_t next_impl();
+    uint64_t get_hash_id();
     const char *info() const;
     std::string info_with_runtime_dims(const dnnl::impl::memory_desc_t *src_md,
             const dnnl::impl::memory_desc_t *wei_md,

--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -254,6 +254,12 @@ status_t dnnl_primitive_destroy(primitive_iface_t *primitive_iface) {
     return success;
 }
 
+extern "C" uint64_t DNNL_API dnnl_primitive_get_id(
+        primitive_iface_t *primitive_iface) {
+    if (primitive_iface == nullptr) return 0;
+    return primitive_iface->get_id();
+}
+
 // primitive_iface_t implementation
 dnnl_primitive::dnnl_primitive(
         const std::shared_ptr<primitive_t> &primitive, engine_t *engine)
@@ -335,6 +341,11 @@ status_t dnnl_primitive::execute(exec_ctx_t &ctx) const {
     ctx.set_scratchpad_grantor(nullptr);
     return status;
 }
+
+uint64_t dnnl_primitive::get_id() const {
+    if (primitive_ == nullptr) return 0;
+    return primitive_->get_id();
+};
 
 status_t dnnl_primitive::get_cache_blob_size(size_t *size) const {
     return primitive_->get_cache_blob_size(engine(), size);

--- a/src/common/primitive_iface.hpp
+++ b/src/common/primitive_iface.hpp
@@ -65,6 +65,7 @@ struct dnnl_primitive : public dnnl::impl::c_compatible {
     dnnl::impl::status_t get_cache_blob(
             dnnl::impl::cache_blob_t cache_blob) const;
     dnnl::impl::status_t execute(dnnl::impl::exec_ctx_t &ctx) const;
+    uint64_t get_id() const;
 
     void retain() { counter_++; }
 

--- a/src/common/serialization.hpp
+++ b/src/common/serialization.hpp
@@ -166,7 +166,6 @@ struct serialization_stream_t {
 
     const std::vector<uint8_t> &get_data() const { return data_; }
 
-private:
     static size_t hash_range(const uint8_t *v, size_t size) {
         size_t seed = 0;
         const uint8_t *end = v + size;

--- a/src/gpu/gpu_primitive.hpp
+++ b/src/gpu/gpu_primitive.hpp
@@ -50,6 +50,7 @@ struct primitive_t : public impl::primitive_t {
         bool empty() const { return empty_impl(); }
 
         const impl::primitive_t *primitive() const { return primitive_; }
+        virtual uint64_t get_id() const { return primitive_->get_id(); }
 
     private:
         virtual bool empty_impl() const { return !bool(primitive_); }
@@ -137,7 +138,6 @@ protected:
         return compute_blocks_;
     }
 
-private:
     void register_primitive(impl::primitive_t *primitive) {
         compute_blocks_.emplace_back(new compute_block_t(primitive));
     }

--- a/src/gpu/intel/compute/kernel.hpp
+++ b/src/gpu/intel/compute/kernel.hpp
@@ -125,6 +125,12 @@ public:
         gpu_assert(false) << "unimplemented function get_binary_size() called";
         return status::runtime_error;
     }
+
+    virtual status_t get_kernel_binary(xpu::binary_t &binary) const {
+        gpu_assert(false) << "unimplemented function get_binary() called";
+        return status::runtime_error;
+    }
+
     virtual status_t get_binary(
             const impl::engine_t *engine, xpu::binary_t &binary) const {
         gpu_assert(false) << "unimplemented function get_binary() called";
@@ -208,6 +214,10 @@ public:
     status_t get_binary_size(
             const impl::engine_t *engine, size_t *binary_size) const {
         return impl_->get_binary_size(engine, binary_size);
+    }
+
+    status_t get_kernel_binary(xpu::binary_t &binary) const {
+        return impl_->get_kernel_binary(binary);
     }
 
     status_t get_binary(

--- a/src/gpu/intel/compute/kernel.hpp
+++ b/src/gpu/intel/compute/kernel.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <utility>
 
+#include "common/serialization.hpp"
 #include "common/utils.hpp"
 #include "common/verbose.hpp"
 #include "gpu/intel/compute/kernel_arg_list.hpp"
@@ -223,6 +224,15 @@ public:
     status_t get_binary(
             const impl::engine_t *engine, xpu::binary_t &binary) const {
         return impl_->get_binary(engine, binary);
+    }
+
+    size_t get_hash() const {
+        xpu::binary_t binary;
+        auto status = get_kernel_binary(binary);
+        gpu_assert(status == status::success);
+        auto hash = serialization_stream_t::hash_range(
+                binary.data(), binary.size());
+        return hash != 0 ? hash : 2147483647; // id is required to be non-zero
     }
 
     const std::vector<scalar_type_t> &arg_types() const {

--- a/src/gpu/intel/gpu_primitive.hpp
+++ b/src/gpu/intel/gpu_primitive.hpp
@@ -48,6 +48,8 @@ struct gpu_primitive_t : public gpu::primitive_t {
 
         compute::kernel_t kernel() const { return kernel_; }
 
+        uint64_t get_id() const override { return kernel_.get_hash(); };
+
     private:
         bool empty_impl() const override { return !bool(kernel_); }
 
@@ -73,6 +75,18 @@ struct gpu_primitive_t : public gpu::primitive_t {
 
         compute::kernel_t kernel_;
     };
+
+    // This may need overriden by implementations that perform performance
+    // tuning via runtime parameters.
+    uint64_t get_id() const override {
+        size_t hash = 0;
+        for (auto &block : compute_blocks_) {
+            auto id = block->get_id();
+            if (id == 0) return 0;
+            hash = hash_combine(hash, id);
+        }
+        return hash != 0 ? hash : 2147483647; // id is required to be non-zero
+    }
 
     status_t get_cache_blob_size(
             impl::engine_t *engine, size_t *size) const override {

--- a/src/gpu/intel/ocl/kernel.cpp
+++ b/src/gpu/intel/ocl/kernel.cpp
@@ -111,6 +111,9 @@ private:
     utils::rw_mutex_t mutex_;
 };
 
+status_t kernel_t::get_kernel_binary(xpu::binary_t &binary) const {
+    return get_ocl_kernel_binary(ocl_kernel(), binary);
+}
 status_t kernel_t::get_binary(
         const impl::engine_t *engine, xpu::binary_t &binary) const {
     auto *ocl_engine = utils::downcast<const engine_t *>(engine);

--- a/src/gpu/intel/ocl/kernel.hpp
+++ b/src/gpu/intel/ocl/kernel.hpp
@@ -38,6 +38,7 @@ public:
 
     cl_kernel ocl_kernel() const { return ocl_kernel_; }
 
+    status_t get_kernel_binary(xpu::binary_t &binary) const override;
     status_t get_binary(
             const impl::engine_t *engine, xpu::binary_t &binary) const override;
     status_t get_binary_size(

--- a/src/gpu/intel/sycl/interop_kernel.cpp
+++ b/src/gpu/intel/sycl/interop_kernel.cpp
@@ -183,6 +183,10 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
     return status::success;
 }
 
+status_t sycl_interop_gpu_kernel_t::get_kernel_binary(
+        xpu::binary_t &binary) const {
+    return gpu::intel::sycl::get_kernel_binary(sycl_kernel(), binary);
+}
 status_t interop_kernel_t::dump() const {
     xpu::binary_t binary;
     CHECK(gpu::intel::sycl::get_kernel_binary(sycl_kernel(), binary));

--- a/src/gpu/intel/sycl/interop_kernel.hpp
+++ b/src/gpu/intel/sycl/interop_kernel.hpp
@@ -41,6 +41,7 @@ public:
         return arg_types_;
     }
 
+    status_t get_kernel_binary(xpu::binary_t &binary) const override;
     status_t dump() const override;
     std::string name() const override {
         return sycl_kernel_.get_info<::sycl::info::kernel::function_name>();

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -120,15 +120,29 @@ void parse_result(res_t &res, const char *pstr) {
         case MISTRUSTED: bs.mistrusted++; break;
         case PASSED: bs.passed++; break;
         case LISTED: bs.listed++; break;
-        case INITIALIZED:
+        case INITIALIZED: {
             // TODO: workaround for failed fill functions.
-            if (bench_mode != bench_mode_t::init) {
+            if (bench_mode != bench_mode_t::init
+                    && bench_mode != bench_mode_t::hash) {
                 is_failed = true;
                 state = "FAILED";
             } else {
                 bs.passed++;
             }
+
+            if (bench_mode == bench_mode_t::hash)
+                if (res.impl_id == 0)
+                    BENCHDNN_PRINT(0, "%d:%s impl_id: %s __REPRO: %s\n",
+                            bs.tests, state, "(unsupported)", pstr);
+                else
+                    BENCHDNN_PRINT(0,
+                            "%d:%s impl_id: 0x%016" PRIx64 " __REPRO: %s\n",
+                            bs.tests, state, res.impl_id, pstr);
+            else
+                BENCHDNN_PRINT(0, "%d:%s __REPRO: %s\n", bs.tests, state, pstr);
+            print_me = false;
             break;
+        }
         default:
             BENCHDNN_PRINT(0, "%s\n",
                     "Error: unknown state encountered in \'parse_results()\'.");

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -178,6 +178,9 @@ using bench_f = int (*)(int, char **);
 std::string locate_file(const std::string &fname);
 int batch(const char *fname, bench_f bench);
 
+int setup_db(const char *fname);
+const std::unordered_map<std::string, uint64_t> &get_db();
+
 /* returns 1 with given probability */
 int flip_coin(ptrdiff_t seed, float probability);
 

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -86,6 +86,8 @@ extern "C" dnnl_status_t dnnl_query_profiling_data(dnnl_stream_t stream,
 #endif
 #endif
 
+extern "C" uint64_t dnnl_primitive_get_id(dnnl_primitive_t);
+
 int check_pd_cache(const_dnnl_primitive_desc_t pd, res_t *res);
 int check_primitive_cache(dnnl_primitive_t p, res_t *res);
 
@@ -522,6 +524,10 @@ int init_prim(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &user_prim,
     if (is_service_prim) {
         user_prim.reset(primw.release());
         return OK;
+    }
+
+    if (has_bench_mode_bit(mode_bit_t::hash)) {
+        res->impl_id = dnnl_primitive_get_id(primw);
     }
 
     auto pd = query_pd(primw);

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -526,8 +526,32 @@ int init_prim(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &user_prim,
         return OK;
     }
 
-    if (has_bench_mode_bit(mode_bit_t::hash)) {
-        res->impl_id = dnnl_primitive_get_id(primw);
+    res->impl_id = dnnl_primitive_get_id(primw);
+
+    if (!get_db().empty() && res->impl_id != 0) {
+        // TODO: Stop using strings and use prb directly
+        std::string s = prb->str();
+
+        auto mode_modifier_start = s.find("--mode-modifier=", 0);
+        auto mode_start = s.find("--mode=", 0);
+        if (mode_modifier_start != std::string::npos) {
+            mode_modifier_start += 17;
+            while (s[mode_modifier_start] == ' ')
+                mode_modifier_start++;
+            s = s.substr(mode_modifier_start, std::string::npos);
+        } else if (mode_start != std::string::npos) {
+            mode_start += 8;
+            while (s[mode_start] == ' ')
+                mode_start++;
+            s = s.substr(mode_start, std::string::npos);
+        }
+
+        auto e = get_db().find(s);
+        if (e != get_db().end() && e->second == res->impl_id) {
+            res->state = SKIPPED;
+            res->reason = "in database";
+            return OK;
+        }
     }
 
     auto pd = query_pd(primw);

--- a/tests/benchdnn/rnn/rnn_task.hpp
+++ b/tests/benchdnn/rnn/rnn_task.hpp
@@ -69,7 +69,8 @@ struct rnn_task_t {
 
     int exec() {
         BENCHDNN_PRINT(1, "run: %s\n", prb_.get()->str());
-        if (res_.state == INITIALIZED && bench_mode != bench_mode_t::init) {
+        if (res_.state == INITIALIZED && bench_mode != bench_mode_t::init
+                && bench_mode != bench_mode_t::hash) {
             const prb_t *prb = prb_.get();
             do_func_(*v_prim_, *prb, &res_);
         }

--- a/tests/benchdnn/utils/bench_mode.hpp
+++ b/tests/benchdnn/utils/bench_mode.hpp
@@ -38,6 +38,8 @@ enum class mode_bit_t : unsigned {
     fast = 0x20,
     // `bitwise` bit is for a numerical determinism validation flow.
     bitwise = 0x40,
+    // `hash` bit is for logging primitive hash.
+    hash = 0x80,
 };
 
 // Mode modifiers is an extension of `bench_mode_t` abstraction which specifies
@@ -69,6 +71,7 @@ enum class bench_mode_t : unsigned {
     perf_fast = perf | static_cast<unsigned>(mode_bit_t::fast),
     corr_perf = corr | perf,
     bitwise = exec | static_cast<unsigned>(mode_bit_t::bitwise),
+    hash = init | static_cast<unsigned>(mode_bit_t::hash)
 };
 
 mode_bit_t operator&(bench_mode_t lhs, mode_bit_t rhs);

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1256,6 +1256,7 @@ static bool parse_mode(
               "    `MODE` values are:\n"
               "    * `L` for listing mode.\n"
               "    * `I` for initialization mode.\n"
+              "    * `H` for hash mode.\n";
               "    * `R` for execution mode (no correctness validation).\n"
               "    * `C` for correctness testing.\n"
               "    * `P` for performance testing.\n"
@@ -1291,6 +1292,8 @@ static bool parse_mode(
                 case 'L': mode = bench_mode_t::list; break;
                 case 'i':
                 case 'I': mode = bench_mode_t::init; break;
+                case 'h':
+                case 'H': mode = bench_mode_t::hash; break;
                 case 'r':
                 case 'R':
                     mode = bench_mode_t::exec;

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <fstream>
 
 #include "utils/cold_cache.hpp"
 #include "utils/parser.hpp"
@@ -856,6 +857,14 @@ bool parse_batch(const bench_f bench, const char *str,
     };
     return parse_single_value_option(
             status, FAIL, str2batch, str, option_name, help);
+}
+
+bool parse_db(const char *str) {
+    static const std::string help
+            = "FILE\n    Instructs the driver to skip previous test results in "
+              "FILE.\n";
+    int status = OK;
+    return parse_single_value_option(status, FAIL, setup_db, str, "diff-db", help);
 }
 
 bool parse_help(const char *str, const std::string &option_name /* = "help"*/) {

--- a/tests/benchdnn/utils/parser.hpp
+++ b/tests/benchdnn/utils/parser.hpp
@@ -279,6 +279,8 @@ bool parse_perf_template(const char *&pt, const char *pt_def,
 bool parse_batch(const bench_f bench, const char *str,
         const std::string &option_name = "batch");
 
+bool parse_db(const char *str);
+
 bool parse_help(const char *str, const std::string &option_name = "help");
 bool parse_main_help(const char *str, const std::string &option_name = "help");
 
@@ -304,7 +306,7 @@ bool parse_driver_shared_settings(S &s, const S &def, const char *str) {
             || parse_skip_impl(s.impl_filter, def.impl_filter, str)
             || parse_perf_template(s.perf_template, s.perf_template_def,
                     s.perf_template_csv(), str)
-            || parse_reset(s, str) || parse_help(str);
+            || parse_reset(s, str) || parse_db(str) || parse_help(str);
 }
 
 void catch_unknown_options(const char *str);

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -96,6 +96,7 @@ struct check_mem_size_args_t {
 
 struct res_t {
     res_state_t state;
+    uint64_t impl_id = 0;
     size_t errors, total;
     timer::timer_map_t timer_map;
     std::string impl_name;

--- a/tests/benchdnn/utils/task.hpp
+++ b/tests/benchdnn/utils/task.hpp
@@ -70,7 +70,8 @@ struct task_t {
     int exec() {
         // Checking for `INITIALIZED` state here prevents from `SKIPPED`
         // problems being executed.
-        if (res_.state == INITIALIZED && bench_mode != bench_mode_t::init) {
+        if (res_.state == INITIALIZED && bench_mode != bench_mode_t::init
+                && bench_mode != bench_mode_t::hash) {
             // Differentiate a message when the run happens...
             BENCHDNN_PRINT(1, "run: %s\n", prb_.str());
             do_func_(*v_prim_, &prb_, &res_);


### PR DESCRIPTION
## Goal
This PR contains a refinement of some debugging code I had for investigating kernel cache bugs. The proposal in this PR is to enable a new testing mode that compares primitives implementations between oneDNN builds and only executes tests when a primitive change is identified. The main goal of this change is to improve testing speed of the  `code -> compile -> debug` cycle, and potentially to speed up CI/perf testing. Due to the nature of these changes, this cannot (generally) be used in Nightly testing. The current PR only implements support for this feature on Intel GPU primitive implementations although it should be easy to extend to other primitives with JIT generated binaries. 

## How it Works
The current PR is based around building an implementation database from a base oneDNN build, and then running a test set on the target branch. The general method is to log a primitive hash in the base oneDNN build, and then only run tests on the target branch if the primitive hashes changed. The current interface if a rough prototype (it definitely needs redesigned) and works by implementing a new Hash mode which initializes all primitives and logs their hashes. Since not all hashes are supported, a sentinel value of 0 is used to signify no support for this feature. The current workflow looks something like:

```
$ ./build_main/tests/benchdnn/benchdnn --matmul --mode=H --mode-modifier=P --engine=gpu --batch=test_matmul_ci | tee test.db
0:SKIPPED (Skip-impl option hit) (640 ms) __REPRO: --mode= --mode-modifier=P --matmul --engine=gpu --dt=f32:u8:f16 --stag=cab --wtag=cab --dtag=bac --attr-fpmath=bf16:true --skip-impl=ref 1x4740x2:1x2x7363
1:INITIALIZED impl_id: 0x17ddfea32b515c7d __REPRO: --mode= --mode-modifier=P --matmul --engine=gpu --dt=f8_e4m3:f8_e5m2:f16 --dtag=bac --skip-impl=ref 2x1x4:2x4x186
2:INITIALIZED impl_id: 0xf7da971f9d94a312 __REPRO: --mode= --mode-modifier=P --matmul --engine=gpu --dt=bf16:u8:f32 --stag=bac --wtag=abc --dtag=bac --attr-fpmath=bf16:true --skip-impl=ref 4x5x1064:4x1064x2
3:INITIALIZED impl_id: 0x1bf5a4cd34bde9bb __REPRO: --mode= --mode-modifier=P --matmul --engine=gpu --dt=f16:u8:f16 --stag=acb --attr-fpmath=f16:true --skip-impl=ref 4x40x2:4x2x67
...
10810:INITIALIZED impl_id: 0x2c739d9e5d81e9b0 __REPRO: --mode= --mode-modifier=P --matmul --engine=gpu --dt=f4_e2m1:f4_e2m1:f4_e3m0 --stag=ab --wtag=ab --bia-dt=f32 --skip-impl=ref 896x320:320x1280_n"RNN-T:Prediction_Input*12"
tests:10811 passed:9545 skipped:1266 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 33.56s; create_pd: 5.90s (18%); create_prim: 204.46s (609%);

$ ./build/tests/benchdnn/benchdnn --matmul --mode-modifier=P --engine=gpu --diff-db=test.db --batch=test_matmul_ci 
0:SKIPPED (Skip-impl option hit) (622 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=f32:u8:f16 --stag=cab --wtag=cab --dtag=bac --attr-fpmath=bf16:true --skip-impl=ref 1x4740x2:1x2x7363
1:SKIPPED (in database) (620 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=f8_e4m3:f8_e5m2:f16 --dtag=bac --skip-impl=ref 2x1x4:2x4x186
2:SKIPPED (in database) (620 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=bf16:u8:f32 --stag=bac --wtag=abc --dtag=bac --attr-fpmath=bf16:true --skip-impl=ref 4x5x1064:4x1064x2
3:SKIPPED (in database) (619 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=f16:u8:f16 --stag=acb --attr-fpmath=f16:true --skip-impl=ref 4x40x2:4x2x67
...
10810:SKIPPED (in database) (1 ms) __REPRO: --mode-modifier=P --matmul --engine=gpu --dt=f4_e2m1:f4_e2m1:f4_e3m0 --stag=ab --wtag=ab --bia-dt=f32 --skip-impl=ref 896x320:320x1280_n"RNN-T:Prediction_Input*12"
tests:10811 passed:0 skipped:10811 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 32.97s; create_pd: 4.61s (14%); create_prim: 207.52s (630%); fill: 0.00s (0%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```
On this particular case, this allows for up to a 7x performance improvement, although improvement can be much more significant as this test set uses a lot of very small test sizes.

By its nature, this style of testing is not perfect. There is always the possibility for a hash collision or a runtime input change to cause a false skip (although runtime parameters can be added to primitive hashes once found). In my opinion, these issues are outweighed by significantly faster testing during development.
