### PR TITLE
graph: backend: dnnl: clean up macros and env vars

### DIFF
--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -144,16 +144,6 @@ dnnl::memory::format_tag get_format_tag(const dnnl::memory::desc &md);
 size_t generate_constant_md_hash(
         size_t part_id, const std::vector<dnnl::memory::desc> &const_mds);
 
-#ifndef NDEBUG
-#define BACKEND_DNNL_ENFORCE(condition, message) \
-    do { \
-        error::wrap_c_api((condition) ? dnnl_success : dnnl_invalid_arguments, \
-                (message)); \
-    } while (false)
-#else
-#define BACKEND_DNNL_ENFORCE(condition, message)
-#endif
-
 #define BACKEND_DNNL_CHECK(statement) \
     do { \
         status_t ret = (statement); \

--- a/src/graph/backend/dnnl/dnnl_backend.hpp
+++ b/src/graph/backend/dnnl/dnnl_backend.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2024 Intel Corporation
+ * Copyright 2020-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,22 +94,6 @@ public:
 
     status_t get_partitions(
             graph_t &agraph, partition_policy_t policy) override {
-        // Note: This environment variable is internal and for test purpose. It
-        // can be changed or removed without prior notice. Users should avoid
-        // using it in their applications. Enabling the environment variable may
-        // cause some tests and examples to fail.
-        const bool disable_dnnl_bkd
-                = graph::utils::getenv_int_internal("DISABLE_DNNL_BACKEND", 0)
-                > 0;
-        if (disable_dnnl_bkd) return status::success;
-
-        // Note: This environment variable is internal and for test/debug
-        // purpose. It can be changed or removed without prior notice. Users
-        // should avoid using it in their applications. Enabled by default.
-        const bool enable_large_partition
-                = graph::utils::getenv_int_internal("ENABLE_LARGE_PARTITION", 1)
-                > 0;
-
         // FIXME(xx): Here we only changes the passes in registry. If json file
         // existed, pm will run passes according to the json file, the env var
         // will not take effect.
@@ -117,11 +101,9 @@ public:
         // - 50.f > priority > 20.f: large fusion pattern
         // - 20.f >= priority > 8.f: normal fusion pattern
         // - priority <= 8.f: debug fusion pattern (single op fusion)
-        const float priority_ths = (policy == graph::partition_policy::fusion
-                                           && enable_large_partition)
+        const float priority_ths = (policy == graph::partition_policy::fusion)
                 ? std::numeric_limits<float>::max()
-                : policy == graph::partition_policy::fusion ? 20.0f
-                                                            : 8.0f;
+                : 8.0f;
 
         const auto &dnnl_pass_filter
                 = [priority_ths](const graph::pass::pass_base_ptr &pass,

--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -512,8 +512,7 @@ pool_executable_t::desc_t pool_executable_t::create_desc(
                 ? algorithm::pooling_avg_exclude_padding
                 : algorithm::pooling_avg_include_padding;
     } else {
-        BACKEND_DNNL_ENFORCE(
-                0, "Currently only int8 MaxPool/AvgPool is supported.");
+        assert(!"only int8 MaxPool/AvgPool is supported.");
     }
 
     dnnl::pooling_forward::primitive_desc pd(p_engine, prop, algo, src, dst,
@@ -594,9 +593,7 @@ pool_bwd_executable_t::desc_t pool_bwd_executable_t::create_desc(
                 ? algorithm::pooling_avg_exclude_padding
                 : algorithm::pooling_avg_include_padding;
     } else {
-        BACKEND_DNNL_ENFORCE(0,
-                "Currently only MaxPoolBackprop/AvgPoolBackprop is "
-                "supported.");
+        assert(!"only MaxPoolBackprop/AvgPoolBackprop is supported.");
     }
 
     if (op->get_attr<std::string>(op_attr::kind) == "maxpool") {
@@ -979,9 +976,7 @@ eltwise_executable_t::desc_t eltwise_executable_t::create_desc(
 
     const algorithm algo = static_cast<dnnl::algorithm>(
             op->get_attr<int64_t>(op_attr::alg_kind));
-    if (algo == algorithm::undef) {
-        BACKEND_DNNL_ENFORCE(0, "Unsupported eltwise op.");
-    }
+    if (algo == algorithm::undef) { assert(!"unsupported eltwise op."); }
 
     dnnl::eltwise_forward::primitive_desc pd;
     pd = dnnl::eltwise_forward::primitive_desc(p_engine, prop_kind::forward,
@@ -1156,7 +1151,7 @@ resampling_executable_t::desc_t resampling_executable_t::create_desc(
     } else if (mode == "linear" || mode == "bilinear" || mode == "trilinear") {
         algo = algorithm::resampling_linear;
     } else {
-        BACKEND_DNNL_ENFORCE(0, "Unsupported resampling mode.");
+        assert(!"unsupported resampling mode.");
     }
 
     dnnl::resampling_forward::primitive_desc pd;
@@ -1193,7 +1188,7 @@ resampling_bwd_executable_t::desc_t resampling_bwd_executable_t::create_desc(
     } else if (mode == "linear" || mode == "bilinear" || mode == "trilinear") {
         algo = algorithm::resampling_linear;
     } else {
-        BACKEND_DNNL_ENFORCE(0, "Unsupported resampling mode.");
+        assert(!"unsupported resampling mode.");
     }
 
     auto src = make_dnnl_memory_desc(
@@ -1503,9 +1498,7 @@ reduction_executable_t::desc_t reduction_executable_t::create_desc(
 
     const algorithm alg = static_cast<dnnl::algorithm>(
             op->get_attr<int64_t>(op_attr::alg_kind));
-    if (alg == algorithm::undef) {
-        BACKEND_DNNL_ENFORCE(0, "Unsupported reduction op.");
-    }
+    if (alg == algorithm::undef) { assert(!"unsupported reduction op."); }
     float p = op->has_attr(op_attr::p) ? op->get_attr<float>(op_attr::p) : 0.f;
 
     float eps = 0.0f;


### PR DESCRIPTION
Part of the backend code clean and refactor.
- remove the macro BACKEND_DNNL_ENFORCE.
- remove internal env vars: _DNNL_DISABLE_DNNL_BACKEND, _DNNL_ENABLE_LARGE_PARTITION.

It seems they are all seldomly used and don't provide additional values.