### PR TITLE
cpu: rnn: remove unnecessary memory allocations

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -312,7 +312,6 @@ enum {
     key_rnn_diff_gates,
     key_rnn_src_layer_trans,
     key_rnn_src_iter_trans,
-    key_rnn_ht,
     key_rnn_diff_ht,
     key_rnn_ptrs_bia,
     key_rnn_ptrs_wei_layer,

--- a/src/cpu/rnn/cell_common.cpp
+++ b/src/cpu/rnn/cell_common.cpp
@@ -119,7 +119,7 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
             types::data_type_size(rnn.src_iter_c_dt), rnn.ws_states_iter_c_nld,
             src_iter_c_ld);
 
-    const ws_gates_aoc_t<const scratch_data_t> scratch_gates(
+    const scratch_gates_aoc_t<const scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const weights_peephole_aoc_t<float> diff_weights_peephole(
             rnn, diff_weights_peephole_);

--- a/src/cpu/rnn/cell_gru_lbr.cpp
+++ b/src/cpu/rnn/cell_gru_lbr.cpp
@@ -57,7 +57,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     } else {
         CHECK((this->*gemm_iter_func)('N', 'N', rnn.n_gates * rnn.dhc, rnn.mb,
                 rnn.sic, 1.0, w_iter_[0], rnn.weights_iter_ld, src_iter_,
-                src_iter_ld, 0.0, scratch_cell_, rnn.ws_gates_ld));
+                src_iter_ld, 0.0, scratch_cell_, rnn.scratch_gates_ld));
     }
     this->rnn_postgemm_->execute(rnn, cell_position, ws_gates_, scratch_gates_,
             augru_attention_, dst_layer_, dst_iter_c_, src_iter_, src_iter_c_,
@@ -102,7 +102,8 @@ dnnl_status_t common_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
     const auto src_layer_ld = rnn.src_layer_ld(cell_position);
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
-    const ws_gates_aoc_t<scratch_data_t> scratch_gates_r(rnn, scratch_cell_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates_r(
+            rnn, scratch_cell_);
 
     rnn_postgemm->execute(rnn, cell_position, ws_gates_, scratch_gates_,
             augru_attention_, dst_layer_, nullptr, src_iter_, nullptr, nullptr,

--- a/src/cpu/rnn/ref_postgemm_gru.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru.cpp
@@ -344,7 +344,8 @@ void gru_bwd_part1_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
     const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const ws_diff_states_iter_aoc_t<acc_data_t> diff_src_iter(
             rnn, diff_src_iter_);
     const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
@@ -393,7 +394,8 @@ void gru_bwd_part2_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
     const ws_states_iter_aoc_t<const src_data_t> src_iter(
             rnn, src_iter_, src_iter_ld);
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(
             rnn, diff_dst_layer_);
     const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(

--- a/src/cpu/rnn/ref_postgemm_lstm.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm.cpp
@@ -272,7 +272,8 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
         acc_data_t *diff_dst_iter_, acc_data_t *diff_dst_iter_c_,
         const float *weights_peephole_, const void *bias_) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const weights_peephole_aoc_t<const float> weights_peephole(
             rnn, weights_peephole_);
     const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);

--- a/src/cpu/rnn/ref_postgemm_rnn.cpp
+++ b/src/cpu/rnn/ref_postgemm_rnn.cpp
@@ -147,7 +147,8 @@ void rnn_bwd_postgemm_template(T1 func1, T2 to_src, const float *scales,
         scratch_data_t *scratch_gates_, acc_data_t *diff_dst_iter_,
         acc_data_t *diff_dst_layer_) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
-    const ws_gates_aoc_t<scratch_data_t> scratch_gates(rnn, scratch_gates_);
+    const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
+            rnn, scratch_gates_);
     const ws_diff_states_iter_aoc_t<acc_data_t> diff_dst_iter(
             rnn, diff_dst_iter_);
     const ws_diff_states_layer_aoc_t<acc_data_t> diff_dst_layer(

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -257,8 +257,7 @@ status_t dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
             const dim_t LDA2 = rnn_.ws_states_iter_ld;
             const dim_t LDA3 = rnn_.dst_layer_ld_;
             const dim_t LDB = rnn_.weights_iter_ld;
-            const dim_t LDC
-                    = rnn_.is_lbr ? rnn_.ws_gates_ld : rnn_.scratch_gates_ld;
+            const dim_t LDC = rnn_.scratch_gates_ld;
             const bool do_sum = !rnn_.is_lbr;
             if (LDA1 >= K)
                 CHECK(init_matmul_pd(

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -595,12 +595,6 @@ void ref_rnn_common_t<aprop, src_type, weights_type,
     scratchpad.template book<void *>(
             key_rnn_ptrs_bia, ptr_wei_sz * bias_dt_size);
 
-    scratchpad.template book<scratch_t>(key_rnn_gates, rnn_.scratch_gates_size);
-    scratchpad.template book<ht_t>(key_rnn_ht, rnn_.scratch_ht_size);
-    scratchpad.template book<gemm_acc_t>(
-            key_rnn_diff_ht, rnn_.scratch_diff_ht_size);
-    scratchpad.template book<scratch_t>(key_rnn_cell, rnn_.scratch_cell_size);
-
 #if DNNL_X64
     if (rnn_.is_brgemm)
         ref_rnn_brgemm_t::init_scratchpad(
@@ -2042,9 +2036,6 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     auto ptr_wei_projection
             = scratchpad.template get<weights_t *>(key_rnn_ptrs_wei_projection);
     auto ptr_bias = scratchpad.template get<void *>(key_rnn_ptrs_bia);
-    // Here we use scratch_gates for the output of GEMMs on FWD and on input of GEMMs for BWD.
-    // None of the values are kept for bwd
-    auto scratch_gates = scratchpad.template get<scratch_t>(key_rnn_gates);
 #if DNNL_X64
     const auto scratch_gates_blocked
             = scratchpad.template get<scratch_t>(key_rnn_gates_blocked);
@@ -2053,10 +2044,6 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     const auto scratch_src_iter
             = scratchpad.template get<scratch_t>(key_rnn_src_iter_trans);
 #endif
-
-    auto scratch_ht = scratchpad.template get<ht_t>(key_rnn_ht);
-    auto scratch_diff_ht = scratchpad.template get<gemm_acc_t>(key_rnn_diff_ht);
-    auto scratch_cell = scratchpad.template get<scratch_t>(key_rnn_cell);
 
     gemm_acc_t *amx_scratchpad = nullptr;
 #if DNNL_X64
@@ -2116,6 +2103,21 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     /* Pack(if using packed gemm API) or copy(if input arrays have bad leading
      * dimension */
     (this->*bias_preparation_func)(rnn, ptr_bias, bias, ws_bias);
+
+    // Here we use scratch_gates for the output of GEMMs on FWD and on input of GEMMs for BWD.
+    // None of the values are kept for bwd
+    auto scratch_gates = rnn.scratch_gates_size
+            ? (scratch_t *)(scratch_ptr + scratch_gates_offset_)
+            : nullptr;
+    auto scratch_ht = rnn.scratch_ht_size
+            ? (ht_t *)(scratch_ptr + scratch_ht_offset_)
+            : nullptr;
+    auto scratch_diff_ht = rnn.scratch_diff_ht_size
+            ? (gemm_acc_t *)(scratch_ptr + scratch_diff_ht_offset_)
+            : nullptr;
+    auto scratch_cell = rnn.scratch_cell_size
+            ? (scratch_t *)(scratch_ptr + scratch_cell_offset_)
+            : nullptr;
 
     const memory_desc_t *weights_layer_md = pd()->weights_md(0);
     const memory_desc_t *weights_iter_md = pd()->weights_md(1);

--- a/src/cpu/rnn/rnn_utils.cpp
+++ b/src/cpu/rnn/rnn_utils.cpp
@@ -126,8 +126,6 @@ void rnn_utils::set_offsets(const rnn_conf_t &rnn, size_t &ws_gates_offset,
     register_space(ws_gates);
     register_space(ws_ht);
     register_space(ws_states_layer);
-    register_space(ws_states_iter);
-    register_space(ws_states_iter);
 
     // For all currently supported cells, ws_iter should not be used
     // at all since dst_iter == dst_layer

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -1175,15 +1175,12 @@ void set_workspace_sizes(rnn_conf_t &rnn, const rnn_desc_t &rd) {
 
     /* set other sizes */
     /// scratchpad buffer for each cell to hold intermediate data in gru/lbr_gru
-    rnn.scratch_cell_size = rnn.is_lbr
-            ? (size_t)rnn.scratch_gates_nld * rnn.scratch_gates_ld
-                    * sizeof(typename T::gemm_acc_t)
-            : (utils::one_of(rd.cell_kind, alg_kind::vanilla_gru,
-                       alg_kind::vanilla_augru)
-                            ? (size_t)rnn.ws_states_layer_nld
-                                    * rnn.ws_states_layer_ld
-                                    * sizeof(typename T::gemm_acc_t)
-                            : 0);
+    rnn.scratch_cell_size = (utils::one_of(rd.cell_kind, alg_kind::vanilla_gru,
+                                     alg_kind::vanilla_augru, alg_kind::lbr_gru,
+                                     alg_kind::lbr_augru)
+                    ? sizeof(typename T::scratch_t) * rnn.scratch_gates_nld
+                            * rnn.scratch_gates_ld
+                    : 0);
     /// workspace needed for lbr GRU
     rnn.ws_per_cell = (size_t)rnn.is_lbr * rnn.mb * rnn.dhc
             * sizeof(typename T::gemm_acc_t);

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
@@ -900,7 +900,7 @@ void brgemm_diff_wei_peep_t<scratch_t>::kernel(
             types::data_type_size(rnn_.src_iter_c_dt),
             rnn_.ws_states_iter_c_nld, src_iter_c_ld_);
 
-    const rnn_utils::ws_gates_aoc_t<const scratch_t> scratch_gates(
+    const rnn_utils::scratch_gates_aoc_t<const scratch_t> scratch_gates(
             rnn_, scratch_gates_);
     const rnn_utils::weights_peephole_aoc_t<float> diff_weights_peephole(
             rnn_, diff_weights_peephole_);

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
@@ -207,7 +207,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             for (dim_t i = 0; i < rnn_.m_block; ++i) {
                 auto *C_o = C_cell_i + i * cell_stride;
                 PRAGMA_OMP_SIMD()
-                for (dim_t j = 0; j < rnn_.n_block; ++j)
+                for (dim_t j = 0; j < nstl::min(rnn_.n_block, cell_stride); ++j)
                     C_o[j] = 0;
             }
         }


### PR DESCRIPTION
It was found during analysis of performance regression in RNN that memory for "scratch gates" was requested from a scratchpad incorrectly: its size was calculated in bytes, but then this value was used as a number of array elements for memory "booking". Moreover, the size of "scratch gates" was taken into account when another (common) block size was calculated and necessary offsets were calculated, but that subblock and corresponding offsets were not used.
Some other similar cases were found too.

Just changing the size of allocated scratch gates was not enough, as different implementations used different LD values. Buffer overflow did not happen because memory size was large enough (sometimes too large).

The PR reduces an amount of space requested by RNN primitive, especially for (LBR_)(AU)GRU.
Some examples of scratchpad size (_before/after_):
`--rnn --allow-enum-tags-only=0 --engine=cpu --prop=FWD_I --alg=LBR_GRU --direction=right2left --flags= --cfg=f32 --tag=abc:any:abc --trivial-strides=true --attr-scratchpad=user l1t160mb1sic64slc288dhc64dic64`
_1'148'472 / 395'448_

`--rnn --allow-enum-tags-only=0 --engine=cpu --prop=FWD_I --alg=VANILLA_LSTM --direction=right2left --flags= --cfg=f32u8f32f32 --tag=abc:any:abc --trivial-strides=true --attr-scratchpad=user l1t160mb1sic48slc288dhc48dic48`
_3'334'648 / 2'629'816_

`--rnn --tag=any:any:any --alg=LBR_GRU --activation=UNDEF l1t50mb100sic1760slc1760dhc1760dic1760`
_240'098'360 / 76'763'832_

`--rnn --tag=any:any:any --alg=VANILLA_AUGRU --activation=UNDEF l1t50mb100sic1760slc1760dhc1760dic1760`
_239'350'384 / 83'055'856_