### PR TITLE
oneDNN v3.8.1 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.8.0")
+set(PROJECT_VERSION "3.8.1")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.8:
* Fixed correctness issue in reorder primitive with non-trivial strides on Intel CPUs (a762d3248ee5e04b2348f3a5aeecfa64da4634d8)
* Fixed runtime error in convolution weight gradient on Xe2 architecture-based Intel GPUs (a8fac73036f67657f51c10b385f967c64607e802, c409ef949ea112e8fc1caf480d55a07247b4a702)
* Fixed performance regression in `bf16` convolution on Intel Datacenter GPU Max Series (98170d0f138458f4b3fcefca773be2ef7e73959f, c6bae4aa45dbe9ff9fe4e51173dc301550832e08, c5edd53195f6b1465f4ab4857d64a704bb38e8e1, bb1a5919fbedd4ce078f2fcf368a3e099f6c3942)
* Improved performance of `fp16` matmul with `fp8` compressed weights on Intel GPUs (58f3ec1510a4b10e51e57227229d2b2cfe23f55a, abff1764af8a93dda5c9c8be11c5a1a5da31daa7, ffd7dd34d837f6ddb50d2b88515c5f45bb18ed4f, 3b1e855f440a13124d33c05e1ab671eba1401bba, 2e140de469d28b3f49d3284dc0e215b9b43b718a, 3429f79274957e4bd9b9c6ec12bcf2a4e8362a5b)
* Fixed runtime error in `fp16` pooling primitive on Xe2 architecture based Intel GPUs (c0f6b6ded756c35d50b383c8078fdec1b3ad2f09)
* Improved performance of `fp16` matmul with `int4` weights and `32 < m <= 64` on Intel GPUs (2fa7072a4d632e341a10d883243c0b54359da2fc)
* Fixed correctness issues in `bf16` matmul with 3 or more dimensional tensors on processors with Intel AMX support (dd20965518965ff0f63093c1f90c957cbe9ad3e6, ea1b4a169d3fe59a8c8a5d60e5da30a5167e0b52)
* Fixed performance regression in `fp16` or `bf16` matmul with transposed source and weight tensors on Intel Datacenter GPU Max Series (e45e1aa4fe44e0ba0cfb74d58272fea59c47f683)
* Improved performance of `bf16` matmul with `int4` weights on Intel GPUs (7a15c231c569432ca74f7dd1db260f1f8877980c)
* Fixed runtime error in `fp16` SDPA subgraph with head size 512 on Intel Core Ultra (Series 2) processor integrated GPU (bde698584cbc6ca3f02649c8ff743f9b5d3d527e)
