### PR TITLE
doc:sphinx: add last updated timestamp

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -243,3 +243,14 @@ def addTocTrees(app, env, docnames):
                 tocTree += "   " + file + "\n"
             tocTree += "\n\n"
             f.write(tocTree)
+
+def get_last_updated(file_path):
+    try:
+        git_cmd = ['git', 'log', '-1', '--format=%ad', '--date=short', file_path]
+        last_updated = subprocess.check_output(git_cmd).decode('utf-8').strip()
+        return last_updated
+    except Exception:
+        return ''
+
+# Format used for the timestamp
+html_last_updated_fmt = '%b %d, %Y'  


### PR DESCRIPTION
# Description

I attempted to add the last updated timestamp to have a clear update trail. On my local system, it's working as expected.

![image](https://github.com/user-attachments/assets/5730715b-fff5-4e87-8263-cee32671432c)

Please review and let me know whether we can implement this.
