### PR TITLE
gtests: graph: cleanup context at end of test

### DIFF
--- a/tests/gtests/graph/api/ocl/test_cpp_api_engine.cpp
+++ b/tests/gtests/graph/api/ocl/test_cpp_api_engine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -126,5 +126,8 @@ TEST(OCLApi, Engine) {
                     device_id, ctx, alloc, cache_blob);
         });
     }
+
+    err = clReleaseContext(ctx);
+    GRAPH_TEST_OCL_CHECK(err);
 }
 #endif


### PR DESCRIPTION
Found by clang 19.1.6 + address sanitizer. Related to [MFDNN-12551](https://jira.devtools.intel.com/browse/MFDNN-12551).