### PR TITLE
ci: aarch64: Add manual trigger to the performance aarch64 workflow 

### DIFF
--- a/.github/workflows/performance-aarch64.yml
+++ b/.github/workflows/performance-aarch64.yml
@@ -18,6 +18,7 @@
 name: "Performance AArch64"
 
 on:
+  workflow_dispatch:
   workflow_call:
 
 #* Stop stale workflows


### PR DESCRIPTION
# Description

This enables the performance-aarch64.yml workflow to be triggered manually
via the GitHub Actions UI using `workflow_dispatch`.

### General

- This workflow runs on the same hardware as nightly runs (`c7g.metal`)
- Useful for testing changes without waiting for the nightly pipeline.