### PR TITLE
benchdnn: mem_check: reduce the allowed combined memory limit

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -55,7 +55,7 @@ int fill_mem(
                 mem_dt, mem_fp, nullptr, get_perf_fill_cfg(mem_dt.dt()));
     }
 
-    int min_val = MAX2(-8, static_cast<int>(lowest_dt(mem_dt.dt())));
+    int min_val = static_cast<int>(MAX2(-8.f, lowest_dt(mem_dt.dt())));
     // Tenrary op supports a third input which can't be negative so far.
     if (input_idx == 2) min_val = 0;
 

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1117,7 +1117,8 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
     const double capacity_factor = 0.75;
     const double benchdnn_device_limit = capacity_factor * device_max_capacity;
     const double benchdnn_cpu_limit = capacity_factor * cpu_device_capacity;
-    const double benchdnn_combined_limit = 0.90 * cpu_device_capacity;
+    // Note: used to be 0.90 until large f64 conv cases on Xe2-LPG emerged.
+    const double benchdnn_combined_limit = 0.80 * cpu_device_capacity;
     assert(benchdnn_device_limit > 0 && benchdnn_cpu_limit > 0);
 
     auto dir_c_str = [&res]() {

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -612,6 +612,8 @@ void check_correctness(const prb_t *prb, const std::vector<data_kind_t> &kinds,
     // and ref CPU failures.
     if (prim_ref) {
         BENCHDNN_PRINT(1, "run ref: %s\n", res->prim_ref_repro.c_str());
+    } else {
+        BENCHDNN_PRINT(8, "%s\n", "[NAIVE_REF]: Start");
     }
 
     TIME_REF(compute_ref(prb, dir, ref_args, prim_ref));

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -1018,6 +1018,14 @@ static int check_zero_padding_impl(
     std::atomic<int> ok(true);
 
     for (int dim_m_idx = 0; dim_m_idx < ndims; ++dim_m_idx) {
+        if (dims[dim_m_idx] != pdims[dim_m_idx]) {
+            BENCHDNN_PRINT(
+                    8, "[CHECK_ZERO_PAD]: Arg:%d\n", exec_arg2data_kind(arg));
+            break;
+        }
+    }
+
+    for (int dim_m_idx = 0; dim_m_idx < ndims; ++dim_m_idx) {
         if (dims[dim_m_idx] == pdims[dim_m_idx]) continue;
 
         auto dim_l = product(pdims, pdims + dim_m_idx);

--- a/tests/benchdnn/utils/cold_cache.cpp
+++ b/tests/benchdnn/utils/cold_cache.cpp
@@ -47,7 +47,8 @@ cold_cache_t::cold_cache_t(
         const std::vector<dnnl_exec_arg_t> &dnnl_args, dnnl_stream_t stream)
     : cold_cache_input_(cold_cache_input)
     , enabled_(use_cold_cache(dnnl_args))
-    , n_buffers_top_limit_(is_gpu() ? gpu_n_buffers_top_limit_ : SIZE_MAX) {
+    , n_buffers_top_limit_(
+              is_gpu() ? gpu_n_buffers_top_limit_ : cpu_n_buffers_top_limit_) {
 
     // Note: there's an additional return from ctor below if it was identified
     // that no buffers are needed.

--- a/tests/benchdnn/utils/cold_cache.hpp
+++ b/tests/benchdnn/utils/cold_cache.hpp
@@ -117,6 +117,8 @@ private:
 
     // Memory allocations are time consuming on GPU, thus, introducing the
     // upper bound for the number of buffers in cold-cache.
+    // For CPU the enormous number of buffers may lead to what looks like a
+    // hang. In fact, just takes a very long time to complete.
     // Since `no_ref_memory` allocations use `memset` call to initialize the
     // data, the assumption is it makes newly created memory objects with newly
     // allocated buffer underneath get into the GPU cache. Using these memory
@@ -124,6 +126,7 @@ private:
     // Thus, introducing an extra reorder with brand new memory objects which
     // sole purpose is to reset the state of the cache by entirely thrashing it.
     static constexpr size_t gpu_n_buffers_top_limit_ = 100;
+    static constexpr size_t cpu_n_buffers_top_limit_ = 10000;
 
     size_t cc_counter_ = 0;
 


### PR DESCRIPTION
Workaround for https://jira.devtools.intel.com/browse/MFDNN-13654

Reduce the number of allowed cases when it comes to CPU RAM limit.