### PR TITLE
benchdnn: memory: gpu: enable support for RNG memory fill

### DIFF
--- a/src/gpu/intel/ocl/ocl_philox.cl
+++ b/src/gpu/intel/ocl/ocl_philox.cl
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#define INF_NAN_MASK 0xBFFFBFFF
+#include "gpu/intel/ocl/ocl_philox.h"
+
+__kernel void ocl_philox_kernel(__global uint *data, ulong nbytes, ulong seed) {
+    const ulong gid = get_global_id(0);
+    const ulong block_size = 4;
+    const ulong offset = gid * block_size;
+    const ulong working_items = nbytes >> 2;
+
+    if (offset >= working_items) return;
+
+    uint4 rands = ref_philox_4x32(offset, seed) & (uint4)(INF_NAN_MASK);
+    const ulong tail = working_items - offset;
+
+    if (tail >= block_size) {
+        vstore4(rands, 0, data + offset);
+    } else {
+        if (tail >= 1) data[offset] = rands.s0;
+        if (tail >= 2) data[offset + 1] = rands.s1;
+        if (tail == 3) data[offset + 2] = rands.s2;
+    }
+}

--- a/src/gpu/intel/ocl/ocl_philox.h
+++ b/src/gpu/intel/ocl/ocl_philox.h
@@ -47,7 +47,7 @@ uint4 ref_philox_4x32(long idx, uint seed) {
 }
 
 uint philox_4x32(long idx, uint seed) {
-    return ref_philox_4x32(idx >> 2, seed)[idx & 3];
+    return ref_philox_4x32(idx, seed)[~idx & 3L];
 }
 
 ushort philox_8x16(long idx, uint seed) {

--- a/src/gpu/intel/ocl/ocl_philox.h
+++ b/src/gpu/intel/ocl/ocl_philox.h
@@ -20,7 +20,7 @@
 #define DT_UNDEF 1
 #include "gpu/intel/ocl/ocl_types.h"
 
-uint philox_4x32(long idx, uint seed) {
+uint4 ref_philox_4x32(long idx, uint seed) {
 #define PHILOX_4UINT_ROUND(mul, ctr, key) \
     as_uint4(convert_ulong2(ctr.s31) * mul) ^ (uint4)(ctr.s20 ^ key, 0, 0).s3120
 
@@ -43,7 +43,11 @@ uint philox_4x32(long idx, uint seed) {
     ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key0.sEF);
     ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key1.s01);
     ctr = PHILOX_4UINT_ROUND(ctr_mul, ctr, key1.s23);
-    return ctr[~idx & 3L];
+    return ctr;
+}
+
+uint philox_4x32(long idx, uint seed) {
+    return ref_philox_4x32(idx >> 2, seed)[idx & 3];
 }
 
 ushort philox_8x16(long idx, uint seed) {

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -29,6 +29,7 @@
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "oneapi/dnnl/dnnl_ocl.hpp"
+#include "src/gpu/intel/gpu_primitive.hpp"
 #include "src/xpu/ocl/usm_utils.hpp"
 #endif
 
@@ -538,6 +539,59 @@ void dnn_mem_t::memset(int value, size_t size, int buffer_index) const {
     SAFE_V(FAIL);
 }
 
+void dnn_mem_t::memset_rng(size_t size, int buffer_index) const {
+    bool is_opencl = is_opencl_engine(engine_);
+    bool is_sycl = is_sycl_engine(engine_);
+    auto mem = m_padded_ ? m_padded_ : m_;
+    void *mem_handle;
+    DNN_SAFE_V(dnnl_memory_get_data_handle_v2(mem, &mem_handle, buffer_index));
+
+    if (is_opencl) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+        const auto *ocl_compute_engine = dnnl::impl::utils::downcast<
+                dnnl::impl::gpu::intel::compute::compute_engine_t *>(engine_);
+        stream_t stream(engine_);
+
+        static std::vector<const char *> rng_kernel_name
+                = {"ocl_philox_kernel"};
+
+        std::vector<dnnl::impl::gpu::intel::compute::kernel_t> kernels(1);
+        dnnl::impl::gpu::intel::compute::kernel_ctx_t kernel_ctx;
+        DNN_SAFE_V(ocl_compute_engine->create_kernels(
+                &kernels, rng_kernel_name, kernel_ctx));
+
+        assert(size <= UINT64_MAX);
+        const uint64_t mem_size = static_cast<uint64_t>(size);
+        static constexpr uint64_t DEFAULT_SEED = -1;
+
+        dnnl::impl::gpu::intel::compute::kernel_arg_list_t arg_list;
+        arg_list.set(0, *mem->memory_storage());
+        arg_list.set(1, mem_size);
+        arg_list.set(2, DEFAULT_SEED);
+
+        const uint64_t block_size = 16;
+        const auto gws = dnnl::impl::gpu::intel::compute::nd_range_t(
+                size / block_size + (size % block_size > 0));
+
+        DNN_SAFE_V(dnnl::impl::gpu::intel::gpu_primitive_t::parallel_for(
+                dnnl::impl::exec_ctx_t(stream), gws, kernels[0], arg_list));
+
+        DNN_SAFE_V(dnnl_stream_wait(stream));
+        return;
+#endif
+    } else if (is_sycl) {
+#ifdef DNNL_WITH_SYCL
+        this->memset(dnnl_mem_default_perf_test_value, size, buffer_index);
+        return;
+#endif
+    }
+    if (is_cpu(engine_)) {
+        ::memset(mem_handle, dnnl_mem_default_perf_test_value, size);
+        return;
+    }
+    SAFE_V(FAIL);
+}
+
 dnn_mem_t dnn_mem_t::create_from_host_ptr(
         const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr) {
     // Pre-allocated handle_info won't use prefill no matter what.
@@ -859,8 +913,8 @@ int dnn_mem_t::initialize(
             if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
                     || cold_cache_input.cold_cache_mode_
                             != default_cold_cache_input().cold_cache_mode_) {
-                // Fill memory directly with 0x3F3F3F3F (0.747059f) number.
-                this->memset(dnnl_mem_default_perf_test_value, sz, i);
+                // Try to fill memory with random values.
+                this->memset_rng(sz, i);
             } else {
                 // Fill memory with a magic number (NAN for fp data types)
                 // to catch possible uninitialized access.

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -548,7 +548,7 @@ void dnn_mem_t::memset_rng(size_t size, int buffer_index) const {
 
     if (is_opencl) {
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        const auto *ocl_compute_engine = dnnl::impl::utils::downcast<
+        auto *ocl_compute_engine = static_cast<
                 dnnl::impl::gpu::intel::compute::compute_engine_t *>(engine_);
         stream_t stream(engine_);
 

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -172,6 +172,7 @@ struct dnn_mem_t {
     void map() const;
     void unmap() const;
     void memset(int value, size_t size, int buffer_index) const;
+    void memset_rng(size_t size, int buffer_index) const;
 
     static dnn_mem_t create_from_host_ptr(
             const dnnl_memory_desc_t &md, dnnl_engine_t engine, void *host_ptr);


### PR DESCRIPTION
# Description

Systems with data compression enabled by the driver by default wont generate meaningful performance data with `benchdnn ... --mode=F `

- Reuse [ocl_philox.h](https://github.com/oneapi-src/oneDNN/blob/main/src/gpu/intel/ocl/ocl_philox.h) routine to directly fill gpu mem with random vals via a dedicated opencl kernel. 

Fixes [MFDNN-12589](https://jira.devtools.intel.com/browse/MFDNN-12589)

# Checklist

## General


- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?
