### PR TITLE
[GPU] add cl-opt-disable option

### DIFF
--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -189,6 +189,10 @@ private:
             add_option("-DOCL_DEBUG");
         }
 
+        if (gpu_utils::dev_getenv("cl_opt_disable", 0)) {
+            add_option("-cl-opt-disable");
+        }
+
         if (gpu_utils::dev_getenv("enable_ocl_werror", is_dev_mode()))
             add_option("-Werror ");
     }


### PR DESCRIPTION
One of sign that there is a driver issue is passing tests when kernels were compiled without optimization. To make such investigation easier PR adds this option and env variable in dev mode.