### PR TITLE
xe: sdpa: Fix LNL config with head_size of 512

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa_configs.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa_configs.cpp
@@ -190,7 +190,7 @@ sdpa_config_t xe2_q_h512_s64_2nd = {16, 16, 64, 16, 8, 1, 8, 1};
 sdpa_config_t xe2_q_h512_2nd = {16, 16, 64, 16, 16, 1, 16, 1};
 
 sdpa_config_t xe2_h512_s128_integrated = {16, 16, 64, 16, 8, 2, 8, 2};
-sdpa_config_t xe2_h512_integrated = {16, 16, 32, 16, 16, 1, 16, 1};
+sdpa_config_t xe2_h512_integrated = {16, 16, 16, 16, 32, 1, 32, 1};
 
 sdpa_config_t xe2_h512_s256_2nd_integrated = {16, 16, 64, 16, 8, 1, 8, 1};
 sdpa_config_t xe2_h512_s1024_2nd_integrated = {16, 16, 64, 16, 8, 2, 8, 2};


### PR DESCRIPTION
# Description

Some configurations were freezing on LNL systems with a head size of 512. This PR fixes the offending configuration by reducing the tile size of each tile and increasing the number of sub-groups per work-group.

Fixes [MFDNN-13646](https://jira.devtools.intel.com/browse/MFDNN-13646)