### PR TITLE
[backport] x64: matmul: Fix buffer C usage

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -757,7 +757,8 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
     current_lda_ = get_actual_lda();
 
     // Need a temp C buffer if a BRGEMM creates partial results
-    need_buf_c_ = (nthr_k_ > 1);
+    need_buf_c_ = (nthr_k_ > 1 && K > k_chunk_elems_)
+            || (acc_dt != dst_dt || with_sum);
 
     efficiency_score_ = calculate_blocking_scores();
 


### PR DESCRIPTION
Fixes [MFDNN-13675](https://jira.devtools.intel.com/browse/MFDNN-13675). 
Incorrect `need_buf_c` flag setting fix. 
It's a backport of #3274 