### PR TITLE
graph: backend: dnnl: deconv pattern name refactor

### DIFF
--- a/src/graph/backend/dnnl/patterns/convtranspose_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/convtranspose_fusion.cpp
@@ -50,9 +50,7 @@ DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(convtranspose_fusion)
                 |
               [bias]*
                 |
-        [ Abs/Clamp/Elu/GELU/Log/Sigmoid/SoftPlus/
-          ReLU/Round/Sqrt/Square/Tanh/Add/Multiply/
-          Maximum/Minimum/Divide/Subtract]*[0,3]
+[unary/binary]*[0,MAX_REPETITION)
                 |
             [quant_out]*  
                 |      
@@ -67,7 +65,7 @@ While CPU supports.
 */
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(
-        dnnl, int8_convtranspose_post_ops_fusion_cpu)
+        dnnl, x8s8x8_convtranspose_post_ops_cpu)
         .set_priority(10.5f)
         .set_engine_kind(engine_kind::cpu)
         .set_kind(partition_kind_t::quantized_convtranspose_post_ops)
@@ -138,7 +136,7 @@ While CPU supports.
 */
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(
-        dnnl, int8_convtranspose_post_ops_fusion_gpu)
+        dnnl, x8s8x8_convtranspose_post_ops_gpu)
         .set_priority(10.5f)
         .set_engine_kind(engine_kind::gpu)
         .set_kind(partition_kind_t::quantized_convtranspose_post_ops)
@@ -218,9 +216,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(
                 |     /
                add
                 |
-        [ Abs/Clamp/Elu/GELU/Log/Sigmoid/SoftPlus/
-          ReLU/Round/Sqrt/Square/Tanh/Add/Multiply/
-          Maximum/Minimum/Divide/Subtract]*[0,3]
+[unary/binary]*[0,MAX_REPETITION)
                 |
             quant_out 
                 |      
@@ -236,7 +232,7 @@ While CPU supports.
 */
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(
-        dnnl, int8_convtranspose_add_post_ops_fusion_cpu)
+        dnnl, x8s8x8_convtranspose_add_post_ops_cpu)
         .set_priority(10.6f)
         .set_engine_kind(engine_kind::cpu)
         .set_kind(partition_kind_t::quantized_convtranspose_post_ops)
@@ -296,7 +292,7 @@ While CPU supports.
 */
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE
 DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(
-        dnnl, int8_convtranspose_add_post_ops_fusion_gpu)
+        dnnl, x8s8x8_convtranspose_add_post_ops_gpu)
         .set_priority(10.6f)
         .set_engine_kind(engine_kind::gpu)
         .set_kind(partition_kind_t::quantized_convtranspose_post_ops)
@@ -354,8 +350,15 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(
             return std::make_shared<quantized_convtranspose>();
         });
 #endif
-
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, convtranspose_post_ops_fusion)
+/*
+          convtranspose
+                |
+              [bias]*
+                |
+[unary/binary]*[0,MAX_REPETITION)
+                |
+*/
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_convtranspose_post_ops)
         .set_priority(10.4f)
         .set_kind(partition_kind_t::convtranspose_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",

--- a/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
@@ -109,7 +109,7 @@ public:
         g.finalize();
 
         graph::pass::pass_base_ptr apass
-                = get_pass("convtranspose_post_ops_fusion");
+                = get_pass("fp_convtranspose_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -431,7 +431,7 @@ public:
         g.finalize();
 
         graph::pass::pass_base_ptr apass
-                = get_pass("convtranspose_post_ops_fusion");
+                = get_pass("fp_convtranspose_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -804,7 +804,7 @@ TEST(test_convtranspose_operator_kernel, convtranspose_relu) {
         g.finalize();
 
         graph::pass::pass_base_ptr apass
-                = get_pass("convtranspose_post_ops_fusion");
+                = get_pass("fp_convtranspose_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -906,7 +906,7 @@ TEST(test_convtranspose_operator_kernel, convtranspose_swish) {
         g.finalize();
 
         graph::pass::pass_base_ptr apass
-                = get_pass("convtranspose_post_ops_fusion");
+                = get_pass("fp_convtranspose_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -1047,8 +1047,8 @@ TEST(test_convtranspose_execute_subgraph_int8,
     // -------------------------case 2----------------------------------
     graph::pass::pass_base_ptr apass
             = get_pass(engine->kind() == graph::engine_kind::gpu
-                            ? "int8_convtranspose_post_ops_fusion_gpu"
-                            : "int8_convtranspose_post_ops_fusion_cpu");
+                            ? "x8s8x8_convtranspose_post_ops_gpu"
+                            : "x8s8x8_convtranspose_post_ops_cpu");
     ASSERT_TRUE(apass != nullptr);
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -1185,7 +1185,7 @@ TEST(test_convtranspose_execute_subgraph_int8,
 
     // -------------------------case 2----------------------------------
     graph::pass::pass_base_ptr apass
-            = get_pass("int8_convtranspose_post_ops_fusion_cpu");
+            = get_pass("x8s8x8_convtranspose_post_ops_cpu");
     ASSERT_TRUE(apass != nullptr);
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -1368,8 +1368,8 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3d) {
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
                 = get_pass(engine->kind() == graph::engine_kind::gpu
-                                ? "int8_convtranspose_post_ops_fusion_gpu"
-                                : "int8_convtranspose_post_ops_fusion_cpu");
+                                ? "x8s8x8_convtranspose_post_ops_gpu"
+                                : "x8s8x8_convtranspose_post_ops_cpu");
         ASSERT_TRUE(apass != nullptr);
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
@@ -1610,7 +1610,7 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose2dEltwise_CPU) {
 
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
-                = get_pass("int8_convtranspose_post_ops_fusion_cpu");
+                = get_pass("x8s8x8_convtranspose_post_ops_cpu");
         ASSERT_TRUE(apass != nullptr);
         apass->run(graph);
         ASSERT_EQ(graph.get_num_partitions(), 1U);
@@ -1824,7 +1824,7 @@ TEST(test_convtranspose_execute_subgraph_int8,
 
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
-                = get_pass("int8_convtranspose_post_ops_fusion_cpu");
+                = get_pass("x8s8x8_convtranspose_post_ops_cpu");
         ASSERT_TRUE(apass != nullptr);
         apass->run(graph);
         ASSERT_EQ(graph.get_num_partitions(), 1U);
@@ -1990,8 +1990,8 @@ TEST(test_convtranspose_execute_subgraph_int8, X8X8F32ConvTransposeSwish) {
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
                 = get_pass(engine->kind() == graph::engine_kind::gpu
-                                ? "int8_convtranspose_post_ops_fusion_gpu"
-                                : "int8_convtranspose_post_ops_fusion_cpu");
+                                ? "x8s8x8_convtranspose_post_ops_gpu"
+                                : "x8s8x8_convtranspose_post_ops_cpu");
         ASSERT_TRUE(apass != nullptr);
         apass->run(graph);
         ASSERT_EQ(graph.get_num_partitions(), 1U);
@@ -2239,8 +2239,8 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3dAdd) {
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
                 = get_pass(engine->kind() == graph::engine_kind::gpu
-                                ? "int8_convtranspose_add_post_ops_fusion_gpu"
-                                : "int8_convtranspose_add_post_ops_fusion_cpu");
+                                ? "x8s8x8_convtranspose_add_post_ops_gpu"
+                                : "x8s8x8_convtranspose_add_post_ops_cpu");
         ASSERT_TRUE(apass != nullptr);
         apass->run(graph);
         ASSERT_EQ(graph.get_num_partitions(), 1U);
@@ -2446,8 +2446,8 @@ TEST(test_convtranspose_execute_subgraph_int8, ConvTranspose1d2d3dBinary) {
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
                 = get_pass(engine->kind() == graph::engine_kind::gpu
-                                ? "int8_convtranspose_post_ops_fusion_gpu"
-                                : "int8_convtranspose_post_ops_fusion_cpu");
+                                ? "x8s8x8_convtranspose_post_ops_gpu"
+                                : "x8s8x8_convtranspose_post_ops_cpu");
         ASSERT_TRUE(apass != nullptr);
         apass->run(graph);
         ASSERT_EQ(graph.get_num_partitions(), 1U);
@@ -2692,9 +2692,9 @@ TEST(test_convtranspose_execute_subgraph_int8,
         graph.finalize();
 
         graph::pass::pass_base_ptr apass1
-                = get_pass("int8_convtranspose_add_post_ops_fusion_cpu");
+                = get_pass("x8s8x8_convtranspose_add_post_ops_cpu");
         graph::pass::pass_base_ptr apass2
-                = get_pass("int8_convtranspose_post_ops_fusion_cpu");
+                = get_pass("x8s8x8_convtranspose_post_ops_cpu");
         apass1->run(graph);
         apass2->run(graph);
         ASSERT_EQ(graph.get_num_partitions(), 2U);
@@ -2885,7 +2885,7 @@ TEST(test_convtranspose_execute_subgraph_fp32, Convtranspose3Postops) {
 
         // -------------------------case 2----------------------------------
         graph::pass::pass_base_ptr apass
-                = get_pass("convtranspose_post_ops_fusion");
+                = get_pass("fp_convtranspose_post_ops");
         ASSERT_TRUE(apass != nullptr);
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);

--- a/tests/gtests/graph/unit/backend/dnnl/test_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_pass.cpp
@@ -3259,7 +3259,7 @@ TEST(test_pass, FuseConvtransposeBiasadd) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 2U);
 
-    pass::pass_base_ptr apass = get_pass("convtranspose_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_convtranspose_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -3304,7 +3304,7 @@ TEST(test_pass, FuseConvtransposeAdd) {
         agraph.finalize();
         ASSERT_EQ(agraph.num_ops(), 2U);
 
-        pass::pass_base_ptr apass = get_pass("convtranspose_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_convtranspose_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -3357,7 +3357,7 @@ TEST(test_pass, FuseConvtransposeAddTwoInputs) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 3U);
 
-    pass::pass_base_ptr apass = get_pass("convtranspose_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_convtranspose_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -3402,7 +3402,7 @@ TEST(test_pass, FuseConvtransposeRelu) {
         agraph.finalize();
         ASSERT_EQ(agraph.num_ops(), 2U);
 
-        pass::pass_base_ptr apass = get_pass("convtranspose_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_convtranspose_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -3450,7 +3450,7 @@ TEST(test_pass, FuseConvtransposeReLUTwoInputs) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 3U);
 
-    pass::pass_base_ptr apass = get_pass("convtranspose_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_convtranspose_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -13372,7 +13372,7 @@ TEST(test_pass, FuseToInt8ConvTransposeAdd_CPU) {
         agraph.finalize();
 
         pass::pass_base_ptr apass
-                = get_pass("int8_convtranspose_add_post_ops_fusion_cpu");
+                = get_pass("x8s8x8_convtranspose_add_post_ops_cpu");
         ASSERT_NE(apass, nullptr);
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -13614,7 +13614,7 @@ TEST(test_pass, FuseToInt8ConvtransposeEltwise_CPU) {
             agraph.finalize();
 
             pass::pass_base_ptr apass
-                    = get_pass("int8_convtranspose_post_ops_fusion_cpu");
+                    = get_pass("x8s8x8_convtranspose_post_ops_cpu");
             ASSERT_TRUE(apass != nullptr);
             apass->run(agraph);
             ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -13848,7 +13848,7 @@ TEST(test_pass, FuseToInt8ConvtransposeBinary_CPU) {
             agraph.finalize();
 
             pass::pass_base_ptr apass
-                    = get_pass("int8_convtranspose_post_ops_fusion_cpu");
+                    = get_pass("x8s8x8_convtranspose_post_ops_cpu");
             ASSERT_TRUE(apass != nullptr);
             apass->run(agraph);
             ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -14438,7 +14438,7 @@ TEST(test_pass, ConvtransposePostops) {
                     agraph.finalize();
 
                     pass::pass_base_ptr apass
-                            = get_pass("convtranspose_post_ops_fusion");
+                            = get_pass("fp_convtranspose_post_ops");
                     apass->run(agraph);
                     ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -14587,7 +14587,7 @@ TEST(test_pass, Convtranspose3Postops) {
 
         agraph.finalize();
 
-        pass::pass_base_ptr apass = get_pass("convtranspose_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_convtranspose_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 


### PR DESCRIPTION
# Description

Refactored the deconv pattern according to document *DNNL Backend Fusion Pattern Definition*:
1. Replaced `int8` in pattern names with `x8s8x8`
2. Removed the word `fusion` from pattern names
3. Updated comments: changed `[ Abs/Clamp...]*[0,3]` to `[unary/binary]*[0,MAX_REPETITION)`
4. For floating-point patterns, added the `fp_` prefix to their names


Task MFDNN-10451.