### PR TITLE
Fix Wundef build host compiler issue (fixes MFDNN-13664)

### DIFF
--- a/cmake/host_compiler.cmake
+++ b/cmake/host_compiler.cmake
@@ -33,6 +33,8 @@ if(DPCPP_HOST_COMPILER_KIND MATCHES "^(GNU|CLANG)$")
     # Common flags for GNU and CLANG IDs.
     platform_unix_and_mingw_common_ccxx_flags(DPCPP_HOST_COMPILER_OPTS)
     platform_unix_and_mingw_common_cxx_flags(DPCPP_HOST_COMPILER_OPTS)
+    # Stripping Wundef before passing it into a host compiler.
+    string(REGEX REPLACE "-Wundef" "" DPCPP_HOST_COMPILER_OPTS "${DPCPP_HOST_COMPILER_OPTS}")
 
     sdl_unix_common_ccxx_flags(DPCPP_HOST_COMPILER_OPTS)
     sdl_unix_src_ccxx_flags(DPCPP_SRC_COMPILER_OPTS)

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -59,9 +59,12 @@ void gates_reduction(const rnn_utils::rnn_conf_t &rnn,
         rnn_utils::cell_position_t cell_position, const gates_t *ws_gates_,
         acc_t *diff_bias_) {
 
-    // @todo block k on simd-width to enable vectorization in
+    // @TODO: block k on simd-width to enable vectorization in
     // parallel_nd path
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP && _OPENMP >= 201307 \
+    // Note: `defined(_OPENMP)` is needed for `icx -fsycl` compilation. The
+    // second pass for device code doesn't contain OpenMP macros.
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP && defined(_OPENMP) \
+        && _OPENMP >= 201307 \
         && (!defined(__INTEL_COMPILER) || __INTEL_COMPILER < 1910)
 #pragma omp parallel for simd collapse(2)
     for (int i = 0; i < rnn.n_gates; i++)


### PR DESCRIPTION
MFDNN-13664

For host compiler it's a workaround, doesn't add much value to what's already been enabled.