### PR TITLE
graph: backend: dnnl: make matmul use any layout format only for constant cases

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
@@ -936,13 +936,13 @@ TEST_P(int8_matmul_with_diff_inputs_t, Int8MatmulPasses) {
 
 INSTANTIATE_TEST_SUITE_P(test_subgraph_pass, int8_matmul_with_diff_inputs_t,
         testing::Values(matmul_params_t {{1, 1024}, {1000, 1024}, {1000},
-                                {1, 1000}, false, true, false, 7, 8},
+                                {1, 1000}, false, true, false, 7, 7},
                 matmul_params_t {{1, 1024}, {1000, 1024}, {1000}, {1, 1000},
-                        false, true, true, 7, 8},
+                        false, true, true, 7, 7},
                 matmul_params_t {{4, 3, 64}, {3, 64}, {3}, {4, 3, 3}, false,
-                        true, false, 8, 9},
+                        true, false, 8, 8},
                 matmul_params_t {{4, 3, 64}, {3, 64}, {3}, {4, 3, 3}, false,
-                        true, true, 8, 9}));
+                        true, true, 8, 8}));
 
 class matmul_with_diff_inputs_t
     : public ::testing::TestWithParam<matmul_params_t> {};
@@ -1041,19 +1041,16 @@ TEST_P(matmul_with_diff_inputs_t, MatmulPasses) {
 
     ASSERT_EQ(dnnl_impl::layout_propagation(subgraph), graph::status::success);
     auto final_subgraph_size = params.final_subgraph_size;
-    if (params.transpose_a && p_eng.get_kind() == dnnl::engine::kind::gpu) {
-        final_subgraph_size -= 1;
-    }
     ASSERT_EQ(subgraph->get_ops().size(), final_subgraph_size);
 }
 
 INSTANTIATE_TEST_SUITE_P(test_subgraph_pass, matmul_with_diff_inputs_t,
         testing::Values(matmul_params_t {{1, 1024}, {1000, 1024}, {1000},
-                                {1, 1000}, false, true, false, 4, 5},
+                                {1, 1000}, false, true, false, 4, 4},
                 matmul_params_t {{4, 3, 64}, {3, 64}, {3}, {4, 3, 3}, false,
-                        true, false, 6, 7},
+                        true, false, 6, 6},
                 matmul_params_t {{4, 64, 3}, {3, 64}, {3}, {4, 3, 3}, true,
-                        true, false, 6, 8}));
+                        true, false, 6, 6}));
 
 TEST(test_subgraph_pass, ExecutionArgsSet) {
     ///////////////////////////


### PR DESCRIPTION
# Description
Create matmul src and weight mds with any layout only when they are constant

Fix MFDNN-13714

# Performance improvements
## benchdnn graph
| HW       | mha cases speedup |
| :------- | :---------------------- |
| PVC      | 1.21x   |
| BMG      | 1.17x   |
| Arc-A770 |  1.30x   |
| SPR      | 1.01x   |

## Pytorch GPU model
| model                          | dtype | HW  | inductor speedup | eager speedup |
| :----------------------------- | :---- | :-- | ----------------: | ------------: |
| GPT2ForSequenceClassification  | fp32  | PVC |           1.06203 |       1.05513 |
| GPT2ForSequenceClassification  | fp16  | PVC |           1.39628 |       1.35299 |
| GPT2ForSequenceClassification  | bf16  | PVC |           1.40592 |       1.35395 |
| PLBartForConditionalGeneration | fp32  | PVC |           1.07212 |       0.99772 |
| PLBartForConditionalGeneration | fp16  | PVC |           1.03491 |       1.00943 |
| PLBartForConditionalGeneration | bf16  | PVC |           1.02930 |       1.00978 |
| MegatronBertForCausalLM        | fp32  | PVC |           1.01970 |       0.99272 |
| MegatronBertForCausalLM        | fp16  | PVC |           1.03874 |       0.99610 |
| MegatronBertForCausalLM        | bf16  | PVC |           0.99199 |       1.00457 |
| hf_GPT2                        | fp32  | PVC |           1.03786 |       1.03452 |
| hf_GPT2                        | fp16  | PVC |           1.44831 |       1.40425 |
| hf_GPT2                        | bf16  | PVC |           1.44748 |       1.40106 |
| llama_v2_7b_16h                | fp32  | PVC |           1.00268 |       1.00336 |
| llama_v2_7b_16h                | fp16  | PVC |           1.01445 |       1.00231 |
| llama_v2_7b_16h                | bf16  | PVC |           1.06454 |       1.01447 |

