### PR TITLE
[GPU][GEMM] Restore fp8 check

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.hpp
@@ -67,6 +67,12 @@ struct gen_gemm_t : public gpu_gemm_t {
             int stepping = dev_info_->stepping_id();
             init_attrs();
             const auto d = desc();
+
+            VDISPATCH_GEMM(
+                    IMPLICATION(utils::one_of(d->a_type(), f8_e5m2, f8_e4m3),
+                            arch_ >= arch_t::xe_hpc),
+                    VERBOSE_UNSUPPORTED_DT); /* temporary; pending gemmstone pulldown */
+
             CHECK(set_default_formats(false));
 
             with_sround_ = attr()->rounding_mode_.get(DNNL_ARG_DST)


### PR DESCRIPTION
# Description

Restore FP8 support check dropped during rebase. Allows unsupported cases to run on pre-XeHPC platforms. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

