### PR TITLE
ci: aarch64: remove fixed graph tests from the skip list

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "acl": "v52.0.0",
+        "acl": "v52.0.1",
         "gcc": "13",
         "clang": "17",
         "onednn-base": "v3.7"

--- a/.github/automation/aarch64/get_acl.sh
+++ b/.github/automation/aarch64/get_acl.sh
@@ -25,7 +25,7 @@ echo "github workspace $GITHUB_WORKSPACE"
 os_type=$(uname)
 
 ACL_WITH_ASSERTS=${ACL_WITH_ASSERTS:-0}
-ACL_VERSION=${ACL_VERSION:-v52.0.0}
+ACL_VERSION=${ACL_VERSION:-v52.0.1}
 
 if [[ "$os_type" == "Linux" ]]; then
   echo "This machine is running Linux"

--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -24,8 +24,7 @@ set -eo pipefail
 OS=${OS:-"Linux"}
 
 # AArch64 does not officially support graph for now.
-SKIPPED_GRAPH_TEST_FAILURES="test_graph_unit_dnnl_sdp_decomp_cpu"
-SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_mqa_decomp_cpu"
+SKIPPED_GRAPH_TEST_FAILURES=""
 
 # described in issue: https://github.com/uxlfoundation/oneDNN/issues/2175
 SKIPPED_TEST_FAILURES="test_benchdnn_modeC_matmul_multidims_cpu"
@@ -39,11 +38,10 @@ if [[ "$OS" == "Linux" ]]; then
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_ci_cpu"
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_different_dt_ci_cpu"
 
-    SKIPPED_GRAPH_TEST_FAILURES+="|test_benchdnn_modeC_graph_ci_cpu"
-    SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-gqa-cpp"
-    SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-mqa-cpp"
-    SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
-    SKIPPED_GRAPH_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
+    # Note: the order here matters. The first test added to
+    # SKIPPED_GRAPH_TEST_FAILURES should not have a '|' character to avoid
+    # skipping everything.
+    SKIPPED_GRAPH_TEST_FAILURES+="test_benchdnn_modeC_graph_ci_cpu"
     SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
 fi
 


### PR DESCRIPTION
# Description
The issue causing these failures was fixed in Compute Library 52.0.1

Unskipped tests:
```
cpu-graph-gqa-cpp
cpu-graph-mqa-cpp
cpu-graph-sdpa-cpp
cpu-graph-sdpa-stacked-qkv-cpp
test_graph_unit_dnnl_mqa_decomp_cpu
test_graph_unit_dnnl_sdp_decomp_cpu
```

Partially resolves #2674 

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?