### PR TITLE
cpu: aarch64: conv: fix fast math fallback

### DIFF
--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -56,7 +56,7 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
         status_t init(engine_t *engine) {
             using namespace utils;
 #if defined(DNNL_AARCH64_USE_ACL)
-            if (get_fpmath_mode() == fpmath_mode::bf16) {
+            if (attr()->fpmath_.mode_ == fpmath_mode::bf16) {
                 // prefer ACL to jit for fpmath_mode::bf16 if available
                 // since it supports lower precision calculation
                 return status::unimplemented;

--- a/src/cpu/aarch64/jit_sve_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_convolution.hpp
@@ -47,7 +47,7 @@ struct jit_sve_convolution_fwd_t : public primitive_t {
 
         status_t init(engine_t *engine) {
 #if defined(DNNL_AARCH64_USE_ACL)
-            if (get_fpmath_mode() == fpmath_mode::bf16) {
+            if (attr()->fpmath_.mode_ == fpmath_mode::bf16) {
                 // prefer ACL to jit for fpmath_mode::bf16 if available
                 // since it supports lower precision calculation
                 return status::unimplemented;


### PR DESCRIPTION
When running fast math convolution, we should run ACL instead of JIT. This is a change introduced in https://github.com/uxlfoundation/oneDNN/pull/2838/files. However, this patch was not working when using --attr-fpmath as outlined in https://github.com/uxlfoundation/oneDNN/issues/3266. This is causing the nightly performance tests to fail.

performance:
~2.5x speedups for benchdnn conv cases using --attr-fpmath=bf16