### PR TITLE
Fix performance regressions in RNN

### DIFF
--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -558,6 +558,7 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init(
             CHECK(memory_desc_init_by_tag(
                     this->ws_md_, 1, ws_dims, data_type::u8, format_tag::x));
         }
+        rnn_.cell_kind = this->desc()->cell_kind;
     }
     return st;
 }

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -664,6 +664,8 @@ struct rnn_conf_t {
     // for merged layer computation in brgemm
     dim_t Mlayermerged;
     dim_t mlayermerged_block, Mlayermerged_blocks;
+
+    alg_kind_t cell_kind = alg_kind::undef;
 };
 
 bool is_ldigo(const memory_desc_wrapper &md);

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
@@ -258,7 +258,6 @@ private:
     const dim_t Al_k_tail_offset_;
     const dim_t Bl_kb_offset_;
     const dim_t Bl_k_tail_offset_;
-    const dim_t n_gates_;
 
     const brgemm_kernel_t *const brgemm_kernel_layer_main_;
     const brgemm_kernel_t *const brgemm_kernel_layer_n_tail_;

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
@@ -45,6 +45,7 @@ public:
     void execute() const;
 
 private:
+    int calculate_nthr() const;
     void kernel(const int ithr, const int nthr) const;
     void kernel_fused_iter_layer(const int ithr, const int nthr) const;
 
@@ -61,7 +62,6 @@ private:
     scratch_t *const C_cell_;
     const dim_t LDAl_;
     const dim_t LDAi_;
-    const dim_t max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
     const int work_amount_;
@@ -100,6 +100,7 @@ private:
     brgemm_batch_element_t *const addr_batch_global_;
     const postgemm_fused_t fused_postgemm_;
     const bool is_fused_layer_iter_brgemm_;
+    const int max_nthr_;
 };
 
 template <typename src_t, typename weights_t, typename gemm_acc_t>

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -438,7 +438,7 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
     };
 
     dim_t n_block = nstl::min(rnn.N, rnn.n_block);
-    dim_t n_tail = nstl::min(rnn.N, rnn.nproj_tail);
+    dim_t n_tail = nstl::min(rnn.N, rnn.n_tail);
     if (rnn.LDA1[0] < rnn.k1_block && rnn.LDA1[1] < rnn.k1_block
             && rnn.LDA1[2] < rnn.k1_block)
         return status::unimplemented;

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -508,8 +508,10 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
 
     // enable merged across n_iter dimension layer part of the cell computation
     // TODO: extend coverage for other problem types
-    const bool mlc_cell_type_ok = cell_kind == alg_kind::vanilla_lstm
-            && !rnn.is_lstm_projection && !rnn.is_lstm_peephole;
+    const bool mlc_cell_type_ok
+            = (cell_kind == alg_kind::vanilla_lstm && !rnn.is_lstm_projection
+                      && !rnn.is_lstm_peephole)
+            || (cell_kind == alg_kind::lbr_gru && rnn.brgemm_isa == x64::avx2);
     const int mlc_mb_max_threshold = 1;
     const int mlc_n_iter_min_threshold = 2;
     const int mlc_n_layer_max_threshold = 1;


### PR DESCRIPTION
The PR fixes some performance regressions (compared to the version 3.3): [MFDNN-12215](https://jira.devtools.intel.com/browse/MFDNN-12215)

Changes:

-   "merged gemm layer" calculation is enabled in case of LBR_GRU (for AVX2) cell type; this was used in 3.3 but disappeared later;
-   "merged gemm layer" calculation is divided into smaller parts (better distribution between threads);
-   matrix block width ("n_block" parameter) is increased in case of AVX2 with mb=1, i.e. when matrix-vector multiplication is performed on each iteration (brgemm generates better jit-code for AVX2 if its parameter N=32 compared to N=16; performance difference is about 1.5);
-  only one thread is used for iteration calculations for small problems in case of AVX2 if TBB is used; this removes significant overhead for small problems;
-  other minor changes.

The most improvement is achieved for LBR_GRU and VANILLA_LSTM cells in AVX2/TBB case that is the main topic of MFDNN-12215. Performance comparison between the version 3.3, the main branch, and this PR for the problems mentioned in MFDNN-12215 follows (8 threads were used):

```
ADL (Intel(R) Core(TM) i9-12900) + TBB,  8 threads, ms

      3.3    main   PR
1     0.17   0.35  0.12
2     0.17   0.35  0.12
3     0.16   0.34  0.11
4     0.17   0.34  0.11

9     0.16  0.48  0.16
10    0.16  0.47  0.16
11    0.80   0.86  0.62
12    0.80   0.87  0.62

(Problems 5-8 are the same as 1-4; 13-16 are the same as 9-12)

```
 
To be implemented/improved: switching to one thread in other cases (AVX512, OMP).