### PR TITLE
benchdnn: binary: add strides option support

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -97,13 +97,16 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     bool force_f32_dt = init_pd_args.force_f32_dt;
 
     auto src0_d = dnn_mem_t::init_md(prb->ndims, prb->vdims[0].data(),
-            force_f32_dt ? dnnl_f32 : prb->sdt[0], prb->stag[0]);
+            force_f32_dt ? dnnl_f32 : prb->sdt[0], prb->stag[0],
+            prb->strides[STRIDES_SRC_0]);
 
     auto src1_d = dnn_mem_t::init_md(prb->ndims, prb->vdims[1].data(),
-            force_f32_dt ? dnnl_f32 : prb->sdt[1], prb->stag[1]);
+            force_f32_dt ? dnnl_f32 : prb->sdt[1], prb->stag[1],
+            prb->strides[STRIDES_SRC_1]);
 
     auto dst_d = dnn_mem_t::init_md(prb->ndims, prb->dst_dims.data(),
-            force_f32_dt ? dnnl_f32 : prb->ddt, prb->dtag);
+            force_f32_dt ? dnnl_f32 : prb->ddt, prb->dtag,
+            prb->strides[STRIDES_DST]);
 
     dnnl_alg_kind_t alg = attr_t::post_ops_t::kind2dnnl_kind(prb->alg);
 

--- a/tests/benchdnn/binary/binary.hpp
+++ b/tests/benchdnn/binary/binary.hpp
@@ -45,6 +45,7 @@ struct settings_t : public base_settings_t {
     std::vector<dnnl_data_type_t> ddt {dnnl_f32};
     std::vector<std::vector<std::string>> stag {{tag::abx, tag::any}};
     std::vector<std::string> dtag {tag::any};
+    std::vector<vdims_t> strides {vdims_t(STRIDES_SIZE)};
     std::vector<alg_t> alg {alg_t::ADD};
 
     const char *perf_template_csv() const {
@@ -56,7 +57,7 @@ struct settings_t : public base_settings_t {
 
     bool has_single_setup() const override {
         return sdt.size() == 1 && ddt.size() == 1 && stag.size() == 1
-                && dtag.size() == 1 && alg.size() == 1
+                && dtag.size() == 1 && strides.size() == 1 && alg.size() == 1
                 && base_settings_t::has_single_setup();
     }
 };
@@ -64,16 +65,16 @@ struct settings_t : public base_settings_t {
 struct prb_t : public prb_vdims_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
-        : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0], s.alg[0],
-                s.inplace[0], s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
-                s.impl_filter) {
+        : prb_t(s.prb_vdims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
+                s.strides[0], s.alg[0], s.inplace[0], s.attributes.front(),
+                s.ctx_init[0], s.ctx_exe[0], s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 
     prb_t(const prb_vdims_t &prb_vdims,
             const std::vector<dnnl_data_type_t> &sdt, dnnl_data_type_t ddt,
             const std::vector<std::string> &stag, const std::string &dtag,
-            alg_t alg, bool inplace, const attr_t &attr,
+            const vdims_t &strides, alg_t alg, bool inplace, const attr_t &attr,
             const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
             const impl_filter_t &impl_filter)
         : prb_vdims_t(prb_vdims)
@@ -81,6 +82,7 @@ struct prb_t : public prb_vdims_t {
         , ddt(ddt)
         , stag(stag)
         , dtag(dtag)
+        , strides(strides)
         , alg(alg)
         , inplace(inplace)
         , attr(attr)
@@ -95,6 +97,7 @@ struct prb_t : public prb_vdims_t {
     dnnl_data_type_t ddt;
     std::vector<std::string> stag;
     std::string dtag;
+    vdims_t strides;
     alg_t alg;
     bool inplace;
     attr_t attr;

--- a/tests/benchdnn/binary/binary_aux.cpp
+++ b/tests/benchdnn/binary/binary_aux.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ std::string prb_t::set_repro_line() {
     if (canonical || ddt != def.ddt[0]) s << "--ddt=" << ddt << " ";
     if (canonical || stag != def.stag[0]) s << "--stag=" << stag << " ";
     if (canonical || dtag != def.dtag[0]) s << "--dtag=" << dtag << " ";
+    if (canonical || strides != def.strides[0])
+        s << "--strides==" << vdims2str(strides) << " ";
     if (canonical || alg != def.alg[0]) s << "--alg=" << alg << " ";
     if (canonical || inplace != def.inplace[0])
         s << "--inplace=" << bool2str(inplace) << " ";

--- a/tests/benchdnn/doc/driver_binary.md
+++ b/tests/benchdnn/doc/driver_binary.md
@@ -17,6 +17,10 @@ where *binary-knobs* are:
             Refer to [tags](knobs_tag.md) for details.
  - `--dtag={any [default], ...}` -- physical dst memory layout.
             Refer to [tags](knobs_tag.md) for details.
+- `--strides=SRC0_STRIDES:SRC1_STRIDES:DST_STRIDES` -- physical memory layout
+            specification for `src0`, `src1`, and `dst` tensors through
+            strides values. Refer to [option documentation](knob_strides.md)
+            for details.
  - `--alg={ADD [default], DIV, EQ, GE, GT, LE, LT, MAX, MIN, MUL, NE, SELECT, SUB}`
             -- algorithm for binary operations.
             Refer to [binary primitive](https://uxlfoundation.github.io/oneDNN/dev_guide_binary.html)

--- a/tests/benchdnn/doc/knob_strides.md
+++ b/tests/benchdnn/doc/knob_strides.md
@@ -18,14 +18,16 @@ For example, tensor `2x3` can be represented in multiple ways:
 
 ## Usage
 ```
-    --strides=SRC_DIMS[:WEI_DIMS]:DST_DIMS
+    --strides=SRC_DIMS[:OPTIONAL_DIMS]:DST_DIMS
 ```
 
 This is a general representation of strides option support across benchdnn.
-The order of arguments is always the same: source, weights, and destination.
-Weights strides are required if the driver has weights support. However, they
-can't be specified if the driver doesn't have a notion of weights for the
-operation, and only two inputs are expected in this case.
+The order of arguments is always the same: source, optional dimensions, and
+destination. `OPTIONAL_DIMS` can be `WEI_DIMS` for primitives having weights, or
+`SRC1_DIMS` for primitives having two source inputs. Weights strides are
+required if the driver has weights support. However, strides for the optional
+dimensions can't be specified if the driver doesn't support them and only two
+inputs are expected in this case.
 
 `DIMS` generic form is \f$D_0xD_1x...xD_n\f$, where `n` should match the problem
 number of dimensions.

--- a/tests/benchdnn/utils/dims.hpp
+++ b/tests/benchdnn/utils/dims.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,7 +56,9 @@ struct prb_vdims_t {
 // strides for SRC, WEI, and DST
 enum {
     STRIDES_SRC = 0,
+    STRIDES_SRC_0 = STRIDES_SRC,
     STRIDES_WEI = 1,
+    STRIDES_SRC_1 = STRIDES_WEI,
     STRIDES_DST = 2,
     STRIDES_SIZE = 3,
 };


### PR DESCRIPTION

This PR adds support for the `--strides` option in the binary driver (addresses MFDNN-13506).
Unlike other drivers, the binary driver requires setting strides separately for both `src0` and `src1`. The format is:
```
--strides=SRC_0_DIMS:SRC_1_DIMS:DST_DIMS
```

Partial specification is supported:
- Only destination: `--strides=::DST_DIMS`
- One source only: `--strides=SRC_0_DIMS::DST_DIMS` or `--strides=:SRC_1_DIMS:DST_DIMS`

Example:
```
./benchdnn --binary --strides=6x3x1:6x3x1:6x3x1 --alg=ADD 1x2x3:1x2x3
```

`--strides` is mutually exclusive with tag-based options:
- Destination: `--dtag` cannot be used with destination strides
- Source: `--stag` cannot be used if either `src0` or `src1` uses strides

Valid combinations:
- All strides, no tags
- Only destination tag with source strides
- Only source tags when no source stride is used

Invalid combinations include mixing stride and tag for the same tensor or using partial `--stag` (e.g., `:tag` or `tag:`), which is unsupported.