### PR TITLE
common: verbose: print info for conditional tensor for binary select

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -636,6 +636,7 @@ int get_arg_index(int arg) {
     switch (arg) {
         case DNNL_ARG_SRC_0: return 0;
         case DNNL_ARG_SRC_1: return 1;
+        case DNNL_ARG_SRC_2: return 2;
         default: return -1;
     }
     return -1;
@@ -647,7 +648,8 @@ std::string get_arg(int arg) {
     std::string s;
     switch (arg) {
         case DNNL_ARG_SRC: // DNNL_ARG_SRC_0
-        case DNNL_ARG_SRC_1: s = "src"; break;
+        case DNNL_ARG_SRC_1:
+        case DNNL_ARG_SRC_2: s = "src"; break;
         case DNNL_ARG_DST: s = "dst"; break;
         case DNNL_ARG_WEIGHTS: s = "wei"; break;
         case DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST:
@@ -864,6 +866,12 @@ std::string init_info_binary(const engine_t *e, const pd_t *pd) {
        << " ";
     ss << md2fmt_str("src", src1_md, pd->invariant_src_user_format_kind(1))
        << " ";
+    if (pd->desc()->alg_kind == alg_kind_t::dnnl_binary_select) {
+        auto src2_md = pd->invariant_src_md(2);
+        ss << md2fmt_str("src", src2_md, pd->invariant_src_user_format_kind(2))
+           << " ";
+    }
+
     ss << md2fmt_str("dst", dst_md, pd->invariant_dst_user_format_kind());
 
     ss << "," << pd->attr() << ",";


### PR DESCRIPTION
The PR enables printing verbose info for the conditional (`src2`) tensor for the binary select primitive operations.
Addresses MFDNN-13617.

#### New Output:
```
DNNL_VERBOSE=profile_exec ./tests/benchdnn/benchdnn --binary --engine=gpu --sdt=f32:f32 --ddt=s8 --stag=nhwc:nchw --alg=SELECT 3x5x6x9:3
onednn_verbose,v1,info,oneDNN v3.9.0 (commit 974d84ac3703de539b080faf0e20da9f78e664d4)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with float16, Intel DL Boost and bfloat16 support 
onednn_verbose,v1,info,gpu,runtime:OpenCL
onednn_verbose,v1,info,gpu,engine,opencl device count:1 
onednn_verbose,v1,info,gpu,engine,0,name:Intel(R) Data Center GPU Max 1100,driver_version:23.43.27642,binary_kernels:enabled
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:abcd::f0 dst:s8::blocked:acdb::f0,,,3x5x6x9,0.00390625
onednn_verbose,v1,primitive,exec,cpu,reorder,jit_direct_copy:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,3x1x1x1,0.000976562
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:acdb::f0,,,3x5x6x9,0.00195312
onednn_verbose,v1,primitive,exec,gpu,binary,ocl:simple:any,undef,src:f32::blocked:acdb::f0 src:f32::blocked:abcd::f0 src:s8::blocked:acdb::f0 dst:s8:a:blocked:acdb::f0,,alg:binary_select,3x5x6x9:3x1x1x1,1.4939
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:s8::blocked:acdb::f0 dst:f32::blocked:abcd::f0,,,3x5x6x9,0.00488281
0:PASSED (865 ms) __REPRO: --binary --engine=gpu --ddt=s8 --stag=nhwc:nchw --alg=select 3x5x6x9:3x1x1x1
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.88s; create_pd: 0.02s (3%); create_prim: 0.46s (53%); fill: 0.14s (16%); execute: 0.00s (0%); compute_ref: 0.00s (0%); compare: 0.01s (1%);
```
