### PR TITLE
governance: add Renato Arantes as onednn-cpu-aarch64 codeowner

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -165,6 +165,7 @@ Team: @uxlfoundation/onednn-cpu-aarch64
 | Siddhartha Menon   | @Sqvid                | Arm Ltd           | Code Owner |
 | Sunita Nadampalli  | @snadampal            | Amazon.com, Inc.  | Code Owner |
 | Ryo Suzuki         | @Ryo-not-rio          | Arm Ltd           | Code Owner |
+| Renato Arantes     | @renato-arantes       | Arm Ltd           | Code Owner |
 
 ### OpenPOWER (PPC64)
 


### PR DESCRIPTION
# Description

I propose Renato Arantes (@renato-arantes) as a codeowner for @uxlfoundation/onednn-cpu-aarch64. He has [several contributions over the last few years](https://github.com/uxlfoundation/oneDNN/commits?author=renato-arantes).

cc: @vpirogov 