### PR TITLE
[GPU] Modify GEMM attr group to support reshape

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -97,6 +97,16 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
     int dst_qmask_M = src_qmask_K;
     int dst_qmask_N = wei_qmask_N;
 
+    // per_tensor_mask is the default mask created whenever per_tensor policy
+    // is used by benchdnn.
+    // TODO: per_tensor masks should reflect problem dimensions.
+    int per_tensor_mask = 0xfff;
+    int per_tensor_eq = 0x0;
+
+    for (int i = 0; i < ndims_src; ++i) {
+        per_tensor_eq |= (1 << i);
+    }
+
     // Check scales
     if (!attr->scales_.has_default_values()) {
         const auto &sc = attr->scales_;
@@ -106,7 +116,8 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
             const int mask_src = sc.get_mask(DNNL_ARG_SRC);
 
             VCHECK_MATMUL_UNIMPL(utils::one_of(mask_src, 0, src_qmask_K,
-                                         src_qmask_M + src_qmask_K),
+                                         src_qmask_M + src_qmask_K,
+                                         per_tensor_mask, per_tensor_eq),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
 
             if (!sc.get(DNNL_ARG_SRC).has_default_groups()) {

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -274,10 +274,10 @@ bool jit_gemm_pd_t::zp_ok() {
         if (!attr_zps.has_default_groups(DNNL_ARG_B)) {
             if (!valid_2d_mask(cmask_b_, ndims)) return false;
 
-            const auto src_q2d_group_m = attr_zps.get_group(DNNL_ARG_B, 0);
+            const auto src_q2d_group_n = attr_zps.get_group(DNNL_ARG_B, 0);
             zp_group_k_b_ = attr_zps.get_group(DNNL_ARG_B, 1);
             // Non-trivial M group unsupported.
-            if (src_q2d_group_m != 1) return false;
+            if (!utils::one_of(src_q2d_group_n, 1, desc()->n())) return false;
             // Zero points with non-trivial groups only supported
             // when target tensor is being dequantized.
             if (dy_quant_enabled_ && !utils::one_of(d->b_type(), s4, u4)

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
@@ -92,9 +92,9 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     int zp_group_k_a_ = -1;
     int zp_group_k_b_ = -1;
 
-    int cmask_a_ = -1;
-    int cmask_b_ = -1;
-    int cmask_c_ = -1;
+    int cmask_a_ = INT_MIN;
+    int cmask_b_ = INT_MIN;
+    int cmask_c_ = INT_MIN;
 
     int src_scales_group_k_ = -1;
     int wei_scales_group_k_ = -1;
@@ -158,11 +158,10 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     bool wei_scales_2d() const { return wei_scales_2d_; }
     bool src_scales_2d() const { return src_scales_2d_; }
 
-    bool quant_attr_2d(int arg, const quant_entries_t &attr) const;
-    int quant_attr_ndims(
-            int arg, const quant_entries_t &attr, const memory_desc_t &d) const;
+    bool quant_entry_2d(int arg, const quant_entries_t &entry) const;
+    int quant_entry_ndims(
+            const quant_entry_t &entry, const memory_desc_t &md) const;
 
-    int quant_attr_cmask(int arg, const quant_entries_t &attr) const;
     bool dy_quant_enabled();
     bool wei_decomp();
     bool quant_enabled();

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
@@ -159,6 +159,8 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     bool src_scales_2d() const { return src_scales_2d_; }
 
     bool quant_attr_2d(int arg, const quant_entries_t &attr) const;
+    int quant_attr_ndims(
+            int arg, const quant_entries_t &attr, const memory_desc_t &d) const;
 
     int quant_attr_cmask(int arg, const quant_entries_t &attr) const;
     bool dy_quant_enabled();

--- a/src/gpu/intel/ocl/gemm_matmul.hpp
+++ b/src/gpu/intel/ocl/gemm_matmul.hpp
@@ -95,7 +95,7 @@ struct gemm_matmul_t : public gpu_primitive_t {
                     attr_compat_2d &= (trivial_zp_group || a_md->dims[0] == 1);
                 }
 
-            auto map_gemm_zp = [&](int arg, int gemm_arg, bool reshape = false,
+            auto map_gemm_zp = [&](int arg, bool reshape = false,
                                        int diff_dims = 0, dim_t g_dim = 0) {
                 const auto &zp = attr()->zero_points_;
                 if (zp.has_default_values(arg)) return status::success;
@@ -142,7 +142,7 @@ struct gemm_matmul_t : public gpu_primitive_t {
             if (!attr()->zero_points_.has_default_values()) {
                 CHECK(map_gemm_zp(DNNL_ARG_SRC, false, orig_dims - 2));
                 CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, false, orig_dims - 2));
-                CHECK(map_gemm_zp(DNNL_ARG_DST, DNNL_ARG_C));
+                CHECK(map_gemm_zp(DNNL_ARG_DST));
             }
 
             auto maybe_reshape
@@ -294,9 +294,9 @@ struct gemm_matmul_t : public gpu_primitive_t {
                                 trivial_sc_group ? a_dim : 0));
                     }
                     if (!attr()->zero_points_.has_default_values()) {
-                        CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, DNNL_ARG_A, true,
+                        CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, true,
                                 orig_dims - reshape_size));
-                        CHECK(map_gemm_zp(DNNL_ARG_SRC, DNNL_ARG_B, true,
+                        CHECK(map_gemm_zp(DNNL_ARG_SRC, true,
                                 orig_dims - reshape_size,
                                 trivial_zp_group ? a_dim : 0));
                     }

--- a/src/gpu/intel/ocl/gemm_matmul.hpp
+++ b/src/gpu/intel/ocl/gemm_matmul.hpp
@@ -57,7 +57,7 @@ struct gemm_matmul_t : public gpu_primitive_t {
             auto orig_dims = a_md->ndims;
 
             auto map_gemm_zp = [&](int arg, int gemm_arg, bool reshape = false,
-                                       int diff_dims = 0) {
+                                       int diff_dims = 0, dim_t g_dim = 0) {
                 const auto &zp = attr()->zero_points_;
                 if (zp.has_default_values(arg)) return status::success;
 
@@ -68,54 +68,67 @@ struct gemm_matmul_t : public gpu_primitive_t {
                 dims_t dims {};
                 if (!zp.get(arg).has_default_groups()) {
                     nd = 2; // Note: hardcoded so far.
-                    dims[0] = zp.get_group(arg, 0);
+                    dims[0] = ((arg == DNNL_ARG_SRC && g_dim)
+                                    ? g_dim
+                                    : zp.get_group(arg, 0));
                     dims[1] = zp.get_group(arg, 1);
                 }
                 CHECK(gemm_attr.zero_points_.set(arg, mask, dt, nd, dims));
                 return status::success;
             };
 
-            // The function shrinks the mask for scales and updates it in
-            // `scales` object.
-            auto adjust_scales_mask
-                    = [&](scales_t &scales, int arg, int diff_dims) {
-                          if (attr()->scales_.has_default_values(arg))
-                              return status::success;
-
-                          int mask = attr()->scales_.get_mask(arg) >> diff_dims;
-                          data_type_t dt = attr()->scales_.get_data_type(arg);
-                          int nd = 0;
-                          dims_t dims {};
-                          if (!attr()->scales_.get(arg).has_default_groups()) {
-                              nd = 2; // Note: hardcoded so far.
-                              dims[0] = attr()->scales_.get_group(arg, 0);
-                              dims[1] = attr()->scales_.get_group(arg, 1);
-                          }
-                          CHECK(scales.set(arg, mask, dt, nd, dims));
-                          return status::success;
-                      };
-            if (!attr()->zero_points_.has_default_values()) {
-                CHECK(map_gemm_zp(
-                        DNNL_ARG_SRC, DNNL_ARG_B, false, orig_dims - 2));
-                CHECK(map_gemm_zp(
-                        DNNL_ARG_WEIGHTS, DNNL_ARG_A, false, orig_dims - 2));
-                CHECK(map_gemm_zp(DNNL_ARG_DST, DNNL_ARG_C));
-            }
-
-            bool grouped_a_attr = false, grouped_b_attr = false;
             const auto &scales = gemm_attr.scales_;
             const auto &zp = attr()->zero_points_;
-            if (!attr()->scales_.has_default_values()) {
-                if (!scales.get(DNNL_ARG_SRC).has_default_groups())
-                    grouped_a_attr = true;
-                if (!scales.get(DNNL_ARG_WEIGHTS).has_default_groups())
-                    grouped_b_attr = true;
-            }
-            if (zp.has_default_values()) {
-                if (!zp.get(DNNL_ARG_SRC).has_default_groups())
-                    grouped_a_attr = true;
-                if (!zp.get(DNNL_ARG_WEIGHTS).has_default_groups())
-                    grouped_b_attr = true;
+
+            dim_t k_dim = a_md->dims[orig_dims - 1];
+            dim_t alt_dim = a_md->dims[orig_dims - 2];
+            bool attr_compat_2d = true;
+            bool trivial_sc_group = false, trivial_zp_group = false;
+
+            // 2D reshape is incompatible with grouped attrs unless they are trivial.
+            if (!scales.has_default_values())
+                if (!scales.get(DNNL_ARG_SRC).has_default_groups()) {
+                    trivial_sc_group
+                            = ((k_dim / scales.get_group(DNNL_ARG_SRC, 1) <= 1)
+                                    && (alt_dim
+                                                    / scales.get_group(
+                                                            DNNL_ARG_SRC, 0)
+                                            <= 1));
+                    attr_compat_2d &= (trivial_sc_group || a_md->dims[0] == 1);
+                }
+            if (!zp.has_default_values())
+                if (!zp.get(DNNL_ARG_SRC).has_default_groups()) {
+                    trivial_zp_group = ((k_dim / zp.get_group(DNNL_ARG_SRC, 1)
+                                                <= 1)
+                            && (alt_dim / zp.get_group(DNNL_ARG_SRC, 0) <= 1));
+                    attr_compat_2d &= (trivial_zp_group || b_md->dims[0] == 1);
+                }
+
+            // The function shrinks the mask for scales and updates it in
+            // `scales` object.
+            auto adjust_scales = [&](scales_t &scales, int arg, int diff_dims,
+                                         dim_t g_dim = 0) {
+                if (attr()->scales_.has_default_values(arg))
+                    return status::success;
+
+                int mask = attr()->scales_.get_mask(arg) >> diff_dims;
+                data_type_t dt = attr()->scales_.get_data_type(arg);
+                int nd = 0;
+                dims_t dims {};
+                if (!attr()->scales_.get(arg).has_default_groups()) {
+                    nd = 2; // Note: hardcoded so far.
+                    dims[0] = ((arg == DNNL_ARG_SRC && g_dim)
+                                    ? g_dim
+                                    : attr()->scales_.get_group(arg, 0));
+                    dims[1] = attr()->scales_.get_group(arg, 1);
+                }
+                CHECK(scales.set(arg, mask, dt, nd, dims));
+                return status::success;
+            };
+            if (!attr()->zero_points_.has_default_values()) {
+                CHECK(map_gemm_zp(DNNL_ARG_SRC, false, orig_dims - 2));
+                CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, false, orig_dims - 2));
+                CHECK(map_gemm_zp(DNNL_ARG_DST, DNNL_ARG_C));
             }
 
             auto maybe_reshape
@@ -132,12 +145,10 @@ struct gemm_matmul_t : public gpu_primitive_t {
                     orig_c_dims[i] = c_md->dims[i];
                     orig_bias_dims[i] = bias_md->dims[i];
                 }
-                //for batch dim can map broadcast to 2d: eg. 4x1x4096:1x4096x16 -> 4x4096:4096x16
-                auto reshape_2d = (batch_b_dims == 1 && b_md->ndims > 2);
-                auto reshape_3d = a_md->ndims > 3;
-                // Grouped attrs require non-batch dims to be preserved.
-                if (grouped_a_attr) reshape_2d &= a_md->dims[0] == 1;
-                if (grouped_b_attr) reshape_2d &= b_md->dims[0] == 1;
+                // for batch dim can map broadcast to 2d: eg. 4x1x4096:1x4096x16 -> 4x4096:4096x16
+                auto reshape_2d = (batch_b_dims == 1 && b_md->ndims > 2
+                        && attr_compat_2d);
+                auto reshape_3d = (a_md->ndims > 3);
                 if (reshape_2d || reshape_3d) {
                     auto ndims = a_md->ndims;
                     auto reshape_size = reshape_2d ? 2 : 3;
@@ -154,6 +165,7 @@ struct gemm_matmul_t : public gpu_primitive_t {
                             return status::unimplemented;
                     }
                     dims_t a_dims, b_dims, c_dims, bia_dims;
+                    auto new_scales = gemm_attr.scales_;
                     if (reshape_2d) {
                         a_dims[0] = a_dim;
                         a_dims[1] = a_md->dims[a_md->ndims - 1];
@@ -166,6 +178,8 @@ struct gemm_matmul_t : public gpu_primitive_t {
                                 ? bias_md->dims[bias_md->ndims - 1]
                                 : 1;
                     } else {
+                        trivial_zp_group = false;
+                        trivial_sc_group = false;
                         a_dims[0] = a_dim;
                         a_dims[1] = a_md->dims[ndims - 2];
                         a_dims[2] = a_md->dims[ndims - 1];
@@ -190,7 +204,6 @@ struct gemm_matmul_t : public gpu_primitive_t {
                                 reshape_size, bia_dims));
                     }
                     auto tmp_post_ops = post_ops;
-                    auto scales = gemm_attr.scales_;
                     for (int i = 0; i < attr()->post_ops_.len(); i++) {
                         auto &po = post_ops.entry_[i];
                         if (po.is_binary()) {
@@ -260,18 +273,22 @@ struct gemm_matmul_t : public gpu_primitive_t {
                         }
                     }
 
-                    if (!attr()->scales_.has_default_values())
-                        for (auto i : {DNNL_ARG_WEIGHTS, DNNL_ARG_SRC})
-                            CHECK(adjust_scales_mask(
-                                    scales, i, orig_dims - reshape_size));
+                    if (!attr()->scales_.has_default_values()) {
+                        CHECK(adjust_scales(new_scales, DNNL_ARG_A,
+                                orig_dims - reshape_size, 0));
+                        CHECK(adjust_scales(new_scales, DNNL_ARG_B,
+                                orig_dims - reshape_size,
+                                trivial_sc_group ? a_dim : 0));
+                    }
                     if (!attr()->zero_points_.has_default_values()) {
                         CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, DNNL_ARG_A, true,
                                 orig_dims - reshape_size));
                         CHECK(map_gemm_zp(DNNL_ARG_SRC, DNNL_ARG_B, true,
-                                orig_dims - reshape_size));
+                                orig_dims - reshape_size,
+                                trivial_zp_group ? a_dim : 0));
                     }
                     post_ops = tmp_post_ops;
-                    gemm_attr.scales_ = std::move(scales);
+                    gemm_attr.scales_ = std::move(new_scales);
                     a_md = &a_md_reshaped;
                     b_md = &b_md_reshaped;
                     c_md = &c_md_reshaped;

--- a/tests/benchdnn/inputs/matmul/harness_matmul_3d_bcast
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_3d_bcast
@@ -1,0 +1,15 @@
+--reset
+--dt=u8:s8:f16
+--bia-dt=f16
+--attr-scales=src0:per_tensor:f16:1x32
+
+# random batched shapes for correctness testing
+2x1x32:1x32x1
+3x1x32:1x32x20
+30x1x32:1x32x20
+
+# batch broadcast shapes
+7x1x32:1x32x8
+128x1x32:1x32x16
+2x1x32:1x32x8
+26x1x32:1x32x65

--- a/tests/benchdnn/inputs/matmul/test_matmul_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_gpu
@@ -60,6 +60,9 @@
 --attr-post-ops=sum+add:f32+add:u8:per_dim_01+mul:f32:per_dim_0+add:s8:per_tensor+add:f32:per_dim_01+linear:2:-1
 3x30x1:3x1x20
 
+# test batch reshape with attributes
+--batch=harness_matmul_3d_bcast
+
 # test regressions
 --batch=harness_matmul_regression_f32
 


### PR DESCRIPTION
# Description

Address performance regressions in batched gemm with grouped attrs. Previously disabled 3d->2d reshape to avoid correctness issues, in some cases we can instead reshape grouped dims to preserve correctness and performance. 

Added support for `per_tensor` grouped attrs with 3d->2d reshape to support OV use cases.  

Fixes # https://jira.devtools.intel.com/browse/MFDNN-13651

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
