### PR TITLE
common: verbose: use correct flags for vprof

### DIFF
--- a/src/common/verbose.hpp
+++ b/src/common/verbose.hpp
@@ -170,8 +170,12 @@ static inline int format_type_checker(const char *, ...) {
 // anyway to condition collecting stamp/duration)
 #define VPROF(stamp, apitype, logtype, logsubtype, info, duration) \
     { \
-        VFORMAT(stamp, dnnl::impl::verbose_t::exec_profile, apitype, logtype, \
-                logsubtype, "%s,%g", info, duration); \
+        auto flag = dnnl::impl::verbose_t::exec_profile; \
+        if (strcmp(#logtype, "create") == 0 \
+                || strcmp(#logtype, "create_nested") == 0) \
+            flag = dnnl::impl::verbose_t::create_profile; \
+        VFORMAT(stamp, flag, apitype, logtype, logsubtype, "%s,%g", info, \
+                duration); \
     }
 
 struct verbose_t {


### PR DESCRIPTION
Using `ONEDNN_VERBOSE=profile_create` looks for the `exec_profile` verbose flag instead of the `create_profile` verbose flag, which causes the header to not be printed, as well as other logger-related logic getting incorrect flags. This just corrects the behaviour so that `VPROF` calls using the `create` or `create_nested` logtype look for the `create_profile` verbose flag as expected.