### PR TITLE
x64: brgemm matmul: update extendable_k_ condition

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -959,7 +959,7 @@ void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
         // TODO: review extendable_k_ condition to cover more cases
         extendable_k_ = (K % wei_k_blk != 0) && (brgemm_k_elems > wei_k_blk)
                 && wei_zp_type == none && !use_buffer_a
-                && !packed_sparse_weights;
+                && !packed_sparse_weights && current_lda_ == K;
 
         if (extendable_k_) {
             if (brgemm_k_elems >= K) {


### PR DESCRIPTION
Backport of #3060.
Fixes MFDNN-13594