### PR TITLE
cpu: aarch64: revert "cpu: aarch64: conv: fix fast math NAN issue"

### DIFF
--- a/src/cpu/aarch64/acl_convolution_utils.hpp
+++ b/src/cpu/aarch64/acl_convolution_utils.hpp
@@ -170,10 +170,6 @@ status_t execute_forward_conv_acl(const exec_ctx_t &ctx,
                     arm_compute::TensorShape(aux_mem[id].size), 1,
                     arm_compute::DataType::U8);
             auto buffer = scratchpad.get<void>(key.second);
-            // Set Im2Col input buffer
-            // Temporary fix for https://github.com/uxlfoundation/oneDNN/issues/2303
-            if (id == 10) { std::memset(buffer, 0, aux_mem[id].size); }
-
             tmp_tensors[id].allocator()->init(info, aux_mem[id].alignment);
             tmp_tensors[id].allocator()->import_memory(buffer);
             pack.add_tensor(aux_mem[id].slot, &tmp_tensors[id]);


### PR DESCRIPTION
# Description

This reverts commit 7400e1615673ab99089592cd776668db1b47a70a.

The underlying issue was fixed in ComputeLibrary 52.0.1

Original patch merged here: https://github.com/uxlfoundation/oneDNN/pull/3138

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?