### PR TITLE
xe: fix locale handling

### DIFF
--- a/src/gpu/intel/compute/kernel_ctx.hpp
+++ b/src/gpu/intel/compute/kernel_ctx.hpp
@@ -48,6 +48,8 @@ public:
 
     std::string options() const {
         std::ostringstream oss;
+        oss.imbue(std::locale::classic());
+
         for (auto &opt : option_set_)
             oss << " " << opt;
 

--- a/src/gpu/intel/config.hpp
+++ b/src/gpu/intel/config.hpp
@@ -138,6 +138,7 @@ public:
 
     std::string str() const override {
         std::ostringstream oss;
+        oss.imbue(std::locale::classic());
         oss << short_name() << "=" << (int)value_;
         return oss.str();
     }
@@ -151,6 +152,7 @@ public:
 
     std::string str() const override {
         std::ostringstream oss;
+        oss.imbue(std::locale::classic());
         oss << short_name() << "=" << value_;
         return oss.str();
     }
@@ -164,6 +166,7 @@ public:
 
     std::string str() const override {
         std::ostringstream oss;
+        oss.imbue(std::locale::classic());
         oss << short_name() << "=" << value_;
         return oss.str();
     }
@@ -237,6 +240,7 @@ protected:
 
     std::string get_config_line() const {
         std::ostringstream oss;
+        oss.imbue(std::locale::classic());
         auto params = get_all_params(/*do_sort=*/true);
         bool is_first = true;
         for (auto *p : params) {

--- a/src/gpu/intel/jit/conv/lookup_table.cpp
+++ b/src/gpu/intel/jit/conv/lookup_table.cpp
@@ -44,10 +44,12 @@ conv_lookup_table_t::conv_lookup_table_t(const char **entries) {
     while (*entries) {
         conv_lookup_table_t::entry_t e;
         std::istringstream iss(*entries);
+        iss.imbue(std::locale::classic());
         e.parse(iss);
 #ifdef DNNL_DEV_MODE
         {
             std::ostringstream oss;
+            oss.imbue(std::locale::classic());
             e.stringify(oss);
             gpu_assert(oss.str() == *entries)
                     << "parsed from:\n  " << *entries << "\nstringified to\n  "

--- a/src/gpu/intel/jit/gemm/generator/pieces/problem_utils.cpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/problem_utils.cpp
@@ -61,6 +61,7 @@ static inline void append(std::ostringstream &s, Type T1, Type T2);
 std::string GEMMProblem::toString() const
 {
     std::ostringstream ss;
+    ss.imbue(std::locale::classic());
 
     switch (batch) {
         default:                                      break;
@@ -120,6 +121,7 @@ std::string GEMMProblem::toString() const
 std::string GEMMProblem::scalarsToString() const
 {
     std::ostringstream ss;
+    ss.imbue(std::locale::classic());
     append(ss, alpha);
     ss << ' ';
     append(ss, beta);

--- a/src/gpu/intel/jit/gemm/generator/strategy_parser.cpp
+++ b/src/gpu/intel/jit/gemm/generator/strategy_parser.cpp
@@ -139,6 +139,7 @@ static void getTiling(std::stringstream &s, MatrixAddressingStrategy &astrategy)
 void parseStrategy(const char *str, HW hw, const GEMMProblem &problem, GEMMStrategy &strategy)
 {
     std::stringstream s(str);
+    s.imbue(std::locale::classic());
     bool overrideFusedLoop = false;
     bool gotSR = false;
 
@@ -467,6 +468,7 @@ void parseStrategy(const char *str, HW hw, const GEMMProblem &problem, GEMMStrat
             else if (mod.substr(0, 2) == "ks") {
                 char eat;
                 std::stringstream ms(mod);
+                ms.imbue(std::locale::classic());
                 ms >> eat >> eat >> strategy.unrollKSLM;
                 if (!ms.eof() && (ms.peek() == '/'))
                     ms >> eat >> strategy.unrollKSLMMasked;
@@ -520,6 +522,7 @@ void parseStrategy(const char *str, HW hw, const GEMMProblem &problem, GEMMStrat
                         strategy.slmB = true;
                     }
                     std::stringstream ms(mod);
+                    ms.imbue(std::locale::classic());
                     ms >> strategy.slmBuffers;
                     ms >> eat;
                     if (!ms.eof())
@@ -529,6 +532,7 @@ void parseStrategy(const char *str, HW hw, const GEMMProblem &problem, GEMMStrat
                 case 'k': {
                     char eat;
                     std::stringstream ms(mod);
+                    ms.imbue(std::locale::classic());
                     ms >> eat >> strategy.unroll[LoopK];
                     if (!ms.eof() && (ms.peek() == '/'))
                         ms >> eat >> strategy.unrollK_masked;
@@ -723,6 +727,7 @@ const char *parsePrecisions(const char *s, Type &precision1, Type &precision2)
 std::string unparseStrategy(HW hw, const GEMMProblem &problem, const GEMMStrategy &strategy)
 {
     std::stringstream s;
+    s.imbue(std::locale::classic());
 
     bool anyOptAlignAB = strategy.optAlignAB || strategy.optAlignAB2D;
 

--- a/src/gpu/intel/microkernels/shim.cpp
+++ b/src/gpu/intel/microkernels/shim.cpp
@@ -199,6 +199,7 @@ std::vector<const ActualT *> matchProtocol(
 std::string generateShim(const Package &package, HostLanguage language,
         const ShimOptions &options) {
     std::stringstream shim;
+    shim.imbue(std::locale::classic());
 
     bool cpp = (language == HostLanguage::SYCL);
 

--- a/third_party/ngen/ngen_interface.hpp
+++ b/third_party/ngen/ngen_interface.hpp
@@ -598,6 +598,7 @@ std::string InterfaceHandler::generateZeInfo() const
 #endif
 
     std::stringstream md;
+    md.imbue(std::locale::classic());
 
     const char *version = "1.8";
 

--- a/third_party/ngen/ngen_opencl.hpp
+++ b/third_party/ngen/ngen_opencl.hpp
@@ -140,6 +140,7 @@ std::vector<uint8_t> OpenCLCodeGenerator<hw>::getPatchTokenBinary(cl_context con
 {
     using super = ELFCodeGenerator<hw>;
     std::ostringstream dummyCL;
+    dummyCL.imbue(std::locale::classic());
     auto modOptions = options;
 
     if ((hw >= HW::XeHP) && (super::interface_.needGRF > 128))


### PR DESCRIPTION
Fixes #3181.

While investigating #3181, it was found that the oneDNN GPU component had dependencies on locale through the use of `std::stringstream ` for string manipulation. These dependencies occurred for a few different reasons:

1. When generating OpenCL C code, the expected locale is `C` and passing in different locale resulted in invalid syntax due to integer formatting.
2. The ZeBin binary format encodes textual metadata in the binary. By changing the locale, the metadata becomes malformed.
3. Some GPU primitives have strategy databases stored in a human readable format. When parsing these databases, changes in the locale resulted in incorrect parsing.

This PR contains a fix for the above issues identified during manual testing.