### PR TITLE
x64: matmul: Fix nthr issues in matmul

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -754,7 +754,7 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
     current_lda_ = get_actual_lda();
 
     // Need a temp C buffer if a BRGEMM creates partial results
-    need_buf_c_ = (nthr_k_ != 1) || (k_blk_ != K);
+    need_buf_c_ = (nthr_k_ > 1);
 
     efficiency_score_ = calculate_blocking_scores();
 

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -830,6 +830,7 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
         const int min_N_blk = !bgmmc.is_runtime_N && low_parallelism
                         && is_amx_xf16 && !bm_conf_utils.check_n_blk_fixed()
                         && bgmmc.N_blk > 32 && !runtime_dims
+                        && !bgmmc.transposed_B // Transposed copy B kernel doesn't support adjusting N_blk
                 ? 32
                 : bgmmc.N_blk;
         const int desired_M_chunk = bgmmc.is_runtime_M

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1791,21 +1791,12 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
 
     bgmmc.buffer_a_per_thread_sz = bgmmc.buffer_a_m_stride * bgmmc.M_chunk_size;
 
-    bgmmc.buffer_b_gb_stride = bgmmc.tr_b_dt_sz * rnd_up(bgmmc.LDB, bgmmc.N_blk)
-            * bgmmc.wei_k_blk;
+    bgmmc.buffer_b_gb_stride
+            = bgmmc.tr_b_dt_sz * bgmmc.LDB * bgmmc.K_blk * bgmmc.wei_k_blk;
     bgmmc.buffer_b_k_brg_stride
-            = bgmmc.buffer_b_gb_stride * bgmmc.K_chunk_size * bgmmc.K_blk;
-
-    // TODO: (Refactoring) the only usage of `buffer_b_chunk_sz`
-    // and `buffer_b_n_blk_stride` is here. Remove it if not needed.
-    bgmmc.buffer_b_n_blk_stride = bgmmc.tr_b_dt_sz
-            * ((bgmmc.N_blk / bgmmc.LDB) * bgmmc.LDB2
-                    + (bgmmc.N_blk % bgmmc.LDB)
-                            * data_type_vnni_granularity(bgmmc.wei_dt));
-
-    bgmmc.buffer_b_chunk_sz
-            = bgmmc.buffer_b_k_brg_stride * bgmmc.brgemm_batch_size;
-    bgmmc.buffer_b_per_thread_sz = bgmmc.buffer_b_chunk_sz;
+            = bgmmc.buffer_b_gb_stride * bgmmc.brgemm_batch_size;
+    bgmmc.buffer_b_per_thread_sz
+            = bgmmc.buffer_b_k_brg_stride * bgmmc.K_chunk_size;
 
     bgmmc.buffer_reduce_per_thread_sz = 0;
     if (bgmmc.reduce_kind == matmul_reduce_kind::src) {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -694,13 +694,12 @@ struct matmul_avx512_blocking_params_t {
         return lda;
     }
 
-    inline bool is_buffer_c_required(
-            dim_t acc_dt, dim_t dst_dt, bool with_sum) const {
-        const size_t k_chunk_elems = k_blk * batch_size;
+    inline bool is_buffer_c_required(const brgemm_matmul_conf_t &bgmmc) const {
+        const size_t k_chunk_elems = bgmmc.K_chunk_elems;
         if (nthr_k > 1 && static_cast<size_t>(mp.K) > k_chunk_elems)
             return true;
 
-        return ((acc_dt != dst_dt || with_sum)
+        return ((bgmmc.acc_dt != bgmmc.dst_dt || bgmmc.with_sum)
                 && (static_cast<size_t>(mp.K) > k_chunk_elems
                         || mp.K % k_blk > 0));
     }
@@ -716,8 +715,7 @@ struct matmul_avx512_blocking_params_t {
 
         bgmmc.nthr_k = nthr_k;
 
-        bgmmc.use_buffer_c = is_buffer_c_required(
-                bgmmc.acc_dt, bgmmc.dst_dt, bgmmc.with_sum);
+        bgmmc.use_buffer_c = is_buffer_c_required(bgmmc);
         bgmmc.LDA = bgmmc.adjust_a_strides || bgmmc.use_buffer_a
                         || bgmmc.treat_A_as_plain
                 ? get_actual_lda(bgmmc.use_buffer_a, bgmmc.tr_a_dt_sz)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -177,9 +177,6 @@ struct brgemm_matmul_conf_t {
 
     dim_t buffer_b_gb_stride;
     dim_t buffer_b_k_brg_stride;
-    dim_t buffer_b_n_blk_stride;
-
-    dim_t buffer_b_chunk_sz;
     dim_t buffer_b_per_thread_sz;
 
     dim_t buffer_reduce_per_thread_sz;

--- a/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci
@@ -813,7 +813,7 @@
 --reset --skip-impl=ref --stag=any --wtag=abc --dtag=abc --dt=u8:u8:u8  7x438x12:7x12x932
 --reset --skip-impl=ref --stag=acb --wtag=acb --dtag=any --dt=f64:f64:f64  3x104x4812:3x4812x2
 --reset --skip-impl=ref --stag=bac --wtag=cab --dtag=bac --dt=f32:u8:f32 --attr-fpmath=f16:true 2x5x2:2x2x7771
-# --reset --skip-impl=ref --stag=bac --wtag=acb --dtag=any --dt=bf16:bf16:f32  1x2680x1662:1x1662x3848
+--reset --skip-impl=ref --stag=bac --wtag=acb --dtag=any --dt=bf16:bf16:f32  1x2680x1662:1x1662x3848
 --reset --skip-impl=ref --stag=cab --wtag=any --dtag=any --dt=bf16:u4:u8  3x1x897:3x897x102
 --reset --skip-impl=ref --stag=bac --wtag=cab --dtag=abc --dt=bf16:bf16:bf16  7x375x264:7x264x4
 --reset --skip-impl=ref --stag=any --wtag=acb --dtag=bac --dt=f64:f64:f64  1x1x31:1x31x2199


### PR DESCRIPTION
### This PR fixes two issues: 

- [x] [MFDNN-13311](https://jira.devtools.intel.com/browse/MFDNN-13311). Partially was fixed in #3161. 

Transposed B copy kernel doesn't support arbitrary `N_blk`, for the reference please see: [brgemm_matmul_copy_utils.cpp#L4563](https://github.com/uxlfoundation/oneDNN/blob/8c68c00247971ec96c45388b70f45f3feec17ca4/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp#L4563). So `min_N_blk` should be equal `N_blk` in AMX blocking heuristics and will remain unchanged.

- [x] [MFDNN-13614](https://jira.devtools.intel.com/browse/MFDNN-13614) and [MFDNN-13567](https://jira.devtools.intel.com/browse/MFDNN-13567)

Incorrect `need_buf_c` assignment which leads to NANs in the result for the specific case `--reset --skip-impl=ref --stag=bac --wtag=acb --dtag=any --dt=bf16:bf16:f32 1x2680x1662:1x1662x3848` for `nthr >= 165`. 


++ Minor refactoring: removed unused attributes from `brgemm_matmul_conf_t` related to buffer B.