### PR TITLE
benchdnn: graph: enhance batch size rewrite for SDPA

### DIFF
--- a/tests/benchdnn/graph/deserialize.cpp
+++ b/tests/benchdnn/graph/deserialize.cpp
@@ -522,6 +522,17 @@ bool deserialized_graph_t::check_tensor_with_mb(size_t tensor_id,
     if (mb_rewrite_ret.find(tensor_id) != mb_rewrite_ret.end())
         return mb_rewrite_ret.at(tensor_id);
 
+    const auto broadcast_mb_rewrite
+            = [tensor_id](const deserialized_op_t &aop) -> bool {
+        const deserialized_lt *target_lt = nullptr;
+        int max_rank = 0;
+        for (const auto &lt : aop.in_lts_) {
+            max_rank = MAX2(max_rank, static_cast<int>(lt.shape_.size()));
+            if (lt.id_ == tensor_id) { target_lt = &lt; }
+        }
+        return static_cast<int>(target_lt->shape_.size()) == max_rank;
+    };
+
     bool ret = true;
     // TODO: initialize with false to avoid multiple re-initialization
     for (const auto &aop : in_lt_2_ops_.at(tensor_id)) {
@@ -531,12 +542,17 @@ bool deserialized_graph_t::check_tensor_with_mb(size_t tensor_id,
                         || tensor_id == aop.in_lts_[1].id_);
         // The second and third inputs of dynamic dequantize are allowed to
         // rewrite md only when the sebsequent op supports mb rewriting.
+        std::string qtype;
         const bool dynamicdq_mb_rewrite = (aop.kind_ == "DynamicDequantize")
                 && aop.in_lts_[0].shape_.size() > 2
                 && check_tensor_with_mb(aop.out_lts_[0].id_, mb_rewrite_ret)
-                && (tensor_id == aop.in_lts_[0].id_
-                        || tensor_id == aop.in_lts_[1].id_
-                        || tensor_id == aop.in_lts_[2].id_);
+                && aop.get_attr_string(qtype, "qtype")
+                && ((qtype == "per_group"
+                            && (tensor_id == aop.in_lts_[0].id_
+                                    || tensor_id == aop.in_lts_[1].id_
+                                    || tensor_id == aop.in_lts_[2].id_))
+                        || ((qtype == "per_channel" || qtype == "per_tensor")
+                                && tensor_id == aop.in_lts_[0].id_));
 
         if (std::find(unsupport_mb_rewrite_ops_.begin(),
                     unsupport_mb_rewrite_ops_.end(), aop.kind_)
@@ -561,16 +577,11 @@ bool deserialized_graph_t::check_tensor_with_mb(size_t tensor_id,
                 ret = check_tensor_with_mb(aop.out_lts_[0].id_, mb_rewrite_ret);
             }
         } else if (std::find(binary_ops_.begin(), binary_ops_.end(), aop.kind_)
-                != binary_ops_.end()) {
+                        != binary_ops_.end()
+                || aop.kind_ == "Select") {
             // binary ops need consider rank of 2 inputs
             ret = false;
-            size_t max_rank_id = aop.in_lts_[0].shape_.size()
-                            >= aop.in_lts_[1].shape_.size()
-                    ? aop.in_lts_[0].id_
-                    : aop.in_lts_[1].id_;
-            if ((aop.in_lts_[0].shape_.size() == aop.in_lts_[1].shape_.size()
-                        && aop.in_lts_[1].shape_[0] != 1)
-                    || tensor_id == max_rank_id) {
+            if (broadcast_mb_rewrite(aop)) {
                 ret = check_tensor_with_mb(aop.out_lts_[0].id_, mb_rewrite_ret);
             }
         } else if (aop.kind_ == "PReLU" && tensor_id == aop.in_lts_[1].id_) {

--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -194,7 +194,8 @@ void flex_rewrite_t::rewrite(deserialized_graph_t &dgraph) {
     bool change_stride = false;
     inports_shape_rewrite(dgraph, change_stride);
     if (!(op_attrs_.size() == 1 && op_attrs_.count(0)
-                && op_attrs_.at(0) == "default")) {
+                && op_attrs_.at(0) == "default")
+            || mb_ != 0) {
         op_attrs_rewrite(dgraph);
     }
     infer_output_shape(dgraph, change_stride);
@@ -1129,9 +1130,17 @@ void flex_rewrite_t::inports_shape_rewrite(
 void flex_rewrite_t::op_attrs_rewrite(deserialized_graph_t &dgraph) {
     std::vector<size_t> op_ids_;
     op_ids_.reserve(dgraph.ops_.size());
-    for (const auto &aop : dgraph.ops_) {
+    for (auto &aop : dgraph.ops_) {
         op_ids_.emplace_back(aop.id_);
+        if (aop.kind_ == "StaticReshape" && mb_ != 0) {
+            auto &shape = aop.attrs_["shape"].s64_vector_;
+            shape.front() = mb_;
+        }
     }
+
+    if (op_attrs_.size() == 1 && op_attrs_.count(0)
+            && op_attrs_.at(0) == "default")
+        return;
 
     for (const auto &temp_attrs : op_attrs_) {
         auto iter = std::find(op_ids_.begin(), op_ids_.end(), temp_attrs.first);

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -61,13 +61,13 @@
 --reset --case=complex_fusion/mha/sdpa-compressed-kv-implicit-causal-mask-int8-gs128.json
 
 # Re-written graphs
---reset --dt=f32,bf16,f16 --in-shapes=4:4x16x32x256+5:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
+--reset --dt=f32,bf16,f16 --mb=4 --case=complex_fusion/mha/MHA-GPT-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --mb=20 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=3:10x16x384x64+4:10x1x64x384+0:10x1x384x64+1:10x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=4:56x12x128x64+5:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
+--reset --dt=f32,bf16,f16 --mb=56 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=2:1x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=0:56x8x1024x80+1:56x8x77x80+2:56x8x77x80 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
---reset --dt=f32,bf16,f16 --in-shapes=0:20x16x384x64+1:20x16x384x64+8:20x16x384x64+5:20x1x1x384 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
+--reset --dt=f32,bf16,f16 --mb=56 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
+--reset --dt=f32,bf16,f16 --mb=20 --case=complex_fusion/mha/sdpa-plain-wo-scale-f16-bs1.json
 --reset --dt=f32,bf16,f16 --in-shapes=5:1x1x384x384,5:1x16x384x384 --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:2x16x384x64+1:2x16x384x64+5:2x1x1x384+8:2x16x384x64  --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
 --reset --dt=f32,bf16,f16 --in-shapes=0:32x16x128x64+1:32x16x128x64+5:32x16x128x128+8:32x16x128x64  --case=complex_fusion/mha/sdpa-plain-simplified-f16.json
@@ -80,11 +80,11 @@
 --reset --dt=f32,bf16,f16 --op-attrs=40:axis:-2+41:axis:-1 --in-shapes=1:1x32x128x64+2:1x32x128x64+3:1x32x128x64 --case=complex_fusion/mha/sdpa-plain-implicit-causal-mask-fp32-bs1.json
 
 # Re-written int8 graphs
---reset --in-shapes=5:4x16x32x256+4:4x16x256x33+0:4x16x33x256+1:4x1x1x33+3:4x1x32x33 --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
---reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
---reset --in-shapes=5:56x12x128x64+4:56x12x64x128+0:56x12x128x64+1:56x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
+--reset --mb=4 --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json
+--reset --mb=20 --case=complex_fusion/mha/MHA-bert_large-inf-int8-bs1.json
+--reset --mb=56 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
 --reset --in-shapes=2:1x1x1x128 --case=complex_fusion/mha/MHA-distill_bert-inf-int8-bs1.json
---reset --in-shapes=4:20x16x384x64+3:20x16x64x384+0:20x16x384x64+1:20x1x1x384 --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
+--reset --mb=20 --case=complex_fusion/mha/sdpa-plain-wo-scale-int8-bs1.json
 --reset --in-shapes=0:1x32x96x384*abdc+1:1x32x1x384+2:1x32x1x384+3:1x32x384x96+6:1x32x384x96+7:1x32x384x1+8:1x32x384x1 --op-attrs=0:group_shape:1x1x96x1+8:group_shape:1x1x1x96 --case=complex_fusion/mha/sdpa-compressed-kv-implicit-causal-mask-int8-gs128.json
 
 # phi3-mini-4k-instruct


### PR DESCRIPTION
## Description

The PR keeps enhancing the batch rewriting mechanism to support more SDPA patterns:
1. Support mb rewrite for broadcasting ops such as select.
2. Support mb rewrite for staticReshape, which indicates shape information in the attribute.