### PR TITLE
ci: aarch64: skip long-running graph tests in debug builds

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -31,6 +31,11 @@ if [[ "$OS" == "Linux" ]]; then
     if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
         # as test_matmul is time consuming , we only run it in release mode to save time.
         SKIPPED_TEST_FAILURES+="|test_matmul"
+        # The following graph tests are too time-consuming for Debug mode.
+        SKIPPED_TEST_FAILURES+="|cpu-graph-gated-mlp-int4-cpp"
+        SKIPPED_TEST_FAILURES+="|test_graph_unit_dnnl_sdp_decomp_cpu"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-stacked-qkv-cpp"
+        SKIPPED_TEST_FAILURES+="|cpu-graph-sdpa-cpp"
     fi
 
     SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_ci_cpu"


### PR DESCRIPTION
# Description

Some graph tests take a very long time to run on debug builds.
[Example CI run](https://github.com/uxlfoundation/oneDNN/actions/runs/15346773848/job/43184820374?pr=3371).

This change allows us to run these only on release builds, significantly speeding up the pipeline.