### PR TITLE
xe: softmax: restore missing inf_as_zero functionality

### DIFF
--- a/src/gpu/intel/ocl/reusable_softmax.cl
+++ b/src/gpu/intel/ocl/reusable_softmax.cl
@@ -57,9 +57,13 @@ reusable_softmax_fwd_generic(__global SRC_DATA_T *src, __global DST_DATA_T *dst,
     if (USE_WORKGROUP_REDUCTION) { denom_ = work_group_reduce_add(denom_); }
     if (USE_SUBGROUP_REDUCTION) { denom_ = sub_group_reduce_add(denom_); }
 
-    denom_ = LOGSOFTMAX                              ? log(denom_)
-            : (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) ? 1.0f
-                                                     : 1.0f / denom_;
+    if (LOGSOFTMAX) {
+        denom_ = log(denom_);
+    } else if (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) {
+        denom_ = 1.0f;
+    } else {
+        denom_ = 1.0f / denom_;
+    }
 
     for (off_t c = begin; c < end; c += softmax_axis_stride) {
         FLT_ACC_DATA_T unscaled = LOGSOFTMAX
@@ -166,7 +170,14 @@ reusable_softmax_fwd_generic(__global DATA_T *src, __global DST_DATA_T *dst,
         }
     }
     denom_ = sub_group_reduce_add(denom_);
-    denom_ = LOGSOFTMAX ? log(denom_) : 1.0f / denom_;
+
+    if (LOGSOFTMAX) {
+        denom_ = log(denom_);
+    } else if (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) {
+        denom_ = 1.0f;
+    } else {
+        denom_ = 1.0f / denom_;
+    }
 
     dst += data_off;
 
@@ -217,7 +228,13 @@ reusable_softmax_fwd_generic(__global DATA_T *src, __global DST_DATA_T *dst,
     if (off < softmax_axis_size) denom_ += exp(d - max_);
 
     denom_ = sub_group_reduce_add(denom_);
-    denom_ = LOGSOFTMAX ? log(denom_) : 1.0f / denom_;
+    if (LOGSOFTMAX) {
+        denom_ = log(denom_);
+    } else if (SOFTMAX_INF_AS_ZERO && denom_ == 0.f) {
+        denom_ = 1.0f;
+    } else {
+        denom_ = 1.0f / denom_;
+    }
     dst += data_off;
 
     if (off < softmax_axis_size) {


### PR DESCRIPTION
This PR addresses the issue that PR #2525 was missing `inf_as_zero` functionality in the OpenCL softmax kernels (MFDNN-13724).