### PR TITLE
ci: aarch64: simplify skipped test logic

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -23,9 +23,6 @@ set -eo pipefail
 
 OS=${OS:-"Linux"}
 
-# AArch64 does not officially support graph for now.
-SKIPPED_GRAPH_TEST_FAILURES=""
-
 # described in issue: https://github.com/uxlfoundation/oneDNN/issues/2175
 SKIPPED_TEST_FAILURES="test_benchdnn_modeC_matmul_multidims_cpu"
 
@@ -35,28 +32,24 @@ if [[ "$OS" == "Linux" ]]; then
         # as test_matmul is time consuming , we only run it in release mode to save time.
         SKIPPED_TEST_FAILURES+="|test_matmul"
     fi
+
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_ci_cpu"
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_different_dt_ci_cpu"
 
-    # Note: the order here matters. The first test added to
-    # SKIPPED_GRAPH_TEST_FAILURES should not have a '|' character to avoid
-    # skipping everything.
-    SKIPPED_GRAPH_TEST_FAILURES+="test_benchdnn_modeC_graph_ci_cpu"
-    SKIPPED_GRAPH_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
+    SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_ci_cpu"
+    SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_large_partition_cpu"
 fi
 
 # Nightly failures
-SKIPPED_NIGHTLY_TEST_FAILURES="test_benchdnn_modeC_bnorm_all_blocked_cpu"
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_regressions_cpu"
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_conv_int8_cpu"
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_matmul_sparse_gpu_cpu"
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_reorder_all_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_all_blocked_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_regressions_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_conv_int8_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_matmul_sparse_gpu_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_reorder_all_cpu"
 
-# * c7g failures. TODO: scope these to c7g only. Better yet, fix them.
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_binary_all_cpu"
-SKIPPED_NIGHTLY_TEST_FAILURES+="|test_benchdnn_modeC_graph_int8_cpu"
-
-SKIPPED_TEST_FAILURES+="|${SKIPPED_GRAPH_TEST_FAILURES}|${SKIPPED_NIGHTLY_TEST_FAILURES}"
+# c7g failures. TODO: scope these to c7g only. Better yet, fix them.
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_all_cpu"
+SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_int8_cpu"
 
 printf "${SKIPPED_TEST_FAILURES}"

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -24,7 +24,7 @@ on:
     branches: [main, "rls-*"]
     paths:
       - ".github/automation/*"
-      - ".github/automation/aarch64"
+      - ".github/automation/aarch64/**"
       - ".github/workflows/aarch64-acl.yml"
       - ".github/workflows/ci-aarch64.yml"
       - "cmake/**"
@@ -39,7 +39,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - ".github/automation/*"
-      - ".github/automation/aarch64"
+      - ".github/automation/aarch64/**"
       - ".github/workflows/aarch64-acl.yml"
       - ".github/workflows/ci-aarch64.yml"
       - "cmake/**"


### PR DESCRIPTION
# Description

Also fixes a bug where the testset is empty on platforms where no graph tests are skipped.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?