### PR TITLE
[rls-v3.8] x64: matmul: Fix buffer B per thread size initialization.

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1740,18 +1740,20 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
 
     bgmmc.buffer_a_per_thread_sz = bgmmc.buffer_a_m_stride * bgmmc.M_chunk_size;
 
-    bgmmc.buffer_b_gb_stride = bgmmc.tr_b_dt_sz * bgmmc.LDB * bgmmc.K_blk;
+    bgmmc.buffer_b_gb_stride = bgmmc.tr_b_dt_sz * rnd_up(bgmmc.LDB, bgmmc.N_blk)
+            * bgmmc.wei_k_blk;
     bgmmc.buffer_b_k_brg_stride
-            = bgmmc.buffer_b_gb_stride * bgmmc.brgemm_batch_size;
+            = bgmmc.buffer_b_gb_stride * bgmmc.K_chunk_size * bgmmc.K_blk;
 
+    // TODO: (Refactoring) the only usage of `buffer_b_chunk_sz`
+    // and `buffer_b_n_blk_stride` is here. Remove it if not needed.
     bgmmc.buffer_b_n_blk_stride = bgmmc.tr_b_dt_sz
             * ((bgmmc.N_blk / bgmmc.LDB) * bgmmc.LDB2
                     + (bgmmc.N_blk % bgmmc.LDB)
                             * data_type_vnni_granularity(bgmmc.wei_dt));
 
-    bgmmc.buffer_b_chunk_sz = bgmmc.tr_b_dt_sz * rnd_up(bgmmc.N_blk, bgmmc.LDB)
-            * rnd_up(bgmmc.K_chunk_elems, bgmmc.wei_k_blk);
-
+    bgmmc.buffer_b_chunk_sz
+            = bgmmc.buffer_b_k_brg_stride * bgmmc.brgemm_batch_size;
     bgmmc.buffer_b_per_thread_sz = bgmmc.buffer_b_chunk_sz;
 
     bgmmc.buffer_reduce_per_thread_sz = 0;


### PR DESCRIPTION
Backport of https://github.com/uxlfoundation/oneDNN/pull/3161

[Nightly Pre-CI](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f026bd81-fbe9-f1bf-8e3d-a4bf010d0e2d?objectId=job-f026bd81-fbe9-f1bf-8e3d-a4bf010d0e2d&filterName0=jobsPageSearchMKL-DNN&filterDepth=1)
Fixes all -wtag=abcd cases & no new failures. --wtag=abdc to be fixed in the different PR
