### PR TITLE
doc: readme: update list of verified configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,14 +325,14 @@ You can download and install the oneDNN library using one of the following optio
 x86-64 CPU engine was validated on RedHat\* Enterprise Linux 8 with
 * GNU Compiler Collection 8.5, 9.5, 11.1, 11.3
 * Clang\* 11.0, 14.0.6
-* [Intel oneAPI DPC++/C++ Compiler] 2024.0
+* [Intel oneAPI DPC++/C++ Compiler] 2025.1
 
 on Windows Server\* 2019 with
-* Microsoft Visual Studio 2022
-* [Intel oneAPI DPC++/C++ Compiler] 2024.0
+* Microsoft Visual Studio 2022 with MSVC 19.43
+* [Intel oneAPI DPC++/C++ Compiler] 2025.1
 
-on macOS 11 (Big Sur) with
-* Apple LLVM version 13.0
+on macOS 14 (Sonoma) with
+* Apple LLVM version 15.0
 
 AArch64 CPU engine was validated on Ubuntu 22.04 with
 * GNU Compiler Collection 10.0, 13.0
@@ -346,21 +346,20 @@ on macOS 14 (Sonoma) with
 
 GPU engine was validated on Ubuntu\* 22.04 with
 * GNU Compiler Collection 8.5, and 9.5
-* Clang 11.0
-* [Intel oneAPI DPC++/C++ Compiler] 2024.0
+* Clang\* 11.0
+* [Intel oneAPI DPC++/C++ Compiler] 2025.1
 * [Intel Software for General Purpose GPU capabilities] latest stable version
 available at the time of release
 
-on Windows Server 2019 with
-* Microsoft Visual Studio 2022
-* [Intel oneAPI DPC++/C++ Compiler] 2024.0
+on Windows Server\* 2019 with
+* Microsoft Visual Studio 2022 with MSVC 19.43
+* [Intel oneAPI DPC++/C++ Compiler] 2025.1
 * [Intel Arc & Iris Xe Graphics Driver] latest stable version available at the
 time of release
 
 [Intel Software for General Purpose GPU capabilities]: https://dgpu-docs.intel.com/index.html
 [Intel Arc & Iris Xe Graphics Driver]: https://www.intel.com/content/www/us/en/download/785597/intel-arc-iris-xe-graphics-windows.html
 [Arm Compiler for Linux]: https://developer.arm.com/Tools%20and%20Software/Arm%20Compiler%20for%20Linux
-
 
 # Support
 


### PR DESCRIPTION
Updated macOS configuration, Intel oneAPI DPC++/C++ Compiler version and added MSVC version to the list of x86-64 verified configurations.