### PR TITLE
graph: handle different engine instances in compiled partition cache

### DIFF
--- a/src/graph/backend/dnnl/dnnl_partition_impl.hpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -47,6 +47,17 @@ public:
         : compiled_partition_impl_t(
                 engine, inputs, outputs, kernel->get_inplace_pairs())
         , kernel_(kernel) {}
+
+    // Current implementation uses const_cast to reset `engine_` to point to a
+    // new engine object. The input engine remains const-qualified, and library
+    // currently does not modify the engine object itself. If future changes
+    // require modifying the engine object directly, this logic must be revised.
+    // Modifying a const-qualified engine internally would result in undefined
+    // behavior (UB).
+    status_t reset_engine(const engine_t *engine) override {
+        engine_ = const_cast<engine_t *>(engine);
+        return kernel_->reset_engine(engine);
+    }
 
     status_t execute(const stream_t *g_stream,
             const std::vector<tensor_t> &inputs,

--- a/src/graph/backend/dnnl/kernels/batch_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.hpp
@@ -42,7 +42,6 @@ struct batch_norm_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -98,7 +97,6 @@ struct batch_norm_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/binary.hpp
+++ b/src/graph/backend/dnnl/kernels/binary.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ struct binary_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/concat.hpp
+++ b/src/graph/backend/dnnl/kernels/concat.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ struct concat_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/conv_base.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.hpp
@@ -42,7 +42,6 @@ struct conv_base_t : public kernel_base_t {
 protected:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/dummy.hpp
+++ b/src/graph/backend/dnnl/kernels/dummy.hpp
@@ -34,9 +34,6 @@ namespace graph {
 namespace dnnl_impl {
 
 struct dummy_kernel_t : public kernel_base_t {
-private:
-    std::shared_ptr<subgraph_t> subgraph_;
-
 public:
     dummy_kernel_t() = default;
 

--- a/src/graph/backend/dnnl/kernels/eltwise.hpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.hpp
@@ -44,7 +44,6 @@ struct eltwise_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -111,7 +110,6 @@ struct eltwise_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -40,7 +40,6 @@ struct genindex_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/group_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.hpp
@@ -43,7 +43,6 @@ struct group_norm_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/kernel_base.hpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.hpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#include "graph/backend/dnnl/subgraph.hpp"
 #include "graph/interface/c_types_map.hpp"
 #include "graph/interface/logical_tensor.hpp"
 
@@ -51,6 +52,12 @@ struct kernel_base_t {
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs)
             = 0;
+
+    virtual status_t reset_engine(const engine_t *aengine) {
+        dnnl::engine p_engine = make_dnnl_engine(*aengine);
+        if (!subgraph_) return status::invalid_arguments;
+        return subgraph_->reset_engine(p_engine);
+    }
 
     status_t execute(const stream_t *astream,
             const std::vector<tensor_t> &inputs,
@@ -111,6 +118,7 @@ struct kernel_base_t {
 protected:
     std::vector<inplace_pair_t> inplace_pairs_;
     dnnl::engine p_engine_;
+    std::shared_ptr<subgraph_t> subgraph_;
 };
 
 using kernel_ptr = std::shared_ptr<kernel_base_t>;

--- a/src/graph/backend/dnnl/kernels/large_partition.hpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.hpp
@@ -43,7 +43,6 @@ class larger_partition_kernel_t : public kernel_base_t {
 protected:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/layer_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.hpp
@@ -43,7 +43,6 @@ struct layer_norm_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -99,7 +98,6 @@ struct layer_norm_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/log_softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ namespace dnnl_impl {
 struct logsoftmax_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
 
@@ -101,7 +100,6 @@ struct logsoftmax_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/matmul.hpp
+++ b/src/graph/backend/dnnl/kernels/matmul.hpp
@@ -44,7 +44,6 @@ struct matmul_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/mqa.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -102,6 +102,9 @@ public:
         return kernel->ocl_execute_impl(g_stream, inputs, outputs, deps, event);
     }
 #endif
+    status_t reset_engine(const engine_t *g_engine) override {
+        return kernel->reset_engine(g_engine);
+    }
 
     std::string str() const override { return kernel->str(); }
 };

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -48,7 +48,6 @@ private:
     allocator_t *g_alloc_ = nullptr;
     // used for mqa internal memory planning
     registry_t mqa_registry_;
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     subgraph_visualizer_t vis_;
 
@@ -165,6 +164,10 @@ public:
 
     DEF_KERNEL_METHOD_STR(mqa_decomp_kernel_t)
     DNNL_DISALLOW_COPY_AND_ASSIGN(mqa_decomp_kernel_t)
+    status_t reset_engine(const engine_t *g_engine) override {
+        dnnl::engine p_engine = make_dnnl_engine(*g_engine);
+        return mqa_cfg_.reset_engine(p_engine);
+    }
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -474,6 +474,31 @@ dnnl::primitive_attr mqa_decomp_config_t::make_primitive_attr(
     return attr;
 }
 
+#define DECLARE_RESET_ENGINE(primitive_name, primitive_type) \
+    { \
+        const auto desc_t = (primitive_name).get_primitive_desc()->impl(); \
+        dnnl_primitive_desc new_pd_t(desc_t, p_engine.get()); \
+        primitive_type::primitive_desc new_pd(&new_pd_t); \
+        (primitive_name) = primitive_type(new_pd); \
+    }
+
+impl::status_t mqa_decomp_config_t::reset_engine(const dnnl::engine &p_engine) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(1);
+#endif
+    DECLARE_RESET_ENGINE(sub_mm1_prim, matmul);
+    DECLARE_RESET_ENGINE(sub_mm2_prim, matmul);
+    DECLARE_RESET_ENGINE(sub_softmax_prim, softmax_forward);
+    sub_reorder0.reset_engine(p_engine);
+    sub_reorder1.reset_engine(p_engine);
+    sub_reorder2.reset_engine(p_engine);
+    sub_reorder3.reset_engine(p_engine);
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(nthr);
+#endif
+    return dnnl_success;
+}
+
 template status_t
 mqa_decomp_config_t::construct_params<false, dnnl::memory::data_type::f32>(
         std::shared_ptr<subgraph_t> &sg, registry_t &mqa_registry,

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
@@ -27,6 +27,7 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 #include "common/dnnl_thread.hpp"
+#include "common/primitive_desc_iface.hpp"
 
 #include "graph/interface/c_types_map.hpp"
 
@@ -60,6 +61,13 @@ public:
             args.at(DNNL_ARG_DST).set_data_handle(handle);
         } else
             reorder_.execute(astream, args);
+        return status::success;
+    }
+    status_t reset_engine(const dnnl::engine &p_engine) {
+        auto desc_t = reorder_.get_primitive_desc()->impl();
+        dnnl_primitive_desc new_pd_t(desc_t, p_engine.get());
+        dnnl::reorder::primitive_desc new_pd(&new_pd_t);
+        reorder_ = dnnl::reorder(new_pd);
         return status::success;
     }
 
@@ -135,6 +143,7 @@ public:
     status_t construct_params(std::shared_ptr<subgraph_t> &sg,
             registry_t &mqa_registry, const dnnl::engine &p_engine,
             const std::vector<logical_tensor_t> &inputs);
+    impl::status_t reset_engine(const dnnl::engine &p_engine);
 
 private:
     op_ptr get_post_op(const op_ptr &op) const;

--- a/src/graph/backend/dnnl/kernels/pool.hpp
+++ b/src/graph/backend/dnnl/kernels/pool.hpp
@@ -44,7 +44,6 @@ struct pooling_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -104,7 +103,6 @@ struct pooling_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/prelu.hpp
+++ b/src/graph/backend/dnnl/kernels/prelu.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ struct prelu_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -101,7 +100,6 @@ struct prelu_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/quantize.hpp
+++ b/src/graph/backend/dnnl/kernels/quantize.hpp
@@ -42,7 +42,6 @@ namespace dnnl_impl {
 struct quantize_dequantize_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
 

--- a/src/graph/backend/dnnl/kernels/reduction.hpp
+++ b/src/graph/backend/dnnl/kernels/reduction.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ struct reduction_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/reorder.hpp
+++ b/src/graph/backend/dnnl/kernels/reorder.hpp
@@ -44,7 +44,6 @@ struct reorder_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/resampling.hpp
+++ b/src/graph/backend/dnnl/kernels/resampling.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ struct resampling_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
@@ -103,7 +102,6 @@ struct resampling_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -145,7 +145,9 @@ public:
         return kernel->ocl_execute_impl(g_stream, inputs, outputs, deps, event);
     }
 #endif
-
+    status_t reset_engine(const engine_t *g_engine) override {
+        return kernel->reset_engine(g_engine);
+    }
     std::string str() const override { return kernel->str(); }
 };
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -49,7 +49,6 @@ private:
     // used for sdp internal memory planning
     registry_t sdp_registry_;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     subgraph_visualizer_t vis_;
 
@@ -172,6 +171,10 @@ public:
 
     DEF_KERNEL_METHOD_STR(sdp_decomp_kernel_t)
     DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_decomp_kernel_t)
+    status_t reset_engine(const engine_t *g_engine) override {
+        dnnl::engine p_engine = make_dnnl_engine(*g_engine);
+        return sdp_cfg_.reset_engine(p_engine);
+    }
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -27,6 +27,7 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 #include "common/dnnl_thread.hpp"
+#include "common/primitive_desc_iface.hpp"
 
 #include "graph/interface/c_types_map.hpp"
 
@@ -61,6 +62,13 @@ public:
             args.at(DNNL_ARG_DST).set_data_handle(handle);
         } else
             reorder_prim_.execute(astream, args);
+        return status::success;
+    }
+    status_t reset_engine(const dnnl::engine &p_engine) {
+        auto desc_t = reorder_prim_.get_primitive_desc()->impl();
+        dnnl_primitive_desc new_pd_t(desc_t, p_engine.get());
+        dnnl::reorder::primitive_desc new_pd(&new_pd_t);
+        reorder_prim_ = dnnl::reorder(new_pd);
         return status::success;
     }
 
@@ -165,6 +173,7 @@ public:
     impl::status_t construct_params(std::shared_ptr<subgraph_t> &sg,
             registry_t &sdp_registry, const dnnl::engine &p_engine,
             const std::vector<logical_tensor_t> &inputs);
+    impl::status_t reset_engine(const dnnl::engine &p_engine);
 
 private:
     op_ptr get_post_op(const op_ptr &op) const;

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ struct sdp_primitive_kernel_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
 
@@ -97,6 +96,10 @@ public:
 
     DEF_KERNEL_METHOD_STR(sdp_primitive_kernel_t)
     DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_primitive_kernel_t)
+    status_t reset_engine(const engine_t *g_engine) override {
+        UNUSED(g_engine);
+        return dnnl_success;
+    }
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_v1.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_v1.hpp
@@ -44,7 +44,6 @@ struct sdp_primitive_v1_kernel_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
 

--- a/src/graph/backend/dnnl/kernels/shuffle.hpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ struct shuffle_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/softmax.hpp
@@ -42,7 +42,6 @@ namespace dnnl_impl {
 struct softmax_fwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;
 
@@ -103,7 +102,6 @@ struct softmax_bwd_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     std::function<std::shared_ptr<execution_args_set_t>()> resource_ctor_;

--- a/src/graph/backend/dnnl/kernels/sum.hpp
+++ b/src/graph/backend/dnnl/kernels/sum.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ struct sum_t : public kernel_base_t {
 private:
     allocator_t *g_alloc_ = nullptr;
 
-    std::shared_ptr<subgraph_t> subgraph_;
     memory_planner_t memory_planner_;
 
     // function to create execution arguments for primitive

--- a/src/graph/backend/dnnl/subgraph.cpp
+++ b/src/graph/backend/dnnl/subgraph.cpp
@@ -33,6 +33,7 @@
 #include "graph/backend/dnnl/common.hpp"
 #include "graph/backend/dnnl/dnnl_backend.hpp"
 #include "graph/backend/dnnl/internal_attrs.hpp"
+#include "graph/backend/dnnl/op_executable.hpp"
 #include "graph/backend/dnnl/subgraph.hpp"
 #include "graph/backend/dnnl/utils.hpp"
 
@@ -63,6 +64,15 @@ subgraph_t::subgraph_t(const std::vector<op_ptr> &ops, const dnnl::engine &eng,
 subgraph_t::subgraph_t(const std::vector<op_ptr> &ops, bool reset_layout)
     : graph_t(ops), p_engine_(nullptr) {
     if (reset_layout) { set_all_layout_to_any(get_mutable_ops()); }
+}
+
+status_t subgraph_t::reset_engine(const dnnl::engine &eng) {
+    status_t ret = status::success;
+    for (auto const &exec : execs_) {
+        ret = exec->reset_engine(eng);
+        if (ret != status::success) return ret;
+    }
+    return ret;
 }
 
 std::string kind2str(op_kind_t kind) {

--- a/src/graph/backend/dnnl/subgraph.hpp
+++ b/src/graph/backend/dnnl/subgraph.hpp
@@ -71,6 +71,7 @@ public:
 
     subgraph_t(const std::vector<op_ptr> &ops, bool reset_layout = true);
 
+    status_t reset_engine(const dnnl::engine &eng);
     // The inputs and outputs logical tensors given by users at compilation
     // stage
     std::vector<logical_tensor_t> ins_;

--- a/src/graph/interface/allocator.hpp
+++ b/src/graph/interface/allocator.hpp
@@ -53,6 +53,41 @@ public:
         : ocl_malloc_(ocl_malloc), ocl_free_(ocl_free) {}
 #endif
 
+    bool operator==(const dnnl_graph_allocator &other) const {
+        return host_malloc_ == other.host_malloc_
+                && host_free_ == other.host_free_
+#ifdef DNNL_WITH_SYCL
+                && sycl_malloc_ == other.sycl_malloc_
+                && sycl_free_ == other.sycl_free_
+#endif
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+                && ocl_malloc_ == other.ocl_malloc_
+                && ocl_free_ == other.ocl_free_
+#endif
+                ;
+    }
+
+    size_t hash() const {
+        size_t seed = 0;
+        seed = dnnl::impl::hash_combine(
+                seed, reinterpret_cast<uintptr_t>(host_malloc_));
+        seed = dnnl::impl::hash_combine(
+                seed, reinterpret_cast<uintptr_t>(host_free_));
+#ifdef DNNL_WITH_SYCL
+        seed = dnnl::impl::hash_combine(
+                seed, reinterpret_cast<uintptr_t>(sycl_malloc_));
+        seed = dnnl::impl::hash_combine(
+                seed, reinterpret_cast<uintptr_t>(sycl_free_));
+#endif
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+        seed = dnnl::impl::hash_combine(
+                seed, reinterpret_cast<uintptr_t>(ocl_malloc_));
+        seed = dnnl::impl::hash_combine(
+                seed, reinterpret_cast<uintptr_t>(ocl_free_));
+#endif
+        return seed;
+    }
+
     enum class mem_type_t {
         persistent = 0,
         output = 1,

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -679,10 +679,17 @@ status_t dnnl_graph_partition::compile(
 
     compiled_partition.first->init(result.value->pimpl_);
     compiled_partition.second = context.cache_status;
+    if (context.cache_status == cache_state_t::compiled_partition_hit
+            && aengine != compiled_partition.first->get_engine()) {
+        compiled_partition_t *cp = compiled_partition.first;
+        cp->reset_engine(aengine);
+    }
 
     return result.status;
 }
-
+status_t dnnl_graph_compiled_partition::reset_engine(const engine_t *e) {
+    return pimpl_->reset_engine(e);
+}
 status_t dnnl_graph_compiled_partition::execute(const stream_t *astream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs) const {

--- a/src/graph/interface/partition.hpp
+++ b/src/graph/interface/partition.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -227,6 +227,8 @@ public:
         if (!info_.is_initialized()) info_.init(eng, this);
         return info_.c_str();
     }
+
+    graph::status_t reset_engine(const graph::engine_t *e);
 
 private:
     std::shared_ptr<graph::compiled_partition_impl_t> pimpl_;

--- a/src/graph/interface/partition_hashing.cpp
+++ b/src/graph/interface/partition_hashing.cpp
@@ -35,6 +35,8 @@ key_t::key_t(const impl::engine_t *engine,
     , nthread_(dnnl_get_max_threads())
     , engine_id_(engine->engine_id())
     , fpmath_(fpmath)
+    , allocator_(
+              *reinterpret_cast<graph::allocator_t *>(engine->get_allocator()))
     , thread_id_(std::this_thread::get_id()) {
     ins_.reserve(ins.size());
     outs_.reserve(outs.size());
@@ -64,7 +66,8 @@ bool key_t::operator==(const key_t &rhs) const {
 
     bool ret = true && lhs_num_ops == rhs_num_ops && lhs_num_ins == rhs_num_ins
             && lhs_num_outs == rhs_num_outs && nthread_ == rhs.nthread_
-            && engine_id_ == rhs.engine_id_ && fpmath_ == rhs.fpmath_;
+            && engine_id_ == rhs.engine_id_ && fpmath_ == rhs.fpmath_
+            && allocator_ == rhs.allocator_;
     if (!ret) return false;
 
     for (size_t i = 0; i < lhs_num_ops; ++i) {

--- a/src/graph/interface/partition_hashing.cpp
+++ b/src/graph/interface/partition_hashing.cpp
@@ -33,14 +33,7 @@ key_t::key_t(const impl::engine_t *engine,
         const impl::graph::fpmath_t &fpmath)
     : ops_(get_raw_ptrs(ops))
     , nthread_(dnnl_get_max_threads())
-    // Here we use engine as a member of partition_hashing key_t, because for
-    // CPU engine and nativa runtime, the engine_id is nullptr for all engine
-    // instances. The compiled partition would be hit under different engine
-    // instances. For example, first compile with engine 1 -> execute with
-    // engine1 -> second compile with engine 2 (cache hit) -> execute with
-    // engine 2(fail). So we need to use engine as a member of key_t to avoid
-    // execution crash.
-    , engine_(engine)
+    , engine_id_(engine->engine_id())
     , fpmath_(fpmath)
     , thread_id_(std::this_thread::get_id()) {
     ins_.reserve(ins.size());
@@ -71,7 +64,7 @@ bool key_t::operator==(const key_t &rhs) const {
 
     bool ret = true && lhs_num_ops == rhs_num_ops && lhs_num_ins == rhs_num_ins
             && lhs_num_outs == rhs_num_outs && nthread_ == rhs.nthread_
-            && engine_ == rhs.engine_ && fpmath_ == rhs.fpmath_;
+            && engine_id_ == rhs.engine_id_ && fpmath_ == rhs.fpmath_;
     if (!ret) return false;
 
     for (size_t i = 0; i < lhs_num_ops; ++i) {

--- a/src/graph/interface/partition_hashing.hpp
+++ b/src/graph/interface/partition_hashing.hpp
@@ -66,15 +66,15 @@ struct key_t {
     bool operator==(const key_t &other) const;
     const std::thread::id &thread_id() const { return thread_id_; }
     bool has_runtime_dependencies() const {
-        return !(engine_->kind() == engine_kind::cpu
-                && impl::is_native_runtime(engine_->runtime_kind()));
+        return !(engine_id_.kind() == engine_kind::cpu
+                && impl::is_native_runtime(engine_id_.runtime_kind()));
     }
 
     mutable std::vector<op_t *> ops_;
     mutable std::vector<logical_tensor_t> ins_;
     mutable std::vector<logical_tensor_t> outs_;
     int nthread_;
-    const impl::engine_t *engine_;
+    impl::engine_id_t engine_id_;
     const impl::graph::fpmath_t fpmath_;
 
 private:
@@ -152,8 +152,7 @@ struct hash<dnnl::impl::graph::partition_hashing::key_t> {
         size_t seed = 0;
         // Compute hash for nthread_, engine_kind_
         seed = dnnl::impl::hash_combine(seed, key.nthread_);
-        seed = dnnl::impl::hash_combine(
-                seed, reinterpret_cast<uintptr_t>(key.engine_));
+        seed = dnnl::impl::hash_combine(seed, key.engine_id_.hash());
 
         // Combine hash for op_kinds & attributes with the computed hash
         seed = get_array_hash(seed, key.ops_);

--- a/src/graph/interface/partition_hashing.hpp
+++ b/src/graph/interface/partition_hashing.hpp
@@ -76,6 +76,7 @@ struct key_t {
     int nthread_;
     impl::engine_id_t engine_id_;
     const impl::graph::fpmath_t fpmath_;
+    graph::allocator_t allocator_;
 
 private:
     // Thread ID is not used as part of the key, it's only used to get
@@ -153,6 +154,7 @@ struct hash<dnnl::impl::graph::partition_hashing::key_t> {
         // Compute hash for nthread_, engine_kind_
         seed = dnnl::impl::hash_combine(seed, key.nthread_);
         seed = dnnl::impl::hash_combine(seed, key.engine_id_.hash());
+        seed = dnnl::impl::hash_combine(seed, key.allocator_.hash());
 
         // Combine hash for op_kinds & attributes with the computed hash
         seed = get_array_hash(seed, key.ops_);

--- a/src/graph/interface/partition_impl.hpp
+++ b/src/graph/interface/partition_impl.hpp
@@ -277,7 +277,7 @@ public:
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs,
             const std::vector<inplace_pair_t> &inplace_pairs)
-        : engine_(&engine)
+        : engine_(const_cast<engine_t *>(&engine))
         , inputs_(inputs)
         , outputs_(outputs)
         , inplace_pairs_(inplace_pairs) {};
@@ -288,6 +288,8 @@ public:
 
     /// The getters for engine_, which is used in C API implementation
     const engine_t *get_engine() const { return engine_; }
+
+    virtual status_t reset_engine(const engine_t *engine) = 0;
 
     /// The getters for inputs_, which is used in verbose mode
     const std::vector<logical_tensor_t> &get_inputs() const { return inputs_; }
@@ -373,7 +375,7 @@ protected:
     /// The engine which this compiled_partition_impl_t is specialized
     /// for. Should directly store the engine that is given when calling
     /// partition_impl_t::compile
-    const engine_t *engine_;
+    engine_t *engine_;
 
     /// The inputs logical tensors which this compiled_partition_impl_t
     /// is specialized for.Should have exact shape/dtype/layout and be

--- a/tests/gtests/graph/unit/interface/test_compiled_partition.cpp
+++ b/tests/gtests/graph/unit/interface/test_compiled_partition.cpp
@@ -190,13 +190,26 @@ TEST(test_interface_compiled_partition, CacheEngine) {
         std::vector<const impl::graph::logical_tensor_t *> inputs {&input};
         std::vector<const impl::graph::logical_tensor_t *> outputs {&output};
         // Partition compilation
-        par.compile(cpcache, inputs, outputs, eng);
+        ASSERT_EQ(par.compile(cpcache, inputs, outputs, eng),
+                impl::status_t::dnnl_success);
+
+        // Partition execution
+        dnnl::stream strm(engine);
+        impl::stream_t *strm_t = strm.get();
+        auto ts_input = dnnl_graph_tensor(input, eng, DNNL_MEMORY_ALLOCATE);
+        auto ts_output = dnnl_graph_tensor(output, eng, DNNL_MEMORY_ALLOCATE);
+        ASSERT_EQ(cp.execute(strm_t, {ts_input}, {ts_output}),
+                impl::status_t::dnnl_success);
     }
 
 #ifdef DNNL_GRAPH_DISABLE_COMPILED_PARTITION_CACHE
     ASSERT_EQ(get_compiled_partition_cache_size(), 0);
 #else
-    ASSERT_EQ(get_compiled_partition_cache_size(), static_cast<int>(batch_num));
+    if (get_test_engine_kind() == impl::graph::engine_kind::cpu) {
+        ASSERT_EQ(get_compiled_partition_cache_size(), 1);
+    } else if (get_test_engine_kind() == impl::graph::engine_kind::gpu) {
+        ASSERT_GE(get_compiled_partition_cache_size(), batch_num);
+    }
 #endif
 }
 


### PR DESCRIPTION
Fix MFDNN-12121
In this PR,  we add the `reset_engine` method to reset the compiled partition's and kernel's engine. With this PR, the compiled partition and primitive cache can be hit for different engine cases (Same member functions and member variables)