### PR TITLE
xe: generic integrated/discrete detection

### DIFF
--- a/src/gpu/intel/compute/device_info.cpp
+++ b/src/gpu/intel/compute/device_info.cpp
@@ -65,11 +65,6 @@ uint64_t get_future_extensions(
     return extensions;
 }
 
-bool device_info_t::is_integrated() const {
-    auto family = static_cast<ngen::ProductFamily>(gpu_product_family_);
-    return ngen::getPlatformType(family) == ngen::PlatformType::Integrated;
-}
-
 bool device_info_t::mayiuse_sub_group(int size) const {
     switch (gpu_arch()) {
         case gpu_arch_t::gen9:

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -200,7 +200,7 @@ public:
     int gpu_product_family() const { return gpu_product_family_; }
     int stepping_id() const { return stepping_id_; }
     uint64_t native_extensions() const { return native_extensions_; }
-    bool is_integrated() const;
+    bool is_integrated() const { return is_integrated_; }
     uint32_t ip_version() const { return ip_version_; }
     int max_eus_per_wg() const { return max_eus_per_wg_; }
     static int max_eus_per_wg(gpu_arch_t gpu_arch);
@@ -280,6 +280,7 @@ protected:
     int gpu_product_family_ = 0;
     int stepping_id_ = 0;
     uint32_t ip_version_ = 0;
+    bool is_integrated_ = false;
     bool mayiuse_systolic_ = false;
     bool mayiuse_ngen_kernels_ = false;
     bool mayiuse_system_memory_allocators_ = false;

--- a/src/gpu/intel/ocl/device_info.cpp
+++ b/src/gpu/intel/ocl/device_info.cpp
@@ -43,8 +43,8 @@ status_t device_info_t::init_arch(impl::engine_t *engine) {
     OCL_CHECK(err);
 
     init_gpu_hw_info(engine, device, context, ip_version_, gpu_arch_,
-            gpu_product_family_, stepping_id_, native_extensions_,
-            mayiuse_systolic_, mayiuse_ngen_kernels_);
+            gpu_product_family_, is_integrated_, stepping_id_,
+            native_extensions_, mayiuse_systolic_, mayiuse_ngen_kernels_);
 
     err = clReleaseContext(context);
     OCL_CHECK(err);

--- a/src/gpu/intel/ocl/hw_info.cpp
+++ b/src/gpu/intel/ocl/hw_info.cpp
@@ -57,8 +57,9 @@ xpu::runtime_version_t get_driver_version(cl_device_id device) {
 
 status_t init_gpu_hw_info(impl::engine_t *engine, cl_device_id device,
         cl_context context, uint32_t &ip_version, compute::gpu_arch_t &gpu_arch,
-        int &gpu_product_family, int &stepping_id, uint64_t &native_extensions,
-        bool &mayiuse_systolic, bool &mayiuse_ngen_kernels) {
+        int &gpu_product_family, bool &is_integrated, int &stepping_id,
+        uint64_t &native_extensions, bool &mayiuse_systolic,
+        bool &mayiuse_ngen_kernels) {
     using namespace ngen;
     Product product = ngen::OpenCLCodeGenerator<HW::Unknown>::detectHWInfo(
             context, device);
@@ -68,6 +69,7 @@ status_t init_gpu_hw_info(impl::engine_t *engine, cl_device_id device,
     gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product.family));
     gpu_product_family = static_cast<int>(product.family);
     stepping_id = product.stepping;
+    is_integrated = (product.type == PlatformType::Integrated);
 
     mayiuse_systolic = false;
     CHECK(get_ocl_device_enabled_systolic_intel(device, mayiuse_systolic));

--- a/src/gpu/intel/ocl/hw_info.hpp
+++ b/src/gpu/intel/ocl/hw_info.hpp
@@ -32,8 +32,9 @@ xpu::runtime_version_t get_driver_version(cl_device_id device);
 
 status_t init_gpu_hw_info(impl::engine_t *engine, cl_device_id device,
         cl_context context, uint32_t &ip_version, compute::gpu_arch_t &gpu_arch,
-        int &gpu_product_family, int &stepping_id, uint64_t &native_extensions,
-        bool &mayiuse_systolic, bool &mayiuse_ngen_kernels);
+        int &gpu_product_family, bool &is_integrated, int &stepping_id,
+        uint64_t &native_extensions, bool &mayiuse_systolic,
+        bool &mayiuse_ngen_kernels);
 
 } // namespace ocl
 } // namespace intel

--- a/src/gpu/intel/sycl/device_info.cpp
+++ b/src/gpu/intel/sycl/device_info.cpp
@@ -50,15 +50,17 @@ status_t device_info_t::init_arch(impl::engine_t *engine) {
         auto ocl_ctx = xpu::sycl::compat::get_native<cl_context>(ctx);
 
         status = gpu::intel::ocl::init_gpu_hw_info(engine, ocl_dev, ocl_ctx,
-                ip_version_, gpu_arch_, gpu_product_family_, stepping_id_,
-                native_extensions_, mayiuse_systolic_, mayiuse_ngen_kernels_);
+                ip_version_, gpu_arch_, gpu_product_family_, is_integrated_,
+                stepping_id_, native_extensions_, mayiuse_systolic_,
+                mayiuse_ngen_kernels_);
     } else if (be == xpu::sycl::backend_t::level0) {
         auto ze_dev = xpu::sycl::compat::get_native<ze_device_handle_t>(device);
         auto ze_ctx = xpu::sycl::compat::get_native<ze_context_handle_t>(ctx);
 
         status = gpu::intel::sycl::init_gpu_hw_info(engine, ze_dev, ze_ctx,
-                ip_version_, gpu_arch_, gpu_product_family_, stepping_id_,
-                native_extensions_, mayiuse_systolic_, mayiuse_ngen_kernels_);
+                ip_version_, gpu_arch_, gpu_product_family_, is_integrated_,
+                stepping_id_, native_extensions_, mayiuse_systolic_,
+                mayiuse_ngen_kernels_);
     } else {
         assert(!"not_expected");
         status = status::unimplemented;

--- a/src/gpu/intel/sycl/l0/utils.cpp
+++ b/src/gpu/intel/sycl/l0/utils.cpp
@@ -383,8 +383,8 @@ status_t get_l0_device_eu_count(ze_device_handle_t device, int &eu_count) {
 status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
         ze_context_handle_t context, uint32_t &ip_version,
         compute::gpu_arch_t &gpu_arch, int &gpu_product_family,
-        int &stepping_id, uint64_t &native_extensions, bool &mayiuse_systolic,
-        bool &mayiuse_ngen_kernels) {
+        bool &is_integrated, int &stepping_id, uint64_t &native_extensions,
+        bool &mayiuse_systolic, bool &mayiuse_ngen_kernels) {
     using namespace ngen;
     Product product = LevelZeroCodeGenerator<HW::Unknown>::detectHWInfo(
             context, device);
@@ -392,6 +392,7 @@ status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
     gpu_arch = jit::convert_ngen_arch_to_dnnl(ngen::getCore(product.family));
     gpu_product_family = static_cast<int>(product.family);
     stepping_id = product.stepping;
+    is_integrated = (product.type = PlatformType::Integrated);
 
     mayiuse_systolic = false;
     if (get_l0_device_enabled_systolic_intel(device, mayiuse_systolic)

--- a/src/gpu/intel/sycl/l0/utils.hpp
+++ b/src/gpu/intel/sycl/l0/utils.hpp
@@ -48,8 +48,8 @@ status_t func_zeModuleGetNativeBinary(ze_module_handle_t hModule, size_t *pSize,
 status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
         ze_context_handle_t context, uint32_t &ip_version,
         compute::gpu_arch_t &gpu_arch, int &gpu_product_family,
-        int &stepping_id, uint64_t &native_extensions, bool &mayiuse_systolic,
-        bool &mayiuse_ngen_kernels);
+        bool &is_integrated, int &stepping_id, uint64_t &native_extensions,
+        bool &mayiuse_systolic, bool &mayiuse_ngen_kernels);
 
 } // namespace sycl
 } // namespace intel


### PR DESCRIPTION
nGEN has generic logic for integrated/discrete detection, even for platforms that are not detected by name.

This PR updates `device_info_t::is_integrated()` to use it.