### PR TITLE
generic: sycl: Change to indexing in conv kernel

### DIFF
--- a/src/gpu/generic/sycl/ref_convolution.cpp
+++ b/src/gpu/generic/sycl/ref_convolution.cpp
@@ -46,13 +46,13 @@ status_t ref_convolution_fwd_t::pd_t::init_conf() {
 
     conf_.use_data_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC);
+    conf_.use_wei_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS);
     conf_.use_dst_zeropoints
             = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
-    conf_.single_data_zeropoint
-            = attr()->zero_points_.get_mask(DNNL_ARG_SRC) == 0;
-    conf_.single_dst_zeropoint
-            = attr()->zero_points_.get_mask(DNNL_ARG_DST) == 0;
-
+    conf_.data_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_SRC);
+    conf_.wei_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_WEIGHTS);
+    conf_.dst_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_DST);
     conf_.post_ops = sycl_post_ops_t(attr(), dst_md());
 
     conf_.padding[0] = static_cast<int>(desc()->padding[0][0]);
@@ -101,6 +101,22 @@ status_t ref_convolution_bwd_data_t::pd_t::init_conf() {
     conf_.ndims = ndims();
 
     conf_.wk_size = memory_desc_wrapper(diff_src_md()).nelems();
+
+    conf_.do_scale_data = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.do_scale_weights
+            = !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS);
+    conf_.do_scale_dst = !attr()->scales_.has_default_values(DNNL_ARG_DST);
+    conf_.single_weight_scale = attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) == 0;
+
+    conf_.use_data_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_SRC);
+    conf_.use_wei_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_WEIGHTS);
+    conf_.use_dst_zeropoints
+            = !attr()->zero_points_.has_default_values(DNNL_ARG_DST);
+    conf_.data_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_SRC);
+    conf_.wei_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_WEIGHTS);
+    conf_.dst_zp_mask = attr()->zero_points_.get_mask(DNNL_ARG_DST);
 
     conf_.post_ops = sycl_post_ops_t(attr(), diff_src_md());
 

--- a/src/gpu/generic/sycl/sycl_primitive_conf.hpp
+++ b/src/gpu/generic/sycl/sycl_primitive_conf.hpp
@@ -61,9 +61,11 @@ struct sycl_convolution_common_conf_t {
     bool single_weight_scale;
 
     bool use_data_zeropoints;
+    bool use_wei_zeropoints;
     bool use_dst_zeropoints;
-    bool single_data_zeropoint;
-    bool single_dst_zeropoint;
+    int data_zp_mask;
+    int wei_zp_mask;
+    int dst_zp_mask;
 
     int ndims;
 


### PR DESCRIPTION
# Description
Changed indexing to take into account different strides in convolution.
Added zp weights support
Fixed failues for deconv using sycl conv bwd
Changes to the sycl convolution kernel resolve failing benchdnn tests:
```
--mode-modifier=P --conv --engine=gpu --allow-enum-tags-only=false --check-ref-impl=true --dt=u8:s8:u8 --strides=903168x1x4032x9::6422528x1x28672x128 g1mb1ic3ih224oc64oh112kh7sh2ph3n"resnet_50:conv1"
```
```
--mode-modifier=P --conv --engine=gpu --allow-enum-tags-only=false --check-ref-impl=true --dir=BWD_D --dt=u8:s8:u8 --strides=903168x1x4032x9::6422528x1x28672x128 g1mb1ic3ih224oc64oh112kh7sh2ph3n"resnet_50:conv1"
```
```
--mode-modifier=P --deconv --engine=gpu --dir=FWD_I --dt=s8:s8:s8 --attr-scales=src:common:0.25 --attr-post-ops=linear:2:1 ic16iw5oc3ow5kw3pw1n"deconv_ci_1d:1st"

```
see MFDNN-13275

# Checklist

## General

- [ x ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ x ] Have you formatted the code using clang-format?
