### PR TITLE
[GPU] GEMM enable Fp4 weights decompression

### DIFF
--- a/doc/primitives/matmul.md
+++ b/doc/primitives/matmul.md
@@ -103,6 +103,9 @@ types for source, destination, weights, and bias tensors:
 | f16              | f16, u8, s8          | f32                              | f32, f16                    |
 | bf16             | bf16, u8, s8, u4, s4 | f32, bf16                        | f32, bf16                   |
 | f32, bf16, f16   | u8, s8               | f32, bf16, f16                   | f32, bf16, f16              |
+| f32, bf16, f16   | u8, s8               | f32, bf16, f16                   | f32, bf16, f16              |
+| bf16, f16        | f4_e2m1, f4_e3m0     | f32, bf16, f16                   | f32, bf16, f16              |
+| f16              | f8_e5m2, f8_e4m3     | f32, f16, bf16                   | f32, bf16, f16              |
 | f8_e5m2, f8_e4m3 | f8_e5m2, f8_e4m3     | f32, f16, bf16, f8_e5m2, f8_e4m3 | f32, bf16, f16              |
 | f4_e2m1, f4_e3m0 | f4_e2m1, f4_e3m0     | f32, f16, bf16, f4_e2m1, f4_e3m0 | f32, bf16, f16              |
 | u8, s8           | u8, s8, u4, s4       | u8, s8, s32, f32, f16, bf16      | u8, s8, s32, f32, f16, bf16 |

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -64,9 +64,9 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
     // weights decompression.
     const bool wei_is_int = utils::one_of(
             wei_dt, data_type::s8, data_type::u8, data_type::s4, data_type::u4);
-    const bool wei_is_fp8
-            = utils::one_of(wei_dt, data_type::f8_e5m2, data_type::f8_e4m3);
-    if (wei_is_int || wei_is_fp8) {
+    const bool wei_is_fp8_fp4 = utils::one_of(wei_dt, data_type::f8_e5m2,
+            data_type::f8_e4m3, data_type::f4_e2m1, data_type::f4_e3m0);
+    if (wei_is_int || wei_is_fp8_fp4) {
         attr_mask |= smask_t::zero_points_data_type;
         attr_mask |= smask_t::zero_points_groups;
         attr_mask |= smask_t::scales_groups;

--- a/src/gpu/intel/jit/gemm/gen_gemm.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.hpp
@@ -68,9 +68,9 @@ struct gen_gemm_t : public gpu_gemm_t {
             init_attrs();
             const auto d = desc();
 
-            VDISPATCH_GEMM(
-                    IMPLICATION(utils::one_of(d->a_type(), f8_e5m2, f8_e4m3),
-                            arch_ >= arch_t::xe_hpc),
+            VDISPATCH_GEMM(IMPLICATION(utils::one_of(d->a_type(), f8_e5m2,
+                                               f8_e4m3, f4_e2m1, f4_e3m0),
+                                   arch_ >= arch_t::xe_hpc),
                     VERBOSE_UNSUPPORTED_DT); /* temporary; pending gemmstone pulldown */
 
             CHECK(set_default_formats(false));

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -563,6 +563,7 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
         if (dt == Type::f32) { return "[SB]"; }
         if (dt.isInt8() || dt.isInt4()) return "[OB]";
         if (dt.isF8()) return "B";
+        if (dt.isFP4()) return "F";
         return nullptr;
     });
 
@@ -570,6 +571,7 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
         if (dt == Type::f32) { return "[SH]"; }
         if (dt.isInt8() || dt.isInt4()) return "[OH]";
         if (dt.isF8()) return "H";
+        if (dt.isFP4()) return "F";
         return nullptr;
     });
 
@@ -608,7 +610,7 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
     auto update_type = [](Type &T, Type T_new, bool sz_change = false) {
         if ((T.bits() != T_new.bits()) && !sz_change) return;
         if (T.isF8() && T_new.isF8()) return;
-        if (T.isF4() && T_new.isF4()) return;
+        if (T.isF4() && (T_new.isF4() || T_new.isInt4())) return;
         T = T.isSigned() ? T_new.asSigned() : T_new.asUnsigned();
     };
     update_type(problem_.Ta, Ta_new, true);

--- a/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/gemm_setup.cxx
@@ -1555,7 +1555,7 @@ bool BLASKernelGenerator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStr
         // Repacked data can use significantly more registers than the loaded
         // data. Lazy repacking can reduce register utilization and improve load
         // pipelining at (in some cases) the expense of more work.
-        bool lazyRepack = state.Ta_load.isInt4() && one_of(Ta, Type::f16, Type::bf16, Type::f32);    // Other cases are unimplemented
+        bool lazyRepack = state.Ta_load.is4Bit() && one_of(Ta, Type::f16, Type::bf16, Type::f32);    // Other cases are unimplemented
         if (lazyRepack)
             state.ka_repack = std::min(state.ka_repack, strategy.kb_load);
         makeUnbackedRegLayout(Ta, state.Ar_layout, unrollM, state.ka_repack, isLayoutColMajor(state.A_layout), crosspackA, tileM_A, tileK_A, true, splitA);

--- a/src/gpu/intel/jit/gemm/generator/pieces/quantization.cxx
+++ b/src/gpu/intel/jit/gemm/generator/pieces/quantization.cxx
@@ -66,7 +66,7 @@ bool BLASKernelGenerator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMM
     bool downScale   = isA ? problem.downconvertAScales() : problem.downconvertBScales();
 
     bool Tx_bf = problem.Ta_ext ==  Type::bf16 || problem.Tb_ext == Type::bf16;
-    Tx_scaleOp = (Tx_bf ? Type(Tx_ext.isInt4() ? Type::f16 : Type::f32) : Txs);
+    Tx_scaleOp = (Tx_bf ? Type(Tx_ext.is4Bit() ? Type::f16 : Type::f32) : Txs);
     Txo_int    = Txo.isInteger() ? Tx.asSignedInt() : Tx;
     Txs_int    = Tx;
 

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -212,8 +212,8 @@ bool jit_gemm_pd_t::wei_decomp() {
     const auto d = desc();
     using namespace data_type;
     return (utils::one_of(d->c_type(), f32, f16, bf16, f8_e5m2, f8_e4m3)
-                   && utils::one_of(
-                           d->a_type(), u8, s8, s4, u4, f8_e4m3, f8_e5m2)
+                   && utils::one_of(d->a_type(), u8, s8, s4, u4, f8_e4m3,
+                           f8_e5m2, f4_e2m1, f4_e3m0)
                    && utils::one_of(
                            d->b_type(), f16, f32, bf16, f8_e5m2, f8_e4m3))
             && types::data_type_bits(d->a_type())

--- a/src/gpu/intel/ocl/ref_matmul.hpp
+++ b/src/gpu/intel/ocl/ref_matmul.hpp
@@ -88,8 +88,8 @@ struct ref_matmul_t : public gpu_primitive_t {
                               || utils::one_of(wei_dt_, f8_e5m2, f8_e4m3))
                     && utils::one_of(dst_dt_, f32, bf16, f16, src_dt_);
             const bool is_f4
-                    = ((utils::one_of(src_dt_, f4_e2m1, f4_e3m0)
-                               || utils::everyone_is(wei_dt_, f4_e2m1, f4_e3m0))
+                    = ((utils::one_of(src_dt_, f4_e2m1, f4_e3m0, f32, bf16, f16)
+                               || utils::one_of(wei_dt_, f4_e2m1, f4_e3m0))
                             && utils::one_of(dst_dt_, f32, bf16, f16, f4_e3m0,
                                     f4_e2m1, src_dt_));
             const bool is_int8 = utils::one_of(src_dt_, u8, s8)

--- a/tests/benchdnn/inputs/matmul/harness_matmul_decompression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_decompression
@@ -185,6 +185,7 @@
 --skip-impl=ref
 --dt=f16:f8_e5m2:f16,f16:f8_e4m3:f16
 --wtag=any,abc,acb
+--attr-fpmath=f16:true
 --attr-scales=wei:common:2,wei:per_oc:f16,wei:per_ocic:f16:128x1
 2x40x256:2x256x64
 7x41x256:1x256x64
@@ -195,9 +196,48 @@
 --skip-impl=ref
 --dt=f16:f8_e5m2:f16,f16:f8_e4m3:f16
 --wtag=any,ab,ba
+--attr-fpmath=f16:true
 --attr-scales=wei:common:2,wei:per_oc:f16,wei:per_ocic:f16:128x1
 1x4096:4096x4096
 
+# fp4 weights decompression
+--reset
+--skip-impl=ref
+--dt=f16:f4_e2m1:f16,f16:f4_e3m0:f16
+--wtag=any,abc,acb
+--attr-fpmath=f16:true
+--attr-scales=wei:common:2,wei:per_oc:f16,wei:per_ocic:f16:128x1
+2x40x256:2x256x64
+7x41x256:1x256x64
+3x96x512:3x512x64
+3x6x512:1x512x62
+
+--reset
+--skip-impl=ref
+--dt=f16:f4_e2m1:f16,f16:f4_e3m0:f16
+--wtag=any,ab,ba
+--attr-fpmath=f16:true
+--attr-scales=wei:common:2,wei:per_oc:f16,wei:per_ocic:f16:128x1
+1x4096:4096x4096
+
+--reset
+--skip-impl=ref
+--dt=bf16:f4_e2m1:bf16,bf16:f4_e3m0:bf16
+--wtag=any,abc,acb
+--attr-fpmath=bf16:true
+--attr-scales=wei:common:2,wei:per_oc:f16,wei:per_ocic:f16:128x1
+2x40x256:2x256x64
+7x41x256:1x256x64
+3x96x512:3x512x64
+3x6x512:1x512x62
+
+--reset
+--skip-impl=ref
+--dt=f16:f4_e2m1:f16,f16:f4_e3m0:f16
+--wtag=any,ab,ba
+--attr-fpmath=f16:true
+--attr-scales=wei:common:2,wei:per_oc:f16,wei:per_ocic:f16:128x1
+1x4096:4096x4096
 # Dynamic quantization (int8 src, int4/int8 weights)
 --reset
 --skip-impl=ref

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -642,16 +642,28 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
             return;
         }
 
-        if (((prb->src_dt() == dnnl_f8_e4m3 || prb->wei_dt() == dnnl_f8_e4m3
-                     || prb->dst_dt() == dnnl_f8_e4m3)
-                    || (prb->src_dt() == dnnl_f8_e5m2
-                            || prb->wei_dt() == dnnl_f8_e5m2
-                            || prb->dst_dt() == dnnl_f8_e5m2))
+        if ((dnnl::impl::utils::one_of(
+                     dnnl_f8_e4m3, prb->src_dt(), prb->wei_dt(), prb->dst_dt())
+                    || dnnl::impl::utils::one_of(dnnl_f8_e5m2, prb->src_dt(),
+                            prb->wei_dt(), prb->dst_dt()))
                 && (!po.is_def() || !prb->attr.scales.is_def())) {
             BENCHDNN_PRINT(2,
-                    "[SKIP][%s:%d]: GPU supports fp8 through ref only for "
-                    "f8_e4m3 on all platformas and for f8_e5m2 pre-XeHPC with "
-                    "limited post-op support.\n",
+                    "[SKIP][%s:%d]: GPU supports fp8 through ref only on "
+                    "pre-XeHPC platforms with limited post-op support.\n",
+                    __FILE__, __LINE__);
+            res->state = SKIPPED;
+            res->reason = skip_reason::case_not_supported;
+            return;
+        }
+
+        if ((dnnl::impl::utils::one_of(
+                     dnnl_f4_e3m0, prb->src_dt(), prb->wei_dt(), prb->dst_dt())
+                    || dnnl::impl::utils::one_of(dnnl_f4_e2m1, prb->src_dt(),
+                            prb->wei_dt(), prb->dst_dt()))
+                && (!po.is_def() || !prb->attr.scales.is_def())) {
+            BENCHDNN_PRINT(2,
+                    "[SKIP][%s:%d]: GPU supports fp4 through ref only on "
+                    "pre-XeHPC platforms with limited post-op support.\n",
                     __FILE__, __LINE__);
             res->state = SKIPPED;
             res->reason = skip_reason::case_not_supported;


### PR DESCRIPTION
# Description

Permit decompression of fp4 weights in GEMM, reusing strategies for int4. 

Fixes # MFDNN-13543

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
