### PR TITLE
cpu: aarch64: Revert "cpu: aarch64: Nuke winograd"

### DIFF
--- a/doc/primitives/convolution.md
+++ b/doc/primitives/convolution.md
@@ -395,7 +395,8 @@ fall back to an explicit GEMM algorithm.
 @anchor dg_winograd_conv
 ### Winograd Convolution
 
-oneDNN supports the Winograd convolution algorithm on GPU systems.
+oneDNN supports the Winograd convolution algorithm on GPU and AArch64 CPU systems.
+Winograd does not support threadpool on AArch64 CPU systems.
 
 The following side effects should be weighed against the (potential)
 performance boost achieved from using the Winograd algorithm:

--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright 2020-2023, 2025 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/acl_winograd_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+using data_t = prec_traits_t<data_type::f32>::type;
+
+status_t acl_wino_convolution_fwd_t::execute_forward(
+        const exec_ctx_t &ctx) const {
+    // Lock here is needed because resource_mapper does not support
+    // concurrent multithreaded access.
+    std::lock_guard<std::mutex> _lock {this->mtx};
+    // Retrieve primitive resource and configured Compute Library objects
+    auto *acl_resource
+            = ctx.get_resource_mapper()->get<acl_wino_resource_t>(this);
+    acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &acl_wino_obj
+            = acl_resource->get_acl_obj();
+
+    return execute_forward_conv_acl<
+            acl_obj_t<arm_compute::NEWinogradConvolutionLayer>, pd_t, data_t>(
+            ctx, acl_wino_obj, pd());
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -1,0 +1,152 @@
+/*******************************************************************************
+* Copyright 2020-2025 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+#define CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+
+#include "cpu/cpu_convolution_pd.hpp"
+
+#include "cpu/aarch64/acl_convolution_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct acl_wino_resource_t : public resource_t {
+    acl_wino_resource_t()
+        : acl_wino_obj_(utils::make_unique<
+                acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>()) {}
+
+    status_t configure(const acl_conv_conf_t &acp) {
+        if (!acl_wino_obj_) return status::out_of_memory;
+
+        // Init Compute Library tensors based on info from descriptor
+        acl_wino_obj_->src_tensor.allocator()->init(acp.src_tensor_info);
+        acl_wino_obj_->wei_tensor.allocator()->init(acp.wei_tensor_info);
+        acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_tensor_info);
+        acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_tensor_info);
+
+        // clang-format off
+        acl_wino_obj_->conv.configure(
+            &acl_wino_obj_->src_tensor,
+            &acl_wino_obj_->wei_tensor,
+            acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
+            &acl_wino_obj_->dst_tensor,
+            acp.padstride_info,
+            acp.act_info,
+            true); // to support 5x5, 7x7 filter shapes in addition to 3x3
+        // clang-format on
+
+        return status::success;
+    }
+
+    acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &get_acl_obj() const {
+        return *acl_wino_obj_;
+    }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_wino_resource_t);
+
+private:
+    std::unique_ptr<acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>
+            acl_wino_obj_;
+}; // acl_wino_resource_t
+
+struct acl_wino_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        using cpu_convolution_fwd_pd_t::cpu_convolution_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f16);
+            const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f32);
+            bool ok = is_fwd()
+                    && utils::one_of(desc()->alg_kind,
+                            alg_kind::convolution_auto,
+                            alg_kind::convolution_winograd)
+                    && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+                    && !has_zero_dim_memory();
+
+            ok = ok && DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL;
+            if (!ok) return status::unimplemented;
+
+            CHECK(acl_convolution_utils::init_conf_wino(acp_, src_md_,
+                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
+
+            set_default_alg_kind(alg_kind::convolution_winograd);
+
+            CHECK(post_ops.init(
+                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
+            acp_.use_dst_acc_for_sum = post_ops.has_sum();
+
+            if (acp_.use_dst_acc_for_sum) {
+                const memory_desc_wrapper dst_d(&dst_md_);
+                auto scratchpad = scratchpad_registry().registrar();
+                scratchpad.book(memory_tracking::names::key_generic_acc,
+                        dst_d.nelems(), dst_d.data_type_size());
+            }
+
+            return status::success;
+        }
+
+        acl_conv_conf_t acp_ = utils::zero<decltype(acp_)>();
+        acl_post_ops_t post_ops;
+    };
+
+    acl_wino_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+
+        auto r = utils::make_unique<acl_wino_resource_t>();
+        if (!r) return status::out_of_memory;
+
+        // Configure the resource based on information from primitive descriptor
+        CHECK(r->configure(pd()->acp_));
+        mapper.add(this, std::move(r));
+
+        return status::success;
+    }
+
+    ~acl_wino_convolution_fwd_t() override = default;
+
+    using data_t = typename prec_traits_t<data_type::f32>::type;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    // To guard the const execute_forward(), the mutex must be 'mutable'
+    mutable std::mutex mtx;
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+}; // acl_wino_convolution_fwd_t
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -69,6 +69,7 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/acl_depthwise_convolution.hpp"
 #include "cpu/aarch64/acl_gemm_convolution.hpp"
 #include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
+#include "cpu/aarch64/acl_winograd_convolution.hpp"
 #endif
 using namespace dnnl::impl::cpu::aarch64;
 #endif
@@ -135,6 +136,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_SSE41(jit_sse41_1x1_convolution_fwd_t)
             CPU_INSTANCE_AVX2(jit_avx2_convolution_fwd_t)
             CPU_INSTANCE_SSE41(jit_sse41_convolution_fwd_t)
+            CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
             CPU_INSTANCE_AARCH64(brdgmm_dw_convolution_fwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(brgemm_1x1_convolution_fwd_t<sve_512>)
             CPU_INSTANCE_AARCH64(brgemm_convolution_fwd_t<sve_512>)
@@ -241,6 +243,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX512(brgemm_convolution_fwd_t<avx512_core_fp16>)
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t<avx2_vnni_2>)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t<avx2_vnni_2>)
+            CPU_INSTANCE_AARCH64_ACL(acl_wino_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f16>)

--- a/tests/gtests/test_iface_wino_convolution.cpp
+++ b/tests/gtests/test_iface_wino_convolution.cpp
@@ -53,6 +53,12 @@ protected:
         const bool is_gpu = get_test_engine_kind() == engine::kind::gpu;
         input_f32.wino_supported = is_gpu;
         input_f16.wino_supported = is_gpu;
+#elif DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
+#if DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
+        const bool is_cpu = get_test_engine_kind() == engine::kind::cpu;
+        input_f32.wino_supported = is_cpu;
+        input_f16.wino_supported = is_cpu;
+#endif
 #endif
     }
 };


### PR DESCRIPTION
This reverts commit ef1365bfea776be2cf685e1210a87c180f3f6cb3.

Keep Winograd as OpenVINO uses `convolution_auto`
