### PR TITLE
intel: ocl: rnn: modify k_limit to fix pvc regression

### DIFF
--- a/src/gpu/intel/ocl/rnn/utils.cpp
+++ b/src/gpu/intel/ocl/rnn/utils.cpp
@@ -183,12 +183,9 @@ void rnn_utils::init_rnn_conf(conf_t &rnn, const rnn_desc_t &rd,
 
         // For large enough k dimension, parallelization in external gemm
         // kernels is more performant.
-        int eu_count = device_info.eu_count();
-        int ideal_k_block = math::lcm(
-                (int)eu_count, (int)device_info.min_subgroup_size());
-        int ideal_k_limit = math::lcm((int)ideal_k_block, (int)rnn.sic);
-        dim_t k_limit = tail_dhc ? 50 : 160;
-        k_limit = tail_dhc ? 50 : ideal_k_limit;
+        int ideal_k_limit
+                = math::lcm((int)device_info.min_subgroup_size(), (int)rnn.sic);
+        dim_t k_limit = tail_dhc ? 50 : nstl::min(256, ideal_k_limit);
 
         // The fused gemm implementation assumes the dst channel dimension is
         // dense


### PR DESCRIPTION
# Description
These regressions occured as a result of changing the k_limit for fused kernels in RNN while LBR_GRU was added to the existing available algorithms.
Machine: PVC 141703
Base Commit: 34d53b4
Following graphs show that the performance was restored.
Regression graph:
![image](https://github.com/user-attachments/assets/83671f25-e4e6-46f6-a358-8bf1ed793059)


Graph after proposed changes:
![image](https://github.com/user-attachments/assets/f8c6208f-e194-44e8-889a-d08011158158)

