### PR TITLE
cpu: x64: enable hf8 support for matmul on AVX10.2

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -329,7 +329,8 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         return status::unimplemented;
     if (!IMPLICATION(one_of(data_type::f8_e5m2, dt_bias, dt_d)
                         || one_of(data_type::f8_e4m3, dt_bias, dt_d),
-                mayiuse(avx512_core_amx_fp16)))
+                utils::one_of(true, mayiuse(avx512_core_amx_fp16),
+                        mayiuse(avx10_2_512))))
         return status::unimplemented;
     // check that combination of data types is allowed
     if ((brg->dt_a == data_type::u8 && brg->dt_b == data_type::s8)
@@ -536,7 +537,10 @@ status_t brgemm_desc_set_attr(
             && brg->prfC.dist2 < 0)
         brg->prfC.dist2 = 0;
 
-    if (brg->is_fp8 && !is_superset(brg->isa_impl, avx512_core_amx_fp16))
+    if (brg->is_fp8
+            && !utils::one_of(true,
+                    is_superset(brg->isa_impl, avx512_core_amx_fp16),
+                    is_superset(brg->isa_impl, avx10_2_512)))
         return status::unimplemented;
 
     return status::success;

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -356,7 +356,12 @@ struct brgemm_desc_t {
 
     // return 'true' when FP8 MAC is not natively supported by the CPU ISA
     bool is_fp8_via_convert() const {
-        return is_fp8 && utils::one_of(isa_impl, avx10_1_512_amx_fp16);
+        return is_fp8
+                && utils::one_of(isa_impl, avx10_1_512_amx_fp16, avx10_2_512);
+    }
+
+    bool is_fp8_via_convert_non_amx() const {
+        return is_fp8_via_convert() && isa_impl == avx10_2_512;
     }
 
     bool is_input_convert() const { return is_bf32 || is_fp8_via_convert(); }

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -361,6 +361,14 @@ private:
     Vmm vmm_fp8_emu_aux5() const noexcept {
         return Vmm(isa_num_vregs(brg.isa_impl) - 5);
     }
+    Vmm vmm_fp8_load() const noexcept {
+        // Re-use it as output when converting fp8 to f16 vnni
+        return Vmm(isa_num_vregs(brg.isa_impl) - 5);
+    }
+    Vmm vmm_fp8_bcst() const noexcept {
+        // Re-use it as output when converting fp8 to f16 vnni
+        return Vmm(isa_num_vregs(brg.isa_impl) - 4);
+    }
 
     Zmm zmm_tmp_1() const noexcept { return Zmm(1); }
 
@@ -421,6 +429,8 @@ private:
 
     void compute_int8_compensation(dim_t rd_loop, dim_t bd_b, dim_t bd_e,
             dim_t bd_block, dim_t ld_block2, bool is_ld_tail, dim_t vpad);
+    void maybe_pre_process_data(
+            data_type_t dt, const Vmm &vmm_out1, const Vmm &vmm_out2);
     void maybe_pre_process_data(matrix_kind_t matrix_kind, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride, dim_t num_rows,
             dim_t num_col_bytes, bool is_rd_tail);
@@ -1891,6 +1901,21 @@ void jit_brgemm_kernel_t<Wmm>::set_A_B_matrices() {
 }
 
 template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(
+        data_type_t dt, const Vmm &vmm_out1, const Vmm &vmm_out2) {
+    assert(brg.is_fp8_via_convert_non_amx());
+    const Zmm zmm_out1 = Zmm(vmm_out1.getIdx());
+    const Zmm zmm_out2 = Zmm(vmm_out2.getIdx());
+
+    if (dt == data_type::f8_e5m2)
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni(zmm_out1, zmm_out2, zmm_out1);
+    else if (dt == data_type::f8_e4m3)
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni(zmm_out1, zmm_out2, zmm_out1);
+    else
+        assert(!"unsupported data type.");
+}
+
+template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
         const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
         dim_t num_rows, dim_t num_col_bytes, bool is_rd_tail) {
@@ -2108,6 +2133,8 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::dot_product(Vmm v1, Vmm v2, Vmm v3) {
     if (brg.is_f16 && brg.isa_impl == avx10_2_512)
         vdpphps(v1, v2, v3);
+    else if (brg.is_fp8 && brg.is_fp8_via_convert_non_amx())
+        vdpphps(v1, v2, v3);
     else if (brg.is_f32 || brg.is_f16
             || (brg.is_bf16 && brg.isa_impl == avx2_vnni_2))
         uni_vfmadd231ps(v1, v2, v3);
@@ -2206,7 +2233,6 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
         dim_t vpad, dim_t rows_for_rd_tail) {
-    assert(!brg.is_fp8_via_convert() && "No non-AMX path for fp8");
 
     MAYBE_UNUSED(bd_block2);
     dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
@@ -2220,7 +2246,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     dim_t rd_loop = 0, rd_tail_size = 0;
     if (is_rd_tail) {
-        if (brg.is_bf16 || brg.is_f16 || brg.is_int8) {
+        if (brg.is_bf16 || brg.is_f16 || brg.is_int8 || brg.is_fp8) {
             rd_tail_size = brg.rdb_tail % brg.rd_step;
             rd_loop = (rd_tail_size != 0)
                     ? ((brg.rdb_tail / brg.rd_step) + 1) * brg.rd_step
@@ -2245,7 +2271,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         const bool maybe_load_bytes
                 = (rows_for_rd_tail > 0 || brg.brgattr.wary_A_k_tail_read)
                 && is_rd_tail && rd_tail_size != 0
-                && (brg.is_bf16 || brg.is_f16 || brg.is_int8);
+                && (brg.is_bf16 || brg.is_f16 || brg.is_int8 || brg.is_fp8);
         const bool have_to_load_bytes
                 = maybe_load_bytes && (rd == rd_loop - brg.rd_step);
         const auto rows_by_load_bytes
@@ -2266,7 +2292,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     vbcstnebf162ps(vmm_bcast, ptr[reg_aux_A + offset]);
                 else
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
-            } else if (one_of(dt, data_type::s8, data_type::u8)) {
+            } else if (one_of(dt, data_type::s8, data_type::u8,
+                               data_type::f8_e5m2, data_type::f8_e4m3)) {
                 uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (dt == data_type::f16) {
                 if (brg.isa_impl == avx10_2_512) {
@@ -2362,13 +2389,23 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 broadcast_A(bcst(bd), bd, rd);
             for (dim_t ld = 0; ld < ld_block2; ld++) {
                 load_B(0, rd, ld);
+                if (brg.is_fp8_via_convert_non_amx())
+                    maybe_pre_process_data(brg.dt_b, load(), vmm_fp8_load());
                 for (dim_t bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
                     if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
-                    else
-                        dot_product(vmm, load(), bcst(bd));
+                    else {
+                        if (brg.is_fp8_via_convert_non_amx()) {
+                            broadcast_A(bcst(bd), bd, rd);
+                            maybe_pre_process_data(
+                                    brg.dt_a, bcst(bd), vmm_fp8_bcst());
+                            dot_product(vmm, load(), bcst(bd));
+                            dot_product(vmm, vmm_fp8_load(), vmm_fp8_bcst());
+                        } else
+                            dot_product(vmm, load(), bcst(bd));
+                    }
                 }
             }
 
@@ -2380,6 +2417,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
             for (dim_t bd = bd_b; bd < bd_e; bd++) {
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
+                if (brg.is_fp8_via_convert_non_amx())
+                    maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
                 if (prefetch_count_B < ld_block2) {
                     const dim_t prefetch_offset
                             = B_offset(prefetch_count_B++, rd)
@@ -2398,8 +2437,16 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(ld),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
-                    else
-                        dot_product(vmm, load(ld), bcst());
+                    else {
+                        if (brg.is_fp8_via_convert_non_amx()) {
+                            load_B(ld, rd, ld);
+                            maybe_pre_process_data(
+                                    brg.dt_b, load(ld), vmm_fp8_load());
+                            dot_product(vmm, load(ld), bcst());
+                            dot_product(vmm, vmm_fp8_load(), vmm_fp8_bcst());
+                        } else
+                            dot_product(vmm, load(ld), bcst());
+                    }
                 }
             }
         }
@@ -2653,7 +2700,8 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         bd_blocks_for_rd_tail = 0;
     } else {
         rows_for_rd_tail = 0;
-        if (brg.rdb_tail != 0 && (brg.is_bf16 || brg.is_f16 || brg.is_int8)) {
+        if (brg.rdb_tail != 0
+                && (brg.is_bf16 || brg.is_f16 || brg.is_int8 || brg.is_fp8)) {
             const auto rd_tail_size = brg.rdb_tail % brg.rd_step;
             rows_for_rd_tail = rd_tail_size
                     ? div_up(brg.rd_step - rd_tail_size, brg.reduce_dim)

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -346,11 +346,21 @@ private:
     // note: zmm reserv_5 is not necessary since it's only used for 'vdpbf16ps'
 
     // fp8 emulation convert
-    Vmm vmm_fp8_emu_aux1() const noexcept { return Vmm(1); }
-    Vmm vmm_fp8_emu_aux2() const noexcept { return Vmm(2); }
-    Vmm vmm_fp8_emu_aux3() const noexcept { return Vmm(3); }
-    Vmm vmm_fp8_emu_aux4() const noexcept { return Vmm(4); }
-    Vmm vmm_fp8_emu_aux5() const noexcept { return Vmm(5); }
+    Vmm vmm_fp8_emu_aux1() const noexcept {
+        return Vmm(isa_num_vregs(brg.isa_impl) - 1);
+    }
+    Vmm vmm_fp8_emu_aux2() const noexcept {
+        return Vmm(isa_num_vregs(brg.isa_impl) - 2);
+    }
+    Vmm vmm_fp8_emu_aux3() const noexcept {
+        return Vmm(isa_num_vregs(brg.isa_impl) - 3);
+    }
+    Vmm vmm_fp8_emu_aux4() const noexcept {
+        return Vmm(isa_num_vregs(brg.isa_impl) - 4);
+    }
+    Vmm vmm_fp8_emu_aux5() const noexcept {
+        return Vmm(isa_num_vregs(brg.isa_impl) - 5);
+    }
 
     Zmm zmm_tmp_1() const noexcept { return Zmm(1); }
 

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -260,7 +260,7 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f16(
             true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
 
     if (is_fp8_native()) {
-        host_->vcvtnehf82ph(xmm_out, op_in);
+        host_->vcvthf82ph(xmm_out, op_in);
         return;
     }
 
@@ -356,7 +356,7 @@ void fp8_conversion_e4m3_t::vcvt_f8_to_f32(
 
     // f16 <- f8_e4m3
     if (is_fp8_native())
-        host_->vcvtnehf82ph(ymm_mask(xmm_out), op_in);
+        host_->vcvthf82ph(ymm_mask(xmm_out), op_in);
     else
         vcvt_f8_to_f16(ymm_mask(xmm_out), op_in);
 
@@ -376,7 +376,7 @@ void fp8_conversion_e5m2_t::vcvt_f32_to_f8(
     host_->vcvtps2phx(op_in.isXMM() ? xmm_out : ymm_mask(xmm_out), op_in);
     // f8_e5m2 <- f16 (RNE)
     if (is_fp8_native())
-        host_->vcvtneph2bf8(xmm_out, ymm_out);
+        host_->vcvtph2bf8(xmm_out, ymm_out);
     else
         vcvt_f16_to_f8(xmm_out, ymm_out);
 }
@@ -386,7 +386,7 @@ void fp8_conversion_e5m2_t::vcvt_f16_to_f8(
     assert(utils::one_of(
             true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
     if (is_fp8_native()) {
-        host_->vcvtneph2bf8(xmm_out, op_in);
+        host_->vcvtph2bf8(xmm_out, op_in);
         return;
     }
 
@@ -438,7 +438,7 @@ void fp8_conversion_e4m3_t::vcvt_f32_to_f8(
     host_->vcvtps2phx(ymm_mask(xmm_out), op_in);
     // f8_e4m3 <- f16 (RNE)
     if (is_fp8_native())
-        host_->vcvtneph2hf8(xmm_out, ymm_out);
+        host_->vcvtph2hf8(xmm_out, ymm_out);
     else
         vcvt_f16_to_f8(xmm_out, ymm_out);
 }
@@ -448,7 +448,7 @@ void fp8_conversion_e4m3_t::vcvt_f16_to_f8(
     assert(utils::one_of(
             true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
     if (is_fp8_native()) {
-        host_->vcvtneph2hf8(xmm_out, op_in);
+        host_->vcvtph2hf8(xmm_out, op_in);
         return;
     }
 

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -208,7 +208,7 @@ void fp8_conversion_e5m2_t::perform_f8_to_f16_vnni_conversion(
 
 void fp8_conversion_e5m2_t::vcvt_f8_to_f16_vnni(const Xbyak::Zmm &zmm_out1,
         const Xbyak::Zmm &zmm_out2, const Xbyak::Operand &op_in) {
-    constexpr int zmm_permute_idx = 3;
+    const int zmm_permute_idx = xmm_aux3_.getIdx();
     prepare_f8_to_f16_vnni_masks(zmm_permute_idx);
     perform_f8_to_f16_vnni_conversion(
             zmm_out1, zmm_out2, op_in, zmm_permute_idx);
@@ -219,7 +219,7 @@ void fp8_conversion_e5m2_t::vcvt_f8_to_f16_vnni_block(int num_rows,
         const Xbyak::Reg64 &reg_data_out) {
     const Xbyak::Zmm zmm_aux1(xmm_aux1_.getIdx());
     const Xbyak::Zmm zmm_aux2(xmm_aux2_.getIdx());
-    constexpr int zmm_permute_idx = 3;
+    const int zmm_permute_idx = xmm_aux3_.getIdx();
 
     prepare_f8_to_f16_vnni_masks(zmm_permute_idx);
 

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
@@ -77,7 +77,7 @@ protected:
     const Xbyak::Reg64 reg64_aux_;
 
     bool is_fp8_native() {
-        return is_superset(host_->max_cpu_isa(), cpu_isa_t::avx10_2_512_amx_2);
+        return is_superset(host_->max_cpu_isa(), cpu_isa_t::avx10_2_512);
     }
 
     Xbyak::Zmm zmm_mask(

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -241,6 +241,9 @@ status_t check_isa_with_datatype(
             && IMPLICATION(bm_conf_utils.is_f16_with_int_wei(),
                     one_of(isa, avx512_core_amx_fp16, avx512_core_fp16))
             && IMPLICATION(bm_conf_utils.is_f8(),
+                    is_superset(isa, avx512_core_amx_fp16)
+                            || is_superset(isa, avx10_2_512))
+            && IMPLICATION(bm_conf_utils.is_bf8(),
                     is_superset(isa, avx512_core_amx_fp16));
     return ok ? status::success : status::unimplemented;
 }
@@ -272,6 +275,8 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
               && one_of(bgmmc.dst_dt, f16, f32))
     , f8_dt(one_of(bgmmc.src_dt, f8_e5m2, f8_e4m3)
               && one_of(bgmmc.wei_dt, f8_e5m2, f8_e4m3)
+              && one_of(bgmmc.dst_dt, f16, f32, bf16, f8_e5m2, f8_e4m3))
+    , bf8_dt(everyone_is(f8_e5m2, bgmmc.src_dt, bgmmc.wei_dt)
               && one_of(bgmmc.dst_dt, f16, f32, bf16, f8_e5m2, f8_e4m3))
     , int8_dt(utils::one_of(bgmmc.src_dt, u8, s8) && bgmmc.wei_dt == s8
               && one_of(bgmmc.dst_dt, u8, s8, s32, f32, bf16))

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -335,6 +335,8 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_f8() const { return f8_dt; }
 
+    inline bool is_bf8() const { return bf8_dt; }
+
     inline bool is_int8() const { return int8_dt; }
 
     inline bool is_bf32() const { return bf32_dt; }
@@ -384,7 +386,8 @@ struct brgemm_matmul_conf_utils_t {
 private:
     brgemm_matmul_conf_t &bgmmc;
 
-    const bool f32_dt, bf16_dt, f16_dt, f8_dt, int8_dt, bf32_dt, tf32_dt;
+    const bool f32_dt, bf16_dt, f16_dt, f8_dt, bf8_dt, int8_dt, bf32_dt,
+            tf32_dt;
     const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
             f32_bf16_dt, f16_with_int_wei_dt;
     const bool A_any_layout;

--- a/third_party/xbyak/xbyak_mnemonic.h
+++ b/third_party/xbyak/xbyak_mnemonic.h
@@ -2244,19 +2244,18 @@ void vcvtbiasph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1
 void vcvtbiasph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
 void vcvt2ps2ph(const Xmm& x1, const Xmm& x2, const Operand& op)  { opAVX_X_X_XM(x1, x2, op, T_66|T_0F38|T_W0|T_YMM|T_MUST_EVEX, 0x67); }
 void vcvtdq2ph(const Xmm& x, const Operand& op) { checkCvt4(x, op); opCvt(x, op, T_N16|T_N_VL|T_MAP5|T_EW0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x5B); }
-void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_MUST_EVEX | T_F2 | T_MAP5 | T_EW0 | T_YMM | T_N1, 0x1E); }
-void vcvtne2ph2bf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_0F38|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
-void vcvtne2ph2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
-void vcvtne2ph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
-void vcvtne2ph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
+void vcvt2ph2bf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_0F38|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
+void vcvt2ph2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
+void vcvt2ph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
+void vcvt2ph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N1|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
 void vcvtne2ps2bf16(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_F2|T_0F38|T_EW0|T_YMM|T_SAE_Z|T_MUST_EVEX|T_B32, 0x72); }
-void vcvtnebf162ibs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x69); }
-void vcvtnebf162iubs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x6B); }
-void vcvtnehf82ph(const Xmm& x, const Operand& op) { opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX, 0x1e); }
-void vcvtneph2bf8(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_0F38|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
-void vcvtneph2bf8s(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
-void vcvtneph2hf8(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
-void vcvtneph2hf8s(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
+void vcvtbf162ibs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x69); }
+void vcvtbf162iubs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x6B); }
+void vcvthf82ph(const Xmm& x, const Operand& op) { opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX, 0x1e); }
+void vcvtph2bf8(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_0F38|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
+void vcvtph2bf8s(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
+void vcvtph2hf8(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
+void vcvtph2hf8s(const Xmm& x, const Operand& op) { opCvt2(x, op, T_F3|T_MAP5|T_EW0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
 void vcvtpd2ph(const Xmm& x, const Operand& op) { opCvt5(x, op, T_N16|T_N_VL|T_66|T_MAP5|T_EW1|T_ER_Z|T_MUST_EVEX|T_B64, 0x5A); }
 void vcvtpd2qq(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x7B); }
 void vcvtpd2udq(const Xmm& x, const Operand& op) { opCvt2(x, op, T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x79); }


### PR DESCRIPTION
Fixes MFDNN-13571

- Only hf8 support is required for now, and using the same weights blocking format as int8
- removing "ne" from some conversion instructions for avx10.2
- update registers decomposition for fp8 conversion