### PR TITLE
xe: jit: enable lazy signal header allocation

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -458,7 +458,7 @@ private:
         ngen::InstructionModifier mod;
         if (!attr.is_empty())
             mod = mod | to_ngen(attr.as<instruction_modifier_attr_t>().mod);
-        host_->barriermsg(mod, host_->signal_header_);
+        host_->barriermsg(mod, host_->signal_header());
     }
 
     void barrier_wait() { host_->barrierwait(); }
@@ -483,7 +483,7 @@ private:
 
         host_->slmfence(mod, tmp, host_->r0);
         host_->fencewait();
-        host_->barriermsg(mod, host_->signal_header_);
+        host_->barriermsg(mod, host_->signal_header());
         host_->barrierwait();
     }
 

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -236,12 +236,6 @@ public:
         }
         // Enable IEEE f32 -> s32 rounding and f64/f32/f16 denormals.
         or_(1, ngen_generator_t::cr0, ngen_generator_t::cr0, uint16_t(0x14C0));
-
-        // Allocate and initialize signal header for future use.
-        if (exec_cfg_.require_signal_header()) {
-            signal_header_ = ra_.alloc();
-            ngen_generator_t::barrierheader(signal_header_);
-        }
     }
 
     void bind_external_vars(
@@ -428,6 +422,11 @@ public:
     void pad_kernel() {
         for (int rep = 0; rep < 8; rep++)
             nop();
+    }
+
+    const ngen::GRF &signal_header() {
+        if (signal_header_.isInvalid()) { signal_header_ = ra_.alloc(); }
+        return signal_header_;
     }
 
     void emov(const ngen::InstructionModifier &mod, const ngen_operand_t &dst,

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1199,7 +1199,6 @@ status_t init_pd_time_cfg(const conv_problem_t &prb, conv_config_t &cfg,
     cfg.set_exec_cfg(exec_config_t(hw));
     cfg.maybe_override_from_env();
 
-    cfg.set_require_signal_header(true);
     CHECK(init_fma_kind(cfg, pd, engine));
     CHECK(init_simd(cfg));
     CHECK(init_vec_size(cfg));

--- a/src/gpu/intel/jit/conv/config.hpp
+++ b/src/gpu/intel/jit/conv/config.hpp
@@ -599,12 +599,6 @@ public:
         set_exec_cfg(tmp);
     }
 
-    void set_require_signal_header(bool r) {
-        auto tmp = exec_cfg();
-        tmp.set_require_signal_header(r);
-        set_exec_cfg(tmp);
-    }
-
     void set_tiler(const std::shared_ptr<conv_tiler_t> &tiler);
     const conv_tiler_t &tiler() const;
     conv_tiler_t &tiler();

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -146,23 +146,17 @@ class exec_config_t {
 public:
     exec_config_t() = default;
     exec_config_t(const hw_t &hw) : hw_(hw) {}
-    exec_config_t(const hw_t &hw, int regs, int simd,
-            bool require_signal_header = false)
-        : hw_(hw)
-        , regs_(regs)
-        , simd_(simd)
-        , require_signal_header_(require_signal_header) {}
+    exec_config_t(const hw_t &hw, int regs, int simd)
+        : hw_(hw), regs_(regs), simd_(simd) {}
 
     const hw_t &hw() const { return hw_; }
     int regs() const { return regs_; }
     int simd() const { return simd_; }
     int vec_size() const { return vec_size_; }
     int grf_size() const { return hw_.grf_size(); }
-    bool require_signal_header() const { return require_signal_header_; }
     void set_regs(int regs) { regs_ = regs; }
     void set_simd(int simd) { simd_ = simd; }
     void set_vec_size(int vec_size) { vec_size_ = vec_size; }
-    void set_require_signal_header(bool r) { require_signal_header_ = r; }
 
     std::string str() const {
         std::ostringstream oss;
@@ -178,7 +172,6 @@ private:
     int regs_ = 0;
     int simd_ = 0;
     int vec_size_ = 0;
-    bool require_signal_header_ = false;
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -347,7 +347,7 @@ public:
     std::string kernel_name() const override { return "gen_conv_v2"; }
 
     exec_config_t exec_cfg(const impl::engine_t *engine) const override {
-        return exec_config_t(hw_t(engine), regs, simd, true);
+        return exec_config_t(hw_t(engine), regs, simd);
     }
 
     compute::range_t local_range() const override;


### PR DESCRIPTION
Using lazy signal header allocation prevents mismatches between exec_config_t and IR stmts.