### PR TITLE
fix: aarch64: skip acl_layer_normalization for rms lnorm

### DIFF
--- a/src/cpu/aarch64/acl_layer_normalization.cpp
+++ b/src/cpu/aarch64/acl_layer_normalization.cpp
@@ -45,6 +45,9 @@ status_t acl_layer_normalization_fwd_t::pd_t::init(engine_t *engine) {
             "src tensor must have between 2 and 5 (inclusive) "
             "dimensions");
 
+    // skip_mean is set for root-mean-square normalization mode.
+    ACL_CHECK_SUPPORT(skip_mean(), "rms normalization is not supported");
+
     // msdNorm only supports lnorm for src in a channels last format.
     // So if channels aren't last (ie. if they aren't dense),
     // then reorder into a channels last format


### PR DESCRIPTION
# Description

acl_layer_normalization does not support RMS mode and needs to be skipped for this case.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

**Before**:

```
$ ONEDNN_VERBOSE=all ./build/tests/benchdnn/benchdnn --lnorm --dir=FWD_I --flags=M --dt=f32:bf16 5120x1024
onednn_verbose,v1,info,oneDNN v3.9.0 (commit f0d20cd39c101a16df8c40aa2baa47d1908ac3fc)
...
onednn_verbose,v1,primitive,create:cache_miss,cpu,layer_normalization,acl,forward_inference,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0 stats:undef::undef:::,,flags:M,5120x1024,0.0581055
onednn_verbose,v1,primitive,create:cache_hit,cpu,layer_normalization,acl,forward_inference,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0 stats:undef::undef:::,,flags:M,5120x1024,0.00805664
onednn_verbose,v1,cpu,acl,unsupported: Only Ab4a/Ab8a, BA8b4a/BA4b4a and Acdb8a/Acdb4a destination formats supported
onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,0.306152
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,8.5769
onednn_verbose,v1,primitive,exec:external,CpuLayerNormalizationKernel,0.424072
onednn_verbose,v1,primitive,exec,cpu,layer_normalization,acl,forward_inference,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0 stats:undef::undef:::,,flags:M,5120x1024,0.465088
onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,0.0141602
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,0.241943
[   0][DST][0:0] exp_f32:    0.655747 exp:    0.655747 got:           0 diff:0.655747 rdiff:       1
[   1][DST][0:1] exp_f32:    0.655747 exp:    0.655747 got:           0 diff:0.655747 rdiff:       1
[   2][DST][0:2] exp_f32:     1.03485 exp:     1.03485 got:    0.502137 diff:0.532714 rdiff:0.514774
[   3][DST][0:3] exp_f32:    0.276643 exp:    0.276643 got:   -0.502137 diff: 0.77878 rdiff: 2.81511
[   4][DST][0:4] exp_f32:    0.758207 exp:    0.758207 got:    0.135713 diff:0.622494 rdiff:0.821009
[   5][DST][0:5] exp_f32:    0.553286 exp:    0.553286 got:   -0.135713 diff:0.688999 rdiff: 1.24528
[   6][DST][0:6] exp_f32:     1.13731 exp:     1.13731 got:    0.637849 diff:0.499462 rdiff: 0.43916
[   7][DST][0:7] exp_f32:    0.174183 exp:    0.174183 got:   -0.637849 diff:0.812032 rdiff: 4.66195
[   8][DST][0:8] exp_f32:    0.860667 exp:    0.860667 got:    0.271425 diff:0.589242 rdiff:0.684634
[   9][DST][0:9] exp_f32:    0.450826 exp:    0.450826 got:   -0.271425 diff:0.722251 rdiff: 1.60206
[COMPARE_STATS][DST]: trh=0.032768 err_max_diff: 1.73814 err_max_rdiff: 128.087 all_max_diff: 1.73814 all_max_rdiff: 128.087
0:FAILED (errors:5149312 total:5242880) (84 ms) __REPRO: --lnorm --dir=FWD_I --dt=f32:bf16 --flags=M 5120x1024
```

**After**:

```
$ ONEDNN_VERBOSE=all ./build/tests/benchdnn/benchdnn --lnorm --dir=FWD_I --flags=M --dt=f32:bf16 5120x1024
onednn_verbose,v1,info,oneDNN v3.9.0 (commit 7fcd9501f88af980e2d783f8d58bd1f5b6e49280)
..
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,cpu,acl,unsupported: rms normalization is not supported
onednn_verbose,v1,primitive,create:cache_miss,cpu,layer_normalization,simple:any,forward_inference,src:f32::blocked:ab::f0 dst:bf16:a:blocked:ab::f0 stats:undef::undef:::,,flags:M,5120x1024,0.0651855
onednn_verbose,v1,primitive,create:cache_hit,cpu,layer_normalization,simple:any,forward_inference,src:f32::blocked:ab::f0 dst:bf16:a:blocked:ab::f0 stats:undef::undef:::,,flags:M,5120x1024,0.0100098
onednn_verbose,v1,cpu,acl,unsupported: Only Ab4a/Ab8a, BA8b4a/BA4b4a and Acdb8a/Acdb4a destination formats supported
onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,0.341064
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,18.7859
onednn_verbose,v1,primitive,exec,cpu,layer_normalization,simple:any,forward_inference,src:f32::blocked:ab::f0
...
onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:uni,undef,src:bf16::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,0.187012
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:bf16::blocked:ab::f0 dst:f32::blocked:ab::f0,,,5120x1024,0.205078
0:PASSED (102 ms) __REPRO: --lnorm --dir=FWD_I --dt=f32:bf16 --flags=M 5120x1024
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.10s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.03s (26%); execute: 0.02s (16%); compute_ref: 0.01s (7%); compare: 0.03s (30%);
```