### PR TITLE
@mzhukova as code owner for Arch

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -118,6 +118,7 @@ Team: @uxlfoundation/onednn-arch
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
 | Ankit Manerikar    | @avmanerikar          | Intel Corporation | Code Owner |
 | Stefan Palicki     | @spalicki             | Intel Corporation | Code Owner |
+| Maria Zhukova      | @mzhukova             | Intel Corporation | Code Owner |
 
 ## Graph API
 


### PR DESCRIPTION
I would like to nominate Maria Zhukova @mzhukova for the role of code owner of Arch component. Maria is a member of oneDNN Architecture team at Intel and has a [history of contributions](https://github.com/oneapi-src/oneDNN/pulls?q=is%3Apr+author%3Amzhukova) to the library design and implementation.
