### PR TITLE
benchdnn: inputs: graph: replace mul with sub in gated mlp test

### DIFF
--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mlp_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mlp_ci
@@ -1,7 +1,8 @@
 --reset --dt=bf16,f16 --case=complex_fusion/mlp/gated-mlp-f32.json
 
-# WA: use smaller problem to pass correctness check for f32 on pvc.
---reset --in-shapes=0:1x128+1:128x256+4:128x256+13:256x128 --case=complex_fusion/mlp/gated-mlp-f32.json
+# WA1: use smaller problem to pass correctness check for f32 on pvc.
+# WA2: use subtract binary to avoid precision issue for f32 on xe-lpg.
+--reset --in-shapes=0:1x128+1:128x256+4:128x256+13:256x128 --op-kind=12:Subtract --case=complex_fusion/mlp/gated-mlp-f32.json
 
 # f16-int4 case
 --reset --case=complex_fusion/mlp/gated-mlp-int4.json


### PR DESCRIPTION
Fix MFDNN-13430.

Rounding precision issue due to the uncertainty of elements' accumulation order inside the kernel calculation. 

Replace multiply with Subtract(Add is not enough) between 2 matmuls in the test cases. It helps to reduce the intermediate value after binary.