### PR TITLE
cpu: fix omp simd usage that might generate incorrect code

### DIFF
--- a/src/common/dnnl_thread.hpp
+++ b/src/common/dnnl_thread.hpp
@@ -185,18 +185,13 @@ inline int dnnl_get_current_num_threads() {
 #define OMP_GET_NUM_THREADS() 1
 #endif
 
-// Disabling OMP SIMD feature in the following scenarios:
-// * For MSVC as it only supports OpenMP 2.0
-// * In debug mode on Windows to avoid incorrect code generation
-//   by Intel(R) oneAPI DPC++/C++ Compiler
-#if defined(_MSC_VER) \
-        && ((!defined(__clang__) && !defined(__INTEL_COMPILER)) \
-                || defined(_DEBUG))
+// Disabling OMP SIMD feature for MSVC as it only supports OpenMP 2.0
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #define collapse(x)
 #define PRAGMA_OMP_SIMD(...)
 #else
 #define PRAGMA_OMP_SIMD(...) PRAGMA_MACRO(CHAIN2(omp, simd __VA_ARGS__))
-#endif // defined(_MSC_VER) && ((!defined(__clang__) && !defined(__INTEL_COMPILER)) || defined(_DEBUG))
+#endif // defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 
 namespace dnnl {
 namespace impl {

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2024 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -344,7 +344,6 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                             args.dst_md = pd()->dst_md();
                             args.l_offset = d_ - dst;
 
-                            PRAGMA_OMP_SIMD()
                             for (int oS = 0; oS < m; ++oS) {
                                 d_[oS] += b;
                                 post_ops_->execute(d_[oS], args);

--- a/src/cpu/x64/gemm/gemm_utils.hpp
+++ b/src/cpu/x64/gemm/gemm_utils.hpp
@@ -189,12 +189,15 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
             auto src_col = src + j * ld_src;
             auto dst_col = dst + j * ld_dst;
 
-            PRAGMA_OMP_SIMD()
-            for (dim_t i = 0; i < nrows_dst; i++)
-                if (is_f32)
+            if (is_f32) {
+                PRAGMA_OMP_SIMD()
+                for (dim_t i = 0; i < nrows_dst; i++)
                     dst_col[i] = alpha * src_col[i];
-                else
+            } else {
+                PRAGMA_OMP_SIMD()
+                for (dim_t i = 0; i < nrows_dst; i++)
                     dst_col[i] = src_col[i];
+            }
         });
     } else {
         // Naive code for now.
@@ -202,12 +205,15 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
             auto src_col = src + j;
             auto dst_col = dst + j * ld_dst;
 
-            PRAGMA_OMP_SIMD()
-            for (dim_t i = 0; i < nrows_dst; i++)
-                if (is_f32)
+            if (is_f32) {
+                PRAGMA_OMP_SIMD()
+                for (dim_t i = 0; i < nrows_dst; i++)
                     dst_col[i] = alpha * src_col[i * ld_src];
-                else
+            } else {
+                PRAGMA_OMP_SIMD()
+                for (dim_t i = 0; i < nrows_dst; i++)
                     dst_col[i] = src_col[i * ld_src];
+            }
         });
     }
 

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -1335,7 +1335,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 dim_t offset = offset_ + mb * jcp.ngroups * dst_step;
                 for_(dim_t od = 0; od < jcp.od; ++od)
                 for (dim_t oh = 0; oh < jcp.oh; ++oh) {
-                    PRAGMA_OMP_SIMD(reduction(+ : db))
+                    PRAGMA_OMP_SIMD(reduction(+ : db) linear(offset))
                     for (dim_t ow = 0; ow < jcp.ow; ++ow) {
                         db += diff_dst[offset];
                         offset++;


### PR DESCRIPTION
Fix PRAGMA_OMP_SIMD usage that generates incorrect code when vectorization is forced.