### PR TITLE
gpu: nvidia: Change nvidia reorder memcpy to async

### DIFF
--- a/src/gpu/nvidia/cudnn_reorder_impl.hpp
+++ b/src/gpu/nvidia/cudnn_reorder_impl.hpp
@@ -117,17 +117,19 @@ public:
     void execute(cudnnHandle_t handle, void *src, void *dst, void *src_scale,
             void *dst_scale) const override {
         float alpha = 1.0f;
+        cudaStream_t cuda_stream;
+        CUDNN_EXECUTE_FUNC(cudnnGetStream, handle, &cuda_stream);
         if (src_scale) {
             float host_src_scale = 1.0f;
-            CUDA_EXECUTE_FUNC(cuMemcpy, (CUdeviceptr)&host_src_scale,
-                    (CUdeviceptr)src_scale, sizeof(float));
+            CUDA_EXECUTE_FUNC(cuMemcpyAsync, (CUdeviceptr)&host_src_scale,
+                    (CUdeviceptr)src_scale, sizeof(float), cuda_stream);
             alpha *= host_src_scale;
         }
         float beta = beta_;
         if (dst_scale) {
             float host_dst_scale = 1.0f;
-            CUDA_EXECUTE_FUNC(cuMemcpy, (CUdeviceptr)&host_dst_scale,
-                    (CUdeviceptr)dst_scale, sizeof(float));
+            CUDA_EXECUTE_FUNC(cuMemcpyAsync, (CUdeviceptr)&host_dst_scale,
+                    (CUdeviceptr)dst_scale, sizeof(float), cuda_stream);
             alpha /= host_dst_scale;
             beta /= host_dst_scale;
         }
@@ -197,17 +199,19 @@ public:
     void execute(cudnnHandle_t handle, void *src, void *dst, void *src_scale,
             void *dst_scale) const override {
         float alpha = 1.0f;
+        cudaStream_t cuda_stream;
+        CUDNN_EXECUTE_FUNC(cudnnGetStream, handle, &cuda_stream);
         if (src_scale) {
             float host_src_scale = 1.0f;
-            CUDA_EXECUTE_FUNC(cuMemcpy, (CUdeviceptr)&host_src_scale,
-                    (CUdeviceptr)src_scale, sizeof(float));
+            CUDA_EXECUTE_FUNC(cuMemcpyAsync, (CUdeviceptr)&host_src_scale,
+                    (CUdeviceptr)src_scale, sizeof(float), cuda_stream);
             alpha *= host_src_scale;
         }
         float beta = beta_;
         if (dst_scale) {
             float host_dst_scale = 1.0f;
-            CUDA_EXECUTE_FUNC(cuMemcpy, (CUdeviceptr)&host_dst_scale,
-                    (CUdeviceptr)dst_scale, sizeof(float));
+            CUDA_EXECUTE_FUNC(cuMemcpyAsync, (CUdeviceptr)&host_dst_scale,
+                    (CUdeviceptr)dst_scale, sizeof(float), cuda_stream);
             alpha /= host_dst_scale;
             beta /= host_dst_scale;
         }


### PR DESCRIPTION
# Description

When executing nvidia backend sum, scales are set using `map_memory` to get the device memory, set with values on the host and then `unmap_memory` is called to update the device-side memory.
For buffer memory storages this mapping and unmapping is done using `get_host_access` which gives a host accessor. When the host accessor is destroyed the device memory is updated. This guarantees synchronization with regards to the current queue.
The reorder implementation used uses cuMemcpy to get the scales on host. This is run on the default cuda stream, while the sycl queue submits work on a different stream.

This PR proposes getting the stream that the cuDNN operations are submitted to (created from the sycl queue) and submitting the copy of scales on the same stream with cuMemcpyAsync. This would prevent race conditions for copying the scales.

Proposed changes to resolve failing benchdnn tests:
```
--mode-modifier=P --sum --engine=gpu --allow-enum-tags-only=false --sdt=f16:f16:f16 --ddt=f16 --stag=abc:abc:abc --dtag=abc --scales=1 16x52416x1_n"b1f9c7502bfc69ece76f8ab81431d1b4*2"
--mode-modifier=P --sum --engine=gpu --allow-enum-tags-only=false --sdt=f16:f16:f16 --ddt=f16 --stag=abc:abc:abc --dtag=abc --scales=1 16x209664x1_n"393c86752a159bcdda444e62db0b2628*2"
--mode-modifier=P --sum --engine=gpu --allow-enum-tags-only=false --stag=abc:abc --dtag=abc --scales=1 128x128x768_n"0031dec83174f96598b9e67ff632f3e0*2"
--mode-modifier=P --sum --engine=gpu --allow-enum-tags-only=false --sdt=f32:f32:f32 --stag=ab:ab:ab --dtag=ab --scales=1 16384x3072_n"acda06dcbcae48eb07b83155b1d051df*24"
--mode-modifier=P --sum --engine=gpu --allow-enum-tags-only=false --stag=ab:ab --dtag=ab --scales=1 16384x768_n"b311ec6cda5ab943632a8cd733119116*24"
--mode-modifier=P --sum --engine=gpu --allow-enum-tags-only=false --sdt=f32:f32:f32:f32 --stag=ab:ab:ab:ab --dtag=ab --scales=1 16384x768_n"7e30943017736555a69afd2f007a44a8*24"

```

The changes for memcpy have been applied at all locations in the nvidia backend.

See MFDNN-13297

# Checklist

## General

- [ x ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ x ] Have you formatted the code using clang-format?
