### PR TITLE
gtests: graph: unit: fix the filling of test tensors

### DIFF
--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -174,7 +174,9 @@ dnnl::stream make_dnnl_stream(
 
 dnnl::memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt) {
     const logical_tensor_wrapper_t ltw(lt);
-    const auto dtype = static_cast<dnnl::memory::data_type>(ltw.data_type());
+    const auto dtype = ltw.data_type() == graph::data_type::boolean
+            ? data_type::u8
+            : static_cast<data_type>(ltw.data_type());
 
     if (ltw.is_opaque()) {
 #ifdef DNNL_GRAPH_LAYOUT_DEBUG

--- a/tests/gtests/graph/unit/unit_test_common.cpp
+++ b/tests/gtests/graph/unit/unit_test_common.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 
 #include "test_allocator.hpp"
 #include "unit/unit_test_common.hpp"
+
+#include "graph/backend/dnnl/common.hpp"
 
 namespace graph = dnnl::impl::graph;
 
@@ -132,4 +134,9 @@ graph::engine_kind_t get_test_engine_kind() {
 
 void set_test_engine_kind(graph::engine_kind_t kind) {
     test_engine_kind = kind;
+}
+
+dnnl::memory make_memory_from_tensor(const graph::tensor_t &t) {
+    auto eng = graph::dnnl_impl::make_dnnl_engine(*(t.get_engine()));
+    return graph::dnnl_impl::make_dnnl_memory(t, eng);
 }


### PR DESCRIPTION
- A minor fix for creating memory descriptor from logical tensor as boolean data type is not publicly supported by memory descriptor.
- Use memory's map/unmap function to fill test tensors as some test tensors have device buffers which are not accessible on host side.