### PR TITLE
common: verbose: adjust sdpa verbose format

### DIFF
--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -73,9 +73,9 @@ struct sdpa_desc_t : public op_desc_t {
     // primitive_attr_t can't be used because of deleted copy-ctor, but desc_t
     // must be copyable.
     quant_entry_t kq_scales;
-    zero_points_t kq_zero_points;
+    quant_entry_t kq_zero_points;
     quant_entry_t vs_scales;
-    zero_points_t vs_zero_points;
+    quant_entry_t vs_zero_points;
 
     memory_desc_t dst_desc;
     memory_desc_t attn_mask_desc;

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -144,11 +144,11 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     sdpa_desc.k_desc = *k_md;
     if (kq_attr) {
         sdpa_desc.kq_scales = kq_attr->scales_.get(DNNL_ARG_WEIGHTS);
-        sdpa_desc.kq_zero_points = kq_attr->zero_points_;
+        sdpa_desc.kq_zero_points = kq_attr->zero_points_.get(DNNL_ARG_WEIGHTS);
     }
     if (vs_attr) {
         sdpa_desc.vs_scales = vs_attr->scales_.get(DNNL_ARG_WEIGHTS);
-        sdpa_desc.vs_zero_points = vs_attr->zero_points_;
+        sdpa_desc.vs_zero_points = vs_attr->zero_points_.get(DNNL_ARG_WEIGHTS);
     }
     sdpa_desc.v_desc = *v_md;
     sdpa_desc.dst_desc = *dst_md;

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -39,9 +39,9 @@ namespace {
 
 using namespace gemmstone;
 
-/// Returns true if a common scale value is used for each slice of the tensor
-/// operation. For 4D case it's when the mask's two first bits are on and two
-/// last bits are off.
+/// Returns true if a common quantization value is used for each slice of the
+/// tensor operation. For 4D case it's when the mask's two first bits are on
+/// and two last bits are off.
 /// Examples:
 ///   | mask      | result  |
 ///   |-----------+---------|
@@ -50,19 +50,8 @@ using namespace gemmstone;
 ///   |  3 (1100) | true    |
 ///   |  1 (1000) | true    |
 ///   |  8 (0001) | false   |
-bool with_quantize_common(const quant_entry_t &scale_entry) {
-    return !scale_entry.has_default_values()
-            && (((scale_entry.get_mask() & 3) != 0
-                        && (scale_entry.get_mask() & 12) == 0)
-                    || scale_entry.get_mask() == 0);
-}
-
-/// Returns true if a common zero points value is used for each slice of the
-/// tensor operation
-bool with_quantize_common(const zero_points_t &zp) {
-    int mask = zp.get_mask(DNNL_ARG_WEIGHTS);
-    return !zp.has_default_values(DNNL_ARG_WEIGHTS)
-            && (((mask & 3) != 0 && (mask & 12) == 0) || mask == 0);
+bool with_quantize_common(const quant_entry_t &entry) {
+    return !entry.has_default_values() && ((entry.get_mask() & 12) == 0);
 }
 
 } /* anonymous namespace */

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -95,7 +95,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
                     qry_md()->dims[1], key_md()->dims[1], val_md()->dims[1]);
 
             int kq_scales_mask = desc()->kq_scales.get_mask();
-            int kq_zp_mask = desc()->kq_zero_points.get_mask(DNNL_ARG_WEIGHTS);
+            int kq_zp_mask = desc()->kq_zero_points.get_mask();
             if (!desc()->kq_scales.has_default_values()
                     && !desc()->kq_zero_points.has_default_values())
                 VCHECK_SDPA_COND(kq_scales_mask == kq_zp_mask,
@@ -114,9 +114,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         kq_zp_mask);
 
             /// NOTE: Limitation of microkernels
-            if (utils::one_of(
-                        desc()->kq_zero_points.get_data_type(DNNL_ARG_WEIGHTS),
-                        s4, u4)) {
+            if (utils::one_of(desc()->kq_zero_points.get_data_type(), s4, u4)) {
                 VCHECK_SDPA_COND(key_group_size() == 16,
                         "if kq zero points data type is s4 or u4 then the "
                         "group size(%d) must be 16.",
@@ -124,7 +122,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
             }
 
             int vs_scales_mask = desc()->vs_scales.get_mask();
-            int vs_zp_mask = desc()->vs_zero_points.get_mask(DNNL_ARG_WEIGHTS);
+            int vs_zp_mask = desc()->vs_zero_points.get_mask();
             if (!desc()->vs_scales.has_default_values()
                     && !desc()->vs_zero_points.has_default_values())
                 VCHECK_SDPA_COND(vs_scales_mask == vs_zp_mask,
@@ -143,9 +141,7 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         vs_zp_mask);
 
             /// NOTE: Limitation of microkernels
-            if (utils::one_of(
-                        desc()->vs_zero_points.get_data_type(DNNL_ARG_WEIGHTS),
-                        s4, u4)) {
+            if (utils::one_of(desc()->vs_zero_points.get_data_type(), s4, u4)) {
                 VCHECK_SDPA_COND(value_group_size() == 16,
                         "if vs zero points data type is s4 or u4 then the "
                         "group size(%d) must be 16.",


### PR DESCRIPTION
Adjusts the verbose output of sdpa primitives to align with the standard template. Part of [MFDNN-13623](https://jira.devtools.intel.com/browse/MFDNN-13623).