### PR TITLE
graph pattern name refactor

### DIFF
--- a/src/graph/backend/dnnl/patterns/binary_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/binary_fusion.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ using FCreatePattern = graph::pass::FCreatePattern;
 
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(binary_fusion)
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reciprocal_multiply_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_reciprocal_multiply)
         .set_priority(8.2f)
         .set_kind(partition_kind_t::binary_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",
@@ -49,7 +49,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reciprocal_multiply_fusion)
 
 // TODO(zitian): wait for the implementation of comparison ops:
 //      Gt, Ge, Le, Lt, Eq, Ne
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, binary_post_ops_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_binary_post_ops)
         .set_priority(8.3f)
         .set_kind(partition_kind_t::binary_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",

--- a/src/graph/backend/dnnl/patterns/bn_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/bn_fusion.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ using FCreatePattern = graph::pass::FCreatePattern;
 
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(bn_fusion)
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, bn_relu_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_bnorm_relu)
         .set_priority(8.8f)
         .set_kind(partition_kind_t::batch_norm_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",
@@ -52,7 +52,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, bn_relu_fusion)
             return std::make_shared<batch_norm_fwd_t>();
         });
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, int8_bn_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, s8f32s8_bnorm)
         .set_priority(9.f)
         .set_kind(partition_kind_t::batch_norm_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",
@@ -105,7 +105,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, int8_bn_fusion)
     })
 
 #if BUILD_TRAINING
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, bn_bwd_relu_bwd_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_bnorm_bwd_relu_bwd)
         .set_priority(8.8f)
         .set_kind(partition_kind_t::misc_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",

--- a/src/graph/backend/dnnl/patterns/eltwise_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/eltwise_fusion.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ using FCreatePattern = graph::pass::FCreatePattern;
 
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(eltwise_fusion)
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, eltwise_binary_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_eltwise_binary)
         .set_priority(8.2f)
         .set_kind(partition_kind_t::unary_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",

--- a/src/graph/backend/dnnl/patterns/interpolate_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/interpolate_fusion.cpp
@@ -45,7 +45,7 @@ bool check_attributes(op_t *op) {
 
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(interpolate_fusion)
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, interpolate_post_ops_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_interpolate_post_ops)
         .set_priority(8.4f)
         .set_kind(partition_kind_t::interpolate_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",

--- a/src/graph/backend/dnnl/patterns/reduction_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/reduction_fusion.cpp
@@ -44,7 +44,7 @@ bool check_attributes(op_t *graph_op) {
 
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(reduction_fusion)
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reduction_post_ops_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_reduction_post_ops)
         .set_priority(8.4f)
         .set_kind(partition_kind_t::reduction_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",

--- a/src/graph/backend/dnnl/patterns/reorder_fusion.cpp
+++ b/src/graph/backend/dnnl/patterns/reorder_fusion.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ using FCreatePattern = graph::pass::FCreatePattern;
 
 DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(reorder_fusion)
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reorder_sum_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, fp_reorder_sum)
         .set_priority(10.1f)
         .set_kind(partition_kind_t::misc_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",
@@ -53,7 +53,7 @@ DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, reorder_sum_fusion)
             return std::make_shared<float_reorder>();
         });
 
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, int8_reorder_fusion)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, x8_reorder)
         .set_priority(10.1f)
         .set_kind(partition_kind_t::misc_quantized_post_ops)
         .set_attr<FCreatePattern>("FCreatePattern",
@@ -76,7 +76,7 @@ Currently DNNL Backend doesn't support Post-sum/binary with zero points
 on GPU, while CPU supports.
 */
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, int8_reorder_sum_fusion_cpu)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, x8_reorder_sum_cpu)
         .set_priority(10.2f)
         .set_engine_kind(engine_kind::cpu)
         .set_kind(partition_kind_t::misc_quantized_post_ops)
@@ -115,7 +115,7 @@ Currently DNNL Backend doesn't support Post-sum/binary with zero points
 on GPU, while CPU supports.
 */
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE
-DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, int8_reorder_sum_fusion_gpu)
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, x8_reorder_sum_gpu)
         .set_priority(10.2f)
         .set_engine_kind(engine_kind::gpu)
         .set_kind(partition_kind_t::misc_quantized_post_ops)

--- a/tests/gtests/graph/unit/backend/dnnl/test_batch_norm.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_batch_norm.cpp
@@ -262,7 +262,7 @@ public:
         g.finalize();
 
         graph::pass::pass_base_ptr apass = params.with_relu
-                ? get_pass("bn_relu_fusion")
+                ? get_pass("fp_bnorm_relu")
                 : (is_training ? get_pass("bn_fw_train_pass")
                                : get_pass("bn_pass"));
         apass->run(g);
@@ -1032,7 +1032,7 @@ TEST(test_batch_norm_execute, BatchNormInt8) {
                       {ref_dst_ts}, engine, strm),
             graph::status::success);
 
-    graph::pass::pass_base_ptr apass = get_pass("int8_bn_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("s8f32s8_bnorm");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     ASSERT_EQ((g.get_partitions()[0])->get_kind(),
@@ -1153,7 +1153,7 @@ TEST(test_batch_norm_execute, BatchNormReluInt8) {
     ASSERT_EQ(g.add_op(&quant), graph::status::success);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("int8_bn_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("s8f32s8_bnorm");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     ASSERT_EQ((g.get_partitions()[0])->get_kind(),

--- a/tests/gtests/graph/unit/backend/dnnl/test_binary_op.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_binary_op.cpp
@@ -125,7 +125,7 @@ TEST(test_binary_op_execute, MulEltwise) {
         g.add_op(&eltwise_op);
         g.finalize();
 
-        graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         ASSERT_NE(apass, nullptr);
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
@@ -188,7 +188,7 @@ TEST(test_binary_op_execute, BinaryOpAddFusion) {
         g.add_op(&add_op);
         g.finalize();
 
-        graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -299,7 +299,7 @@ TEST(test_binary_op_execute, MinEltwise) {
         g.add_op(&eltwise_op);
         g.finalize();
 
-        graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         ASSERT_NE(apass, nullptr);
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
@@ -354,7 +354,7 @@ TEST(test_binary_op_execute, BinarySqrt) {
     g.add_op(&sqrt_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     ASSERT_NE(apass, nullptr);
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
@@ -412,7 +412,7 @@ TEST(test_binary_op_execute, MaxEltwise) {
         g.add_op(&eltwise_op);
         g.finalize();
 
-        graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         ASSERT_NE(apass, nullptr);
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
@@ -505,7 +505,7 @@ TEST(test_binary_op_execute_subgraph_fp32, BinarySwish) {
                 graph::status::success);
 
         // -------------------------case 2----------------------------------
-        graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -583,7 +583,7 @@ TEST(test_binary_op_execute, Eltwise3BinaryPostops) {
     g.add_op(&sub);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("eltwise_binary_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_eltwise_binary");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -714,7 +714,7 @@ TEST(test_binary_op_execute_subgraph_fp32, Binary3Postops) {
                 graph::status::success);
 
         // -------------------------case 2----------------------------------
-        graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -1553,7 +1553,7 @@ TEST(test_binary_op_execute, AddMul) {
     g.add_op(&mul_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -1623,7 +1623,7 @@ TEST(test_binary_op_execute, AddMulPostSrcAsNxc) {
     g.add_op(&mul_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -1686,7 +1686,7 @@ TEST(test_binary_op_execute, AddRelu) {
     g.add_op(&relu_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -1751,7 +1751,7 @@ TEST(test_binary_op_execute, AddSigmoid) {
     g.add_op(&sigmoid_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -1828,7 +1828,7 @@ TEST(test_binary_op_execute, AddAdd) {
     g.add_op(&add1_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -2024,7 +2024,7 @@ TEST(test_binary_op_execute, MulAddPerTensorBroadcast) {
     g.add_op(&add_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -2090,7 +2090,7 @@ TEST(test_binary_op_execute, MulAddPerHwBroadcast) {
     g.add_op(&add_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -2156,7 +2156,7 @@ TEST(test_binary_op_execute, MulAddPerChannelBroadcast) {
     g.add_op(&add_op);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];

--- a/tests/gtests/graph/unit/backend/dnnl/test_eltwise.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_eltwise.cpp
@@ -768,7 +768,7 @@ TEST(test_eltwise_execute_subgraph_fp32, ReciprocalMul) {
     ASSERT_EQ(g.add_op(&mul_op), graph::status::success);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("reciprocal_multiply_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_reciprocal_multiply");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -1012,7 +1012,7 @@ public:
         g.add_op(&binary_op);
         g.finalize();
 
-        graph::pass::pass_base_ptr apass = get_pass("eltwise_binary_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_eltwise_binary");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];

--- a/tests/gtests/graph/unit/backend/dnnl/test_interpolate.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_interpolate.cpp
@@ -121,7 +121,7 @@ TEST(test_interpolate_execute, InterpolateAddForwardNearest) {
     g.add_op(&add_node);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -191,7 +191,7 @@ TEST(test_interpolate_execute, InterpolateSwish) {
     ASSERT_EQ(g.finalize(), graph::status::success);
     ASSERT_EQ(g.num_ops(), 3U);
 
-    graph::pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -264,7 +264,7 @@ TEST(test_interpolate_execute, Interpolate3PostOps) {
     ASSERT_EQ(g.finalize(), graph::status::success);
     ASSERT_EQ(g.num_ops(), 4U);
 
-    graph::pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];
@@ -376,8 +376,7 @@ TEST(test_interpolate_execute, InterpolatePostOps) {
         g.add_op(&post_node);
         g.finalize();
 
-        graph::pass::pass_base_ptr apass
-                = get_pass("interpolate_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];

--- a/tests/gtests/graph/unit/backend/dnnl/test_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_pass.cpp
@@ -1793,7 +1793,7 @@ TEST(test_pass, FuseBinaryEltwise) {
         ASSERT_EQ(agraph.add_op(&eltwise), status::success);
         agraph.finalize();
 
-        auto apass = get_pass("binary_post_ops_fusion");
+        auto apass = get_pass("fp_binary_post_ops");
         apass->run(agraph);
 
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -1842,7 +1842,7 @@ TEST(test_pass, FuseEltwiseBinary3PostOps) {
     ASSERT_EQ(agraph.add_op(&div), status::success);
     agraph.finalize();
 
-    pass::pass_base_ptr pass = get_pass("eltwise_binary_fusion");
+    pass::pass_base_ptr pass = get_pass("fp_eltwise_binary");
     pass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -1883,7 +1883,7 @@ TEST(test_pass, FuseEltwiseBinaryFail) {
     ASSERT_EQ(agraph.add_op(&div), status::success);
     agraph.finalize();
 
-    pass::pass_base_ptr pass = get_pass("eltwise_binary_fusion");
+    pass::pass_base_ptr pass = get_pass("fp_eltwise_binary");
     pass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 0U);
@@ -2009,7 +2009,7 @@ TEST(test_pass, FuseBnRelu) {
     ASSERT_EQ(agraph.add_op(&relu), status::success);
     agraph.finalize();
 
-    pass::pass_base_ptr apass = get_pass("bn_relu_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_bnorm_relu");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -2104,7 +2104,7 @@ TEST(test_pass, FuseBnBwdReluBwd) {
     ASSERT_EQ(agraph.add_op(&op2), status::success);
     agraph.finalize();
 
-    pass::pass_base_ptr apass = get_pass("bn_bwd_relu_bwd_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_bnorm_bwd_relu_bwd");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -2153,7 +2153,7 @@ TEST(test_pass_system, TestBnBwdReluBwd) {
     ASSERT_EQ(agraph.add_op(&op2), status::success);
     agraph.finalize();
 
-    pass::pass_base_ptr apass = get_pass("bn_bwd_relu_bwd_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_bnorm_bwd_relu_bwd");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -12252,7 +12252,7 @@ TEST(test_pass, FuseBnReLUWithSharedInputs) {
 
     agraph.finalize();
 
-    pass::pass_base_ptr apass = get_pass("bn_relu_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_bnorm_relu");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
     ASSERT_EQ((agraph.get_partitions()[0])->get_kind(),
@@ -12304,7 +12304,7 @@ TEST(test_pass, FuseReorderAdd) {
 
         ASSERT_EQ(agraph.finalize(), status::success);
 
-        pass::pass_base_ptr apass = get_pass("reorder_sum_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_reorder_sum");
         apass->run(agraph);
 
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -12352,7 +12352,7 @@ TEST(test_pass, FailToFuseReorderAdd) {
 
     ASSERT_EQ(agraph.finalize(), status::success);
 
-    pass::pass_base_ptr apass = get_pass("reorder_sum_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_reorder_sum");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 0U);
@@ -12400,7 +12400,7 @@ TEST(test_pass, FuseInt8Reorder) {
 
     ASSERT_EQ(agraph.finalize(), status::success);
 
-    pass::pass_base_ptr apass = get_pass("int8_reorder_fusion");
+    pass::pass_base_ptr apass = get_pass("x8_reorder");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -12524,10 +12524,9 @@ TEST(test_pass, FuseInt8ReorderAdd) {
 
     ASSERT_EQ(agraph.finalize(), status::success);
 
-    graph::pass::pass_base_ptr apass
-            = get_pass(engine_kind == graph::engine_kind::cpu
-                            ? "int8_reorder_sum_fusion_cpu"
-                            : "int8_reorder_sum_fusion_gpu");
+    graph::pass::pass_base_ptr apass = get_pass(
+            engine_kind == graph::engine_kind::cpu ? "x8_reorder_sum_cpu"
+                                                   : "x8_reorder_sum_gpu");
     ASSERT_NE(apass, nullptr);
     apass->run(agraph);
 
@@ -12665,7 +12664,7 @@ TEST(test_pass, FuseInterpolateRelu) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 2U);
 
-    pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
     ASSERT_EQ((agraph.get_partitions()[0])->get_kind(),
@@ -12715,7 +12714,7 @@ TEST(test_pass, FuseInterpolateSwish) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 4U);
 
-    pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
     ASSERT_EQ(agraph.get_partitions()[0]->get_ops().size(), 4U);
@@ -12818,7 +12817,7 @@ TEST(test_pass, FuseInterpolate3PostOps) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 4U);
 
-    pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
     ASSERT_EQ((agraph.get_partitions()[0])->get_kind(),
@@ -12859,7 +12858,7 @@ TEST(test_pass, FuseInterpolateSum) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 2U);
 
-    pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -12898,7 +12897,7 @@ TEST(test_pass, FuseInterpolateMul) {
     agraph.finalize();
     ASSERT_EQ(agraph.num_ops(), 2U);
 
-    pass::pass_base_ptr apass = get_pass("interpolate_post_ops_fusion");
+    pass::pass_base_ptr apass = get_pass("fp_interpolate_post_ops");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -12969,7 +12968,7 @@ TEST(test_pass, FuseReduceAdd) {
         ASSERT_EQ(agraph.add_op(&add), status::success);
         agraph.finalize();
 
-        pass::pass_base_ptr apass = get_pass("reduction_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_reduction_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -13009,7 +13008,7 @@ TEST(test_pass, FuseReduceRelu) {
         ASSERT_EQ(agraph.add_op(&relu), status::success);
         agraph.finalize();
 
-        pass::pass_base_ptr apass = get_pass("reduction_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_reduction_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -14108,7 +14107,7 @@ TEST(test_pass, BinaryPostops) {
 
         agraph.finalize();
 
-        pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -14241,7 +14240,7 @@ TEST(test_pass, Binary3Postops) {
 
         agraph.finalize();
 
-        pass::pass_base_ptr apass = get_pass("binary_post_ops_fusion");
+        pass::pass_base_ptr apass = get_pass("fp_binary_post_ops");
         apass->run(agraph);
         ASSERT_EQ(agraph.get_num_partitions(), 1U);
 
@@ -15027,7 +15026,7 @@ TEST(test_pass, BatchNormReluU8Unfuse) {
         EXPECT_EQ(g.add_op(&relu_op), graph::status::success);
         EXPECT_EQ(g.add_op(&quant), graph::status::success);
         g.finalize();
-        graph::pass::pass_base_ptr apass = get_pass("int8_bn_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("s8f32s8_bnorm");
         apass->run(g);
         EXPECT_NE(g.get_num_partitions(), 1U);
     }

--- a/tests/gtests/graph/unit/backend/dnnl/test_reduce.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_reduce.cpp
@@ -205,8 +205,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceAdd) {
                 graph::status::success);
 
         // -------------------------case 2----------------------------------
-        graph::pass::pass_base_ptr apass
-                = get_pass("reduction_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_reduction_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -300,8 +299,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceRelu) {
                 graph::status::success);
 
         // -------------------------case 2----------------------------------
-        graph::pass::pass_base_ptr apass
-                = get_pass("reduction_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_reduction_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -398,8 +396,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceSwish) {
                 graph::status::success);
 
         // -------------------------case 2----------------------------------
-        graph::pass::pass_base_ptr apass
-                = get_pass("reduction_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_reduction_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];
@@ -514,8 +511,7 @@ TEST(test_reduce_execute_subgraph_fp32, ReduceWith3PostOps_CPU) {
                 graph::status::success);
 
         // -------------------------case 2----------------------------------
-        graph::pass::pass_base_ptr apass
-                = get_pass("reduction_post_ops_fusion");
+        graph::pass::pass_base_ptr apass = get_pass("fp_reduction_post_ops");
         apass->run(g);
         ASSERT_EQ(g.get_num_partitions(), 1U);
         auto part = g.get_partitions()[0];

--- a/tests/gtests/graph/unit/backend/dnnl/test_reorder.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_reorder.cpp
@@ -125,7 +125,7 @@ TEST(test_reorder_execute, Int8Reorder) {
 
     ASSERT_EQ(agraph.finalize(), graph::status::success);
 
-    graph::pass::pass_base_ptr apass = get_pass("int8_reorder_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("x8_reorder");
     apass->run(agraph);
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
     auto part = agraph.get_partitions()[0];
@@ -271,7 +271,7 @@ TEST(test_reorder_execute, ReorderAddBf16) {
 
     ASSERT_EQ(agraph.finalize(), graph::status::success);
 
-    graph::pass::pass_base_ptr apass = get_pass("reorder_sum_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_reorder_sum");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -321,7 +321,7 @@ TEST(test_reorder_compile, ReorderAddGetInplacePair) {
 
     ASSERT_EQ(agraph.finalize(), graph::status::success);
 
-    graph::pass::pass_base_ptr apass = get_pass("reorder_sum_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_reorder_sum");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);
@@ -415,10 +415,9 @@ TEST(test_reorder_execute, Int8ReorderAdd) {
 
     ASSERT_EQ(agraph.finalize(), graph::status::success);
 
-    graph::pass::pass_base_ptr apass
-            = get_pass(engine->kind() == graph::engine_kind::cpu
-                            ? "int8_reorder_sum_fusion_cpu"
-                            : "int8_reorder_sum_fusion_gpu");
+    graph::pass::pass_base_ptr apass = get_pass(
+            engine->kind() == graph::engine_kind::cpu ? "x8_reorder_sum_cpu"
+                                                      : "x8_reorder_sum_gpu");
     apass->run(agraph);
 
     ASSERT_EQ(agraph.get_num_partitions(), 1U);

--- a/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
@@ -1458,7 +1458,7 @@ TEST(test_subgraph_pass, FuseSigmoidMultiplyToSwish) {
     g.add_op(&multiply);
     g.finalize();
 
-    graph::pass::pass_base_ptr apass = get_pass("eltwise_binary_fusion");
+    graph::pass::pass_base_ptr apass = get_pass("fp_eltwise_binary");
     apass->run(g);
     ASSERT_EQ(g.get_num_partitions(), 1U);
     auto part = g.get_partitions()[0];


### PR DESCRIPTION
# Description

Refactored the deconv pattern according to document *DNNL Backend Fusion Pattern Definition*:
1. Replaced `int8` in pattern names with `x8`
2. Removed the word `fusion` from pattern names
4. For floating-point patterns, added the `fp_` prefix to their names

Task MFDNN-10454 and MFDNN-10452.