### PR TITLE
xe: sdpa: add support for reusable sdpa [WIP]

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -186,15 +186,19 @@ DECLARE_2D_TILE_RSELECT(a_scale_tile_type, SUBGROUP_SIZE, ugemm_vs_sg_tile_n, 1,
 #define cooperative_prefetch_2d_k cooperative_prefetch_2d_maybe_rem
 #endif
 
-#if REMAINDER_Q
-#define tile_load_block_rem_q tile_load_block
-#define tile_store_block_rem_q tile_store_block
-#else
-#define tile_load_block_rem_q(t, ptr, n, ld, off_r, off_c) \
-    tile_load_block(t, ptr, ld, off_r, off_c)
-#define tile_store_block_rem_q(t, ptr, n, ld, off_r, off_c) \
-    tile_store_block(t, ptr, ld, off_r, off_c)
-#endif
+#define tile_load_block_rem_q(t, ptr, n, ld, off_r, off_c, load_rem) \
+    if (load_rem) { \
+        tile_load_block(t, ptr, n, ld, off_r, off_c); \
+    } else { \
+        tile_load_block(t, ptr, ld, off_r, off_c); \
+    }
+
+#define tile_store_block_rem_q(t, ptr, n, ld, off_r, off_c, store_rem) \
+    if (store_rem) { \
+        tile_store_block(t, ptr, n, ld, off_r, off_c); \
+    } else { \
+        tile_store_block(t, ptr, ld, off_r, off_c); \
+    }
 
 #define binary_add(x, y) ((x) + (y))
 
@@ -210,7 +214,14 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         ,
         const global MSK_DATA_T *msk
 #endif
-) {
+        ,
+        KEY_OFFSETS, QRY_OFFSETS, VAL_OFFSETS, DST_OFFSETS
+#if WITH_ATTN_MASK
+        ,
+        MSK_OFFSETS
+#endif
+        ,
+        const int remainder_k, const int remainder_q) {
     uint sg_ij = sub_group_broadcast(get_local_id(1), 0);
     uint b0 = get_group_id(1);
     uint b1 = get_group_id(2);
@@ -269,22 +280,22 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     const bool need_sum_barrier = (ugemm_vs_barrier_count == 0);
 
     /* Convert to half precision and store */
-    const size_t k_offset = KEY_OFF(b1, b0_kv, 0, 0);
-    const size_t v_offset = VAL_OFF(b1, b0_kv, 0, 0);
+    const size_t k_offset = KEY_BATCH(b1, b0_kv);
+    const size_t v_offset = VAL_BATCH(b1, b0_kv);
     /* Locate K/Q/V/A matrices within batch */
     K += k_offset / KEY_ELEMENTS_PER_BYTE;
-    Q += QRY_OFF(b1, b0, 0, 0);
+    Q += QRY_BATCH(b1, b0);
     V += v_offset / VAL_ELEMENTS_PER_BYTE;
-    A += DST_OFF(b1, b0, 0, 0, 0);
+    A += DST_BATCH(b1, b0);
 #if WITH_ATTN_MASK
-    msk += MSK_OFF(b1 % MSK_D0, b0 % MSK_D1, 0, 0);
+    msk += MSK_BATCH(b1 % MSK_D0, b0 % MSK_D1);
 #ifndef BLOCK_MSK
     int mask_aligned = (((size_t)msk) % 4) == 0;
 #endif
 #endif
 
 #if KEY_SCALES
-    K_scales += k_offset / KEY_GROUP_SIZE;
+    K_scales += KEY_BATCH(b1, b0_kv) / KEY_GROUP_SIZE;
 #endif
 #if KEY_SCALES == QUANTIZE_COMMON
     float k_scale = KEY_SCALES_TO_FLOAT(*K_scales);
@@ -307,8 +318,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         q_tile_type Q_tile;
         uint q0_copy = q_tile_sg_n * sg_ij;
 #ifdef BLOCK_Q
-        tile_load_block_rem_q(
-                &Q_tile, (global uint *)Q, q, ldq >> 1, 0, wg_j0 + q0_copy);
+    tile_load_block_rem_q(&Q_tile, (global uint *)Q, q, ldq >> 1, 0,
+            wg_j0 + q0_copy, remainder_q);
 #elif Q_ALIGN >= 4
         tile_load(&Q_tile, (global uint *)Q, (d + 1) >> 1, q, ldq >> 1, 0,
                 wg_j0 + q0_copy);
@@ -446,17 +457,18 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 #endif
 
-#if REMAINDER_K
-        /* Prepare k mask: NaN in bounds, -inf out of bounds */
         kmask_tile_type_float k_mask;
+        if (remainder_k) {
+/* Prepare k mask: NaN in bounds, -inf out of bounds */
 #pragma unroll
-        for (int ii = 0; ii < ugemm_kq_sg_tile_m / SUBGROUP_SIZE; ii++)
-            k_mask.x[0][ii] = (k0 + sg_i0_kq + ii * SUBGROUP_SIZE
-                                              + get_sub_group_local_id()
-                                      < k0end)
-                    ? nan(0u)
-                    : -INFINITY;
-#endif
+            for (int ii = 0; ii < ugemm_kq_sg_tile_m / SUBGROUP_SIZE; ii++) {
+                k_mask.x[0][ii] = (k0 + sg_i0_kq + ii * SUBGROUP_SIZE
+                                                  + get_sub_group_local_id()
+                                          < k0end)
+                        ? nan(0u)
+                        : -INFINITY;
+            }
+        }
 
         /* Calculate S = (K^T) * Q */
         s_tile_type S_tile
@@ -497,9 +509,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 
         /* Apply k mask */
-#if REMAINDER_K
-        tile_hbroadcast_min(&S_tile, k_mask);
-#endif
+        if (remainder_k) { tile_hbroadcast_min(&S_tile, k_mask); }
 
 #if WITH_CAUSAL_MASK
 #define less_than(offset_k, offset_q) (offset_q < offset_k)
@@ -808,7 +818,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #ifdef BLOCK_2D_A
     tile_store_block2d(A_tile_dst, A, d, q, lda, sg_i0_vs, sg_j0_vs);
 #elif defined(BLOCK_A)
-    tile_store_block_rem_q(A_tile_dst, A, q, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block_rem_q(
+            A_tile_dst, A, q, lda, sg_i0_vs, sg_j0_vs, remainder_q);
 #else
     tile_store(A_tile_dst, A, d, q, lda, sg_i0_vs, sg_j0_vs);
 #endif

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -20,6 +20,7 @@
 #include "common/c_types_map.hpp"
 #include "common/sdpa_utils.hpp"
 #include "common/type_helpers.hpp"
+#include "common/utils.hpp"
 #include "gemmstone/microkernel_provider.hpp"
 #include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/jit/gemm/gen_gemm_kernel.hpp"
@@ -95,7 +96,7 @@ status_t update_config_from_devenv_values(
     return status::success;
 }
 
-status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
+status_t micro_sdpa_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     using namespace jit;
     using arch_t = compute::gpu_arch_t;
 
@@ -110,7 +111,8 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
 
     /* Retrieve pre-tuned kernel configuration */
     sdpa_config_t *config = nullptr;
-    bool thin_q = (d->queries() <= 16);
+    const dim_t thin_q_threshold = 16;
+    bool thin_q = (d->queries() <= thin_q_threshold);
     bool quantized = with_key_scales() || with_key_zp() || with_value_scales()
             || with_value_zp();
     bool is_integrated = compute_engine->device_info()->is_integrated();
@@ -167,14 +169,27 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
             config->unroll_m_vs * config->wg_m_vs,
             static_cast<long int>(d->head_size()));
 
-    /* Get device information */
-    HWInformation hw_info;
-    hw_info.euCount = dev_info->eu_count();
-    hw_info.gmdid = dev_info->ip_version();
-    hw_info.systolicAvailable = compute_engine->mayiuse(
-            compute::device_ext_t::intel_subgroup_matrix_multiply_accumulate);
+    // serializable minimal set of configuration params for ukernels
+    // will be used to generate shim ukernels in reusable kernel_ctx
+    micro_sdpa_ukernel_params_t ukernel_params;
+    ukernel_params.unroll_m_kq = config->unroll_m_kq;
+    ukernel_params.unroll_n_kq = config->unroll_n_kq;
+    ukernel_params.unroll_m_vs = config->unroll_m_vs;
+    ukernel_params.unroll_n_vs = config->unroll_n_vs;
+    ukernel_params.wg_m_kq = config->wg_m_kq;
+    ukernel_params.wg_n_kq = config->wg_n_kq;
+    ukernel_params.wg_m_vs = config->wg_m_vs;
+    ukernel_params.wg_n_vs = config->wg_n_vs;
 
-    if (hw_info.gmdid == 0) return status::unimplemented;
+    /* Get device information */
+    ukernel_serialized_hwinfo_t hwInfo;
+    hwInfo.euCount = static_cast<uint32_t>(dev_info->eu_count());
+    hwInfo.gmdid = static_cast<uint32_t>(dev_info->ip_version());
+    hwInfo.systolicAvailable = static_cast<uint32_t>(compute_engine->mayiuse(
+            compute::device_ext_t::intel_subgroup_matrix_multiply_accumulate));
+
+    if (hwInfo.gmdid == 0) return status::unimplemented;
+    ukernel_params.hwinfo = hwInfo;
 
     sg_size_ = dev_info->min_subgroup_size();
 
@@ -187,118 +202,125 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
     bool kq_common_zp = with_quantize_common(d->kq_zero_points);
 
     /* Set up GEMMProblem structure for first GEMM: K^T * Q */
-    GEMMProblem problem;
-    problem.Ta_ext = jit::convert_dnnl_to_kernel_type(key_md()->data_type);
-    problem.Tb_ext = jit::convert_dnnl_to_kernel_type(qry_md()->data_type);
+    ukernel_serialized_problem_t problem;
+
+    problem.Ta_ext = static_cast<uint32_t>(
+            jit::convert_dnnl_to_kernel_type(key_md()->data_type));
+    problem.Tb_ext = static_cast<uint32_t>(
+            jit::convert_dnnl_to_kernel_type(qry_md()->data_type));
     if (qry_md()->data_type == data_type::f16) {
-        problem.Ta = problem.Tb = Type::f16;
+        problem.Ta = problem.Tb = static_cast<uint32_t>(Type::f16);
     } else if (qry_md()->data_type == data_type::bf16) {
-        problem.Ta = problem.Tb = Type::bf16;
+        problem.Ta = problem.Tb = static_cast<uint32_t>(Type::bf16);
     } else {
         VCHECK_SDPA_COND(utils::one_of(qry_md()->data_type, data_type::f16,
                                  data_type::bf16),
                 "Q tensor's data type must be bf16 or f16");
     }
-    problem.Tc = problem.Tc_ext = Type::f32;
+    problem.Tc = problem.Tc_ext = static_cast<uint32_t>(Type::f32);
     problem.Ts = problem.Tc;
 
-    auto problem_kq = problem;
-    problem_kq.A.layout = convert_dnnl_to_kernel_layout(key_md());
+    problem.A_layout
+            = static_cast<int>(convert_dnnl_to_kernel_layout(key_md()));
 
-    /* Set up microkernel options */
-    micro::GEMMProtocol::Options opts_kq;
-    opts_kq.localB = true;
-    opts_kq.slmPtr = true;
-
+    problem.with_scales = with_key_scales();
+    problem.with_zp = with_key_zp();
+    problem.with_common_scales = kq_common_scales;
     if (with_key_scales() && !kq_common_scales) {
         auto scale_dt = key_scales_dt();
-        problem_kq.Ta_scale = jit::convert_dnnl_to_kernel_type(scale_dt);
-        problem_kq.A_scale.setAlignment(
-                int8_t(d->keys() * types::data_type_size(scale_dt)));
-        problem_kq.A_scale.layout = MatrixLayout::N;
-        problem_kq.aScale2D = true;
+        problem.Ta_scale = static_cast<uint32_t>(
+                jit::convert_dnnl_to_kernel_type(scale_dt));
+        problem.A_scale_alignment
+                = int8_t(d->keys() * types::data_type_size(scale_dt));
+        problem.A_scale_layout = static_cast<int>(MatrixLayout::N);
+        problem.aScale2D = true;
     }
+
     if (with_key_zp()) {
         auto zp_dt = key_zp_dt();
-        problem_kq.Tao = jit::convert_dnnl_to_kernel_type(zp_dt);
-        problem_kq.AO.setAlignment(
-                int8_t(d->keys() * types::data_type_size(zp_dt)));
-        problem_kq.AO.layout = MatrixLayout::N;
-        problem_kq.aoPtrDims = kq_common_zp ? 0 : 2;
-        problem_kq.aOffset = ABOffset::Calc;
+        problem.Tao = static_cast<uint32_t>(
+                jit::convert_dnnl_to_kernel_type(zp_dt));
+        problem.AO_alignment = int8_t(d->keys() * types::data_type_size(zp_dt));
+        problem.AO_layout = static_cast<int>(MatrixLayout::N);
+        problem.aoPtrDims = kq_common_zp ? 0 : 2;
+        problem.aOffset = static_cast<int>(ABOffset::Calc);
     }
 
     if (with_key_scales() || with_key_zp()) {
-        problem_kq.aqGroupM = 1;
-        problem_kq.aqGroupK
+        problem.aqGroupM = 1;
+        problem.aqGroupK
                 = (kq_common_scales || kq_common_zp) ? 1 : key_group_size();
     }
-    opts_kq.scaleA = with_key_scales() && !kq_common_scales;
-    opts_kq.offsetA = with_key_zp();
-
-    problem_kq.B.layout = MatrixLayout::Pr;
-    problem_kq.C.layout = MatrixLayout::T;
+    problem.B_layout = static_cast<int>(MatrixLayout::Pr);
+    problem.C_layout = static_cast<int>(MatrixLayout::T);
     const memory_desc_wrapper key_mdw(key_md());
     auto ldk = static_cast<int>(
             gemm_desc_t::get_ld(*key_md()) * key_mdw.data_type_size());
-    problem_kq.A.setAlignment(alignmentForLD(ldk));
-    problem_kq.B.setAlignment(64); // Q is packed in VNNI format in SLM
-    problem_kq.B.crosspack = 2;
-    problem_kq.B.tileR = into<uint16_t>(d_max());
-    problem_kq.B.tileC = into<uint16_t>(sg_size_);
+    problem.A_alignment = static_cast<uint8_t>(alignmentForLD(ldk));
+    problem.B_alignment = 64; // Q is packed in VNNI format in SLM
+    problem.B_crosspack = 2;
+    problem.B_tileR = into<uint16_t>(d_max());
+    problem.B_tileC = into<uint16_t>(sg_size_);
+
+    ukernel_params.problem_kq = problem;
+
+    /* Set up microkernel options */
+    ukernel_serialized_opts_t opts_kq;
+    opts_kq.localB = true;
+    opts_kq.slmPtr = true;
+
+    opts_kq.scaleA = with_key_scales() && !kq_common_scales;
+    opts_kq.offsetA = with_key_zp();
+
+    ukernel_params.opts_kq = opts_kq;
 
     /* Set up problem size information */
-    SizeParams sizes;
-    sizes.m = d->keys();
-    sizes.n = d->queries();
-    sizes.k = d->head_size();
-    sizes.batch = d->batch_size();
+    ukernel_serialized_sizes_t heuristic_sizes;
+    // quanatizing sizes to large intervals allows kernel
+    // selection search while avoiding recompilation for every new size
+    heuristic_sizes.m = round_up_seq_interval(d->keys(), arch_);
+    // query size is only tuned to thin_q/non-thin_q cases
+    heuristic_sizes.n = (d->queries() <= thin_q_threshold)
+            ? thin_q_threshold
+            : utils::rnd_up_pow2(d->queries());
+    heuristic_sizes.k
+            = d->head_size(); // baked into kernel regardless, no quantization
+    heuristic_sizes.batch = utils::rnd_up_pow2(d->batch_size());
 
-    /* Set up microkernel strategy */
-    std::vector<StrategyRequirement> reqs_kq;
-    reqs_kq.push_back(StrategyRequirement::UnrollM == config->unroll_m_kq);
-    reqs_kq.push_back(StrategyRequirement::UnrollN == config->unroll_n_kq);
-    reqs_kq.push_back(StrategyRequirement::WGM == config->wg_m_kq);
-    reqs_kq.push_back(StrategyRequirement::WGN == config->wg_n_kq);
+    ukernel_params.sizes_kq = heuristic_sizes;
 
-    /* Ask microkernel provider for microkernel */
-    try {
-        gemm_kq_ = selectGEMMMicrokernel(
-                opts_kq, hw_info, sizes, problem_kq, reqs_kq);
-    } catch (const std::runtime_error &ex) {
-        VCHECK_SDPA_COND(false,
-                "gemm_kq microkernel generation failure with message: %s",
-                ex.what());
-    }
+    /* Set up GEMMProblem structure for second GEMM: V * S  */
+    ukernel_serialized_problem_t problem_vs = problem;
 
     bool vs_common_scales = with_quantize_common(d->vs_scales);
     bool vs_common_zp = with_quantize_common(d->vs_zero_points);
 
-    /* Set up microkernel options */
-    micro::GEMMProtocol::Options opts_vs;
-    opts_vs.localB = true;
-    opts_vs.slmPtr = true;
+    problem_vs.Ta_ext = static_cast<uint32_t>(
+            jit::convert_dnnl_to_kernel_type(val_md()->data_type));
+    problem_vs.A_layout
+            = static_cast<int>(convert_dnnl_to_kernel_layout(val_md()));
 
-    /* Update for second GEMM: V*S */
-    auto problem_vs = std::move(problem);
-    problem_vs.Ta_ext = jit::convert_dnnl_to_kernel_type(val_md()->data_type);
-    problem_vs.A.layout = convert_dnnl_to_kernel_layout(val_md());
+    problem_vs.with_scales = with_value_scales();
+    problem_vs.with_zp = with_value_zp();
+    problem_vs.with_common_scales = vs_common_scales;
     if (with_value_scales() && !vs_common_scales) {
         auto scale_dt = value_scales_dt();
-        problem_vs.Ta_scale = jit::convert_dnnl_to_kernel_type(scale_dt);
-        problem_vs.A_scale.setAlignment(uint8_t(d->head_size()
-                / value_group_size() * types::data_type_size(scale_dt)));
-        problem_vs.A_scale.layout = MatrixLayout::N;
+        problem_vs.Ta_scale = static_cast<uint32_t>(
+                jit::convert_dnnl_to_kernel_type(scale_dt));
+        problem_vs.A_scale_alignment = uint8_t(d->head_size()
+                / value_group_size() * types::data_type_size(scale_dt));
+        problem_vs.A_scale_layout = static_cast<int>(MatrixLayout::N);
         problem_vs.aScale2D = true;
     }
+
     if (with_value_zp()) {
         auto zp_dt = value_zp_dt();
-        problem_vs.Tao = jit::convert_dnnl_to_kernel_type(zp_dt);
-        problem_vs.AO.setAlignment(uint8_t(d->head_size() / value_group_size()
-                * types::data_type_size(zp_dt)));
-        problem_vs.AO.layout = MatrixLayout::N;
+        problem_vs.Tao = static_cast<uint32_t>(
+                jit::convert_dnnl_to_kernel_type(zp_dt));
+        problem_vs.AO_alignment = uint8_t(d->head_size() / value_group_size()
+                * types::data_type_size(zp_dt));
+        problem_vs.AO_layout = static_cast<int>(MatrixLayout::N);
         problem_vs.aoPtrDims = vs_common_zp ? 0 : 2;
-        problem_vs.aOffset = ABOffset::Calc;
     }
     if (with_value_scales() || with_value_zp()) {
         problem_vs.aqGroupM = (vs_common_scales || vs_common_zp)
@@ -306,125 +328,113 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
                 : utils::rnd_up_pow2(value_group_size());
         problem_vs.aqGroupK = 1;
     }
-    opts_vs.scaleA = with_value_scales() && !vs_common_scales;
-    opts_vs.offsetA = with_value_zp();
 
-    problem_vs.B.layout = MatrixLayout::Pr;
-    problem_vs.C.layout = MatrixLayout::N;
+    problem_vs.B_layout = static_cast<int>(MatrixLayout::Pr);
+    problem_vs.C_layout = static_cast<int>(MatrixLayout::N);
     const memory_desc_wrapper val_mdw(val_md());
     auto ldv = static_cast<int>(
             gemm_desc_t::get_ld(*val_md()) * val_mdw.data_type_size());
-    problem_vs.A.setAlignment(alignmentForLD(ldv));
-    problem_vs.B.setAlignment(64); // S is packed in SLM
-    problem_vs.B.crosspack = 16;
-    sizes.m = d->values();
-    sizes.n = gemm_kq_.getSetting("wg_tile_n");
-    sizes.k = gemm_kq_.getSetting("wg_tile_m");
+    problem_vs.A_alignment = static_cast<uint8_t>(alignmentForLD(ldv));
+    problem_vs.B_alignment = 64; // S is packed in SLM
+    problem_vs.B_crosspack = 16;
 
-    /* Set up microkernel strategy */
-    std::vector<StrategyRequirement> reqs_vs;
-    reqs_vs.push_back(StrategyRequirement::UnrollM == config->unroll_m_vs);
-    reqs_vs.push_back(StrategyRequirement::UnrollN == config->unroll_n_vs);
-    reqs_vs.push_back(StrategyRequirement::WGM == config->wg_m_vs);
-    reqs_vs.push_back(StrategyRequirement::WGN == config->wg_n_vs);
+    ukernel_params.problem_vs = problem_vs;
 
-    /* Ask microkernel provider for microkernel */
-    try {
-        auto adjust_vs = [](GEMMStrategy &strategy) {
-            /* Enable dpasw */
-            strategy.dpasw |= strategy.fused;
-        };
-        gemm_vs_ = selectGEMMMicrokernel(
-                opts_vs, hw_info, sizes, problem_vs, reqs_vs, adjust_vs);
-    } catch (const std::runtime_error &ex) {
-        VCHECK_SDPA_COND(false,
-                "gemm_vs microkernel generation failure with message: %s",
-                ex.what());
-    }
-    VDEBUGINFO(4, primitive, sdpa, "kq_gemm: %s, vs_gemm: %s,",
-            problem_kq.toString().c_str(), problem_vs.toString().c_str());
+    // directly tied to config, will recompile w/head size and config updates
+    // no need for interval quantization
+    heuristic_sizes.m = d->values();
+    const int wg_tile_n = config->wg_n_kq * config->unroll_n_kq;
+    const int wg_tile_m = config->wg_m_kq * config->unroll_m_kq;
+    heuristic_sizes.n = wg_tile_n;
+    heuristic_sizes.k = wg_tile_m;
+
+    ukernel_params.sizes_vs = heuristic_sizes;
+
+    /* Set up microkernel options */
+    ukernel_serialized_opts_t opts_vs;
+    opts_vs.localB = true;
+    opts_vs.slmPtr = true;
+
+    opts_vs.scaleA = with_value_scales() && !vs_common_scales;
+    opts_vs.offsetA = with_value_zp();
+
+    ukernel_params.opts_vs = opts_vs;
+
+    conf.ukernel_config = ukernel_params;
 
     return status::success;
 }
 
 status_t micro_sdpa_t::init(impl::engine_t *engine) {
+    CHECK(create_kernel(
+            engine, kernel_, pd()->conf.get_kernel_names()[0], pd()->conf));
+    if (!kernel_) return status::runtime_error;
+    return status::success;
+}
+
+status_t micro_sdpa_t::pd_t::init_conf(impl::engine_t *engine) {
     using namespace micro;
 
-    compute::kernel_ctx_t kernel_ctx;
+    auto *pd = this;
+    auto *d = pd->desc();
 
-    auto *d = pd()->desc();
+    data_type_t data_t = pd->dst_md()->data_type;
+    conf.data_t = data_t;
+    conf.ndims = pd_t::ndims;
 
-    kernel_ctx.set_data_type(pd()->dst_md()->data_type);
+    const memory_desc_wrapper qry_mdw(pd->qry_md());
+    const memory_desc_wrapper key_mdw(pd->key_md());
+    const memory_desc_wrapper val_mdw(pd->val_md());
+    const memory_desc_wrapper dst_mdw(pd->dst_md());
+    const memory_desc_wrapper msk_mdw(pd->attn_mask_md());
 
-    int ndims = 4;
-    const memory_desc_wrapper qry_mdw(pd()->qry_md());
-    const memory_desc_wrapper key_mdw(pd()->key_md());
-    const memory_desc_wrapper val_mdw(pd()->val_md());
-    const memory_desc_wrapper dst_mdw(pd()->dst_md());
-    const memory_desc_wrapper msk_mdw(pd()->attn_mask_md());
-    using offset_t = decltype(offsets_t().src_off);
-    offset_t qry_off, key_off, val_off, dst_off, msk_off;
-    set_offsets(qry_mdw, qry_off);
-    set_offsets(key_mdw, key_off);
-    set_offsets(val_mdw, val_off);
-    set_offsets(dst_mdw, dst_off);
-    set_offsets(msk_mdw, msk_off);
-    def_offsets(qry_off, kernel_ctx, "QRY", ndims);
-    def_offsets(key_off, kernel_ctx, "KEY", ndims);
-    def_offsets(val_off, kernel_ctx, "VAL", ndims);
-    def_offsets(dst_off, kernel_ctx, "DST", ndims);
-    if (pd()->with_attn_mask()) {
-        def_offsets(msk_off, kernel_ctx, "MSK", ndims);
-    }
-    kernel_ctx.define_int("NDIMS", ndims);
+    conf.key_data_t = key_mdw.data_type();
+    conf.qry_data_t = qry_mdw.data_type();
+    conf.val_data_t = val_mdw.data_type();
+    conf.dst_data_t = dst_mdw.data_type();
 
-    def_data_type(kernel_ctx, key_mdw.data_type(), "KEY");
-    def_data_type(kernel_ctx, qry_mdw.data_type(), "QRY");
-    def_data_type(kernel_ctx, val_mdw.data_type(), "VAL");
-    def_data_type(kernel_ctx, dst_mdw.data_type(), "DST");
-    if (pd()->with_attn_mask()) {
-        def_data_type(kernel_ctx, msk_mdw.data_type(), "MSK");
-    }
+    conf.msk_data_t = data_type::undef;
+    if (pd->with_attn_mask()) { conf.msk_data_t = msk_mdw.data_type(); }
 
-    def_data_type(kernel_ctx, pd()->key_scales_dt(), "KEY_ATTR_SCALES");
-    def_data_type(kernel_ctx, pd()->value_scales_dt(), "VAL_ATTR_SCALES");
+    conf.key_scales_data_t = pd->key_scales_dt();
+    conf.value_scales_data_t = pd->value_scales_dt();
 
-    def_data_type(kernel_ctx, pd()->key_zp_dt(), "KEY_ATTR_ZP");
-    def_data_type(kernel_ctx, pd()->value_zp_dt(), "VAL_ATTR_ZP");
+    conf.key_zp_data_t = pd->key_zp_dt();
+    conf.value_zp_data_t = pd->value_zp_dt();
 
     auto Q_num_heads_dim = qry_mdw.dims()[1];
-    kernel_ctx.define_int("KV_GROUP_SIZE", Q_num_heads_dim / d->kv_head_number);
+    conf.kv_group_size = static_cast<int>(Q_num_heads_dim / d->kv_head_number);
 
-    auto ldq = gemm_desc_t::get_ld(*pd()->qry_md()) * qry_mdw.data_type_size();
-    auto ldk = gemm_desc_t::get_ld(*pd()->key_md()) * key_mdw.data_type_size();
-    auto ldv = gemm_desc_t::get_ld(*pd()->val_md()) * val_mdw.data_type_size();
-    auto lda = gemm_desc_t::get_ld(*pd()->dst_md()) * dst_mdw.data_type_size();
-    auto ldmsk = pd()->with_attn_mask()
+    auto ldq = gemm_desc_t::get_ld(*pd->qry_md()) * qry_mdw.data_type_size();
+    auto ldk = gemm_desc_t::get_ld(*pd->key_md()) * key_mdw.data_type_size();
+    auto ldv = gemm_desc_t::get_ld(*pd->val_md()) * val_mdw.data_type_size();
+    auto lda = gemm_desc_t::get_ld(*pd->dst_md()) * dst_mdw.data_type_size();
+    auto ldmsk = pd->with_attn_mask()
             ? msk_mdw.dims()[3] * msk_mdw.data_type_size()
             : 0;
-    kernel_ctx.define_int("Q_ALIGN", alignmentForLD(int(ldq)));
-    kernel_ctx.define_int("K_ALIGN", alignmentForLD(int(ldk)));
-    kernel_ctx.define_int("V_ALIGN", alignmentForLD(int(ldv)));
-    kernel_ctx.define_int("A_ALIGN", alignmentForLD(int(lda)));
 
-    kernel_ctx.define_int("TRANSPOSE_K",
-            gemm_desc_t::get_trans(*pd()->key_md()) == dnnl_trans);
+    conf.q_align = alignmentForLD(int(ldq));
+    conf.k_align = alignmentForLD(int(ldk));
+    conf.v_align = alignmentForLD(int(ldv));
+    conf.a_align = alignmentForLD(int(lda));
 
-    int kq_scale_mask = (static_cast<int>(pd()->with_key_scales()) << 1)
+    conf.transpose_k = gemm_desc_t::get_trans(*pd->key_md()) == dnnl_trans;
+
+    int kq_scale_mask = (static_cast<int>(pd->with_key_scales()) << 1)
             | static_cast<int>(with_quantize_common(d->kq_scales));
-    kernel_ctx.define_int("KEY_SCALES", kq_scale_mask);
+    conf.kq_scale_mask = kq_scale_mask;
 
-    int vs_scale_mask = (static_cast<int>(pd()->with_value_scales()) << 1)
+    int vs_scale_mask = (static_cast<int>(pd->with_value_scales()) << 1)
             | static_cast<int>(with_quantize_common(d->vs_scales));
-    kernel_ctx.define_int("VAL_SCALES", vs_scale_mask);
+    conf.vs_scale_mask = vs_scale_mask;
 
-    int kq_zp_mask = (static_cast<int>(pd()->with_key_zp()) << 1)
+    int kq_zp_mask = (static_cast<int>(pd->with_key_zp()) << 1)
             | static_cast<int>(with_quantize_common(d->kq_zero_points));
-    kernel_ctx.define_int("KEY_ZERO_POINTS", kq_zp_mask);
+    conf.kq_zp_mask = kq_zp_mask;
 
-    int vs_zp_mask = (static_cast<int>(pd()->with_value_zp()) << 1)
+    int vs_zp_mask = (static_cast<int>(pd->with_value_zp()) << 1)
             | static_cast<int>(with_quantize_common(d->vs_zero_points));
-    kernel_ctx.define_int("VAL_ZERO_POINTS", vs_zp_mask);
+    conf.vs_zp_mask = vs_zp_mask;
 
     using namespace data_type;
     auto elems_per_byte = [](data_type_t dt) {
@@ -434,101 +444,238 @@ status_t micro_sdpa_t::init(impl::engine_t *engine) {
             default: return 1;
         }
     };
-    kernel_ctx.define_int(
-            "KEY_ELEMENTS_PER_BYTE", elems_per_byte(key_mdw.data_type()));
-    kernel_ctx.define_int(
-            "KEY_ZP_ELEMENTS_PER_BYTE", elems_per_byte(pd()->key_zp_dt()));
-    kernel_ctx.define_int(
-            "VAL_ELEMENTS_PER_BYTE", elems_per_byte(val_mdw.data_type()));
-    kernel_ctx.define_int(
-            "VAL_ZP_ELEMENTS_PER_BYTE", elems_per_byte(pd()->value_zp_dt()));
 
-    if (pd()->with_key_scales() || pd()->with_key_zp())
-        kernel_ctx.define_int("KEY_GROUP_SIZE", pd()->key_group_size());
-    if (pd()->with_value_scales() || pd()->with_value_zp())
-        kernel_ctx.define_int("VAL_GROUP_SIZE", pd()->value_group_size());
+    conf.key_elements_per_byte = elems_per_byte(key_mdw.data_type());
+    conf.key_zp_elements_per_byte = elems_per_byte(pd->key_zp_dt());
+    conf.val_elements_per_byte = elems_per_byte(val_mdw.data_type());
+    conf.val_zp_elements_per_byte = elems_per_byte(pd->value_zp_dt());
 
-    def_data_type(kernel_ctx, d->scale_dt, "SCALE");
-    kernel_ctx.define_int("INVERT_SCALE", d->invert_scale);
-    kernel_ctx.define_int("WITH_ATTN_SCALE", pd()->with_attn_scale());
-    kernel_ctx.define_int("ATTN_MASK_UNDEF", attn_mask_type::undef);
-    kernel_ctx.define_int("ATTN_MASK_BUFFER", attn_mask_type::buffer);
-    kernel_ctx.define_int("ATTN_MASK_TOP_LEFT", attn_mask_type::top_left);
-    kernel_ctx.define_int(
-            "ATTN_MASK_BOTTOM_RIGHT", attn_mask_type::bottom_right);
+    conf.key_group_size = 1;
+    conf.val_group_size = 1;
+    if (pd->with_key_scales() || pd->with_key_zp())
+        conf.key_group_size = pd->key_group_size();
+    if (pd->with_value_scales() || pd->with_value_zp())
+        conf.val_group_size = pd->value_group_size();
 
-    kernel_ctx.define_int("WITH_ATTN_MASK",
-            pd()->with_attn_mask() && !pd()->with_causal_mask());
-    kernel_ctx.define_int(
-            "BROADCAST_MASK_Q", msk_mdw.dims()[pd_t::mask_q_index] == 1);
+    conf.scale_data_t = d->scale_dt;
 
-    kernel_ctx.define_int("WITH_CAUSAL_MASK", pd()->with_causal_mask());
+    conf.attn_mask_undef = attn_mask_type::undef;
+    conf.attn_mask_buffer = attn_mask_type::buffer;
+    conf.attn_mask_top_left = attn_mask_type::top_left;
+    conf.attn_mask_bottom_right = attn_mask_type::bottom_right;
 
-    kernel_ctx.define_int("SUBGROUP_SIZE", pd()->sg_size());
-    kernel_ctx.define_int("D_MAX", pd()->d_max());
+    conf.invert_scale = d->invert_scale;
+    conf.with_attn_scale = pd->with_attn_scale();
+    conf.with_attn_mask = (pd->with_attn_mask() && !pd->with_causal_mask());
+    conf.broadcast_mask_q = (msk_mdw.dims()[pd_t::mask_q_index] == 1);
+    conf.with_causal_mask = pd->with_causal_mask();
 
-    int tile_k = pd()->gemm_kq().getSetting("wg_tile_m");
-    int tile_q = pd()->gemm_kq().getSetting("wg_tile_n");
-    int tile_v = pd()->gemm_vs().getSetting("wg_tile_m");
+    conf.subgroup_size = pd->sg_size();
+    conf.d_max = pd->d_max();
 
-    bool d_full = (d->head_size() == pd()->d_max());
+    /* Set up microkernel strategy */
+    const sdpa_config_t config = {conf.ukernel_config.unroll_m_kq,
+            conf.ukernel_config.unroll_n_kq, conf.ukernel_config.unroll_m_vs,
+            conf.ukernel_config.unroll_n_vs, conf.ukernel_config.wg_m_kq,
+            conf.ukernel_config.wg_n_kq, conf.ukernel_config.wg_m_vs,
+            conf.ukernel_config.wg_n_vs};
+
+    const int wg_tile_m = config.wg_m_kq * config.unroll_m_kq;
+    int tile_k = wg_tile_m;
+    int tile_v = wg_tile_m;
+
+    bool d_full = (d->head_size() == pd->d_max());
     bool v_full = (d->head_size() == tile_v);
-    bool k_full = ((d->keys() % tile_k) == 0);
 
-    kernel_ctx.define_int("REMAINDER_K", !k_full);
+    conf.d_full = d_full;
+    conf.arch_gte_hpc = (pd->arch() >= compute::gpu_arch_t::xe_hpc);
 
+    conf.block_q = conf.block_a = conf.block_msk = conf.block_2d_a = false;
     if (d_full) {
-        if (ldq % 4 == 0) kernel_ctx.define_int("BLOCK_Q", 1);
-        if (lda % 4 == 0 && v_full) kernel_ctx.define_int("BLOCK_A", 1);
-        if (ldmsk % 4 == 0) kernel_ctx.define_int("BLOCK_MSK", 1);
-        kernel_ctx.define_int("REMAINDER_Q", (d->queries() % tile_q) != 0);
-    } else if (pd()->arch() >= compute::gpu_arch_t::xe_hpc) {
+        conf.block_q = (ldq % 4 == 0);
+        conf.block_a = (lda % 4 == 0 && v_full);
+        conf.block_msk = (ldmsk % 4 == 0);
+    } else if (pd->arch() >= compute::gpu_arch_t::xe_hpc) {
         auto vbytes = d->values() * val_mdw.data_type_size();
-        if (lda % 16 == 0 && vbytes % 4 == 0)
-            kernel_ctx.define_int("BLOCK_2D_A", 1);
+        if (lda % 16 == 0 && vbytes % 4 == 0) conf.block_2d_a = true;
     }
 
-    if (pd()->arch() >= compute::gpu_arch_t::xe_hpc) {
+    if (pd->arch() >= compute::gpu_arch_t::xe_hpc) {
+        conf.prefetch_mask = true;
+        conf.prefetch_k0 = true;
+        conf.prefetch_k = true;
+        conf.prefetch_v = true;
+        bool no_rem = d_full && v_full && (d->keys() % tile_k == 0);
+        conf.prefetch_remainder = !no_rem;
+        conf.prefetch_d_max = nstl::min(pd->d_max(), 64);
+    } else {
+        conf.prefetch_mask = conf.prefetch_k0 = conf.prefetch_k
+                = conf.prefetch_v = conf.prefetch_remainder = false;
+        conf.prefetch_d_max = 0;
+    }
+
+    conf.q_arrive_await_barrier = (d->queries() > 1);
+    conf.softmax_inf_as_zero
+            = (d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
+    return status::success;
+}
+
+status_t micro_sdpa_params_t::get_kernel_ctx(
+        compute::kernel_ctx_t &kernel_ctx) const {
+    using namespace micro;
+
+    kernel_ctx.define_int("NDIMS", ndims);
+    kernel_ctx.set_data_type(data_t);
+
+    def_data_type(kernel_ctx, key_data_t, "KEY");
+    def_data_type(kernel_ctx, qry_data_t, "QRY");
+    def_data_type(kernel_ctx, val_data_t, "VAL");
+    def_data_type(kernel_ctx, dst_data_t, "DST");
+
+    if (with_attn_mask) { def_data_type(kernel_ctx, msk_data_t, "MSK"); }
+
+    def_data_type(kernel_ctx, key_scales_data_t, "KEY_ATTR_SCALES");
+    def_data_type(kernel_ctx, value_scales_data_t, "VAL_ATTR_SCALES");
+
+    def_data_type(kernel_ctx, key_zp_data_t, "KEY_ATTR_ZP");
+    def_data_type(kernel_ctx, value_zp_data_t, "VAL_ATTR_ZP");
+
+    kernel_ctx.define_int("KV_GROUP_SIZE", kv_group_size);
+
+    kernel_ctx.define_int("Q_ALIGN", q_align);
+    kernel_ctx.define_int("K_ALIGN", k_align);
+    kernel_ctx.define_int("V_ALIGN", v_align);
+    kernel_ctx.define_int("A_ALIGN", a_align);
+
+    kernel_ctx.define_int("TRANSPOSE_K", transpose_k);
+
+    kernel_ctx.define_int("KEY_SCALES", kq_scale_mask);
+    kernel_ctx.define_int("VAL_SCALES", vs_scale_mask);
+    kernel_ctx.define_int("KEY_ZERO_POINTS", kq_zp_mask);
+    kernel_ctx.define_int("VAL_ZERO_POINTS", vs_zp_mask);
+
+    kernel_ctx.define_int("KEY_ELEMENTS_PER_BYTE", key_elements_per_byte);
+    kernel_ctx.define_int("KEY_ZP_ELEMENTS_PER_BYTE", key_zp_elements_per_byte);
+    kernel_ctx.define_int("VAL_ELEMENTS_PER_BYTE", val_elements_per_byte);
+    kernel_ctx.define_int("VAL_ZP_ELEMENTS_PER_BYTE", val_zp_elements_per_byte);
+
+    kernel_ctx.define_int("KEY_GROUP_SIZE", key_group_size);
+    kernel_ctx.define_int("VAL_GROUP_SIZE", val_group_size);
+
+    def_data_type(kernel_ctx, scale_data_t, "SCALE");
+    kernel_ctx.define_int("INVERT_SCALE", invert_scale);
+    kernel_ctx.define_int("WITH_ATTN_SCALE", with_attn_scale);
+    kernel_ctx.define_int("ATTN_MASK_UNDEF", attn_mask_undef);
+    kernel_ctx.define_int("ATTN_MASK_BUFFER", attn_mask_buffer);
+    kernel_ctx.define_int("ATTN_MASK_TOP_LEFT", attn_mask_top_left);
+    kernel_ctx.define_int("ATTN_MASK_BOTTOM_RIGHT", attn_mask_bottom_right);
+
+    kernel_ctx.define_int("WITH_ATTN_MASK", with_attn_mask);
+    kernel_ctx.define_int("BROADCAST_MASK_Q", broadcast_mask_q);
+    kernel_ctx.define_int("WITH_CAUSAL_MASK", with_causal_mask);
+
+    kernel_ctx.define_int("SUBGROUP_SIZE", subgroup_size);
+    kernel_ctx.define_int("D_MAX", d_max);
+
+    if (d_full) {
+        if (block_q) kernel_ctx.define_int("BLOCK_Q", 1);
+        if (block_a) kernel_ctx.define_int("BLOCK_A", 1);
+        if (block_msk) kernel_ctx.define_int("BLOCK_MSK", 1);
+    } else if (arch_gte_hpc) {
+        if (block_2d_a) kernel_ctx.define_int("BLOCK_2D_A", 1);
+    }
+
+    if (arch_gte_hpc) {
         kernel_ctx.define_int("PREFETCH_MASK", 1);
         kernel_ctx.define_int("PREFETCH_K0", 1);
         kernel_ctx.define_int("PREFETCH_K", 1);
         kernel_ctx.define_int("PREFETCH_V", 1);
-        bool no_rem = d_full && v_full && (d->keys() % tile_k == 0);
-        kernel_ctx.define_int("PREFETCH_REMAINDER", !no_rem);
-        kernel_ctx.define_int("PREFETCH_D_MAX", nstl::min(pd()->d_max(), 64));
+        kernel_ctx.define_int("PREFETCH_REMAINDER", prefetch_remainder);
+        kernel_ctx.define_int("PREFETCH_D_MAX", prefetch_d_max);
     }
 
-    kernel_ctx.define_int("Q_ARRIVE_AWAIT_BARRIER", d->queries() > 1);
+    kernel_ctx.define_int("Q_ARRIVE_AWAIT_BARRIER", q_arrive_await_barrier);
+    kernel_ctx.define_int("SOFTMAX_INF_AS_ZERO", softmax_inf_as_zero);
 
-    kernel_ctx.define_int("SOFTMAX_INF_AS_ZERO",
-            d->softmax_alg == alg_kind::softmax_accurate_inf_as_zero);
+    gemmstone::HWInformation hw_info;
+    gemmstone::GEMMProblem problem_kq, problem_vs;
+    micro::GEMMProtocol::Options opts_kq, opts_vs;
+    gemmstone::SizeParams sizes_kq, sizes_vs;
+
+    deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
+            opts_vs, sizes_kq, sizes_vs, ukernel_config);
+
+    micro::Package gemm_kq, gemm_vs;
+
+    /* Set up microkernel strategy */
+    const sdpa_config_t config
+            = {ukernel_config.unroll_m_kq, ukernel_config.unroll_n_kq,
+                    ukernel_config.unroll_m_vs, ukernel_config.unroll_n_vs,
+                    ukernel_config.wg_m_kq, ukernel_config.wg_n_kq,
+                    ukernel_config.wg_m_vs, ukernel_config.wg_n_vs};
+
+    std::vector<StrategyRequirement> reqs_kq;
+    reqs_kq.push_back(StrategyRequirement::UnrollM == config.unroll_m_kq);
+    reqs_kq.push_back(StrategyRequirement::UnrollN == config.unroll_n_kq);
+    reqs_kq.push_back(StrategyRequirement::WGM == config.wg_m_kq);
+    reqs_kq.push_back(StrategyRequirement::WGN == config.wg_n_kq);
+
+    std::vector<StrategyRequirement> reqs_vs;
+    reqs_vs.push_back(StrategyRequirement::UnrollM == config.unroll_m_vs);
+    reqs_vs.push_back(StrategyRequirement::UnrollN == config.unroll_n_vs);
+    reqs_vs.push_back(StrategyRequirement::WGM == config.wg_m_vs);
+    reqs_vs.push_back(StrategyRequirement::WGN == config.wg_n_vs);
+
+    /* Ask microkernel provider for microkernel */
+    try {
+        gemm_kq = selectGEMMMicrokernel(
+                opts_kq, hw_info, sizes_kq, problem_kq, reqs_kq);
+    } catch (const std::runtime_error &ex) {
+        VCHECK_SDPA_COND(false,
+                "gemm_kq microkernel generation failure with message: %s",
+                ex.what());
+    }
+
+    /* Ask microkernel provider for microkernel */
+    try {
+        auto adjust_vs = [](GEMMStrategy &strategy) {
+            /* Enable dpasw */
+            strategy.dpasw |= strategy.fused;
+        };
+        gemm_vs = selectGEMMMicrokernel(
+                opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs, adjust_vs);
+    } catch (const std::runtime_error &ex) {
+        VCHECK_SDPA_COND(false,
+                "gemm_vs microkernel generation failure with message: %s",
+                ex.what());
+    }
+    VDEBUGINFO(4, primitive, sdpa, "kq_gemm: %s, vs_gemm: %s,",
+            problem_kq.toString().c_str(), problem_vs.toString().c_str());
 
     /* Generate microkernel shims */
     ShimOptions shimOptions;
-    shimOptions.subgroupSize = pd()->sg_size();
+    shimOptions.subgroupSize = subgroup_size;
     shimOptions.useTileOps = true;
     shimOptions.decorator = "kq";
 
     kernel_ctx.add_custom_header("gemm_kq.h",
-            micro::generateShim(
-                    pd()->gemm_kq(), HostLanguage::OpenCL_C, shimOptions));
+            micro::generateShim(gemm_kq, HostLanguage::OpenCL_C, shimOptions));
 
     shimOptions.microkernelID++;
     shimOptions.decorator = "vs";
 
     kernel_ctx.add_custom_header("gemm_vs.h",
-            micro::generateShim(
-                    pd()->gemm_vs(), HostLanguage::OpenCL_C, shimOptions));
+            micro::generateShim(gemm_vs, HostLanguage::OpenCL_C, shimOptions));
 
-    if (pd()->gemm_kq().grfMin > 128 || pd()->gemm_vs().grfMin > 128)
+    if (gemm_kq.grfMin > 128 || gemm_vs.grfMin > 128)
         kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
 
-    CHECK(create_kernel(engine, &kernel_, "micro_sdpa", kernel_ctx));
-    if (!kernel_) return status::runtime_error;
     return status::success;
 }
 
 status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
+    const auto &conf = pd()->conf;
+
     const auto &qry = CTX_IN_STORAGE(DNNL_ARG_QUERIES);
     const auto &key = CTX_IN_STORAGE(DNNL_ARG_KEYS);
     const auto &val = CTX_IN_STORAGE(DNNL_ARG_VALUES);
@@ -544,14 +691,58 @@ status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
             = CTX_IN_STORAGE(DNNL_ARG_VALUES | DNNL_ARG_ATTR_SCALES);
     const auto &value_zp
             = CTX_IN_STORAGE(DNNL_ARG_VALUES | DNNL_ARG_ATTR_ZERO_POINTS);
+
     const dim_t Q = pd()->desc()->queries();
     const dim_t K = pd()->desc()->keys();
     const dim_t D = pd()->desc()->head_size();
 
-    auto &gemm_kq = pd()->gemm_kq();
-    auto wg_tile_q = gemm_kq.getSetting("wg_tile_n");
-    auto sg_per_wg = gemm_kq.getSetting("sg_per_wg_m")
-            * gemm_kq.getSetting("sg_per_wg_n");
+    const sdpa_config_t config = {conf.ukernel_config.unroll_m_kq,
+            conf.ukernel_config.unroll_n_kq, conf.ukernel_config.unroll_m_vs,
+            conf.ukernel_config.unroll_n_vs, conf.ukernel_config.wg_m_kq,
+            conf.ukernel_config.wg_n_kq, conf.ukernel_config.wg_m_vs,
+            conf.ukernel_config.wg_n_vs};
+    const int kq_wg_tile_m = config.wg_m_kq * config.unroll_m_kq;
+    const int kq_wg_tile_n = config.wg_n_kq * config.unroll_n_kq;
+    auto wg_tile_q = kq_wg_tile_n;
+    auto sg_per_wg = config.wg_m_kq * config.wg_n_kq;
+
+    const memory_desc_wrapper qry_mdw(pd()->qry_md());
+    const memory_desc_wrapper key_mdw(pd()->key_md());
+    const memory_desc_wrapper val_mdw(pd()->val_md());
+    const memory_desc_wrapper dst_mdw(pd()->dst_md());
+    const memory_desc_wrapper msk_mdw(pd()->attn_mask_md());
+    using offset_t = decltype(offsets_t().src_off);
+
+    offset_t key_off, qry_off, val_off, dst_off, msk_off;
+
+    set_offsets(key_mdw, key_off);
+    set_offsets(qry_mdw, qry_off);
+    set_offsets(val_mdw, val_off);
+    set_offsets(dst_mdw, dst_off);
+    set_offsets(msk_mdw, msk_off);
+
+    //TODO: change arg_list type based on large_idx
+    //bool use_int32_offset = conf.use_int32_offset;
+
+    auto append_offs
+            = [](compute::kernel_arg_list_t &arg_list, const offset_t &offs) {
+                  for (int d = 0; d < std::min(MAX_NDIMS, pd_t::ndims); ++d) {
+                      const int dim = static_cast<int>(offs[3][d]);
+                      arg_list.append(dim);
+                  }
+                  for (int d = 0; d < std::min(MAX_NDIMS, pd_t::ndims); ++d) {
+                      const int stride = static_cast<int>(offs[1][d]);
+                      arg_list.append(stride);
+                  }
+                  for (int d = 0; d < std::min(MAX_NDIMS, pd_t::ndims); ++d) {
+                      const int block = static_cast<int>(offs[0][d]);
+                      arg_list.append(block);
+                  }
+                  for (int d = 0; d < std::min(MAX_NDIMS, pd_t::ndims); ++d) {
+                      const int block_stride = static_cast<int>(offs[2][d]);
+                      arg_list.append(block_stride);
+                  }
+              };
 
     int mask_type = static_cast<int>(pd()->desc()->mask_type);
     compute::kernel_arg_list_t arg_list;
@@ -569,6 +760,18 @@ status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
     arg_list.append(value_zp);
     arg_list.append(mask_type);
     if (pd()->with_attn_mask()) arg_list.append(attn_mask);
+
+    append_offs(arg_list, key_off);
+    append_offs(arg_list, qry_off);
+    append_offs(arg_list, val_off);
+    append_offs(arg_list, dst_off);
+
+    if (pd()->with_attn_mask()) { append_offs(arg_list, msk_off); }
+
+    const bool remainder_k = (K % kq_wg_tile_m) != 0;
+    const bool remainder_q = (Q % kq_wg_tile_n) != 0;
+    arg_list.append(static_cast<int>(remainder_k));
+    arg_list.append(static_cast<int>(remainder_q));
 
     compute::range_t lws = {(size_t)pd()->sg_size(), (size_t)sg_per_wg, 1};
     compute::range_t gws = lws;

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+#include "gpu/intel/ocl/micro_sdpa_configs.hpp"
+
 #include "common/c_types_map.hpp"
 #include "common/gemm_types.hpp"
 #include "common/gemm_utils.hpp"
@@ -39,13 +41,71 @@ namespace gpu {
 namespace intel {
 namespace ocl {
 
+struct micro_sdpa_params_t : trivially_serializable_t<micro_sdpa_params_t> {
+
+    const std::vector<const char *> &get_kernel_names() const {
+        static const std::vector<const char *> kernel_names = {"micro_sdpa"};
+        return kernel_names;
+    }
+
+    status_t create_generator(const compute::compute_engine_t &engine,
+            compute::kernel_bundle_t &bundle) const {
+        compute::kernel_ctx_t kernel_ctx;
+        CHECK(get_kernel_ctx(kernel_ctx));
+        auto status = engine.create_kernel_bundle(
+                bundle, get_kernel_names(), kernel_ctx);
+        return status;
+    }
+
+    status_t get_kernel_ctx(compute::kernel_ctx_t &) const;
+
+    int ndims;
+    data_type_t data_t;
+    data_type_t dst_data_t, key_data_t, qry_data_t, val_data_t, msk_data_t;
+    data_type_t key_scales_data_t, value_scales_data_t;
+    data_type_t key_zp_data_t, value_zp_data_t;
+    int kv_group_size;
+
+    int q_align, k_align, v_align, a_align;
+    bool transpose_k;
+    uint8_t padding0[3] = {0};
+
+    int kq_scale_mask, vs_scale_mask, kq_zp_mask, vs_zp_mask;
+    int key_elements_per_byte, key_zp_elements_per_byte, val_elements_per_byte,
+            val_zp_elements_per_byte;
+
+    int key_group_size, val_group_size;
+    data_type_t scale_data_t;
+
+    int attn_mask_undef, attn_mask_buffer, attn_mask_top_left,
+            attn_mask_bottom_right;
+    bool invert_scale, with_attn_scale, with_attn_mask, broadcast_mask_q,
+            with_causal_mask;
+    uint8_t padding1[3] = {0};
+    int subgroup_size, d_max;
+
+    bool d_full, arch_gte_hpc;
+    bool block_q, block_a, block_msk, block_2d_a;
+    bool prefetch_mask, prefetch_k0, prefetch_k, prefetch_v, prefetch_remainder;
+    uint8_t padding2[5] = {0};
+    int prefetch_d_max;
+
+    bool softmax_inf_as_zero;
+    bool q_arrive_await_barrier;
+    uint8_t padding3[2] = {0};
+
+    micro_sdpa_ukernel_params_t ukernel_config;
+};
+DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(micro_sdpa_params_t);
+
 struct micro_sdpa_t : public gpu_primitive_t {
     using gpu_primitive_t::gpu_primitive_t;
     struct pd_t : public sdpa_pd_t {
         using sdpa_pd_t::sdpa_pd_t;
-        static constexpr int mask_mb_indes = 0;
+        static constexpr int mask_mb_index = 0;
         static constexpr int mask_q_index = 2;
         static constexpr int mask_k_index = 3;
+        static constexpr int ndims = 4;
 
         DECLARE_COMMON_PD_T("ocl:micro:any", micro_sdpa_t);
 
@@ -161,7 +221,12 @@ struct micro_sdpa_t : public gpu_primitive_t {
                         vgs, static_cast<long int>(val_md()->dims[3]));
             }
 
-            CHECK(init_microkernels(engine));
+            VDISPATCH_SDPA_SC(init_conf_microkernels(engine),
+                    VERBOSE_PRIMITIVE_CREATION_FAIL,
+                    "micro_sdpa init_conf_microkernels");
+            VDISPATCH_SDPA_SC(init_conf(engine),
+                    VERBOSE_PRIMITIVE_CREATION_FAIL, "micro_sdpa init_conf");
+
             return status::success;
         }
 
@@ -184,9 +249,6 @@ struct micro_sdpa_t : public gpu_primitive_t {
             return status::success;
         }
 
-        const micro::Package &gemm_kq() const { return gemm_kq_; }
-        const micro::Package &gemm_vs() const { return gemm_vs_; }
-
         int sg_size() const { return sg_size_; }
 
         // Block size for head_size, which must be hard-coded into the kernel.
@@ -198,13 +260,14 @@ struct micro_sdpa_t : public gpu_primitive_t {
         }
 
         compute::gpu_arch_t arch() const { return arch_; }
+        micro_sdpa_params_t conf;
 
     private:
-        micro::Package gemm_kq_, gemm_vs_;
         int sg_size_ = 0;
         compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
 
-        status_t init_microkernels(impl::engine_t *engine);
+        status_t init_conf_microkernels(impl::engine_t *engine);
+        status_t init_conf(impl::engine_t *engine);
     };
 
     status_t init(impl::engine_t *engine) override;

--- a/src/gpu/intel/ocl/micro_sdpa_configs.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa_configs.cpp
@@ -287,6 +287,7 @@ sdpa_config_t *choose_config_xehpg(
     }
     return nullptr;
 }
+static std::vector<dim_t> seq_intervals_xehpg = {32, 64, 96, 128, 256, 512};
 
 sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
         bool quantized, bool is_integrated) {
@@ -363,6 +364,8 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
     }
     return nullptr;
 }
+static std::vector<dim_t> seq_intervals_xehpc
+        = {32, 64, 96, 128, 256, 384, 512, 768, 1024, 1152};
 
 sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
         bool quantized, bool is_integrated) {
@@ -465,6 +468,128 @@ sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
     }
     return choose_config_xehpc(
             head_size, seq, thin_q, quantized, is_integrated);
+}
+static std::vector<dim_t> seq_intervals_xe2
+        = {64, 96, 128, 256, 384, 512, 768, 1024, 1152};
+
+
+// adjust heuristic intervals to match the tuned intervals according
+// to the sequence length and gpu architecture
+// this way recompilation both matches the tuned intervals and avoids
+// excessive recompilation with smaller power of 2 sizes
+dim_t round_up_seq_interval(dim_t seq, compute::gpu_arch_t arch) {
+    const std::vector<dim_t> *seq_intervals;
+    switch (arch) {
+        case compute::gpu_arch_t::xe_hpg:
+            seq_intervals = &seq_intervals_xehpg;
+            break;
+        case compute::gpu_arch_t::xe_hpc:
+            seq_intervals = &seq_intervals_xehpc;
+            break;
+        case compute::gpu_arch_t::xe2:
+        case compute::gpu_arch_t::xe3: seq_intervals = &seq_intervals_xe2;
+        default: return utils::rnd_up_pow2(seq);
+    }
+
+    for (auto seq_boundary : *seq_intervals) {
+        if (seq <= seq_boundary) { return seq_boundary; }
+    }
+    return utils::rnd_up_pow2(seq);
+}
+
+void deserialize_config_to_gemmstone(gemmstone::HWInformation &hwInfo,
+        gemmstone::GEMMProblem &problem_kq, gemmstone::GEMMProblem &problem_vs,
+        micro::GEMMProtocol::Options &opts_kq,
+        micro::GEMMProtocol::Options &opts_vs, gemmstone::SizeParams &sizes_kq,
+        gemmstone::SizeParams &sizes_vs,
+        const micro_sdpa_ukernel_params_t &ukernel_config) {
+
+    // hardware info
+    hwInfo.gmdid = ukernel_config.hwinfo.gmdid;
+    hwInfo.euCount = ukernel_config.hwinfo.euCount;
+    hwInfo.systolicAvailable = ukernel_config.hwinfo.systolicAvailable;
+
+    // options kq, vs
+    auto deserialize_options
+            = [](micro::GEMMProtocol::Options &gemmstone_opts,
+                      const ukernel_serialized_opts_t &serialized_opts) {
+                  gemmstone_opts.localB = serialized_opts.localB;
+                  gemmstone_opts.slmPtr = serialized_opts.slmPtr;
+                  gemmstone_opts.scaleA = serialized_opts.scaleA;
+                  gemmstone_opts.offsetA = serialized_opts.offsetA;
+              };
+    deserialize_options(opts_kq, ukernel_config.opts_kq);
+    deserialize_options(opts_vs, ukernel_config.opts_vs);
+
+    // problems kq, vs
+    auto deserialize_problem = [](gemmstone::GEMMProblem &problem,
+                                       const ukernel_serialized_problem_t
+                                               &serialized_problem) {
+        problem.Ta_ext = {
+                static_cast<gemmstone::Type::_Type>(serialized_problem.Ta_ext)};
+        problem.Tb_ext = {
+                static_cast<gemmstone::Type::_Type>(serialized_problem.Tb_ext)};
+        problem.Ta
+                = {static_cast<gemmstone::Type::_Type>(serialized_problem.Ta)};
+        problem.Tb
+                = {static_cast<gemmstone::Type::_Type>(serialized_problem.Tb)};
+        problem.Tc_ext = {
+                static_cast<gemmstone::Type::_Type>(serialized_problem.Tc_ext)};
+        problem.Tc
+                = {static_cast<gemmstone::Type::_Type>(serialized_problem.Tc)};
+        problem.Ts
+                = {static_cast<gemmstone::Type::_Type>(serialized_problem.Ts)};
+        problem.A.layout = static_cast<gemmstone::MatrixLayout>(
+                serialized_problem.A_layout);
+
+        if (serialized_problem.with_scales
+                && !serialized_problem.with_common_scales) {
+            problem.Ta_scale = {static_cast<gemmstone::Type::_Type>(
+                    serialized_problem.Ta_scale)};
+            problem.A_scale.setAlignment(serialized_problem.A_scale_alignment);
+            problem.A_scale.layout = static_cast<gemmstone::MatrixLayout>(
+                    serialized_problem.A_scale_layout);
+            problem.aScale2D = serialized_problem.aScale2D;
+        }
+        if (serialized_problem.with_zp) {
+            problem.Tao = {static_cast<gemmstone::Type::_Type>(
+                    serialized_problem.Tao)};
+            problem.AO.setAlignment(serialized_problem.AO_alignment);
+            problem.AO.layout = static_cast<gemmstone::MatrixLayout>(
+                    serialized_problem.AO_layout);
+            problem.aoPtrDims = serialized_problem.aoPtrDims;
+            problem.aOffset = static_cast<gemmstone::ABOffset>(
+                    serialized_problem.aOffset);
+        }
+        if (serialized_problem.with_scales || serialized_problem.with_zp) {
+            problem.aqGroupM = serialized_problem.aqGroupM;
+            problem.aqGroupK = serialized_problem.aqGroupK;
+        }
+
+        problem.B.layout = static_cast<gemmstone::MatrixLayout>(
+                serialized_problem.B_layout);
+        problem.C.layout = static_cast<gemmstone::MatrixLayout>(
+                serialized_problem.C_layout);
+        problem.A.setAlignment(serialized_problem.A_alignment);
+        problem.B.setAlignment(serialized_problem.B_alignment);
+        problem.B.crosspack = serialized_problem.B_crosspack;
+        problem.B.tileR = serialized_problem.B_tileR;
+        problem.B.tileC = serialized_problem.B_tileC;
+    };
+    deserialize_problem(problem_kq, ukernel_config.problem_kq);
+    deserialize_problem(problem_vs, ukernel_config.problem_vs);
+
+    // sizes kq, vs
+    auto deserialize_sizes
+            = [](gemmstone::SizeParams &sizes,
+                      const ukernel_serialized_sizes_t &serialized_sizes) {
+                  sizes.m = serialized_sizes.m;
+                  sizes.n = serialized_sizes.n;
+                  sizes.k = serialized_sizes.k;
+                  sizes.batch = serialized_sizes.batch;
+              };
+    deserialize_sizes(sizes_kq, ukernel_config.sizes_kq);
+    deserialize_sizes(sizes_vs, ukernel_config.sizes_vs);
 }
 
 } // namespace ocl

--- a/src/gpu/intel/ocl/micro_sdpa_configs.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa_configs.hpp
@@ -18,6 +18,7 @@
 #define GPU_INTEL_OCL_MICRO_SDPA_CONFIGS_HPP
 
 #include "common/c_types_map.hpp"
+#include "gemmstone/microkernel_provider.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -40,6 +41,93 @@ sdpa_config_t *choose_config_xehpc(dim_t head_size, dim_t seq, bool thin_q,
 
 sdpa_config_t *choose_config_xe2(dim_t head_size, dim_t seq, bool thin_q,
         bool quantized, bool is_integrated);
+
+dim_t round_up_seq_interval(dim_t seq, compute::gpu_arch_t arch);
+
+// serializable options for microkernel configuration
+// follows reduced subset of structs from gemmstone that
+// are used for ukernel generation
+struct ukernel_serialized_opts_t
+    : trivially_serializable_t<ukernel_serialized_opts_t> {
+    bool localB, slmPtr, scaleA, offsetA;
+    uint8_t padding[4] = {0};
+};
+DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(ukernel_serialized_opts_t);
+
+struct ukernel_serialized_hwinfo_t
+    : trivially_serializable_t<ukernel_serialized_hwinfo_t> {
+    uint32_t gmdid;
+    uint32_t euCount;
+    bool systolicAvailable;
+    uint8_t padding[7] = {0};
+};
+DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(ukernel_serialized_hwinfo_t);
+
+struct ukernel_serialized_sizes_t
+    : trivially_serializable_t<ukernel_serialized_sizes_t> {
+    int64_t batch = 0;
+    int64_t m = 0, n = 0, k = 0;
+};
+DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(ukernel_serialized_sizes_t);
+
+struct ukernel_serialized_problem_t
+    : trivially_serializable_t<ukernel_serialized_problem_t> {
+    uint32_t Ta_ext, Tb_ext, Tc_ext;
+    uint32_t Ta, Tb, Tc, Ts;
+
+    int A_layout;
+    // default values set for optional quantization variables
+    // to avoid missing hash due to uninitialized values
+    uint32_t Ta_scale = static_cast<uint32_t>(gemmstone::Type::invalid);
+    uint32_t Tao = static_cast<uint32_t>(gemmstone::Type::invalid);
+    int A_scale_layout = static_cast<int>(gemmstone::MatrixLayout::N);
+
+    int AO_layout = static_cast<int>(gemmstone::MatrixLayout::N);
+    int aoPtrDims = 0;
+    int aqGroupM = 1;
+    int aqGroupK = 1;
+
+    int B_layout;
+    int C_layout;
+
+    uint16_t B_tileR;
+    uint16_t B_tileC;
+    uint8_t B_crosspack;
+
+    uint8_t A_alignment;
+    uint8_t A_scale_alignment = 0;
+    uint8_t AO_alignment = 0;
+    uint8_t B_alignment;
+
+    bool aScale2D = false;
+    bool with_scales, with_zp, with_common_scales;
+    uint8_t padding[3] = {0};
+    int aOffset;
+};
+DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(ukernel_serialized_problem_t);
+
+struct micro_sdpa_ukernel_params_t
+    : trivially_serializable_t<micro_sdpa_ukernel_params_t> {
+    int unroll_m_kq, unroll_n_kq;
+    int unroll_m_vs, unroll_n_vs;
+    int wg_m_kq, wg_n_kq;
+    int wg_m_vs, wg_n_vs;
+
+    ukernel_serialized_hwinfo_t hwinfo;
+    ukernel_serialized_problem_t problem_kq;
+    ukernel_serialized_problem_t problem_vs;
+    ukernel_serialized_opts_t opts_kq;
+    ukernel_serialized_opts_t opts_vs;
+    ukernel_serialized_sizes_t sizes_kq, sizes_vs;
+};
+DNNL_ASSERT_TRIVIALLY_SERIALIZABLE(micro_sdpa_ukernel_params_t);
+
+void deserialize_config_to_gemmstone(gemmstone::HWInformation &hwInfo,
+        gemmstone::GEMMProblem &problem_kq, gemmstone::GEMMProblem &problem_vs,
+        micro::GEMMProtocol::Options &opts_kq,
+        micro::GEMMProtocol::Options &opts_vs, gemmstone::SizeParams &sizes_kq,
+        gemmstone::SizeParams &sizes_vs,
+        const micro_sdpa_ukernel_params_t &ukernel_config);
 
 } // namespace ocl
 } // namespace intel

--- a/src/gpu/intel/ocl/sdpa_utils.h
+++ b/src/gpu/intel/ocl/sdpa_utils.h
@@ -28,4 +28,87 @@
 #define VAL_OFF(x0, x1, x2, x3) _4D_OFF(VAL, x0, x1, x2, x3)
 #define MSK_OFF(x0, x1, x2, x3) _4D_OFF(MSK, x0, x1, x2, x3)
 
+#define _BATCH_OFF(tag, x0, x1) \
+    (((x0) % tag##_B0) * tag##_SB0 + ((x0) / tag##_B0) * tag##_S0 \
+            + ((x1) % tag##_B1) * tag##_SB1 + ((x1) / tag##_B1) * tag##_S1)
+
+#define QRY_BATCH(x0, x1) _BATCH_OFF(QRY, x0, x1)
+#define KEY_BATCH(x0, x1) _BATCH_OFF(KEY, x0, x1)
+#define VAL_BATCH(x0, x1) _BATCH_OFF(VAL, x0, x1)
+#define DST_BATCH(x0, x1) _BATCH_OFF(DST, x0, x1)
+#define MSK_BATCH(x0, x1) _BATCH_OFF(MSK, x0, x1)
+
+#define REDUCE_STAGE_0(cat, f)
+#define REDUCE_STAGE_1(cat, f) f(0)
+#define REDUCE_STAGE_2(cat, f) cat(REDUCE_STAGE_1(cat, f), f(1))
+#define REDUCE_STAGE_3(cat, f) cat(REDUCE_STAGE_2(cat, f), f(2))
+#define REDUCE_STAGE_4(cat, f) cat(REDUCE_STAGE_3(cat, f), f(3))
+#define REDUCE2(n, cat, f) REDUCE_STAGE_##n(cat, f)
+#define REDUCE(n, cat, f) REDUCE2(n, cat, f)
+#define INTERNAL_CAT(a, b) a##b
+#define CAT(a, b) INTERNAL_CAT(a, b)
+#define JOIN_COMMA(x, y) x, y
+#define JOIN_SEMICOLON(x, y) \
+    x; \
+    y
+#define CS_PARAM(p0, p1, p2, p3) \
+    JOIN_COMMA(p0, JOIN_COMMA(p1, JOIN_COMMA(p2, p3)))
+
+#define IDX(varname, n) const off_t varname##n
+
+#define KEY_DIMS(n) IDX(KEY_D, n)
+#define KEY_STRIDES(n) IDX(KEY_S, n)
+#define KEY_BLOCKS(n) IDX(KEY_B, n)
+#define KEY_BLOCK_STRIDES(n) IDX(KEY_SB, n)
+
+#define QRY_DIMS(n) IDX(QRY_D, n)
+#define QRY_STRIDES(n) IDX(QRY_S, n)
+#define QRY_BLOCKS(n) IDX(QRY_B, n)
+#define QRY_BLOCK_STRIDES(n) IDX(QRY_SB, n)
+
+#define VAL_DIMS(n) IDX(VAL_D, n)
+#define VAL_STRIDES(n) IDX(VAL_S, n)
+#define VAL_BLOCKS(n) IDX(VAL_B, n)
+#define VAL_BLOCK_STRIDES(n) IDX(VAL_SB, n)
+
+#define DST_DIMS(n) IDX(DST_D, n)
+#define DST_STRIDES(n) IDX(DST_S, n)
+#define DST_BLOCKS(n) IDX(DST_B, n)
+#define DST_BLOCK_STRIDES(n) IDX(DST_SB, n)
+
+#define MSK_DIMS(n) IDX(MSK_D, n)
+#define MSK_STRIDES(n) IDX(MSK_S, n)
+#define MSK_BLOCKS(n) IDX(MSK_B, n)
+#define MSK_BLOCK_STRIDES(n) IDX(MSK_SB, n)
+
+#define KEY_OFFSETS \
+    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, KEY_DIMS), \
+            JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, KEY_STRIDES), \
+                    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, KEY_BLOCKS), \
+                            REDUCE(NDIMS, JOIN_COMMA, KEY_BLOCK_STRIDES))))
+
+#define QRY_OFFSETS \
+    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, QRY_DIMS), \
+            JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, QRY_STRIDES), \
+                    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, QRY_BLOCKS), \
+                            REDUCE(NDIMS, JOIN_COMMA, QRY_BLOCK_STRIDES))))
+
+#define VAL_OFFSETS \
+    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, VAL_DIMS), \
+            JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, VAL_STRIDES), \
+                    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, VAL_BLOCKS), \
+                            REDUCE(NDIMS, JOIN_COMMA, VAL_BLOCK_STRIDES))))
+
+#define DST_OFFSETS \
+    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, DST_DIMS), \
+            JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, DST_STRIDES), \
+                    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, DST_BLOCKS), \
+                            REDUCE(NDIMS, JOIN_COMMA, DST_BLOCK_STRIDES))))
+
+#define MSK_OFFSETS \
+    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, MSK_DIMS), \
+            JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, MSK_STRIDES), \
+                    JOIN_COMMA(REDUCE(NDIMS, JOIN_COMMA, MSK_BLOCKS), \
+                            REDUCE(NDIMS, JOIN_COMMA, MSK_BLOCK_STRIDES))))
+
 #endif

--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -664,7 +664,8 @@ sdpa_tensors_t get_descriptors(dnnl::engine &eng, const sdpa_dims_t &p) {
 
 class sdpa_test_t : public ::testing::TestWithParam<sdpa_dims_t> {
 public:
-    void SetUp() override {
+    // Testing reusable functionality requires shared engine between tests.
+    static void SetUpTestSuite() {
 #ifdef DNNL_SYCL_CUDA
         GTEST_SKIP() << "SDPA primitive tests do not support CUDA";
 #endif
@@ -681,16 +682,23 @@ public:
         eng = dnnl::engine(engine::kind::gpu, 0);
 #endif
         strm = dnnl::stream(eng);
+    }
+
+    void SetUp() override {
         p = GetParam();
         t = get_descriptors(eng, p);
     }
 
 protected:
+    static dnnl::engine eng;
+    static dnnl::stream strm;
+
     sdpa_dims_t p;
-    dnnl::engine eng;
-    dnnl::stream strm;
     sdpa_tensors_t t;
 };
+
+dnnl::engine sdpa_test_t::eng;
+dnnl::stream sdpa_test_t::strm;
 
 bool with_key_transposed = true;
 bool no_key_transposed = false;
@@ -742,7 +750,13 @@ INSTANTIATE_TEST_SUITE_P(llama_3_8b,
                                // mb, hd_num, kv_grp_sz,seq_len, qry_num, hd_size, kg_sz, vgrp_sz,       dt,      qdt,       kdt,        ksdt,      kzpdt,       vdt,       vsdt,      vzpdt,    mskdt, qtype
     testing::Values(
                     sdpa_dims_t{   1,     2,          2,    384,     384,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
-                    sdpa_dims_t{   1,     2,          2,    385,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    384,     384,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    385,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    386,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    387,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    388,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    389,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
+                    sdpa_dims_t{   1,     4,          2,    390,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
                     sdpa_dims_t{   1,     2,          2,    512,     512,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
                     sdpa_dims_t{   1,     2,          2,    513,       1,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },
                     sdpa_dims_t{   1,     2,          2,   1024,    1024,     128,   128,     128, mdt::f16, mdt::f16,  mdt::f16,    mdt::f16,    mdt::s8,  mdt::f16,   mdt::f16,    mdt::s8, mdt::f16, quantize_type::no_quantization,  with_key_transposed, mask_type::twoD },


### PR DESCRIPTION
# Description

This PR introduces support for reusable sdpa so recompilation can be skipped for different sequence and query lengths. Head size is still baked into the kernel. The configuration for microkernel headers has been extracted and made part of the headers since this must now be done ahead of execution for caching. 

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?