### PR TITLE
skip unsupported gtests cases on NV GPU

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/test_batch_norm.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_batch_norm.cpp
@@ -449,6 +449,7 @@ public:
 };
 
 TEST_P(batch_norm_4d_t, TestBatchnorm) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     Test();
 }
 
@@ -473,6 +474,7 @@ INSTANTIATE_TEST_SUITE_P(test_batch_norm_execute, batch_norm_4d_t,
                         graph::data_type::f32}));
 
 TEST(test_batch_norm_compile, BatchNormBackwardFp32) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
 
     graph::op_t bn_op(graph::op_kind::BatchNormTrainingBackward);
@@ -668,6 +670,7 @@ TEST(test_batch_norm_compile, BatchNormBackwardFp32WithSingleOutput) {
 }
 
 TEST(test_batch_norm_compile, BatchNormForwardTrainingWith1DSpatialInput) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
 
     using dims = graph::dnnl_impl::dims;
     using ltw = graph::logical_tensor_wrapper_t;
@@ -802,6 +805,7 @@ TEST(test_batch_norm_compile, BatchNormForwardTrainingWith1DSpatialInput) {
 }
 
 TEST(test_batch_norm_compile, BatchNormForwardTrainingWith0DSpatialInput) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
 
     using dims = graph::dnnl_impl::dims;
     using ltw = graph::logical_tensor_wrapper_t;

--- a/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convolution.cpp
@@ -2795,6 +2795,7 @@ TEST(test_convolution_execute_subgraph_fp32, ConvDepthwise_CPU) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv1dConv2dConv3d) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -3154,11 +3155,13 @@ static inline void quantized_conv2d_eltwise(
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv2dRelu) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     const graph::op_kind_t opk = graph::op_kind::ReLU;
     quantized_conv2d_eltwise(opk, nullptr, nullptr);
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv2dLeakyRelu) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     const graph::op_kind_t opk = graph::op_kind::LeakyReLU;
     const float alpha = 0.02f;
     quantized_conv2d_eltwise(opk, &alpha, nullptr);
@@ -3171,6 +3174,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dMish) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv2dSumRelu) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -3407,6 +3411,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dSumRelu) {
 
 TEST(test_convolution_execute_subgraph_int8,
         Conv2dSumReluWithDifferentSrc1AndDstType_GPU) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -3597,6 +3602,7 @@ TEST(test_convolution_execute_subgraph_int8,
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv2dSumReluNxc) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -3820,6 +3826,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dSumReluNxc) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv1d2d3dX8s8f32) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -3996,6 +4003,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv1d2d3dX8s8f32) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv2dReluX8s8f32) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -4162,6 +4170,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dReluX8s8f32) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, Conv2dSumReluGetInplacePair) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();
@@ -4368,6 +4377,7 @@ TEST(test_convolution_execute_subgraph_int8, Conv2dSumReluGetInplacePair) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasU8s8u8MixBf16) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
     graph::engine_t *engine = get_engine();
     graph::stream_t *strm = get_stream();
@@ -4531,6 +4541,7 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasU8s8u8MixBf16) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasaddU8s8u8MixBf16) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
     graph::engine_t *engine = get_engine();
     graph::stream_t *strm = get_stream();
@@ -4723,6 +4734,7 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasaddU8s8u8MixBf16) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, ConvolutionBiasGeluU8s8u8MixBf16) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
     graph::engine_t *engine = get_engine();
     graph::stream_t *strm = get_stream();
@@ -5041,6 +5053,7 @@ TEST(test_convolution_execute_subgraph_int8, ConvolutionReluMulS8Bf16Accuracy) {
 
 TEST(test_convolution_execute_subgraph_int8,
         ConvolutionBiasaddGeluU8s8u8MixBf16) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
     graph::engine_t *engine = get_engine();
     graph::stream_t *strm = get_stream();
@@ -6317,6 +6330,7 @@ TEST(test_convolution_execute_subgraph_int8, QuantWeiConv2dSumRelu) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, QuantWeiConv2dSumS8Relu) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     static auto isa = dnnl_get_effective_cpu_isa();
     using dims = graph::dnnl_impl::dims;
 
@@ -6615,6 +6629,7 @@ TEST(test_convolution_execute, ConvReluUnfused) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, ConvDepthwise) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
@@ -6795,6 +6810,7 @@ TEST(test_convolution_execute_subgraph_int8, ConvDepthwise) {
 }
 
 TEST(test_convolution_execute_subgraph_int8, ShareCachedWeights) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = graph::dnnl_impl::dims;
 
     graph::engine_t *engine = get_engine();

--- a/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_convtranspose.cpp
@@ -729,6 +729,7 @@ TEST(test_convtranspose_compile,
 }
 
 TEST_P(test_convtranspose_add_compile_t, TestConvTransposeAddCompile) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     TestConvTransposeAdd();
 }
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_large_partition.cpp
@@ -53,6 +53,7 @@ static void fill_data(
 }
 
 TEST(test_large_partition_execute, Int8Resnet50Stage2Block) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
@@ -120,6 +121,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2Block) {
 }
 
 TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithZeroZps) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
@@ -188,6 +190,7 @@ TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithZeroZps) {
 }
 
 TEST(test_large_partition_execute, Int8Resnet50Stage2BlockWithQuantWei) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 
@@ -339,6 +342,7 @@ TEST(test_large_partition_execute, F32Resnet50Stage2Block) {
 }
 
 TEST(test_large_partition_execute, ItexInt8Resnet50Stage2Block) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     graph::engine_t *eng = get_engine();
     graph::stream_t *strm = get_stream();
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_pool.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_pool.cpp
@@ -482,6 +482,7 @@ TEST(test_pool_execute, AvgPoolIncludePad) {
 }
 
 TEST(test_pool_execute, AvgPoolBackwardExcludePad) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
     graph::engine_t *eng = get_engine();
 
@@ -541,6 +542,7 @@ TEST(test_pool_execute, AvgPoolBackwardExcludePad) {
 }
 
 TEST(test_pool_execute, AvgPoolBackwardIncludePad) {
+    SKIP_IF_NV_GPU("not supported on NVIDIA GPU");
     using dims = dnnl::impl::graph::dnnl_impl::dims;
     graph::engine_t *eng = get_engine();
 


### PR DESCRIPTION
A follow-up PR to skip unsupported gtests cases on NV GPU.
Related tickets:

1. MFDNN-13736
2. MFDNN-13685
3. MFDNN-13687
4. MFDNN-13698