### PR TITLE
xe: conv: check GRF access bounds in release build

### DIFF
--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -305,9 +305,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
             if (f_to_xf) step = 8;
 
         //dpasw as well as potential bank conflict allocation permutes registers; -> so use register granularity
-        if (hw < ngen::HW::XeHPC
-                && (!src.check_bounds(0, 64, /*is_dense=*/true)
-                        || !dst.check_bounds(0, 64, /*is_dense=*/true)))
+        if (hw < ngen::HW::XeHPC && (!src.is_dense(64) || !dst.is_dense(64)))
             step = 8;
 
         if (src_df || dst_df) step = 8;


### PR DESCRIPTION
This is a follow-up after [CVS-167104](https://jira.devtools.intel.com/browse/CVS-167104).

Changes:

- Added `reg_buf_t::check_bounds()` check for release builds
- Updated `gen_convolution.cpp` to print errors in case of `status::runtime_error`