### PR TITLE
[Benchdnn][rls-v3.9-pc] Drop LLM shapes from GPU set

### DIFF
--- a/tests/benchdnn/inputs/matmul/test_matmul_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_gpu
@@ -116,8 +116,6 @@
 --batch=option_set_fwks_key_gpu
 --reset
 --batch=option_set_fwks_ext_gpu
---reset
---batch=option_set_fwks_llm_gpu
 
 # Test tf32 configuration
 --reset


### PR DESCRIPTION
# Description

LLM shapes show fails on rls-v3.9-pc due to revert in #3268 . These are expected, fixed in main, but behavior is preserved in rls-v3.9-pc for OpenVINO. dropping tests for clean CI. 

Fixes # [MFDNN-13735](https://jira.devtools.intel.com/browse/MFDNN-13735)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

