### PR TITLE
[GPU] Convolution: fixups and workarounds to address regressions

### DIFF
--- a/src/gpu/intel/jit/conv/plan.cpp
+++ b/src/gpu/intel/jit/conv/plan.cpp
@@ -1248,7 +1248,7 @@ type_t get_accumulation_type(
     if (a.is_int()) return type_t::s32();
     if (a.is_f64()) return type_t::f64();
     if (cfg.fma_kind() == fma_kind_t::mad && a.is_f16() && b.is_f16()
-            && cfg.prb().is_fwd) {
+            && !cfg.prb().is_bwd_w) {
         // FIXME: f16 must use f32 accumulator according to documentation.
         // Temporarily keeping f16 to avoid regressions.
         return type_t::f16();

--- a/src/gpu/intel/jit/conv/tiler.cpp
+++ b/src/gpu/intel/jit/conv/tiler.cpp
@@ -999,7 +999,6 @@ conv_blocking_scheme_t fwd_dw_T_w_I_ngk("ls:[kd,kh,kw],T:[ow],i:[mb,g,#kw]");
 conv_blocking_scheme_t bwd_d_T_wi_I_nio("ls:[oc,kd,kh,kw],T:[ic,iw],i:[mb,ic,oc]");
 conv_blocking_scheme_t bwd_d_T_ni_I_nio("ls:[oc,kd,kh,kw],T:[ic,mb],i:[mb,ic,oc]");
 conv_blocking_scheme_t bwd_d_T_o_I_nio("ls:[oc,kd,kh,kw],T:[oc],i:[mb,ic,oc]");
-conv_blocking_scheme_t bwd_d_T_w_I_on("ls:[oc,kd,kh,kw],T:[iw],i:[oc,mb]");
 conv_blocking_scheme_t bwd_d_T_wi_I_wio("ls:[oc,kd,kh,kw],T:[ic,iw],i:[iw,ic,oc]");
 conv_blocking_scheme_t bwd_d_T_o_I_wio("ls:[oc,kd,kh,kw],T:[oc],i:[iw,ic,oc]");
 conv_blocking_scheme_t bwd_d_dw_T_w_I_wg("ls:[kd,kh,kw],T:[iw],i:[iw,g]");
@@ -1130,19 +1129,15 @@ conv_blocking_scheme_list_t get_blocking_schemes_fwd(const conv_config_t &cfg) {
 conv_blocking_scheme_list_t get_blocking_schemes_bwd_d(
         const conv_config_t &cfg) {
     conv_blocking_scheme_list_t ret(conv_tune_level());
-    const auto &m_iter_dim = cfg.prb().ab_swap_transpose
-            ? pvars::ic
-            : select_iter_dim(cfg, {pvars::mb, pvars::iw});
-    bool m_is_mb = (m_iter_dim == pvars::mb);
-    bool m_is_iw = (m_iter_dim == pvars::iw);
-    bool m_is_ic = (m_iter_dim == pvars::ic);
+    auto m_iter_dim = select_iter_dim(cfg, {pvars::mb, pvars::iw});
+    bool mb_iter = (m_iter_dim == pvars::mb);
+    bool iw_iter = (m_iter_dim == pvars::iw);
     bool ge_xelp = (cfg.hw() >= ngen::HW::XeLP);
-    ret.add(m_is_mb, conv_schemes::bwd_d_T_ni_I_nio);
-    ret.add(m_is_mb, conv_schemes::bwd_d_T_wi_I_nio);
-    ret.add(m_is_mb && ge_xelp, conv_schemes::bwd_d_T_o_I_nio);
-    ret.add(m_is_iw, conv_schemes::bwd_d_T_wi_I_wio);
-    ret.add(m_is_iw && ge_xelp, conv_schemes::bwd_d_T_o_I_wio);
-    ret.add(m_is_ic, conv_schemes::bwd_d_T_w_I_on);
+    ret.add(mb_iter, conv_schemes::bwd_d_T_ni_I_nio);
+    ret.add(mb_iter, conv_schemes::bwd_d_T_wi_I_nio);
+    ret.add(mb_iter && ge_xelp, conv_schemes::bwd_d_T_o_I_nio);
+    ret.add(iw_iter, conv_schemes::bwd_d_T_wi_I_wio);
+    ret.add(iw_iter && ge_xelp, conv_schemes::bwd_d_T_o_I_wio);
     return ret;
 }
 


### PR DESCRIPTION
Jira: [MFDNN-13668](https://jira.devtools.intel.com/browse/MFDNN-13668)

List of changes:

- Fixup for https://github.com/uxlfoundation/oneDNN/pull/2694
    - Restored `f16` accumulator with `f16` backward. It is non-compliant with documentation (must use `f32` accumulator) but we need to fix it properly
    - Restored `bf16` mixed mode with `mad`
- Improvement/mitigation for https://github.com/uxlfoundation/oneDNN/pull/2935
    - Immediate header post-increments are expensive with that PVC WA as it adds `x.dst` dependency
    - Mitigation: move post-increments to the end of statement groups to have postponed batched header updates. Need to test this properly but the change should be beneficial for other platforms
- Fixed BWD_D tiling with NCHW and enabled transposition, this is a fixup for https://github.com/uxlfoundation/oneDNN/pull/3029