### PR TITLE
xbyak: allow repeated assignment of the same opmask index

### DIFF
--- a/third_party/xbyak/xbyak.h
+++ b/third_party/xbyak/xbyak.h
@@ -681,7 +681,7 @@ public:
 	void setBit(int bit);
 	void setOpmaskIdx(int idx, bool /*ignore_idx0*/ = true)
 	{
-		if (mask_) XBYAK_THROW(ERR_OPMASK_IS_ALREADY_SET)
+		if (mask_ && (mask_ != idx)) XBYAK_THROW(ERR_OPMASK_IS_ALREADY_SET)
 		mask_ = idx;
 	}
 	void setRounding(int idx)


### PR DESCRIPTION
This change relaxes the opmask assignment check in `setOpmaskIdx` to allow setting the same opmask index multiple times on a Xbyak register, instead of throwing an exception on any repeated assignment. 
Previously, assigning an opmask index that was already set would always result in a runtime error. With this update, an exception is only thrown if a different opmask index is assigned.

This behavior was problematic in scenarios where the same opmask might be set more than once during JIT code generation, such as when handling binary post-ops with tail processing and comparison operations.

Addresses MFDNN-7033

The change has been upstreamed to Xbyak: https://github.com/herumi/xbyak/pull/209