### PR TITLE
graph: backend: dnnl: backend refactor of adding fusion info attr

### DIFF
--- a/src/graph/backend/dnnl/dnnl_op_def.hpp
+++ b/src/graph/backend/dnnl/dnnl_op_def.hpp
@@ -312,8 +312,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_convolution, 1,
                 // Attributes inherited from Convolution.
                 .SET_CONV_COMMON_ATTRS
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::with_bias, false, attribute_kind::b, false)
                 .set_attr(
                         op_attr::canonicalized, false, attribute_kind::b, false)
@@ -340,8 +340,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_convtranspose, 1,
                         std::vector<int64_t>(DNNL_MAX_NDIMS, 0))
                 .SET_DNNL_CONVTRANSPOSE_COMMON_ATTRS
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::with_bias, false, attribute_kind::b, false)
                 .set_attr(
                         op_attr::canonicalized, false, attribute_kind::b, false)
@@ -427,8 +427,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_pool, 1,
                 .set_attr(op_attr::auto_pad, false, attribute_kind::s, "None",
                         {"None", "SAME_UPPER", "SAME_LOWER", "VALID"})
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::kind, true, attribute_kind::s)
                 .set_attr(
                         op_attr::canonicalized, false, attribute_kind::b, false)
@@ -623,8 +623,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_batchnorm, 1,
                 .set_attr(op_attr::data_format, false, attribute_kind::s, "NXC",
                         {"NXC", "NCX"})
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::is_training, false, attribute_kind::b)
                 .set_attr(op_attr::fuse_relu, false, attribute_kind::b)
                 .set_attr(
@@ -653,8 +653,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_batchnorm_bwd, 1,
                 .set_output(2, "beta_delta")
                 .set_output(3, "scratchpad")
                 .set_attr(op_attr::epsilon, true, attribute_kind::f)
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::data_format, false, attribute_kind::s, "NXC",
                         {"NXC", "NCX"})
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
@@ -684,8 +684,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_resampling_bwd, 1,
                 .set_attr(op_attr::scales, false, attribute_kind::fs)
                 .set_attr(op_attr::data_format, false, attribute_kind::s, "NXC",
                         {"NXC", "NCX"})
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 .set_shape_inference_function(infer_identity_output_shape)
                 .SET_LAYOUT_PROPAGATOR(layout_propagator_for_resampling_bwd)
@@ -728,8 +728,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_binary, 1,
                         {"NXC", "NCX"})
                 // New added attributes
                 .set_attr(op_attr::is_bias_add, false, attribute_kind::b, false)
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::alg_kind, true, attribute_kind::i)
                 .set_attr(
                         op_attr::canonicalized, false, attribute_kind::b, false)
@@ -754,8 +754,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_eltwise, 1,
                 .set_attr(op_attr::alpha, false, attribute_kind::f, 0.f)
                 .set_attr(op_attr::beta, false, attribute_kind::f, 0.f)
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::alg_kind, true, attribute_kind::i)
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 // Analysis rules
@@ -777,8 +777,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_eltwise_bwd, 1,
                 .set_attr(op_attr::beta, false, attribute_kind::f, 0.f)
                 .set_attr(op_attr::use_dst, false, attribute_kind::b, false)
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::alg_kind, true, attribute_kind::i)
                 .set_attr(op_attr::fwd_alg_kind, true, attribute_kind::i)
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
@@ -836,8 +836,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_reduction, 1,
                 // Attributes inherited from front reduction ops
                 .SET_REDUCE_COMMON_ATTRS
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::alg_kind, true, attribute_kind::i)
                 .set_attr(op_attr::p, false, attribute_kind::f, 0.0f)
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
@@ -906,8 +906,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_resampling, 1,
                 .set_attr(op_attr::data_format, false, attribute_kind::s, "NXC",
                         {"NXC", "NCX"})
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(
                         op_attr::canonicalized, false, attribute_kind::b, false)
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
@@ -956,8 +956,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_layernorm_bwd, 1,
                 .set_attr(op_attr::begin_norm_axis, false, attribute_kind::i,
                         int64_t(-1))
                 .set_attr(op_attr::epsilon, false, attribute_kind::f, 1e-5f)
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 .set_shape_inference_function(infer_norm_bprop_output_shape)
                 .SET_LAYOUT_PROPAGATOR(layout_propagator_for_layernorm_bwd)
@@ -978,8 +978,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_matmul, 1,
                 // Attributes inherited from MatMul.
                 .SET_MATMUL_COMMON_ATTRS
                 // New added attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::with_bias, false, attribute_kind::b, false)
                 .set_attr(
                         op_attr::canonicalized, false, attribute_kind::b, false)
@@ -1006,8 +1006,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_softmax, 1,
                         {"none", "inf_as_zero"})
                 // New added attributes
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 // Analysis rules
                 .set_shape_inference_function(infer_identity_output_shape)
                 .SET_LAYOUT_PROPAGATOR(layout_propagator_for_softmax)
@@ -1052,8 +1052,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_layernorm, 1,
                         int64_t(-1))
                 .set_attr(op_attr::use_affine, false, attribute_kind::b, true)
                 .set_attr(op_attr::epsilon, false, attribute_kind::f, 1e-5f)
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 // New added attributes
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 // Analysis rules
@@ -1077,8 +1077,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_reorder, 1,
                 .set_attr(
                         op_attr::qtype, false, attribute_kind::s, "per_tensor")
                 // Attributes
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(
                         op_attr::change_layout, false, attribute_kind::b, false)
                 .set_attr(op_attr::scales, false, attribute_kind::fs)
@@ -1122,8 +1122,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_groupnorm, 1,
                 .set_attr(op_attr::epsilon, false, attribute_kind::f, 1e-5f)
                 .set_attr(op_attr::data_format, false, attribute_kind::s, "NXC",
                         {"NCX", "NXC"})
-                .set_attr(op_attr::fusion_info_key, false, attribute_kind::i,
-                        (int64_t)-1)
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 // New added attributes
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 // Analysis rules
@@ -1171,6 +1171,8 @@ DNNL_GRAPH_OP_SCHEMA(dnnl_sdpa, 1,
                 .set_input(4, "mask") // optional
                 .set_output(0, "output")
                 .set_output(1, "scratchpad")
+                .set_attr(op_attr::fusion_info, false,
+                        attribute_kind::fusion_info)
                 .set_attr(op_attr::with_scale, true, attribute_kind::b)
                 .set_attr(op_attr::is_invert_scale, false, attribute_kind::b,
                         false)

--- a/src/graph/backend/dnnl/fusion_info.hpp
+++ b/src/graph/backend/dnnl/fusion_info.hpp
@@ -324,33 +324,6 @@ private:
     std::vector<std::shared_ptr<meta_op_t>> post_ops_;
 };
 
-// This class is used to manage all fusion infos in a subgraph. The
-// fusion_info_t can't be directly stored in op's attribute system, so we store
-// them in this manager class and then store the generated int64_t typed key in
-// op's attribute system. When using an ops' fusion info, we can use the fusion
-// info key to query it out from the manager.
-class fusion_info_mgr_t {
-public:
-    fusion_info_mgr_t(
-            graph::fpmath_t fpm_mode = {}, bool can_use_blocked_layout = false)
-        : fpmath_mode_(fpm_mode)
-        , can_use_blocked_layout_(can_use_blocked_layout) {}
-
-    // Disable assignment and copy
-    fusion_info_mgr_t(const fusion_info_mgr_t &) = delete;
-    fusion_info_mgr_t(fusion_info_mgr_t &&) = delete;
-    fusion_info_mgr_t &operator=(const fusion_info_mgr_t &) = delete;
-    fusion_info_mgr_t &operator=(fusion_info_mgr_t &&) = delete;
-
-    const fpmath_t &get_fpmath_mode() const { return fpmath_mode_; }
-    bool get_use_blocked_layout() const { return can_use_blocked_layout_; }
-
-private:
-    // specified floating-point math mode for all fusions
-    fpmath_t fpmath_mode_;
-    bool can_use_blocked_layout_;
-};
-
 // This function is used to make a dnnl::primitive_attr from the fusion info.
 // Note that the op and fusion_info arguments must be matched since a fusion
 // info make sense only when it belongs to a specific op.

--- a/src/graph/backend/dnnl/internal_attrs.hpp
+++ b/src/graph/backend/dnnl/internal_attrs.hpp
@@ -51,7 +51,6 @@ const op_attr_t mask_type = 0x10012;
 
 // int64_t
 const op_attr_t alg_kind = 0x10100;
-const op_attr_t fusion_info_key = 0x10103;
 const op_attr_t group_mask = 0x10104;
 const op_attr_t data_type = 0x10105;
 const op_attr_t axis_row = 0x10106;
@@ -96,7 +95,6 @@ static inline std::string internal_attr2str(op_attr_t attr) {
         CASE(is_invert_scale);
         CASE(mask_type);
         CASE(alg_kind);
-        CASE(fusion_info_key);
         CASE(axis_row);
         CASE(axis_col);
         CASE(dw_type);

--- a/src/graph/backend/dnnl/internal_attrs.hpp
+++ b/src/graph/backend/dnnl/internal_attrs.hpp
@@ -69,6 +69,9 @@ const op_attr_t dst_zps = 0x10400;
 const op_attr_t src_zps = 0x10401;
 const op_attr_t permutation = 0x10402;
 
+// backend specific attribute to store op's fusion info
+const op_attr_t fusion_info = 0x10500;
+
 static inline std::string internal_attr2str(op_attr_t attr) {
 #define CASE(a) \
     case (a): return #a
@@ -102,6 +105,7 @@ static inline std::string internal_attr2str(op_attr_t attr) {
         CASE(dst_zps);
         CASE(src_zps);
         CASE(permutation);
+        CASE(fusion_info);
         default: return "undefined_attr";
     }
 #undef CASE

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -129,13 +129,11 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
             p_engine, sub_src1_md, p_engine, sub_src1_d_md, sub_reorder0_attr);
     sub_reorder0.init(sub_reorder0_pd);
 
-    auto &mgr = sg->fusion_info_mgr_;
-
     // per-head: reorder wei1 to dense, first matmul
     // create reorder1 primitive attr
     auto original_reorder1 = mqa_op[0];
     dnnl::primitive_attr sub_reorder1_attr
-            = make_primitive_attr(original_reorder1, mgr);
+            = make_primitive_attr(original_reorder1);
     memory::dims sub_wei1_dims = {1, size_per_head, seq_len};
 
     auto original_matmul1 = mqa_op[1];
@@ -152,7 +150,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     // first matmul
     // create first matmul primitive attr
     dnnl::primitive_attr sub_matmul1_attr
-            = make_primitive_attr(original_matmul1, mgr);
+            = make_primitive_attr(original_matmul1);
     memory::dims sub_mm1_src_dims = {1, seq_len, size_per_head};
     memory::dims sub_mm1_wei_dims = {1, size_per_head, seq_len};
     memory::dims sub_mm1_dst_dims = {1, seq_len, seq_len};
@@ -183,7 +181,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     // create softmax primitive attr
     auto original_softmax = mqa_op[2];
     dnnl::primitive_attr sub_softmax_attr
-            = make_primitive_attr(original_softmax, mgr);
+            = make_primitive_attr(original_softmax);
     sub_softmax_dst_md
             = memory::desc(sub_mm1_dst_dims, dt_src_user, format_tag::abc);
     const auto mode = mqa_op[2]->get_attr<std::string>(op_attr::mode);
@@ -201,7 +199,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     // create reorder2 primitive attr
     auto original_reorder2 = mqa_op[3];
     dnnl::primitive_attr sub_reorder2_attr
-            = make_primitive_attr(original_reorder2, mgr);
+            = make_primitive_attr(original_reorder2);
     memory::dims sub_src2_dims = {1, size_per_head, seq_len};
     sub_src2_user_md
             = memory::desc(sub_src2_dims, dt_src_user, {1, seq_len, 1});
@@ -216,7 +214,7 @@ status_t mqa_decomp_config_t::construct_params(std::shared_ptr<subgraph_t> &sg,
     // create second matmul primitive attr
     auto original_matmul2 = mqa_op[4];
     dnnl::primitive_attr sub_matmul2_attr
-            = make_primitive_attr(original_matmul2, mgr);
+            = make_primitive_attr(original_matmul2);
     memory::dims sub_mm2_src_dims = {1, size_per_head, seq_len};
     memory::dims sub_mm2_wei_dims = {1, seq_len, seq_len};
     memory::dims sub_mm2_dst_dims = {1, size_per_head, seq_len};
@@ -445,7 +443,7 @@ void mqa_decomp_config_t::memory_planning(registry_t &mqa_registry) {
 }
 
 dnnl::primitive_attr mqa_decomp_config_t::make_primitive_attr(
-        std::shared_ptr<op_t> &op, fusion_info_mgr_t &mgr) {
+        std::shared_ptr<op_t> &op) {
     dnnl::primitive_attr attr;
     if (op && op->has_attr(op_attr::fusion_info)) {
         const fusion_info_t &fusion_info

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -447,10 +447,9 @@ void mqa_decomp_config_t::memory_planning(registry_t &mqa_registry) {
 dnnl::primitive_attr mqa_decomp_config_t::make_primitive_attr(
         std::shared_ptr<op_t> &op, fusion_info_mgr_t &mgr) {
     dnnl::primitive_attr attr;
-    if (op && op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        const fusion_info_t &fusion_info = mgr.get_info(key);
+    if (op && op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     if (op && op->get_kind() == op_kind::dnnl_reorder) {

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.hpp
@@ -164,8 +164,7 @@ private:
                 producer.get_attr<std::vector<attr_dt>>(attr_name)[0]);
     }
 
-    dnnl::primitive_attr make_primitive_attr(
-            std::shared_ptr<op_t> &op, fusion_info_mgr_t &mgr);
+    dnnl::primitive_attr make_primitive_attr(std::shared_ptr<op_t> &op);
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -738,10 +738,9 @@ impl::status_t sdp_decomp_config_t::prepare_sdp_scales_zps(
     // 1. src scale, wei scale
     // 2. src zp, wei zp
     // 3. dst scale, dst zp
-    if (op && op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        const fusion_info_t &fusion_info = mgr.get_info(key);
+    if (op && op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         if (fusion_info.with_runtime_scales(true, 0)) {
             memory::desc sub_src_scale_md
                     = memory::desc({1}, dt_scale, format_tag::x);
@@ -829,10 +828,9 @@ impl::status_t sdp_decomp_config_t::prepare_sdp_scales_zps(
 dnnl::primitive_attr sdp_decomp_config_t::make_primitive_attr(
         std::shared_ptr<op_t> &op, fusion_info_mgr_t &mgr) {
     dnnl::primitive_attr attr;
-    if (op && op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        const fusion_info_t &fusion_info = mgr.get_info(key);
+    if (op && op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     if (op && op->get_kind() == op_kind::dnnl_reorder) {

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.hpp
@@ -186,8 +186,7 @@ private:
 
     void memory_planning(registry_t &sdp_registry);
 
-    impl::status_t prepare_sdp_scales_zps(const fusion_info_mgr_t &mgr,
-            std::shared_ptr<op_t> &op, int index,
+    impl::status_t prepare_sdp_scales_zps(std::shared_ptr<op_t> &op, int index,
             std::unordered_map<int, memory> &args,
             const dnnl::engine &p_engine);
 
@@ -200,8 +199,7 @@ private:
                 producer.get_attr<std::vector<attr_dt>>(attr_name)[0]);
     }
 
-    dnnl::primitive_attr make_primitive_attr(
-            std::shared_ptr<op_t> &op, fusion_info_mgr_t &mgr);
+    dnnl::primitive_attr make_primitive_attr(std::shared_ptr<op_t> &op);
 };
 
 } // namespace dnnl_impl

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -374,15 +374,17 @@ status_t sdp_primitive_config_t::init(std::shared_ptr<subgraph_t> &sg,
     attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(mgr.get_fpmath_mode().mode_));
 
-    if (mm1_->has_attr(op_attr::fusion_info_key)
-            && mm1_->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = mm1_->get_attr<int64_t>(op_attr::fusion_info_key);
-        qk_attr = make_dnnl_primitive_attr(mm1_, mgr.get_info(key));
+    if (mm1_->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = mm1_->get_attr<dnnl_impl::fusion_info_t>(
+                        op_attr::fusion_info);
+        qk_attr = make_dnnl_primitive_attr(mm1_, fusion_info);
     }
-    if (mm2_->has_attr(op_attr::fusion_info_key)
-            && mm2_->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = mm2_->get_attr<int64_t>(op_attr::fusion_info_key);
-        vs_attr = make_dnnl_primitive_attr(mm2_, mgr.get_info(key));
+    if (mm2_->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = mm2_->get_attr<dnnl_impl::fusion_info_t>(
+                        op_attr::fusion_info);
+        vs_attr = make_dnnl_primitive_attr(mm2_, fusion_info);
     }
 
     const alg_kind_t softmax_alg = softmax_mode_ == "inf_as_zero"

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -369,10 +369,9 @@ status_t sdp_primitive_config_t::init(std::shared_ptr<subgraph_t> &sg,
 
     dnnl::primitive_attr attr, qk_attr, vs_attr;
 
-    auto &mgr = sg->fusion_info_mgr_;
+    auto &fpm = sg->get_fpmath_mode();
     attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    attr.set_fpmath_mode(
-            static_cast<dnnl::fpmath_mode>(mgr.get_fpmath_mode().mode_));
+    attr.set_fpmath_mode(static_cast<dnnl::fpmath_mode>(fpm.mode_));
 
     if (mm1_->has_attr(op_attr::fusion_info)) {
         const fusion_info_t &fusion_info

--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -143,12 +143,12 @@ status_t layout_propagator_for_conv(op_ptr &op, const dnnl::engine &p_engine,
                 "failed to fill layout info for reorder before conv bias");
     }
 
-    fusion_info_t fusion_info;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        fusion_info = mgr.get_info(key);
+    if (!op->has_attr(op_attr::fusion_info)) {
+        fusion_info_t fusion_info;
+        op->set_attr<fusion_info_t>(op_attr::fusion_info, fusion_info);
     }
+    const fusion_info_t &fusion_info
+            = op->get_attr<fusion_info_t>(op_attr::fusion_info);
 
     if (fusion_info.has_post_dw_conv()) {
         const auto &dw_conv = fusion_info.get_post_dw_conv();

--- a/src/graph/backend/dnnl/layout_propagator.hpp
+++ b/src/graph/backend/dnnl/layout_propagator.hpp
@@ -36,19 +36,19 @@ namespace dnnl_impl {
 
 using layout_propagator_func
         = std::function<status_t(std::shared_ptr<op_t> &, const dnnl::engine &,
-                fusion_info_mgr_t &, pd_cache_t &, subgraph_rewriter_t &)>;
+                pd_cache_t &, const fpmath_t &, bool, subgraph_rewriter_t &)>;
 
 status_t insert_reorder_before(std::shared_ptr<op_t> &, size_t,
-        const dnnl::memory::desc &, const dnnl::engine &, fusion_info_mgr_t &,
-        pd_cache_t &, subgraph_rewriter_t &);
+        const dnnl::memory::desc &, const dnnl::engine &, pd_cache_t &,
+        const fpmath_t &, bool, subgraph_rewriter_t &);
 
 status_t insert_reorder_after(std::shared_ptr<op_t> &, size_t,
-        const dnnl::memory::desc &, const dnnl::engine &, fusion_info_mgr_t &,
-        pd_cache_t &, subgraph_rewriter_t &);
+        const dnnl::memory::desc &, const dnnl::engine &, pd_cache_t &,
+        const fpmath_t &, bool, subgraph_rewriter_t &);
 
 #define DECLARE_LAYOUT_PROPAGATOR(op_name) \
     status_t layout_propagator_for_##op_name(std::shared_ptr<op_t> &, \
-            const dnnl::engine &, fusion_info_mgr_t &, pd_cache_t &, \
+            const dnnl::engine &, pd_cache_t &, const fpmath_t &, bool, \
             subgraph_rewriter_t &);
 
 DECLARE_LAYOUT_PROPAGATOR(conv);

--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -70,10 +70,8 @@ conv_fwd_executable_t::desc_t conv_fwd_executable_t::create_desc(
 
     dnnl::primitive_attr prm_attr;
     fusion_info_t fusion_info;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        fusion_info = mgr.get_info(key);
+    if (op->has_attr(op_attr::fusion_info)) {
+        fusion_info = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
@@ -187,10 +185,10 @@ deconv_fwd_executable_t::desc_t deconv_fwd_executable_t::create_desc(
     dilates = get_compatible_dilates(dilates);
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto fpmath = mgr.get_fpmath_mode();
@@ -248,10 +246,10 @@ deconv_bwd_data_executable_t::desc_t deconv_bwd_data_executable_t::create_desc(
     dilates = get_compatible_dilates(dilates);
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto fpmath = mgr.get_fpmath_mode();
@@ -302,9 +300,10 @@ deconv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
     dilates = get_compatible_dilates(dilates);
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
@@ -345,10 +344,10 @@ matmul_executable_t::desc_t matmul_executable_t::create_desc(
     }
     const bool can_use_blocked_layout = mgr.get_use_blocked_layout();
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto fpmath = mgr.get_fpmath_mode();
@@ -424,10 +423,10 @@ pool_executable_t::desc_t pool_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -511,9 +510,10 @@ pool_bwd_executable_t::desc_t pool_bwd_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -614,10 +614,10 @@ batchnorm_executable_t::desc_t batchnorm_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -668,10 +668,10 @@ batchnorm_bwd_executable_t::desc_t batchnorm_bwd_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -707,10 +707,10 @@ layernorm_executable_t::desc_t layernorm_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
 
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
@@ -758,10 +758,10 @@ layernorm_bwd_executable_t::desc_t layernorm_bwd_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -809,10 +809,10 @@ conv_bwd_data_executable_t::desc_t conv_bwd_data_executable_t::create_desc(
     dilates = get_compatible_dilates(dilates);
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto fpmath = mgr.get_fpmath_mode();
@@ -870,9 +870,10 @@ conv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
     dilates = get_compatible_dilates(dilates);
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     auto fpmath = mgr.get_fpmath_mode();
@@ -929,10 +930,10 @@ eltwise_executable_t::desc_t eltwise_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -965,10 +966,10 @@ eltwise_bwd_executable_t::desc_t eltwise_bwd_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1060,10 +1061,10 @@ concat_executable_t::desc_t concat_executable_t::create_desc(
     const auto axis = res.second;
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1099,10 +1100,10 @@ resampling_executable_t::desc_t resampling_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
     // resampling src doesn't support any
@@ -1142,10 +1143,10 @@ resampling_bwd_executable_t::desc_t resampling_bwd_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1189,10 +1190,10 @@ binary_executable_t::desc_t binary_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1247,10 +1248,10 @@ prelu_executable_t::desc_t prelu_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1282,10 +1283,10 @@ prelu_bwd_executable_t::desc_t prelu_bwd_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1325,10 +1326,10 @@ softmax_executable_t::desc_t softmax_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1427,10 +1428,10 @@ shuffle_executable_t::desc_t shuffle_executable_t::create_desc(
     const int axis = static_cast<int>(op->get_attr<int64_t>(op_attr::axis));
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1459,10 +1460,10 @@ reduction_executable_t::desc_t reduction_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
@@ -1497,10 +1498,10 @@ reorder_executable_t::desc_t reorder_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
 
     // generate mask
@@ -1751,10 +1752,10 @@ groupnorm_executable_t::desc_t groupnorm_executable_t::create_desc(
     }
 
     dnnl::primitive_attr prm_attr;
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        prm_attr = make_dnnl_primitive_attr(op, mgr.get_info(key));
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
 
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
@@ -1818,10 +1819,8 @@ void genindex_executable_t ::execute(const stream &stream,
 
 static void get_arg_indices_for_post_ops(const op_t *op, fusion_info_mgr_t &mgr,
         arg_indices_t &indices, size_t &base_index) {
-    const fusion_info_t &fusion_info
-            = (op->has_attr(op_attr::fusion_info_key)
-                      && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1)
-            ? mgr.get_info(op->get_attr<int64_t>(op_attr::fusion_info_key))
+    const fusion_info_t &fusion_info = op->has_attr(op_attr::fusion_info)
+            ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
     const auto &pops = fusion_info.get_post_ops();
     for (size_t i = 0; i < pops.size(); i++) {
@@ -1857,10 +1856,8 @@ static arg_indices_t get_arg_indices_for_conv_and_matmul(
         arg_indices.insert({DNNL_ARG_BIAS, indices_t {input, index++}});
     }
 
-    const fusion_info_t &fusion_info
-            = (op->has_attr(op_attr::fusion_info_key)
-                      && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1)
-            ? mgr.get_info(op->get_attr<int64_t>(op_attr::fusion_info_key))
+    const fusion_info_t &fusion_info = op->has_attr(op_attr::fusion_info)
+            ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
 
     if (fusion_info.with_runtime_scales(true, 0)) {
@@ -1992,10 +1989,8 @@ static arg_indices_t get_arg_indices_for_siso_op(
     size_t index = 0;
     arg_indices.insert({DNNL_ARG_FROM, indices_t {input, index++}});
 
-    const fusion_info_t &fusion_info
-            = (op->has_attr(op_attr::fusion_info_key)
-                      && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1)
-            ? mgr.get_info(op->get_attr<int64_t>(op_attr::fusion_info_key))
+    const fusion_info_t &fusion_info = op->has_attr(op_attr::fusion_info)
+            ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
 
     get_arg_indices_for_post_ops(op, mgr, arg_indices, index);
@@ -2251,10 +2246,8 @@ static arg_indices_t get_arg_indices_for_lnorm_and_gnorm(
         arg_indices.insert({DNNL_ARG_SHIFT, indices_t {input, in_index++}});
     }
 
-    const fusion_info_t &fusion_info
-            = (op->has_attr(op_attr::fusion_info_key)
-                      && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1)
-            ? mgr.get_info(op->get_attr<int64_t>(op_attr::fusion_info_key))
+    const fusion_info_t &fusion_info = op->has_attr(op_attr::fusion_info)
+            ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
 
     get_arg_indices_for_post_ops(op, mgr, arg_indices, in_index);
@@ -2322,10 +2315,8 @@ arg_indices_t reorder_executable_t::get_arg_indices(
     size_t index = 0;
     arg_indices.insert({DNNL_ARG_FROM, indices_t {input, index++}});
 
-    const fusion_info_t &fusion_info
-            = (op->has_attr(op_attr::fusion_info_key)
-                      && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1)
-            ? mgr.get_info(op->get_attr<int64_t>(op_attr::fusion_info_key))
+    const fusion_info_t &fusion_info = op->has_attr(op_attr::fusion_info)
+            ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
 
     if ((op->has_attr(op_attr::with_runtime_scales)

--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -52,7 +52,7 @@ const indices_t::type_t output = indices_t::type_t::output;
 
 conv_fwd_executable_t::desc_t conv_fwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -75,10 +75,8 @@ conv_fwd_executable_t::desc_t conv_fwd_executable_t::create_desc(
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
-    const bool can_use_blocked_layout = mgr.get_use_blocked_layout();
 
     auto src = make_dnnl_memory_desc(
             op->get_input_value(0)->get_logical_tensor());
@@ -120,7 +118,7 @@ conv_fwd_executable_t::desc_t conv_fwd_executable_t::create_desc(
         }
     };
 
-    if (!can_use_blocked_layout) {
+    if (!use_block_layout) {
         src = to_nxc_format(src);
         dst = to_nxc_format(dst);
     } else {
@@ -168,7 +166,7 @@ conv_fwd_executable_t::desc_t conv_fwd_executable_t::create_desc(
 
 deconv_fwd_executable_t::desc_t deconv_fwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -191,7 +189,6 @@ deconv_fwd_executable_t::desc_t deconv_fwd_executable_t::create_desc(
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
 
@@ -229,7 +226,7 @@ deconv_fwd_executable_t::desc_t deconv_fwd_executable_t::create_desc(
 
 deconv_bwd_data_executable_t::desc_t deconv_bwd_data_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -252,7 +249,6 @@ deconv_bwd_data_executable_t::desc_t deconv_bwd_data_executable_t::create_desc(
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
 
@@ -282,8 +278,8 @@ deconv_bwd_data_executable_t::desc_t deconv_bwd_data_executable_t::create_desc(
 
 deconv_bwd_weights_executable_t::desc_t
 deconv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
-        const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-        pd_cache_t &pd_cache) {
+        const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+        const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -305,7 +301,6 @@ deconv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
                 = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
 
@@ -335,14 +330,13 @@ deconv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
 
 matmul_executable_t::desc_t matmul_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::matmul::primitive_desc>(
                 pd_cache.at(op.get()));
         return {pd, true};
     }
-    const bool can_use_blocked_layout = mgr.get_use_blocked_layout();
     dnnl::primitive_attr prm_attr;
     if (op->has_attr(op_attr::fusion_info)) {
         const fusion_info_t &fusion_info
@@ -350,7 +344,6 @@ matmul_executable_t::desc_t matmul_executable_t::create_desc(
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
 
@@ -363,16 +356,14 @@ matmul_executable_t::desc_t matmul_executable_t::create_desc(
                       op->get_input_value(0)->get_logical_tensor())
                       .is_constant()
             && is_constant_cache_enabled(p_engine);
-    if (can_use_blocked_layout && const_activation) {
-        src = to_format_any(src);
-    }
+    if (use_block_layout && const_activation) { src = to_format_any(src); }
     auto wei = make_dnnl_memory_desc(
             op->get_input_value(1)->get_logical_tensor());
     bool const_weight = logical_tensor_wrapper_t(
                                 op->get_input_value(1)->get_logical_tensor())
                                 .is_constant()
             && is_constant_cache_enabled(p_engine);
-    if (can_use_blocked_layout && const_weight) { wei = to_format_any(wei); }
+    if (use_block_layout && const_weight) { wei = to_format_any(wei); }
     auto dst = make_dnnl_memory_desc(
             op->get_output_value(0)->get_logical_tensor());
     const bool keep_dst_layout = op->has_attr(op_attr::keep_dst_layout)
@@ -404,7 +395,7 @@ matmul_executable_t::desc_t matmul_executable_t::create_desc(
 
 pool_executable_t::desc_t pool_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::pooling_forward::primitive_desc>(
@@ -492,7 +483,7 @@ pool_executable_t::desc_t pool_executable_t::create_desc(
 
 pool_bwd_executable_t::desc_t pool_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -584,7 +575,7 @@ pool_bwd_executable_t::desc_t pool_bwd_executable_t::create_desc(
 
 batchnorm_executable_t::desc_t batchnorm_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -646,7 +637,7 @@ batchnorm_executable_t::desc_t batchnorm_executable_t::create_desc(
 
 batchnorm_bwd_executable_t::desc_t batchnorm_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -697,7 +688,7 @@ batchnorm_bwd_executable_t::desc_t batchnorm_bwd_executable_t::create_desc(
 
 layernorm_executable_t::desc_t layernorm_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -749,7 +740,7 @@ layernorm_executable_t::desc_t layernorm_executable_t::create_desc(
 
 layernorm_bwd_executable_t::desc_t layernorm_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
                 dnnl::layer_normalization_backward::primitive_desc>(
@@ -792,7 +783,7 @@ layernorm_bwd_executable_t::desc_t layernorm_bwd_executable_t::create_desc(
 
 conv_bwd_data_executable_t::desc_t conv_bwd_data_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -815,14 +806,12 @@ conv_bwd_data_executable_t::desc_t conv_bwd_data_executable_t::create_desc(
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
-    const bool can_use_blocked_layout = mgr.get_use_blocked_layout();
 
     auto diff_dst = make_dnnl_memory_desc(
             op->get_input_value(0)->get_logical_tensor());
-    if (!can_use_blocked_layout)
+    if (!use_block_layout)
         diff_dst = to_nxc_format(diff_dst);
     else
         diff_dst = to_format_any(diff_dst);
@@ -831,7 +820,7 @@ conv_bwd_data_executable_t::desc_t conv_bwd_data_executable_t::create_desc(
     weight = to_format_any(weight);
     auto diff_src = make_dnnl_memory_desc(
             op->get_output_value(0)->get_logical_tensor());
-    if (!can_use_blocked_layout)
+    if (!use_block_layout)
         diff_src = to_nxc_format(diff_src);
     else
         diff_src = to_format_any(diff_src);
@@ -852,8 +841,8 @@ conv_bwd_data_executable_t::desc_t conv_bwd_data_executable_t::create_desc(
 
 conv_bwd_weights_executable_t::desc_t
 conv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
-        const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-        pd_cache_t &pd_cache) {
+        const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+        const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -876,20 +865,18 @@ conv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     prm_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    auto fpmath = mgr.get_fpmath_mode();
     prm_attr.set_fpmath_mode(
             static_cast<dnnl::fpmath_mode>(fpmath.mode_), fpmath.apply_to_int_);
-    const bool can_use_blocked_layout = mgr.get_use_blocked_layout();
 
     auto src = make_dnnl_memory_desc(
             op->get_input_value(0)->get_logical_tensor());
-    if (!can_use_blocked_layout)
+    if (!use_block_layout)
         src = to_nxc_format(src);
     else
         src = to_format_any(src);
     auto diff_dst = make_dnnl_memory_desc(
             op->get_input_value(1)->get_logical_tensor());
-    if (!can_use_blocked_layout)
+    if (!use_block_layout)
         diff_dst = to_nxc_format(diff_dst);
     else
         diff_dst = to_format_any(diff_dst);
@@ -913,7 +900,7 @@ conv_bwd_weights_executable_t::create_desc(std::shared_ptr<op_t> &op,
 
 eltwise_executable_t::desc_t eltwise_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::eltwise_forward::primitive_desc>(
@@ -958,7 +945,7 @@ eltwise_executable_t::desc_t eltwise_executable_t::create_desc(
 
 eltwise_bwd_executable_t::desc_t eltwise_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
                 dnnl::eltwise_backward::primitive_desc>(pd_cache.at(op.get()));
@@ -1006,7 +993,7 @@ eltwise_bwd_executable_t::desc_t eltwise_bwd_executable_t::create_desc(
 
 sum_executable_t::desc_t sum_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::sum::primitive_desc>(
                 pd_cache.at(op.get()));
@@ -1035,7 +1022,7 @@ sum_executable_t::desc_t sum_executable_t::create_desc(
 
 concat_executable_t::desc_t concat_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         return {graph::utils::any_cast<dnnl::concat::primitive_desc>(
                         pd_cache.at(op.get())),
@@ -1090,7 +1077,7 @@ concat_executable_t::desc_t concat_executable_t::create_desc(
 
 resampling_executable_t::desc_t resampling_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -1134,7 +1121,7 @@ resampling_executable_t::desc_t resampling_executable_t::create_desc(
 
 resampling_bwd_executable_t::desc_t resampling_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
                 dnnl::resampling_backward::primitive_desc>(
@@ -1181,7 +1168,7 @@ resampling_bwd_executable_t::desc_t resampling_bwd_executable_t::create_desc(
 
 binary_executable_t::desc_t binary_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::binary::primitive_desc>(
@@ -1239,7 +1226,7 @@ binary_executable_t::desc_t binary_executable_t::create_desc(
 
 prelu_executable_t::desc_t prelu_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::prelu_forward::primitive_desc>(
@@ -1274,7 +1261,7 @@ prelu_executable_t::desc_t prelu_executable_t::create_desc(
 
 prelu_bwd_executable_t::desc_t prelu_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::prelu_backward::primitive_desc>(
@@ -1317,7 +1304,7 @@ prelu_bwd_executable_t::desc_t prelu_bwd_executable_t::create_desc(
 
 softmax_executable_t::desc_t softmax_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::softmax_forward::primitive_desc>(
@@ -1365,7 +1352,7 @@ softmax_executable_t::desc_t softmax_executable_t::create_desc(
 
 softmax_bwd_executable_t::desc_t softmax_bwd_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<
@@ -1417,7 +1404,7 @@ softmax_bwd_executable_t::desc_t softmax_bwd_executable_t::create_desc(
 
 shuffle_executable_t::desc_t shuffle_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::shuffle_forward::primitive_desc>(
                 pd_cache.at(op.get()));
@@ -1451,7 +1438,7 @@ shuffle_executable_t::desc_t shuffle_executable_t::create_desc(
 
 reduction_executable_t::desc_t reduction_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::reduction::primitive_desc>(
@@ -1490,7 +1477,7 @@ reduction_executable_t::desc_t reduction_executable_t::create_desc(
 
 reorder_executable_t::desc_t reorder_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     if (pd_cache.find(op.get()) != pd_cache.end()) {
         auto pd = graph::utils::any_cast<dnnl::reorder::primitive_desc>(
                 pd_cache.at(op.get()));
@@ -1592,10 +1579,11 @@ reorder_executable_t::desc_t reorder_executable_t::create_desc(
 }
 
 bn_folding_t::desc_t bn_folding_t::create_desc(std::shared_ptr<op_t> &op,
-        const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-        pd_cache_t &pd_cache) {
-    UNUSED(mgr);
+        const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+        const fpmath_t &fpmath, bool use_block_layout) {
     UNUSED(pd_cache);
+    UNUSED(fpmath);
+    UNUSED(use_block_layout);
 
     desc_t desc;
 
@@ -1741,7 +1729,7 @@ bn_folding_t::desc_t bn_folding_t::create_desc(std::shared_ptr<op_t> &op,
 
 groupnorm_executable_t::desc_t groupnorm_executable_t::create_desc(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
 
     // first look up the cache
     if (pd_cache.find(op.get()) != pd_cache.end()) {
@@ -1817,8 +1805,8 @@ void genindex_executable_t ::execute(const stream &stream,
     stream.get()->after_exec_hook();
 }
 
-static void get_arg_indices_for_post_ops(const op_t *op, fusion_info_mgr_t &mgr,
-        arg_indices_t &indices, size_t &base_index) {
+static void get_arg_indices_for_post_ops(
+        const op_t *op, arg_indices_t &indices, size_t &base_index) {
     const fusion_info_t &fusion_info = op->has_attr(op_attr::fusion_info)
             ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
@@ -1843,8 +1831,7 @@ static void get_arg_indices_for_post_ops(const op_t *op, fusion_info_mgr_t &mgr,
     }
 }
 
-static arg_indices_t get_arg_indices_for_conv_and_matmul(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+static arg_indices_t get_arg_indices_for_conv_and_matmul(const op_t *op) {
     arg_indices_t arg_indices;
 
     // add input args
@@ -1880,7 +1867,7 @@ static arg_indices_t get_arg_indices_for_conv_and_matmul(
                 indices_t {input, index++}});
     }
 
-    get_arg_indices_for_post_ops(op, mgr, arg_indices, index);
+    get_arg_indices_for_post_ops(op, arg_indices, index);
 
     if (fusion_info.with_runtime_scales(false, 0)) {
         arg_indices.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
@@ -1899,23 +1886,19 @@ static arg_indices_t get_arg_indices_for_conv_and_matmul(
     return arg_indices;
 }
 
-arg_indices_t conv_fwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_conv_and_matmul(op, mgr);
+arg_indices_t conv_fwd_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_conv_and_matmul(op);
 }
 
-arg_indices_t deconv_fwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_conv_and_matmul(op, mgr);
+arg_indices_t deconv_fwd_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_conv_and_matmul(op);
 }
 
-arg_indices_t matmul_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_conv_and_matmul(op, mgr);
+arg_indices_t matmul_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_conv_and_matmul(op);
 }
 
-arg_indices_t binary_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t binary_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
     const algorithm algo = static_cast<dnnl::algorithm>(
             op->get_attr<int64_t>(op_attr::alg_kind));
@@ -1927,7 +1910,7 @@ arg_indices_t binary_executable_t::get_arg_indices(
     if (algo == algorithm::binary_select) {
         arg_indices.insert({DNNL_ARG_SRC_2, indices_t {input, index++}});
     }
-    get_arg_indices_for_post_ops(op, mgr, arg_indices, index);
+    get_arg_indices_for_post_ops(op, arg_indices, index);
 
     // add output args
     arg_indices.insert({DNNL_ARG_DST, indices_t {output, 0}});
@@ -1936,9 +1919,7 @@ arg_indices_t binary_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t prelu_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t prelu_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     // add input args
@@ -1953,9 +1934,7 @@ arg_indices_t prelu_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t prelu_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t prelu_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     // add input args
@@ -1971,9 +1950,7 @@ arg_indices_t prelu_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t memory_reparser_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t memory_reparser_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
     arg_indices.insert({DNNL_ARG_FROM, indices_t {input, 0}});
     arg_indices.insert({DNNL_ARG_TO, indices_t {output, 0}});
@@ -1981,8 +1958,7 @@ arg_indices_t memory_reparser_t::get_arg_indices(
 }
 
 // for single-input-single-output op
-static arg_indices_t get_arg_indices_for_siso_op(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+static arg_indices_t get_arg_indices_for_siso_op(const op_t *op) {
     arg_indices_t arg_indices;
 
     // add input args
@@ -1993,7 +1969,7 @@ static arg_indices_t get_arg_indices_for_siso_op(
             ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
 
-    get_arg_indices_for_post_ops(op, mgr, arg_indices, index);
+    get_arg_indices_for_post_ops(op, arg_indices, index);
     if (fusion_info.with_runtime_scales(false, 0)) {
         arg_indices.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
                 indices_t {input, index++}});
@@ -2013,38 +1989,31 @@ static arg_indices_t get_arg_indices_for_siso_op(
     return arg_indices;
 }
 
-arg_indices_t pool_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_siso_op(op, mgr);
+arg_indices_t pool_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_siso_op(op);
 }
 
-arg_indices_t softmax_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_siso_op(op, mgr);
+arg_indices_t softmax_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_siso_op(op);
 }
 
-arg_indices_t eltwise_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_siso_op(op, mgr);
+arg_indices_t eltwise_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_siso_op(op);
 }
 
-arg_indices_t shuffle_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_siso_op(op, mgr);
+arg_indices_t shuffle_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_siso_op(op);
 }
 
-arg_indices_t reduction_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_siso_op(op, mgr);
+arg_indices_t reduction_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_siso_op(op);
 }
 
-arg_indices_t resampling_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_siso_op(op, mgr);
+arg_indices_t resampling_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_siso_op(op);
 }
 
-arg_indices_t pool_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t pool_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     // add input args
@@ -2059,9 +2028,7 @@ arg_indices_t pool_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-static arg_indices_t get_arg_indices_for_miso_op(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+static arg_indices_t get_arg_indices_for_miso_op(const op_t *op) {
     arg_indices_t arg_indices;
 
     for (size_t i = 0; i < op->num_inputs(); ++i) {
@@ -2074,19 +2041,15 @@ static arg_indices_t get_arg_indices_for_miso_op(
     return arg_indices;
 }
 
-arg_indices_t concat_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_miso_op(op, mgr);
+arg_indices_t concat_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_miso_op(op);
 }
 
-arg_indices_t sum_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_miso_op(op, mgr);
+arg_indices_t sum_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_miso_op(op);
 }
 
-arg_indices_t bn_folding_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t bn_folding_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     size_t in_idx = 0;
@@ -2114,9 +2077,7 @@ arg_indices_t bn_folding_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t conv_bwd_data_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t conv_bwd_data_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     arg_indices.insert({DNNL_ARG_DIFF_DST, indices_t {input, 0}});
@@ -2128,14 +2089,11 @@ arg_indices_t conv_bwd_data_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t deconv_bwd_data_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return conv_bwd_data_executable_t::get_arg_indices(op, mgr);
+arg_indices_t deconv_bwd_data_executable_t::get_arg_indices(const op_t *op) {
+    return conv_bwd_data_executable_t::get_arg_indices(op);
 }
 
-arg_indices_t conv_bwd_weights_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t conv_bwd_weights_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     arg_indices.insert({DNNL_ARG_SRC, indices_t {input, 0}});
@@ -2147,14 +2105,11 @@ arg_indices_t conv_bwd_weights_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t deconv_bwd_weights_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return conv_bwd_weights_executable_t::get_arg_indices(op, mgr);
+arg_indices_t deconv_bwd_weights_executable_t::get_arg_indices(const op_t *op) {
+    return conv_bwd_weights_executable_t::get_arg_indices(op);
 }
 
-arg_indices_t batchnorm_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t batchnorm_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     size_t in_index = 0;
@@ -2203,8 +2158,7 @@ arg_indices_t batchnorm_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t batchnorm_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t batchnorm_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
     size_t index = 0;
 
@@ -2234,8 +2188,7 @@ arg_indices_t batchnorm_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-static arg_indices_t get_arg_indices_for_lnorm_and_gnorm(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+static arg_indices_t get_arg_indices_for_lnorm_and_gnorm(const op_t *op) {
     arg_indices_t arg_indices;
 
     size_t in_index = 0;
@@ -2250,7 +2203,7 @@ static arg_indices_t get_arg_indices_for_lnorm_and_gnorm(
             ? op->get_attr<fusion_info_t>(op_attr::fusion_info)
             : fusion_info_t();
 
-    get_arg_indices_for_post_ops(op, mgr, arg_indices, in_index);
+    get_arg_indices_for_post_ops(op, arg_indices, in_index);
 
     if (fusion_info.with_runtime_scales(false, 0)) {
         arg_indices.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
@@ -2271,13 +2224,11 @@ static arg_indices_t get_arg_indices_for_lnorm_and_gnorm(
     return arg_indices;
 }
 
-arg_indices_t layernorm_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_lnorm_and_gnorm(op, mgr);
+arg_indices_t layernorm_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_lnorm_and_gnorm(op);
 }
 
-arg_indices_t layernorm_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t layernorm_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     arg_indices.insert({DNNL_ARG_SRC, indices_t {input, 0}});
@@ -2308,8 +2259,7 @@ arg_indices_t layernorm_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t reorder_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t reorder_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     size_t index = 0;
@@ -2333,7 +2283,7 @@ arg_indices_t reorder_executable_t::get_arg_indices(
                 indices_t {input, index++}});
     }
 
-    get_arg_indices_for_post_ops(op, mgr, arg_indices, index);
+    get_arg_indices_for_post_ops(op, arg_indices, index);
 
     if (fusion_info.with_runtime_scales(false, 0)) {
         arg_indices.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
@@ -2354,10 +2304,8 @@ arg_indices_t reorder_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t host_scalar_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t host_scalar_executable_t::get_arg_indices(const op_t *op) {
     UNUSED(op);
-    UNUSED(mgr);
     arg_indices_t arg_indices;
 
     arg_indices.insert({DNNL_ARG_FROM, indices_t {input, 0}});
@@ -2365,9 +2313,7 @@ arg_indices_t host_scalar_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t softmax_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t softmax_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     arg_indices.insert({DNNL_ARG_DIFF_DST, indices_t {input, 0}});
@@ -2379,9 +2325,7 @@ arg_indices_t softmax_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t resampling_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t resampling_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     arg_indices.insert({DNNL_ARG_DIFF_DST, indices_t {input, 1}});
@@ -2392,9 +2336,7 @@ arg_indices_t resampling_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t eltwise_bwd_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
+arg_indices_t eltwise_bwd_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
 
     if (op->get_attr<bool>(op_attr::use_dst)) {
@@ -2410,15 +2352,12 @@ arg_indices_t eltwise_bwd_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t groupnorm_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    return get_arg_indices_for_lnorm_and_gnorm(op, mgr);
+arg_indices_t groupnorm_executable_t::get_arg_indices(const op_t *op) {
+    return get_arg_indices_for_lnorm_and_gnorm(op);
 }
 
-arg_indices_t genindex_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+arg_indices_t genindex_executable_t::get_arg_indices(const op_t *op) {
     UNUSED(op);
-    UNUSED(mgr);
 
     arg_indices_t arg_indices;
     arg_indices.insert({DNNL_ARG_SRC, indices_t {input, 0}});
@@ -2427,10 +2366,7 @@ arg_indices_t genindex_executable_t::get_arg_indices(
     return arg_indices;
 }
 
-arg_indices_t sdpa_executable_t::get_arg_indices(
-        const op_t *op, fusion_info_mgr_t &mgr) {
-    UNUSED(mgr);
-
+arg_indices_t sdpa_executable_t::get_arg_indices(const op_t *op) {
     arg_indices_t arg_indices;
     // add input args
     size_t index = 0;

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -84,16 +84,13 @@ struct indices_t {
 // We should be able to know this map according the information on an op.
 using arg_indices_t = std::unordered_map<int, indices_t>;
 
-using arg_indices_getter_func
-        = std::function<arg_indices_t(const op_t *, fusion_info_mgr_t &)>;
+using arg_indices_getter_func = std::function<arg_indices_t(const op_t *)>;
 
 // A dummy arg indices getter which is only used for those internal ops that are
 // only for fusion purpose, like dnnl_add_zps and dnnl_sub_zps. The dummy getter
 // should never be called.
-inline arg_indices_t dummy_arg_indices_getter(
-        const op_t *op, fusion_info_mgr_t &mgr) {
+inline arg_indices_t dummy_arg_indices_getter(const op_t *op) {
     UNUSED(op);
-    UNUSED(mgr);
     assertm(false, "dummy getter should never be called");
     return arg_indices_t {};
 }
@@ -102,8 +99,7 @@ inline arg_indices_t dummy_arg_indices_getter(
 // getter can be used to generate the <dnnl_arg, in/output index> map. According
 // to that, we can form the execution args by using the in/outputs list in op.
 #define DECLARE_ARG_INDICES_GETTER \
-    static arg_indices_t get_arg_indices( \
-            const op_t *op, fusion_info_mgr_t &mgr);
+    static arg_indices_t get_arg_indices(const op_t *op);
 
 #define DECLARE_RESET_ENGINE(primitive) \
     status_t reset_engine(const dnnl::engine &p_engine) override { \
@@ -133,19 +129,20 @@ struct op_executable_t {
 };
 
 using executable_creator_func = std::function<std::shared_ptr<op_executable_t>(
-        std::shared_ptr<op_t> &, const dnnl::engine &, fusion_info_mgr_t &,
-        pd_cache_t &)>;
+        std::shared_ptr<op_t> &, const dnnl::engine &, pd_cache_t &,
+        const fpmath_t &, bool)>;
 
 // A dummy executable creator which is only used for those internal ops that are
 // only for fusion purpose, like dnnl_add_zps and dnnl_sub_zps. The dummy
 // creator should never be called.
 inline std::shared_ptr<op_executable_t> dummy_executable_creator(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
     UNUSED(op);
     UNUSED(p_engine);
-    UNUSED(mgr);
     UNUSED(pd_cache);
+    UNUSED(fpmath);
+    UNUSED(use_block_layout);
     assertm(false, "dummy executable creator should never be called");
     return {};
 }
@@ -155,8 +152,9 @@ inline std::shared_ptr<op_executable_t> dummy_executable_creator(
 template <typename T>
 inline std::shared_ptr<op_executable_t> executable_creator(
         std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-        fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
-    return std::make_shared<T>(op, p_engine, mgr, pd_cache);
+        pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout) {
+    return std::make_shared<T>(
+            op, p_engine, pd_cache, fpmath, use_block_layout);
 }
 
 // Used to declare the desc_t class and the static create_desc method inside an
@@ -172,8 +170,8 @@ inline std::shared_ptr<op_executable_t> executable_creator(
         bool is_from_cache() const { return from_cache_; } \
     }; \
     static desc_t create_desc(std::shared_ptr<op_t> &op, \
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr, \
-            pd_cache_t &pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache, \
+            const fpmath_t &fpmath, bool use_block_layout);
 
 // This class is a dummy executable which doesn't do any actual computation.
 // This dummy executable can be used to:
@@ -245,11 +243,13 @@ struct memory_reparser_t : public dummy_impl_t {
     DECLARE_ARG_INDICES_GETTER;
 
     memory_reparser_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
         UNUSED(op);
         UNUSED(p_engine);
-        UNUSED(mgr);
         UNUSED(pd_cache);
+        UNUSED(fpmath);
+        UNUSED(use_block_layout);
     }
 
     void execute(const stream &stream,
@@ -326,9 +326,7 @@ struct memory_reparser_t : public dummy_impl_t {
 
 template <op_attr_t attr_name, typename attr_dt, typename target_dt>
 struct const_memory_filler_t : public op_executable_t {
-    static arg_indices_t get_arg_indices(
-            const op_t *op, fusion_info_mgr_t &mgr) {
-        UNUSED(mgr);
+    static arg_indices_t get_arg_indices(const op_t *op) {
         arg_indices_t arg_indices;
         // We only set dst argument, to which constant data will be copied
         arg_indices.insert(
@@ -337,11 +335,12 @@ struct const_memory_filler_t : public op_executable_t {
     }
 
     const_memory_filler_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
         UNUSED(p_engine);
-        UNUSED(mgr);
         UNUSED(pd_cache);
+        UNUSED(fpmath);
+        UNUSED(use_block_layout);
         // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
         attr_data_
                 = get_attr_data(op->get_attr<std::vector<attr_dt>>(attr_name),
@@ -433,12 +432,13 @@ struct host_scalar_executable_t : public op_executable_t {
     DECLARE_ARG_INDICES_GETTER;
 
     host_scalar_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
         UNUSED(op);
         UNUSED(p_engine);
-        UNUSED(mgr);
         UNUSED(pd_cache);
+        UNUSED(fpmath);
+        UNUSED(use_block_layout);
     }
 
     void execute(const stream &stream,
@@ -527,9 +527,10 @@ struct conv_fwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::convolution_forward);
 
     conv_fwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::convolution_forward(desc);
         if (op->has_attr(op_attr::with_sum))
             with_sum_ = op->get_attr<bool>(op_attr::with_sum);
@@ -706,9 +707,10 @@ struct deconv_fwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::deconvolution_forward);
 
     deconv_fwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::deconvolution_forward(desc);
         if (op->has_attr(op_attr::with_sum))
             with_sum_ = op->get_attr<bool>(op_attr::with_sum);
@@ -786,9 +788,10 @@ struct deconv_bwd_data_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::deconvolution_backward_data);
 
     deconv_bwd_data_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::deconvolution_backward_data(desc);
     }
 
@@ -827,9 +830,10 @@ struct deconv_bwd_weights_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::deconvolution_backward_weights);
 
     deconv_bwd_weights_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::deconvolution_backward_weights(desc);
     }
 
@@ -867,7 +871,8 @@ struct matmul_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::matmul);
 
     matmul_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
         using ltw = logical_tensor_wrapper_t;
         // if with zero dimension, the matmul op will take no effect, we
         // construct a dummy kernel
@@ -878,7 +883,8 @@ struct matmul_executable_t : public op_executable_t {
             return;
         }
 
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::matmul(desc);
 
         // The scratchpad size of pd created by using any format tag may be
@@ -1001,9 +1007,10 @@ struct eltwise_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::eltwise_forward);
 
     eltwise_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::eltwise_forward(desc);
     }
 
@@ -1041,9 +1048,10 @@ struct eltwise_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::eltwise_backward);
 
     eltwise_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::eltwise_backward(desc);
     }
 
@@ -1081,7 +1089,8 @@ struct binary_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::binary);
 
     binary_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
         using ltw = logical_tensor_wrapper_t;
         // if with zero dimension, the binary op will take no effect, we
         // construct a dummy kernel
@@ -1092,7 +1101,8 @@ struct binary_executable_t : public op_executable_t {
             return;
         }
 
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::binary(desc);
 
         if (op->has_attr(op_attr::with_sum))
@@ -1204,8 +1214,10 @@ struct concat_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::concat);
 
     concat_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::concat(desc);
     }
 
@@ -1243,9 +1255,10 @@ struct shuffle_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::shuffle_forward);
 
     shuffle_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::shuffle_forward(desc);
     }
 
@@ -1283,8 +1296,10 @@ struct pool_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::pooling_forward);
 
     pool_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::pooling_forward(desc);
     }
 
@@ -1322,9 +1337,10 @@ struct pool_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::pooling_backward);
 
     pool_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::pooling_backward(desc);
     }
 
@@ -1362,8 +1378,10 @@ struct prelu_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::prelu_forward);
 
     prelu_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::prelu_forward(desc);
     }
 
@@ -1401,9 +1419,10 @@ struct prelu_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::prelu_backward);
 
     prelu_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::prelu_backward(desc);
     }
 
@@ -1441,9 +1460,10 @@ struct reorder_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::reorder);
 
     reorder_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::reorder(desc);
         if (op->has_attr(op_attr::with_sum))
             with_sum_ = op->get_attr<bool>(op_attr::with_sum);
@@ -1568,12 +1588,13 @@ struct bn_folding_t : public op_executable_t {
     };
 
     static desc_t create_desc(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout);
 
     bn_folding_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
-        desc_ = create_desc(op, p_engine, mgr, pd_cache);
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
+        desc_ = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         add_prim_ = dnnl::binary(desc_.add_pd_);
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
         && DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
@@ -1960,9 +1981,10 @@ struct conv_bwd_data_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::convolution_backward_data);
 
     conv_bwd_data_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::convolution_backward_data(desc);
     }
 
@@ -2001,9 +2023,10 @@ struct conv_bwd_weights_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::convolution_backward_weights);
 
     conv_bwd_weights_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::convolution_backward_weights(desc);
     }
 
@@ -2042,14 +2065,15 @@ struct batchnorm_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::batch_normalization_forward);
 
     batchnorm_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache)
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout)
         : is_training_(op->get_attr<bool>(op_attr::is_training)) {
         float momentum = 0.5;
         if (op->has_attr(op_attr::momentum))
             momentum = op->get_attr<float>(op_attr::momentum);
         scales_ = {momentum, 1 - momentum};
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::batch_normalization_forward(desc);
     }
 
@@ -2220,9 +2244,10 @@ struct batchnorm_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::batch_normalization_backward);
 
     batchnorm_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::batch_normalization_backward(desc);
     }
 
@@ -2260,9 +2285,10 @@ struct resampling_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::resampling_forward);
 
     resampling_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::resampling_forward(desc);
         if (op->has_attr(op_attr::with_sum))
             with_sum_ = op->get_attr<bool>(op_attr::with_sum);
@@ -2345,9 +2371,10 @@ struct resampling_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::resampling_backward);
 
     resampling_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::resampling_backward(desc);
     }
 
@@ -2386,9 +2413,10 @@ struct layernorm_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::layer_normalization_forward);
 
     layernorm_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::layer_normalization_forward(desc);
     }
 
@@ -2427,9 +2455,10 @@ struct layernorm_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::layer_normalization_backward);
 
     layernorm_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::layer_normalization_backward(desc);
     }
 
@@ -2467,8 +2496,10 @@ struct sum_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::sum);
 
     sum_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            pd_cache_t &pd_cache, const fpmath_t &fpmath,
+            bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::sum(desc);
     }
 
@@ -2506,9 +2537,10 @@ struct softmax_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::softmax_forward);
 
     softmax_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::softmax_forward(desc);
     }
 
@@ -2546,9 +2578,10 @@ struct softmax_bwd_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::softmax_backward);
 
     softmax_bwd_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::softmax_backward(desc);
     }
 
@@ -2586,9 +2619,10 @@ struct reduction_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::reduction);
 
     reduction_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::reduction(desc);
 
         if (op->has_attr(op_attr::with_sum))
@@ -2669,9 +2703,10 @@ struct groupnorm_executable_t : public op_executable_t {
     DECLARE_RESET_ENGINE(dnnl::group_normalization_forward);
 
     groupnorm_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache) {
-        auto desc = create_desc(op, p_engine, mgr, pd_cache);
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout) {
+        auto desc
+                = create_desc(op, p_engine, pd_cache, fpmath, use_block_layout);
         prim_ = dnnl::group_normalization_forward(desc);
     }
 
@@ -2712,8 +2747,8 @@ struct genindex_executable_t : public op_executable_t {
     DECLARE_ARG_INDICES_GETTER;
 
     genindex_executable_t(std::shared_ptr<op_t> &op,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr,
-            pd_cache_t &pd_cache)
+            const dnnl::engine &p_engine, pd_cache_t &pd_cache,
+            const fpmath_t &fpmath, bool use_block_layout)
         : axis_(op->get_attr<int64_t>(op_attr::axis)) {
         using ltw = logical_tensor_wrapper_t;
         const auto &input_lt = op->get_input_value(0)->get_logical_tensor();
@@ -2869,7 +2904,7 @@ struct sdpa_executable_t : public op_executable_t {
     DECLARE_ARG_INDICES_GETTER;
 
     sdpa_executable_t(std::shared_ptr<op_t> &op, const dnnl::engine &p_engine,
-            fusion_info_mgr_t &mgr, pd_cache_t &pd_cache)
+            pd_cache_t &pd_cache, const fpmath_t &fpmath, bool use_block_layout)
         : with_scale_(op->get_attr<bool>(op_attr::with_scale))
         , mask_type_(static_cast<attn_mask_type_t>(
                   op->get_attr<int64_t>(op_attr::mask_type))) {
@@ -2898,8 +2933,7 @@ struct sdpa_executable_t : public op_executable_t {
 
         dnnl::primitive_attr attr;
         attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-        attr.set_fpmath_mode(
-                static_cast<dnnl::fpmath_mode>(mgr.get_fpmath_mode().mode_));
+        attr.set_fpmath_mode(static_cast<dnnl::fpmath_mode>(fpmath.mode_));
         if (op->has_attr(op_attr::is_invert_scale))
             is_invert_scale_ = op->get_attr<bool>(op_attr::is_invert_scale);
 

--- a/src/graph/backend/dnnl/passes/compile_ops.cpp
+++ b/src/graph/backend/dnnl/passes/compile_ops.cpp
@@ -40,9 +40,10 @@ namespace dnnl_impl {
 /// complete shape/dtype/layout information. We can create executable for these
 /// ops.
 status_t compile_ops(std::shared_ptr<subgraph_t> &sg) {
-    auto &mgr = sg->fusion_info_mgr_;
     const auto &p_engine = *(sg->p_engine_);
     auto &pd_cache = sg->pd_cache_;
+    auto &fpm = sg->get_fpmath_mode();
+    bool use_block_layout = sg->can_use_blocked_layout_;
 
     return topo_order_visit(sg->get_output_ops(), [&](op_t *op) {
         const op_schema_t *opm
@@ -61,7 +62,7 @@ status_t compile_ops(std::shared_ptr<subgraph_t> &sg) {
                 "executable_creator");
 
         std::shared_ptr<op_executable_t> exec
-                = creator(cur_op, p_engine, mgr, pd_cache);
+                = creator(cur_op, p_engine, pd_cache, fpm, use_block_layout);
         VCHECK_COMPILE_OPS(exec != nullptr, status::invalid_graph_op,
                 "unimplemented op, can't compile op %s",
                 op->get_name().c_str());

--- a/src/graph/backend/dnnl/passes/insert_ops.cpp
+++ b/src/graph/backend/dnnl/passes/insert_ops.cpp
@@ -747,7 +747,6 @@ status_t insert_unsqueeze_and_squeeze_for_matmul(
 
 impl::status_t insert_runtime_u8_to_s8_for_matmul(
         std::shared_ptr<subgraph_t> &sg) {
-    auto &mgr = sg->fusion_info_mgr_;
     subgraph_rewriter_t rewriter(sg);
     for (auto &cur_op : sg->get_ops()) {
         if (cur_op->get_kind() != op_kind::dnnl_matmul) continue;
@@ -764,11 +763,11 @@ impl::status_t insert_runtime_u8_to_s8_for_matmul(
         bool with_bias = cur_op->has_attr(op_attr::with_bias)
                 && cur_op->get_attr<bool>(op_attr::with_bias);
         const bool has_runtime_src_scales
-                = with_runtime_scales(cur_op, mgr, true, 0);
+                = with_runtime_scales(cur_op, true, 0);
         const bool has_runtime_wei_scales
-                = with_runtime_scales(cur_op, mgr, true, 1);
-        const bool has_runtime_src_zps = with_runtime_zps(cur_op, mgr, true, 0);
-        const bool has_runtime_wei_zps = with_runtime_zps(cur_op, mgr, true, 1);
+                = with_runtime_scales(cur_op, true, 1);
+        const bool has_runtime_src_zps = with_runtime_zps(cur_op, true, 0);
+        const bool has_runtime_wei_zps = with_runtime_zps(cur_op, true, 1);
 
         size_t index = 2;
         if (with_bias) index += 1;
@@ -831,9 +830,6 @@ impl::status_t insert_runtime_u8_to_s8_for_matmul(
                 cur_op->set_attr<fusion_info_t>(
                         op_attr::fusion_info, fusion_info);
             }
-
-            // fusion_info_t &fusion_info = mgr.get_mutable_info(key);
-            // fusion_info.set_zero_points(zps_op->shared_from_this(), true, 1);
 
             // connect add_zp and constant data
             cur_op->add_input(const_data_dst_value);

--- a/src/graph/backend/dnnl/passes/memory_planning.cpp
+++ b/src/graph/backend/dnnl/passes/memory_planning.cpp
@@ -63,11 +63,11 @@ std::vector<op_inplace_pair_t> get_op_inplace_pairs(
 
     // Make post-sum inplace has higher priority since it affects both
     // performance and memory footprint
-    if (op.has_attr(op_attr::fusion_info_key)
-            && op.get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
+    if (op.has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op.get_attr<fusion_info_t>(op_attr::fusion_info);
         // sum post ops support inplace
-        int64_t key = op.get_attr<int64_t>(op_attr::fusion_info_key);
-        const auto &pops = mgr.get_info(key).get_post_ops();
+        const auto &pops = fusion_info.get_post_ops();
 
         // the post-ops input offset
         size_t index = 1;
@@ -78,14 +78,10 @@ std::vector<op_inplace_pair_t> get_op_inplace_pairs(
                             && op.get_attr<bool>(op_attr::with_bias)
                     ? 3 // src, wei, bias
                     : 2; // src, wei
-            if (mgr.get_info(key).with_runtime_scales(true, 0)) { index += 1; }
-            if (mgr.get_info(key).with_runtime_scales(true, 1)) { index += 1; }
-            if (mgr.get_info(key).with_runtime_zero_points(true, 0)) {
-                index += 1;
-            }
-            if (mgr.get_info(key).with_runtime_zero_points(true, 1)) {
-                index += 1;
-            }
+            if (fusion_info.with_runtime_scales(true, 0)) { index += 1; }
+            if (fusion_info.with_runtime_scales(true, 1)) { index += 1; }
+            if (fusion_info.with_runtime_zero_points(true, 0)) { index += 1; }
+            if (fusion_info.with_runtime_zero_points(true, 1)) { index += 1; }
         } else if (op.get_kind() == op_kind::dnnl_binary) {
             index = 2;
         } else {

--- a/src/graph/backend/dnnl/passes/memory_planning.hpp
+++ b/src/graph/backend/dnnl/passes/memory_planning.hpp
@@ -436,23 +436,21 @@ private:
             const std::vector<logical_tensor_t> &inputs);
 
     status_t assign_external_outputs_buffer(std::shared_ptr<subgraph_t> &sg,
-            const std::vector<logical_tensor_t> &outputs,
-            fusion_info_mgr_t &mgr);
+            const std::vector<logical_tensor_t> &outputs);
 
-    status_t assign_internal_persistent_buffer(
-            std::shared_ptr<subgraph_t> &sg, fusion_info_mgr_t &mgr);
+    status_t assign_internal_persistent_buffer(std::shared_ptr<subgraph_t> &sg);
 
     status_t assign_internal_temporary_buffer(std::shared_ptr<subgraph_t> &sg,
             const std::unordered_map<value_t *, size_t> &edge_ref_count,
-            fusion_info_mgr_t &mgr, bool enable_standard_sharing);
+            bool enable_standard_sharing);
 
     status_t prepare_subgraph_inplace_pairs(
             std::shared_ptr<subgraph_t> &sg, bool enable_standard_sharing);
 
     status_t book_buffers(std::shared_ptr<subgraph_t> &sg);
 
-    status_t prepare_execution_args_set(std::shared_ptr<subgraph_t> &sg,
-            const dnnl::engine &p_engine, fusion_info_mgr_t &mgr);
+    status_t prepare_execution_args_set(
+            std::shared_ptr<subgraph_t> &sg, const dnnl::engine &p_engine);
 
     execution_args_set_t exec_args_set_;
 

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -2553,9 +2553,10 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
     const static std::set<op_kind_t> reorder_op_set = {op_kind::dnnl_reorder};
 
     auto fuse_two_adjacent_reorders = [&](bool &changed) -> status_t {
-        auto &mgr = sg->fusion_info_mgr_;
         auto &p_engine = sg->p_engine_;
         auto &pd_cache = sg->pd_cache_;
+        auto &fpm = sg->get_fpmath_mode();
+        bool use_block_layout = sg->can_use_blocked_layout_;
 
         std::vector<std::pair<op_t *, op_t *>> fuse_groups;
 
@@ -2756,7 +2757,7 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
                 pd_cache.erase(fused_op.get());
             }
             const auto &pd = reorder_executable_t::create_desc(
-                    fused_op, *p_engine, mgr, pd_cache);
+                    fused_op, *p_engine, pd_cache, fpm, use_block_layout);
             const memory::desc scratchpad_desc = pd.scratchpad_desc();
             CHECK(fill_layout_info(scratchpad_val, scratchpad_desc));
 

--- a/src/graph/backend/dnnl/passes/utils.cpp
+++ b/src/graph/backend/dnnl/passes/utils.cpp
@@ -198,14 +198,11 @@ status_t infer_shape(std::shared_ptr<subgraph_t> &sg) {
     // internal dw_type attr to record the post-dw-conv info used to infer
     // correct shape. Here the dw_type attr is a temporary attr only used during
     // shape infer, and will be removed from the op before existing shape infer.
-    const auto &mgr = sg->fusion_info_mgr_;
     std::vector<op_ptr> conv_fused_post_s2_dw_conv;
     for (auto &op : sg->get_ops()) {
         fusion_info_t fusion_info;
-        if (op->has_attr(op_attr::fusion_info_key)
-                && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-            int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-            fusion_info = mgr.get_info(key);
+        if (op->has_attr(op_attr::fusion_info)) {
+            fusion_info = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         }
 
         if (fusion_info.has_post_dw_conv()) {
@@ -622,10 +619,9 @@ bool is_typecast(const op_t *op) {
 
 bool with_runtime_zps(const op_ptr &op, const fusion_info_mgr_t &mgr,
         bool is_input, size_t index) {
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        const fusion_info_t &fusion_info = mgr.get_info(key);
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         return fusion_info.with_runtime_zero_points(is_input, index);
     } else {
         return false;
@@ -634,10 +630,9 @@ bool with_runtime_zps(const op_ptr &op, const fusion_info_mgr_t &mgr,
 
 bool with_runtime_scales(const op_ptr &op, const fusion_info_mgr_t &mgr,
         bool is_input, size_t index) {
-    if (op->has_attr(op_attr::fusion_info_key)
-            && op->get_attr<int64_t>(op_attr::fusion_info_key) != -1) {
-        int64_t key = op->get_attr<int64_t>(op_attr::fusion_info_key);
-        const fusion_info_t &fusion_info = mgr.get_info(key);
+    if (op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
         return fusion_info.with_runtime_scales(is_input, index);
     } else {
         return false;

--- a/src/graph/backend/dnnl/passes/utils.cpp
+++ b/src/graph/backend/dnnl/passes/utils.cpp
@@ -617,8 +617,7 @@ bool is_typecast(const op_t *op) {
     return is_typecast;
 }
 
-bool with_runtime_zps(const op_ptr &op, const fusion_info_mgr_t &mgr,
-        bool is_input, size_t index) {
+bool with_runtime_zps(const op_ptr &op, bool is_input, size_t index) {
     if (op->has_attr(op_attr::fusion_info)) {
         const fusion_info_t &fusion_info
                 = op->get_attr<fusion_info_t>(op_attr::fusion_info);
@@ -628,8 +627,7 @@ bool with_runtime_zps(const op_ptr &op, const fusion_info_mgr_t &mgr,
     }
 }
 
-bool with_runtime_scales(const op_ptr &op, const fusion_info_mgr_t &mgr,
-        bool is_input, size_t index) {
+bool with_runtime_scales(const op_ptr &op, bool is_input, size_t index) {
     if (op->has_attr(op_attr::fusion_info)) {
         const fusion_info_t &fusion_info
                 = op->get_attr<fusion_info_t>(op_attr::fusion_info);

--- a/src/graph/backend/dnnl/passes/utils.hpp
+++ b/src/graph/backend/dnnl/passes/utils.hpp
@@ -378,14 +378,11 @@ std::string kind2str(op_kind_t kind);
 // which only has different input/output data type.
 bool is_typecast(const op_t *op);
 
-bool with_runtime_scales(const std::shared_ptr<op_t> &op,
-        const fusion_info_mgr_t &mgr, bool is_input, size_t index);
+bool with_runtime_scales(
+        const std::shared_ptr<op_t> &op, bool is_input, size_t index);
 
-bool with_runtime_dst_scales(
-        const std::shared_ptr<op_t> &op, const fusion_info_mgr_t &mgr);
-
-bool with_runtime_zps(const std::shared_ptr<op_t> &op,
-        const fusion_info_mgr_t &mgr, bool is_input, size_t index);
+bool with_runtime_zps(
+        const std::shared_ptr<op_t> &op, bool is_input, size_t index);
 
 // This function is used to check if a dnnl_reorder op is converted from or act
 // as a Reorder op. This function will only return true for a dnnl_reorder op

--- a/src/graph/backend/dnnl/subgraph.cpp
+++ b/src/graph/backend/dnnl/subgraph.cpp
@@ -56,7 +56,7 @@ subgraph_t::subgraph_t(const std::vector<op_ptr> &ops, const dnnl::engine &eng,
         bool reset_layout)
     : graph_t(ops, static_cast<engine_kind_t>(eng.get_kind()))
     , p_engine_(&eng)
-    , fusion_info_mgr_(fpm_mode, can_use_blocked_layout) {
+    , can_use_blocked_layout_(can_use_blocked_layout) {
     set_fpmath_mode(fpm_mode.mode_, fpm_mode.apply_to_int_);
     if (reset_layout) { set_all_layout_to_any(get_mutable_ops()); }
 }

--- a/src/graph/backend/dnnl/subgraph.hpp
+++ b/src/graph/backend/dnnl/subgraph.hpp
@@ -80,8 +80,7 @@ public:
     // The engine that the subgraph is compiled for
     const dnnl::engine *p_engine_;
 
-    // This manager holds each op's fusion information
-    fusion_info_mgr_t fusion_info_mgr_;
+    bool can_use_blocked_layout_;
 
     // The custom cache to store the created primitive desc
     pd_cache_t pd_cache_;

--- a/src/graph/interface/c_types_map.hpp
+++ b/src/graph/interface/c_types_map.hpp
@@ -307,6 +307,7 @@ const attribute_kind_t i = 2;
 const attribute_kind_t is = 3;
 const attribute_kind_t s = 4;
 const attribute_kind_t b = 5;
+const attribute_kind_t fusion_info = 6; //special attribute kind for fusion info
 } // namespace attribute_kind
 
 using allocator_t = dnnl_graph_allocator;

--- a/src/graph/utils/attribute_value.hpp
+++ b/src/graph/utils/attribute_value.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2022 Intel Corporation
+ * Copyright 2021-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,40 +29,57 @@
 namespace dnnl {
 namespace impl {
 namespace graph {
+namespace dnnl_impl {
+
+class fusion_info_t; // Forward declaration of fusion_info_t
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+namespace dnnl {
+namespace impl {
+namespace graph {
 namespace utils {
 // Add new attribute types by specializing on the C++ type and
 // defining an enum value below
 template <typename value_type>
-struct attribute_value_traits;
+struct attribute_value_traits_t;
 
 template <>
-struct attribute_value_traits<int64_t> {
+struct attribute_value_traits_t<int64_t> {
     static attribute_kind_t constexpr kind = attribute_kind::i;
 };
 
 template <>
-struct attribute_value_traits<std::vector<int64_t>> {
+struct attribute_value_traits_t<std::vector<int64_t>> {
     static attribute_kind_t constexpr kind = attribute_kind::is;
 };
 
 template <>
-struct attribute_value_traits<float> {
+struct attribute_value_traits_t<float> {
     static attribute_kind_t constexpr kind = attribute_kind::f;
 };
 
 template <>
-struct attribute_value_traits<std::vector<float>> {
+struct attribute_value_traits_t<std::vector<float>> {
     static attribute_kind_t constexpr kind = attribute_kind::fs;
 };
 
 template <>
-struct attribute_value_traits<std::string> {
+struct attribute_value_traits_t<std::string> {
     static attribute_kind_t constexpr kind = attribute_kind::s;
 };
 
 template <>
-struct attribute_value_traits<bool> {
+struct attribute_value_traits_t<bool> {
     static attribute_kind_t constexpr kind = attribute_kind::b;
+};
+
+template <>
+struct attribute_value_traits_t<dnnl::impl::graph::dnnl_impl::fusion_info_t> {
+    static attribute_kind_t constexpr kind = attribute_kind::fusion_info;
 };
 
 template <typename value_type>
@@ -76,11 +93,14 @@ constexpr attribute_kind_t get_attribute_kind() {
                     || std::is_same<std::vector<float>, value_type>::value
                     || std::is_same<std::vector<int64_t>, value_type>::value
                     || std::is_same<std::string, value_type>::value
-                    || std::is_same<bool, value_type>::value,
+                    || std::is_same<bool, value_type>::value
+                    || std::is_same<dnnl::impl::graph::dnnl_impl::fusion_info_t,
+                            value_type>::value,
             "value_type should be one of int64_t, float, string, "
-            "bool, vector<float>, or vector<int64_t>.");
+            "bool, vector<float>, vector<int64_t> or fusion_info_t class "
+            "type.");
 
-    return attribute_value_traits<base_value_type<value_type>>::kind;
+    return attribute_value_traits_t<base_value_type<value_type>>::kind;
 }
 
 template <typename value_type>

--- a/tests/gtests/graph/unit/backend/dnnl/test_internal_attrs_cpu.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_internal_attrs_cpu.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ TEST(test_internal_attrs, InternalAttr2str) {
     CASE(is_bias_add);
     CASE(with_sum);
     CASE(alg_kind);
-    CASE(fusion_info_key);
     CASE(dw_type);
     CASE(kind);
     CASE(p);

--- a/tests/gtests/graph/unit/backend/dnnl/test_op_executable.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_op_executable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,20 +33,20 @@ namespace dnnl_impl = graph::dnnl_impl;
 
 TEST(test_op_executable, DummyArgIndicesGetterDeathTest) {
     graph::op_t op {0, graph::op_kind::Wildcard, "op"};
-    dnnl_impl::fusion_info_mgr_t mgr;
 #ifndef NDEBUG
-    EXPECT_DEATH(dnnl_impl::dummy_arg_indices_getter(&op, mgr),
+    EXPECT_DEATH(dnnl_impl::dummy_arg_indices_getter(&op),
             "dummy getter should never be called");
 #endif
 }
 
 TEST(test_op_executable, DummyExecutableCreatorDeathTest) {
     dnnl::engine p_engine;
-    dnnl_impl::fusion_info_mgr_t mgr;
     dnnl_impl::pd_cache_t pd_cache;
+    const graph::fpmath_t fpm;
+    bool use_block_layout = false;
     auto op = std::make_shared<graph::op_t>(0, graph::op_kind::Wildcard, "op");
-    EXPECT_DEBUG_DEATH(
-            dnnl_impl::dummy_executable_creator(op, p_engine, mgr, pd_cache),
+    EXPECT_DEBUG_DEATH(dnnl_impl::dummy_executable_creator(
+                               op, p_engine, pd_cache, fpm, use_block_layout),
             "dummy executable creator should never be called");
 }
 

--- a/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_subgraph_pass.cpp
@@ -212,10 +212,9 @@ TEST(test_subgraph_pass, LowerDownToInt8Conv) {
                 return op->get_kind() == dnnl_impl::op_kind::dnnl_convolution;
             });
     ASSERT_NE(qconv_op, subgraph->get_ops().end());
-    ASSERT_TRUE((*qconv_op)->has_attr(dnnl_impl::op_attr::fusion_info_key));
-    int64_t key = (*qconv_op)->get_attr<int64_t>(
-            dnnl_impl::op_attr::fusion_info_key);
-    auto &fusion_info = subgraph->fusion_info_mgr_.get_info(key);
+    ASSERT_TRUE((*qconv_op)->has_attr(dnnl_impl::op_attr::fusion_info));
+    const auto &fusion_info = (*qconv_op)->get_attr<dnnl_impl::fusion_info_t>(
+            dnnl_impl::op_attr::fusion_info);
     const auto &post_ops = fusion_info.get_post_ops();
     ASSERT_EQ(post_ops.size(), 2U);
 }
@@ -330,11 +329,10 @@ TEST(test_subgraph_pass, LowerDownToInt8Matmul) {
                 return op->get_kind() == dnnl_impl::op_kind::dnnl_matmul;
             });
     ASSERT_NE(qmatmul_op, subgraph->get_ops().end());
-    ASSERT_TRUE((*qmatmul_op)->has_attr(dnnl_impl::op_attr::fusion_info_key));
-    int64_t key
-            = (*qmatmul_op)
-                      ->get_attr<int64_t>(dnnl_impl::op_attr::fusion_info_key);
-    auto &fusion_info = subgraph->fusion_info_mgr_.get_info(key);
+    ASSERT_TRUE((*qmatmul_op)->has_attr(dnnl_impl::op_attr::fusion_info));
+    const auto &fusion_info = (*qmatmul_op)
+                                      ->get_attr<dnnl_impl::fusion_info_t>(
+                                              dnnl_impl::op_attr::fusion_info);
     const auto &post_ops = fusion_info.get_post_ops();
     ASSERT_EQ(post_ops.size(), 1U);
 }
@@ -2326,10 +2324,9 @@ TEST(test_subgraph_pass, FuseNCXConvolutionBinaryAddNC11PostSrc) {
                 return op->get_kind() == dnnl_impl::op_kind::dnnl_convolution;
             });
     ASSERT_NE(qconv_op, subgraph->get_ops().end());
-    ASSERT_TRUE((*qconv_op)->has_attr(dnnl_impl::op_attr::fusion_info_key));
-    int64_t key = (*qconv_op)->get_attr<int64_t>(
-            dnnl_impl::op_attr::fusion_info_key);
-    auto &fusion_info = subgraph->fusion_info_mgr_.get_info(key);
+    ASSERT_TRUE((*qconv_op)->has_attr(dnnl_impl::op_attr::fusion_info));
+    const auto &fusion_info = (*qconv_op)->get_attr<dnnl_impl::fusion_info_t>(
+            dnnl_impl::op_attr::fusion_info);
     const auto &post_ops = fusion_info.get_post_ops();
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
         && DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA
@@ -2492,10 +2489,9 @@ TEST(test_subgraph_pass, FuseNXCConvolutionBinaryAddNC11PostSrc) {
                 return op->get_kind() == dnnl_impl::op_kind::dnnl_convolution;
             });
     ASSERT_NE(qconv_op, subgraph->get_ops().end());
-    ASSERT_TRUE((*qconv_op)->has_attr(dnnl_impl::op_attr::fusion_info_key));
-    int64_t key = (*qconv_op)->get_attr<int64_t>(
-            dnnl_impl::op_attr::fusion_info_key);
-    auto &fusion_info = subgraph->fusion_info_mgr_.get_info(key);
+    ASSERT_TRUE((*qconv_op)->has_attr(dnnl_impl::op_attr::fusion_info));
+    const auto &fusion_info = (*qconv_op)->get_attr<dnnl_impl::fusion_info_t>(
+            dnnl_impl::op_attr::fusion_info);
     const auto &post_ops = fusion_info.get_post_ops();
 #if DNNL_GPU_RUNTIME != DNNL_RUNTIME_NONE \
         && DNNL_GPU_VENDOR == DNNL_VENDOR_NVIDIA


### PR DESCRIPTION
### Background
Preliminary work for MFDNN-13442. The main purpose of this PR is to bind the `fusion_info` as an attribute directly onto the op, rather than using a `fusion_info_key` to reference a container(currently a vector store in `fusion_info_mgr`) that manages the fusion info.

### Works
- [x] Add new `fusion_info` attr. 
- [x] Update all op's attr with new attr
- [x] Gtest update
- [x] remove `fusion_info_mgr_t`