### PR TITLE
gpu: generic: Add skip for unsupported zeropad dt

### DIFF
--- a/tests/benchdnn/zeropad/zeropad.cpp
+++ b/tests/benchdnn/zeropad/zeropad.cpp
@@ -116,6 +116,12 @@ static dnnl_status_t perf_func(
 void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
     skip_unimplemented_data_type({prb->dt}, FWD_D, res);
 
+    // check on sycl engine if dt is one of supported zeropad dt's
+    // if not supported skip
+    if (is_generic_gpu() && prb->dt == dnnl_f64) {
+        res->state = SKIPPED;
+        res->reason = skip_reason::case_not_supported;
+    }
     if (is_nvidia_gpu() || is_amd_gpu()) {
         res->state = SKIPPED;
         res->reason = skip_reason::case_not_supported;


### PR DESCRIPTION
# Description

When testing on generic gpu, if `benchdnn` attempt to run zeropad with unsupported data type the test fails. 
PR introduces check for `f64` specifically as `skip_unimplemented_data_type` already checks for other datat ypes, but because zeropad does not support `f64` and the `skip_unimplemented_data_type` checks if the engine supports the data type not the primitive running the test with `f64` is reported as failure.

see MFDNN-13216
