### PR TITLE
xe: sdpa: Optimizations for causal mask. Use split barriers for Q tensor

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -319,6 +319,10 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         /* Store Q tile to SLM */
         tile_store_t_sys_src1(
                 Q_tile, (local uint *)&Q_slm[0], D_MAX / 2, q0_copy, 0);
+
+#if Q_ARRIVE_AWAIT_BARRIER
+        intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
+#endif
     }
 
     /* Load scale */
@@ -408,7 +412,11 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         tile_fill(S_max_tile, -INFINITY);
 
         /* Wait for Q data to reach SLM */
+#if Q_ARRIVE_AWAIT_BARRIER
+        intel_work_group_barrier_wait(CLK_LOCAL_MEM_FENCE);
+#else
         barrier(CLK_LOCAL_MEM_FENCE);
+#endif
     }
 
     /* Main loop over k blocks */

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -498,6 +498,8 @@ status_t micro_sdpa_t::init(impl::engine_t *engine) {
         kernel_ctx.define_int("PREFETCH_D_MAX", nstl::min(pd()->d_max(), 64));
     }
 
+    kernel_ctx.define_int("Q_ARRIVE_AWAIT_BARRIER", d->queries() > 1);
+
     kernel_ctx.define_int("SOFTMAX_INF_AS_ZERO",
             d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
 

--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -209,12 +209,12 @@ void fill_mask(std::vector<float> &mask, const memory::desc &desc) {
 
 void fill_causal_mask(
         std::vector<float> &mask, const memory::desc &desc, mask_type mask_t) {
-    size_t seq_len = desc.get_dims()[3];
-    size_t query_num = desc.get_dims()[2];
-    size_t batches = desc.get_dims()[1] * desc.get_dims()[0];
-    for (size_t b = 0; b < batches; b++) {
-        for (size_t q = 0; q < query_num; q++) {
-            for (size_t k = 0; k < seq_len; k++) {
+    int64_t seq_len = desc.get_dims()[3];
+    int64_t query_num = desc.get_dims()[2];
+    int64_t batches = desc.get_dims()[1] * desc.get_dims()[0];
+    for (int64_t b = 0; b < batches; b++) {
+        for (int64_t q = 0; q < query_num; q++) {
+            for (int64_t k = 0; k < seq_len; k++) {
                 if (mask_t == mask_type::causal_br
                                 ? ((q + seq_len - query_num) >= k)
                                 : (q >= k)) {


### PR DESCRIPTION
# Description

This PR optimizes SDPA with causal masks by skipping the processing of masked out values. This includes skipping work-groups and reducing the number of iterations of the inner loop of the micro_sdpa kernel. With this change we are seeing a speedup of up to 1.9x over the same kernel before this change.

Additionally this PR uses split barriers instead of the regular OpenCL barrier when reading Q tenor's values into shared memory. This is only faster for first token cases so I have gated the feature behind a kernel definition.

Fixes: [MFDNN-13683](https://jira.devtools.intel.com/browse/MFDNN-13683)