### PR TITLE
graph: backend: dnnl: support gemma GQA from tensorflow

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -179,11 +179,14 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     int MBO = sdp_cfg_.batch_size, MBI = sdp_cfg_.num_head_q;
 
     char *src1_user_pointer = static_cast<char *>(
-            inputs[sdp_cfg_.graph_inport[0]].get_data_handle());
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_config_t::mm1_src]]
+                    .get_data_handle());
     char *wei1_user_pointer = static_cast<char *>(
-            inputs[sdp_cfg_.graph_inport[1]].get_data_handle());
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_config_t::mm1_wei]]
+                    .get_data_handle());
     char *wei2_user_pointer = static_cast<char *>(
-            inputs[sdp_cfg_.graph_inport[2]].get_data_handle());
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_config_t::mm2_wei]]
+                    .get_data_handle());
     char *dst2_user_pointer = static_cast<char *>(outputs[0].get_data_handle());
 
     size_t block_size = sdp_registry_.size();
@@ -219,20 +222,25 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
                     = res->mem_map[sdp_cfg_.sub_mm1_post_mem[start_index++]
                                            .get()][tid];
             sub_mm1_post_scale_tid.set_data_handle(
-                    inputs[sdp_cfg_.graph_inport[3]].get_data_handle());
+                    inputs[sdp_cfg_.graph_inport
+                                    [sdp_decomp_config_t::mm1_scale]]
+                            .get_data_handle());
         }
         if (sdp_cfg_.has_soft_capping) {
             auto &sub_mm1_post_soft_cap_tid
                     = res->mem_map[sdp_cfg_.sub_mm1_post_mem[start_index++]
                                            .get()][tid];
             sub_mm1_post_soft_cap_tid.set_data_handle(static_cast<char *>(
-                    inputs[sdp_cfg_.graph_inport[4]].get_data_handle()));
+                    inputs[sdp_cfg_.graph_inport
+                                    [sdp_decomp_config_t::mm1_soft_capping]]
+                            .get_data_handle()));
         }
         if (sdp_cfg_.has_attention_mask) {
             auto &sub_mm1_post_add_tid
                     = res->mem_map[sdp_cfg_.sub_mm1_post_mem[start_index++]
                                            .get()][tid];
-            const auto &mask_input = inputs[sdp_cfg_.graph_inport[5]];
+            const auto &mask_input = inputs
+                    [sdp_cfg_.graph_inport[sdp_decomp_config_t::mm1_add]];
             const auto mask_strides
                     = ltw(mask_input.get_logical_tensor()).vstrides();
             const auto mask_dims = ltw(mask_input.get_logical_tensor()).vdims();
@@ -254,7 +262,9 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
         if (sdp_cfg_.has_select) {
             auto &sub_select_cond_tid
                     = res->mem_map[sdp_cfg_.sub_select_cond.get()][tid];
-            const auto &select_cond_input = inputs[sdp_cfg_.graph_inport[6]];
+            const auto &select_cond_input
+                    = inputs[sdp_cfg_.graph_inport
+                                     [sdp_decomp_config_t::select_condition]];
             const auto select_cond_strides
                     = ltw(select_cond_input.get_logical_tensor()).vstrides();
             const auto select_cond_dims
@@ -282,7 +292,9 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
 
             auto &sub_select_src0_tid
                     = res->mem_map[sdp_cfg_.sub_select_src0.get()][tid];
-            const auto &select_src0_input = inputs[sdp_cfg_.graph_inport[7]];
+            const auto &select_src0_input
+                    = inputs[sdp_cfg_.graph_inport
+                                     [sdp_decomp_config_t::select_other_input]];
             const auto select_src0_strides
                     = ltw(select_src0_input.get_logical_tensor()).vstrides();
             const auto select_src0_dims

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -73,7 +73,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
         BACKEND_DNNL_ADD_PASS(pipeline, insert_runtime_u8_to_s8_for_matmul);
     }
     BACKEND_DNNL_ADD_PASS(pipeline, binary_canonicalization);
-    BACKEND_DNNL_ADD_PASS(pipeline, fuse_post_ops);
+    BACKEND_DNNL_ADD_PASS(pipeline, sdp_fuse_post_ops);
     BACKEND_DNNL_ADD_PASS(pipeline, insert_permute_for_matmul);
     if (quantized) {
         BACKEND_DNNL_ADD_PASS(pipeline, remove_quant_data_with_no_effect);
@@ -183,7 +183,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     char *wei1_user_pointer = static_cast<char *>(
             inputs[sdp_cfg_.graph_inport[1]].get_data_handle());
     char *wei2_user_pointer = static_cast<char *>(
-            inputs[sdp_cfg_.graph_inport[4]].get_data_handle());
+            inputs[sdp_cfg_.graph_inport[2]].get_data_handle());
     char *dst2_user_pointer = static_cast<char *>(outputs[0].get_data_handle());
 
     size_t block_size = sdp_registry_.size();
@@ -201,6 +201,10 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
         // prepare execution args and allocate real memory
         prepare_sub_args(var_grantor, tid, block_size, res->mem_map);
 
+        const size_t group_head = sdp_cfg_.num_head_q / sdp_cfg_.num_head_kv;
+        const size_t wei_head_offset = bi / group_head;
+        const size_t group_id = bi % group_head;
+
         // reorder0
         auto &sub_src1_tid = res->mem_map[sdp_cfg_.sub_src1.get()][tid];
         // reorder1:
@@ -215,13 +219,20 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
                     = res->mem_map[sdp_cfg_.sub_mm1_post_mem[start_index++]
                                            .get()][tid];
             sub_mm1_post_scale_tid.set_data_handle(
-                    inputs[sdp_cfg_.graph_inport[2]].get_data_handle());
+                    inputs[sdp_cfg_.graph_inport[3]].get_data_handle());
+        }
+        if (sdp_cfg_.has_soft_capping) {
+            auto &sub_mm1_post_soft_cap_tid
+                    = res->mem_map[sdp_cfg_.sub_mm1_post_mem[start_index++]
+                                           .get()][tid];
+            sub_mm1_post_soft_cap_tid.set_data_handle(static_cast<char *>(
+                    inputs[sdp_cfg_.graph_inport[4]].get_data_handle()));
         }
         if (sdp_cfg_.has_attention_mask) {
             auto &sub_mm1_post_add_tid
                     = res->mem_map[sdp_cfg_.sub_mm1_post_mem[start_index++]
                                            .get()][tid];
-            const auto &mask_input = inputs[sdp_cfg_.graph_inport[3]];
+            const auto &mask_input = inputs[sdp_cfg_.graph_inport[5]];
             const auto mask_strides
                     = ltw(mask_input.get_logical_tensor()).vstrides();
             const auto mask_dims = ltw(mask_input.get_logical_tensor()).vdims();
@@ -229,6 +240,12 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
             if (mask_dims.size() == 4) {
                 if (mask_dims[0] != 1) mask_offset += bo * mask_strides[0];
                 if (mask_dims[1] != 1) mask_offset += bi * mask_strides[1];
+            } else if (mask_dims.size() == 5) {
+                if (mask_dims[0] != 1) mask_offset += bo * mask_strides[0];
+                if (mask_dims[1] != 1)
+                    mask_offset += wei_head_offset * mask_strides[1];
+                if (mask_dims[2] != 1)
+                    mask_offset += group_id * mask_strides[2];
             }
             sub_mm1_post_add_tid.set_data_handle(
                     static_cast<char *>(mask_input.get_data_handle())
@@ -237,17 +254,26 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
         if (sdp_cfg_.has_select) {
             auto &sub_select_cond_tid
                     = res->mem_map[sdp_cfg_.sub_select_cond.get()][tid];
-            const auto &select_cond_input = inputs[sdp_cfg_.graph_inport[5]];
+            const auto &select_cond_input = inputs[sdp_cfg_.graph_inport[6]];
             const auto select_cond_strides
                     = ltw(select_cond_input.get_logical_tensor()).vstrides();
             const auto select_cond_dims
                     = ltw(select_cond_input.get_logical_tensor()).vdims();
+
             size_t select_cond_offset = 0;
             if (select_cond_dims.size() == 4) {
                 if (select_cond_dims[0] != 1)
                     select_cond_offset += bo * select_cond_strides[0];
                 if (select_cond_dims[1] != 1)
                     select_cond_offset += bi * select_cond_strides[1];
+            } else if (select_cond_dims.size() == 5) {
+                if (select_cond_dims[0] != 1)
+                    select_cond_offset += bo * select_cond_strides[0];
+                if (select_cond_dims[1] != 1)
+                    select_cond_offset
+                            += wei_head_offset * select_cond_strides[1];
+                if (select_cond_dims[2] != 1)
+                    select_cond_offset += group_id * select_cond_strides[2];
             }
             sub_select_cond_tid.set_data_handle(
                     static_cast<char *>(select_cond_input.get_data_handle())
@@ -256,17 +282,26 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
 
             auto &sub_select_src0_tid
                     = res->mem_map[sdp_cfg_.sub_select_src0.get()][tid];
-            const auto &select_src0_input = inputs[sdp_cfg_.graph_inport[6]];
+            const auto &select_src0_input = inputs[sdp_cfg_.graph_inport[7]];
             const auto select_src0_strides
                     = ltw(select_src0_input.get_logical_tensor()).vstrides();
             const auto select_src0_dims
                     = ltw(select_src0_input.get_logical_tensor()).vdims();
+
             size_t select_src0_offset = 0;
             if (select_src0_dims.size() == 4) {
                 if (select_src0_dims[0] != 1)
                     select_src0_offset += bo * select_src0_strides[0];
                 if (select_src0_dims[1] != 1)
                     select_src0_offset += bi * select_src0_strides[1];
+            } else if (select_src0_dims.size() == 5) {
+                if (select_src0_dims[0] != 1)
+                    select_src0_offset += bo * select_src0_strides[0];
+                if (select_src0_dims[1] != 1)
+                    select_src0_offset
+                            += wei_head_offset * select_src0_strides[1];
+                if (select_src0_dims[2] != 1)
+                    select_src0_offset += group_id * select_src0_strides[2];
             }
             sub_select_src0_tid.set_data_handle(
                     static_cast<char *>(select_src0_input.get_data_handle())
@@ -283,11 +318,14 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
         // matmul2
         auto &sub_mm2_dst_tid = res->mem_map[sdp_cfg_.sub_mm2_dst.get()][tid];
 
-        const size_t sub_src1_offset = (bo * sdp_cfg_.src1_strides[0]
-                                               + bi * sdp_cfg_.src1_strides[1])
+        const size_t sub_src1_head_offset = sdp_cfg_.ndims == 4
+                ? bi * sdp_cfg_.src1_strides[1]
+                : wei_head_offset * sdp_cfg_.src1_strides[1]
+                        + group_id * sdp_cfg_.src1_strides[2];
+        const size_t sub_src1_offset
+                = (bo * sdp_cfg_.src1_strides[0] + sub_src1_head_offset)
                 * get_mem_dt_size(sub_src1_tid);
-        const size_t group_head = sdp_cfg_.num_head_q / sdp_cfg_.num_head_kv;
-        size_t wei_head_offset = bi / group_head;
+
         const size_t sub_wei1_offset
                 = (bo * sdp_cfg_.wei1_strides[0]
                           + wei_head_offset * sdp_cfg_.wei1_strides[1])
@@ -296,8 +334,13 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
                 = (bo * sdp_cfg_.wei2_strides[0]
                           + wei_head_offset * sdp_cfg_.wei2_strides[1])
                 * get_mem_dt_size(sub_wei2_user_tid);
+
+        const size_t sub_dst_user_head_offset = sdp_cfg_.ndims == 4
+                ? bi * sdp_cfg_.dst_strides[1]
+                : wei_head_offset * sdp_cfg_.dst_strides[1]
+                        + group_id * sdp_cfg_.dst_strides[2];
         const size_t sub_dst_user_offset
-                = (bo * sdp_cfg_.dst_strides[0] + bi * sdp_cfg_.dst_strides[1])
+                = (bo * sdp_cfg_.dst_strides[0] + sub_dst_user_head_offset)
                 * get_mem_dt_size(sub_dst_user_tid);
 
         sub_wei1_user_tid.set_data_handle(wei1_user_pointer + sub_wei1_offset);

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -169,6 +169,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
     int thread_num = 1;
     dnnl_threadpool_interop_get_max_concurrency(&thread_num);
     sdp_cfg_.nthr = thread_num;
+    tp_stream->after_exec_hook();
 #endif
 
     thread_local_cache_t<sdp_args_set_t> res_cache;
@@ -326,6 +327,10 @@ status_t sdp_decomp_kernel_t<quantized, dt>::execute_impl(
         sdp_cfg_.sub_mm2_prim.execute(strm, res->sub_mm2_args[tid]);
         sdp_cfg_.sub_reorder3.execute(strm, res->sub_reorder3_args[tid]);
     };
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    tp_stream->before_exec_hook();
+#endif
+
     parallel_nd_ext(sdp_cfg_.nthr, MBO, MBI, loop);
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -87,6 +87,16 @@ public:
     // Used to record the exact input offset in subgraph
     // [mm1_src,mm1_wei,mm2_wei,mm1_scale,mm1_soft_capping,mm1_add,select_condition,select_other_input]
     std::vector<int> graph_inport;
+    enum input_index_t {
+        mm1_src = 0,
+        mm1_wei,
+        mm2_wei,
+        mm1_scale,
+        mm1_soft_capping,
+        mm1_add,
+        select_condition,
+        select_other_input
+    };
 
     // Primitives that actually perform calculations
     primitive sub_mm1_prim, sub_softmax_prim, sub_mm2_prim, sub_select_prim;

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -74,7 +74,7 @@ public:
     sdp_decomp_config_t() = default;
 
     // SDP input dimension
-    dim_t batch_size, num_head_q, num_head_kv, seq_len_q, seq_len_kv;
+    dim_t ndims, batch_size, num_head_q, num_head_kv, seq_len_q, seq_len_kv;
     dim_t head_size_qk, head_size_v;
 
     // SDP input and output strides
@@ -85,7 +85,7 @@ public:
     int nthr;
 
     // Used to record the exact input offset in subgraph
-    // [mm1_src,mm1_wei,mm1_scale,mm1_add,mm2_wei,select_condition,select_other_input]
+    // [mm1_src,mm1_wei,mm2_wei,mm1_scale,mm1_soft_capping,mm1_add,select_condition,select_other_input]
     std::vector<int> graph_inport;
 
     // Primitives that actually perform calculations
@@ -125,7 +125,8 @@ public:
     // shared memory
     memory sub_max_src1_src2, sub_max_dst1_wei2;
 
-    bool has_scale = false, has_attention_mask = false, has_select = false;
+    bool has_scale = false, has_attention_mask = false, has_select = false,
+         has_soft_capping = false;
     // Used to record the ops from select
     std::vector<op_ptr> select_op;
     std::vector<int> select_outop_index;

--- a/src/graph/backend/dnnl/passes/transform.hpp
+++ b/src/graph/backend/dnnl/passes/transform.hpp
@@ -48,6 +48,12 @@ status_t replace_quant_data_with_binary_post_op(
 
 status_t fuse_post_ops(std::shared_ptr<subgraph_t> &sg);
 
+// This pass is only used in the sdpa decompose kernel and handle matmul post
+// op. There is no any limit for matmul+post_binary about dims broadcast like
+// full tensor and per tensor broadcast. Because the implementation of sdpa
+// decompose kernel is actually 2d.
+status_t sdp_fuse_post_ops(std::shared_ptr<subgraph_t> &sg);
+
 status_t fuse_src_zero_points(std::shared_ptr<subgraph_t> &sg);
 
 status_t fuse_dst_zero_points(std::shared_ptr<subgraph_t> &sg);

--- a/src/graph/backend/dnnl/patterns/utils.hpp
+++ b/src/graph/backend/dnnl/patterns/utils.hpp
@@ -429,6 +429,20 @@ inline graph::utils::pm::repetition_t *optional_explicit_mask(
     return optional_mask;
 }
 
+inline graph::utils::pm::repetition_t *optional_soft_capping(
+        const std::shared_ptr<graph::utils::pm::pb_graph_t> &pgraph,
+        graph::utils::pm::pb_node_t *input) {
+    auto graph = std::make_shared<graph::utils::pm::pb_graph_t>();
+    auto tanh = graph->append_op(graph::op_kind::Tanh);
+    auto multiply = graph->append_op(graph::op_kind::Multiply,
+            graph::utils::pm::in_edges_t {in_edge(0, tanh, 0)});
+    graph->create_input_port(0, tanh, 0);
+    graph->create_output_port(0, multiply, 0);
+    auto optional_soft_capping
+            = pgraph->append_optional(graph, {in_edge(0, input, 0)});
+    return optional_soft_capping;
+}
+
 inline bool check_inputs_xf16(op_t *op) {
     for (size_t i = 0; i < op->num_inputs(); ++i) {
         const logical_tensor_t &iport

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -39,6 +39,18 @@
 --reset --dt=2:f32+6:f32 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --case=complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
 
+--reset --case=complex_fusion/mha/codegemma-bf16-f32.json
+--reset --in-shapes=0:1x16x2x256+1:1x16x256x2+5:1x16x2x2+9:1x16x2x256 --case=complex_fusion/mha/codegemma-bf16-f32.json
+--reset --in-shapes=0:1x16x257x256+1:1x16x256x257+5:1x16x257x257+9:1x16x257x256 --case=complex_fusion/mha/codegemma-bf16-f32.json
+--reset --in-shapes=0:1x16x1x256+1:1x16x256x257+5:1x16x1x257+9:1x16x257x256 --case=complex_fusion/mha/codegemma-bf16-f32.json
+--reset --op-attrs=0:transpose_b:1 --in-shapes=0:1x16x2x256+1:1x16x2x256+5:1x16x2x2+9:1x16x2x256 --case=complex_fusion/mha/codegemma-bf16-f32.json
+
+--reset --case=complex_fusion/mha/gemma2-bf16-f32.json
+--reset --in-shapes=0:1x8x2x2x256+1:1x8x1x256x2+8:1x8x2x2x2+12:1x8x1x2x256 --case=complex_fusion/mha/gemma2-bf16-f32.json
+--reset --in-shapes=0:1x8x2x257x256+1:1x8x1x256x257+8:1x8x2x257x257+12:1x8x1x257x256 --case=complex_fusion/mha/gemma2-bf16-f32.json
+--reset --in-shapes=0:1x8x2x1x256+1:1x8x1x256x257+8:1x8x2x1x257+12:1x8x1x257x256 --case=complex_fusion/mha/gemma2-bf16-f32.json
+--reset --op-attrs=0:transpose_b:1 --case=complex_fusion/mha/gemma2-bf16-f32.json
+
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 --reset --dt=3:bf16+4:bf16+2:bf16+1:bf16+11:bf16+0:bf16+12:bf16+14:bf16+16:bf16 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -16,6 +16,8 @@
 --reset --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
 --reset --dt=4:f32+9:f32+14:f32 --case=complex_fusion/mha/GQA-fp16-v2.json
 --reset --case=complex_fusion/mha/sdpa-plain-bottom-right-implicit-causal-mask-f16-f32.json
+--reset --case=complex_fusion/mha/codegemma-bf16-f32.json
+--reset --case=complex_fusion/mha/gemma2-bf16-f32.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --dt=1:bf16+2:bf16+3:bf16+4:bf16+5:bf16+6:bf16+104:bf16 --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/codegemma-bf16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/codegemma-bf16-f32.json
@@ -1,0 +1,336 @@
+{
+    "version": "3.9.0",
+    "engine_kind": "cpu",
+    "fpmath_mode": "strict",
+    "fpmath_mode_apply_to_int": "false",
+    "input_ports": [
+        0,
+        1,
+        3,
+        5,
+        6,
+        9
+    ],
+    "output_ports": [
+        10
+    ],
+    "graph": [
+        {
+            "id": 0,
+            "name": "matmul_1",
+            "kind": "MatMul",
+            "attrs": {
+                "transpose_a": {
+                    "type": "bool",
+                    "value": 0
+                },
+                "transpose_b": {
+                    "type": "bool",
+                    "value": 0
+                }
+            },
+            "inputs": [
+                {
+                    "id": 0,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 1,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 2,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 1,
+            "name": "multiply_1",
+            "kind": "Multiply",
+            "attrs": {
+                "auto_broadcast": {
+                    "type": "string",
+                    "value": "numpy"
+                }
+            },
+            "inputs": [
+                {
+                    "id": 2,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 3,
+                    "dtype": "f32",
+                    "shape": [
+                        1
+                    ],
+                    "stride": [
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 4,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "select",
+            "kind": "Select",
+            "attrs": {
+                "auto_broadcast": {
+                    "type": "string",
+                    "value": "numpy"
+                }
+            },
+            "inputs": [
+                {
+                    "id": 5,
+                    "dtype": "boolean",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 6,
+                    "dtype": "f32",
+                    "shape": [
+                        1
+                    ],
+                    "stride": [
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 4,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 7,
+                    "dtype": "f32",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 3,
+            "name": "softmax",
+            "kind": "SoftMax",
+            "attrs": {
+                "axis": {
+                    "type": "s64",
+                    "value": -1
+                }
+            },
+            "inputs": [
+                {
+                    "id": 7,
+                    "dtype": "f32",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 8,
+                    "dtype": "bf16",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 4,
+            "name": "matmul_2",
+            "kind": "MatMul",
+            "attrs": {
+                "transpose_a": {
+                    "type": "bool",
+                    "value": 0
+                },
+                "transpose_b": {
+                    "type": "bool",
+                    "value": 0
+                }
+            },
+            "inputs": [
+                {
+                    "id": 8,
+                    "dtype": "bf16",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 9,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 10,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        16,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        1048576,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/gemma2-bf16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/gemma2-bf16-f32.json
@@ -1,0 +1,472 @@
+{
+    "version": "3.9.0",
+    "engine_kind": "cpu",
+    "fpmath_mode": "strict",
+    "fpmath_mode_apply_to_int": "false",
+    "input_ports": [
+        0,
+        1,
+        3,
+        6,
+        8,
+        9,
+        12
+    ],
+    "output_ports": [
+        13
+    ],
+    "graph": [
+        {
+            "id": 0,
+            "name": "matmul_1",
+            "kind": "MatMul",
+            "attrs": {
+                "transpose_a": {
+                    "type": "bool",
+                    "value": 0
+                },
+                "transpose_b": {
+                    "type": "bool",
+                    "value": 0
+                }
+            },
+            "inputs": [
+                {
+                    "id": 0,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 1,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        8,
+                        1,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        524288,
+                        65536,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 2,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 1,
+            "name": "multiply_1",
+            "kind": "Multiply",
+            "attrs": {
+                "auto_broadcast": {
+                    "type": "string",
+                    "value": "numpy"
+                }
+            },
+            "inputs": [
+                {
+                    "id": 2,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 3,
+                    "dtype": "f32",
+                    "shape": [
+                        1
+                    ],
+                    "stride": [
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 4,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 2,
+            "name": "tanh",
+            "kind": "Tanh",
+            "attrs": {},
+            "inputs": [
+                {
+                    "id": 4,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 5,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 3,
+            "name": "multiply_2",
+            "kind": "Multiply",
+            "attrs": {
+                "auto_broadcast": {
+                    "type": "string",
+                    "value": "numpy"
+                }
+            },
+            "inputs": [
+                {
+                    "id": 5,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 6,
+                    "dtype": "f32",
+                    "shape": [
+                        1
+                    ],
+                    "stride": [
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 7,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 4,
+            "name": "select",
+            "kind": "Select",
+            "attrs": {
+                "auto_broadcast": {
+                    "type": "string",
+                    "value": "numpy"
+                }
+            },
+            "inputs": [
+                {
+                    "id": 8,
+                    "dtype": "boolean",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 9,
+                    "dtype": "f32",
+                    "shape": [
+                        1
+                    ],
+                    "stride": [
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 7,
+                    "dtype": "f32",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 10,
+                    "dtype": "f32",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 5,
+            "name": "softmax",
+            "kind": "SoftMax",
+            "attrs": {
+                "axis": {
+                    "type": "s64",
+                    "value": -1
+                }
+            },
+            "inputs": [
+                {
+                    "id": 10,
+                    "dtype": "f32",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 11,
+                    "dtype": "bf16",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        },
+        {
+            "id": 6,
+            "name": "matmul_2",
+            "kind": "MatMul",
+            "attrs": {
+                "transpose_a": {
+                    "type": "bool",
+                    "value": 0
+                },
+                "transpose_b": {
+                    "type": "bool",
+                    "value": 0
+                }
+            },
+            "inputs": [
+                {
+                    "id": 11,
+                    "dtype": "bf16",
+                    "shape": [
+                        -9223372036854775808
+                    ],
+                    "stride": [
+                        -9223372036854775808
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                },
+                {
+                    "id": 12,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        8,
+                        1,
+                        256,
+                        256
+                    ],
+                    "stride": [
+                        524288,
+                        65536,
+                        65536,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ],
+            "outputs": [
+                {
+                    "id": 13,
+                    "dtype": "bf16",
+                    "shape": [
+                        1,
+                        8,
+                        2,
+                        1,
+                        256
+                    ],
+                    "stride": [
+                        4096,
+                        512,
+                        256,
+                        256,
+                        1
+                    ],
+                    "layout_type": "strided",
+                    "property_type": "undef"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Description
Support the code-gemma and gemma2 pattern from TensorFlow team with larger partition and decompose kernel. In this PR, we support the following 2 new features.
1. We support the[ soft-capping mechanism](https://huggingface.co/blog/gemma2#soft-capping-and-attention-implementations) （tanh+multiply）
2. We support the 5d input GQA in the decompose kernel.
