### PR TITLE
graph: extend gelu op to support tanh approximation

### DIFF
--- a/doc/graph/operations/GELU.md
+++ b/doc/graph/operations/GELU.md
@@ -5,11 +5,19 @@ GELU {#dev_guide_op_gelu}
 
 GELU operation applies following formula on every element of \src tensor (the
 variable names follow the standard @ref dev_guide_conventions):
+
 \f[ dst = 0.5 * src * (1.0 + erf(src) / \sqrt2) \f]
+
+When the attribute `mode` is specified as `gelu_tanh`, an approximation
+implementation is used:
+
+\f[ dst = 0.5 * src * (1.0 + \tanh[\sqrt{\frac{2}{\pi}} (src + 0.044715 * s^3)]) \f]
 
 ## Operation attributes
 
-GELU operation does not support any attribute.
+| Attribute Name                             | Description                             | Value Type | Supported Values                  | Required or Optional |
+|:-------------------------------------------|:----------------------------------------|:-----------|:----------------------------------|:---------------------|
+| [mode](@ref dnnl::graph::op::attr::mode)   | Specifies the computation mode of GELU. | string     | `gelu_erf` (default), `gelu_tanh` | Optional             |
 
 ## Execution arguments
 

--- a/doc/graph/operations/GELUBackward.md
+++ b/doc/graph/operations/GELUBackward.md
@@ -7,7 +7,9 @@ GELUBackward operation computes gradient for GELU.
 
 ## Operation attributes
 
-GELUBackward operation does not support any attribute.
+| Attribute Name                             | Description                                     | Value Type | Supported Values                  | Required or Optional |
+|:-------------------------------------------|:------------------------------------------------|:-----------|:----------------------------------|:---------------------|
+| [mode](@ref dnnl::graph::op::attr::mode)   | Specifies the computation mode of GELUBackward. | string     | `gelu_erf` (default), `gelu_tanh` | Optional             |
 
 ## Execution arguments
 

--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -965,6 +965,7 @@ public:
         /// Specifies a mode attribute of an op.
         /// Interpolate: "nearest", "linear", "bilinear", or "trilinear".
         /// SoftMax: "none", "inf_as_zero".
+        /// GELU/GELUBackward: "gelu_erf", "gelu_tanh".
         mode = dnnl_graph_op_attr_mode,
         /// Specifies a qtype attribute to an op. The value can be "per_channel"
         /// or "per_tensor". The attribute is defined for quantization

--- a/include/oneapi/dnnl/dnnl_graph_types.h
+++ b/include/oneapi/dnnl/dnnl_graph_types.h
@@ -374,6 +374,7 @@ typedef enum {
     /// Specifies a mode attribute of an op.
     /// Interpolate: "nearest", "linear", "bilinear", or "trilinear".
     /// SoftMax: "none", "inf_as_zero".
+    /// GELU/GELUBackward: "gelu_erf", "gelu_tanh".
     dnnl_graph_op_attr_mode,
     /// Specifies a qtype attribute to an op. The value can be "per_channel" or
     /// "per_tensor". The attribute is defined for quantization operations.

--- a/src/graph/interface/op_def.hpp
+++ b/src/graph/interface/op_def.hpp
@@ -428,6 +428,8 @@ DNNL_GRAPH_OP_SCHEMA(GELU, 1,
                 .set_num_outputs(1)
                 .set_input(0, "src", "T")
                 .set_output(0, "dst", "T")
+                .set_attr(op_attr::mode, false, attribute_kind::s, "gelu_erf",
+                        {"gelu_erf", "gelu_tanh"})
                 .set_type_constraints(
                         "T", {data_type::f32, data_type::bf16, data_type::f16})
                 .set_shape_inference_function(infer_identity_output_shape))
@@ -439,6 +441,8 @@ DNNL_GRAPH_OP_SCHEMA(GELUBackward, 1,
                 .set_input(0, "src", "T")
                 .set_input(1, "diff_dst", "T")
                 .set_output(0, "diff_src", "T")
+                .set_attr(op_attr::mode, false, attribute_kind::s, "gelu_erf",
+                        {"gelu_erf", "gelu_tanh"})
                 .set_type_constraints(
                         "T", {data_type::f32, data_type::bf16, data_type::f16})
                 .set_shape_inference_function(infer_identity_output_shape))

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -965,6 +965,14 @@ bool get_eltwise_alg(
             return false;
         alg = map_kind_to_alg.at(op_kind);
     }
+
+    // check gelu mode
+    if (op_kind == "GELU" || op_kind == "GELUBackward") {
+        const auto it = base_op_ref.attrs_.find("mode");
+        if (it != base_op_ref.attrs_.end()
+                && it->second.str_value_ == "gelu_tanh")
+            alg = ::eltwise::alg_t::GELU_TANH;
+    }
     return true;
 }
 

--- a/tests/benchdnn/inputs/graph/op/f32/gelu.json
+++ b/tests/benchdnn/inputs/graph/op/f32/gelu.json
@@ -1,0 +1,65 @@
+{
+  "version": "3.9.0",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0
+  ],
+  "output_ports": [
+    1
+  ],
+  "graph": [
+    {
+      "id": 0,
+      "name": "ELTWISE_0",
+      "kind": "GELU",
+      "attrs": {
+        "mode": {
+          "type": "string",
+          "value": "gelu_tanh"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            28,
+            28
+          ],
+          "stride": [
+            25088,
+            784,
+            28,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            28,
+            28
+          ],
+          "stride": [
+            25088,
+            784,
+            28,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/benchdnn/inputs/graph/op/harness_bf16_all
+++ b/tests/benchdnn/inputs/graph/op/harness_bf16_all
@@ -132,6 +132,7 @@
 --reset --dt=bf16 --case=op/f32/greaterequal.json
 --reset --dt=bf16 --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json
 --reset --dt=bf16 --in-shapes=1:1 --case=op/f32/greaterequal.json
+--reset --dt=bf16 --op-attrs=0:mode:gelu_erf,0:mode:gelu_tanh --case=op/f32/gelu.json
 
 # select
 --reset --dt=bf16 --in-shapes=2:1x1x1x128 --case=op/f32/select.json

--- a/tests/benchdnn/inputs/graph/op/harness_f16_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f16_all
@@ -131,6 +131,7 @@
 --reset --dt=f16 --case=op/f32/greaterequal.json
 --reset --dt=f16 --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json
 --reset --dt=f16 --in-shapes=1:1 --case=op/f32/greaterequal.json
+--reset --dt=f16 --op-attrs=0:mode:gelu_erf,0:mode:gelu_tanh --case=op/f32/gelu.json
 
 # select
 --reset --dt=bf16 --in-shapes=2:1x1x1x128 --case=op/f32/select.json

--- a/tests/benchdnn/inputs/graph/op/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f32_all
@@ -852,3 +852,4 @@
 --reset --case=op/f32/greaterequal.json
 --reset --in-shapes=1:1x1x1x1 --case=op/f32/greaterequal.json
 --reset --in-shapes=1:1 --case=op/f32/greaterequal.json
+--reset --op-attrs=0:mode:gelu_erf,0:mode:gelu_tanh --case=op/f32/gelu.json

--- a/tests/gtests/graph/unit/interface/test_op_schema_cpu.cpp
+++ b/tests/gtests/graph/unit/interface/test_op_schema_cpu.cpp
@@ -2680,8 +2680,8 @@ TEST(test_interface_op_schema, Gelu) {
     const op_kind_t op_kind_ = op_kind::GELU;
     const size_t expected_in_size = 1;
     const size_t expected_out_size = 1;
-    const size_t expected_attr_size = 0;
-    const std::map<op_attr_t, bool> attrs_data = {};
+    const size_t expected_attr_size = 1;
+    const std::map<op_attr_t, bool> attrs_data = {{op_attr::mode, false}};
 
     verify_op_schema(op_kind_, expected_in_size, expected_out_size,
             expected_attr_size, attrs_data);
@@ -2697,8 +2697,8 @@ TEST(test_interface_op_schema, GELUBackward) {
     const op_kind_t op_kind_ = op_kind::GELUBackward;
     const size_t expected_in_size = 2;
     const size_t expected_out_size = 1;
-    const size_t expected_attr_size = 0;
-    const std::map<op_attr_t, bool> attrs_data = {};
+    const size_t expected_attr_size = 1;
+    const std::map<op_attr_t, bool> attrs_data = {{op_attr::mode, false}};
 
     verify_op_schema(op_kind_, expected_in_size, expected_out_size,
             expected_attr_size, attrs_data);


### PR DESCRIPTION
Fixes MFDNN-13548

Currently, the GELU operation only supports `erf` based implementation. This PR adds a `mode` attribute to GELU and GELUBackward operation, so the users can specify `tanh` based approximation.

```c++
auto gelu = op(id, op::kind::GELU, "gelu");
gelu.set_attr<std::string>(op::attr::mode, "gelu_tanh"); // this is optional, but default it's gelu_erf.
gelu.add_input(in);
gelu.add_output(out);
graph.add_op(gelu);
```