### PR TITLE
tests: gtest: add check for khr_get_default_context

### DIFF
--- a/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
+++ b/src/gpu/amd/miopen_gemm_inner_product_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,7 +59,7 @@ protected:
             case miopenInt8:
                 blas_dt = rocblas_datatype_i8_r;
                 return status::success;
-#if MIOPEN_HAS_INT8X4
+#if defined(MIOPEN_HAS_INT8X4)
             case miopenInt8x4:
                 blas_dt = rocblas_datatype_i8_r;
                 return status::success;

--- a/src/gpu/amd/sycl_hip_utils.hpp
+++ b/src/gpu/amd/sycl_hip_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 * Copyright 2020 Codeplay Software Limited
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -134,7 +134,7 @@ inline status_t convert_data_type(const memory_desc_t *mem_desc,
         case data_type_t::dnnl_s8: {
             if (vectorized
                     && mem_desc->format_desc.blocking.inner_blks[0] == 4) {
-#if MIOPEN_HAS_INT8X4
+#if defined(MIOPEN_HAS_INT8X4)
                 *miopen_data_type = miopenDataType_t::miopenInt8x4;
 #else
                 return status::unimplemented;

--- a/tests/gtests/sycl/api/test_engine.cpp
+++ b/tests/gtests/sycl/api/test_engine.cpp
@@ -196,8 +196,13 @@ TEST_P(sycl_engine_test_t, SubDevice) {
                     // context.
                     ASSERT_NO_THROW(
                             eng = sycl_interop::make_engine(sub_dev_i,
-                                    sub_dev_i.get_platform()
+                                    sub_dev_i
+                                            .get_platform()
+#if defined(SYCL_KHR_DEFAULT_CONTEXT)
+                                            .khr_get_default_context()));
+#else
                                             .ext_oneapi_get_default_context()));
+#endif
                     test_subdevice(eng);
                 }
             },


### PR DESCRIPTION
Build issues fixes:
1. `ext_oneapi_get_default_context` is deprecated in newest Intel Compiler in favor of `khr_get_default_context`. I have added a check for new implementation based on presence of mandatory `SYCL_KHR_DEFAULT_CONTEXT` macro.
2. added `defined()` guard to `MIOPEN_HAS_INT8X4` macro