### PR TITLE
[GPU] Add Root Mean Square (RMS) normalization support to lnorm

### DIFF
--- a/src/gpu/intel/ocl/ref_layer_normalization.cl
+++ b/src/gpu/intel/ocl/ref_layer_normalization.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/ref_layer_normalization.cl
+++ b/src/gpu/intel/ocl/ref_layer_normalization.cl
@@ -40,17 +40,19 @@ __kernel void ref_lnorm_fwd(__global DATA_T *src, __global float *mean,
 
     int s_off = STAT_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
 
-    ACC_DATA_T v_mean = CALCULATE_STATS ? 0 : mean[s_off];
+    ACC_DATA_T v_mean = (CALCULATE_STATS || SKIP_MEAN) ? 0 : mean[s_off];
     ACC_DATA_T v_variance = CALCULATE_STATS ? 0 : variance[s_off];
 
     if (CALCULATE_STATS) {
-        for (int c = 0; c < C; ++c) {
-            x[NDIMS - 1] = c;
-            int src_off = SRC_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
+        if (!SKIP_MEAN) {
+            for (int c = 0; c < C; ++c) {
+                x[NDIMS - 1] = c;
+                int src_off = SRC_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
 
-            v_mean += SRC_TO_REF(src[src_off]);
+                v_mean += SRC_TO_REF(src[src_off]);
+            }
+            v_mean /= C;
         }
-        v_mean /= C;
 
         for (int c = 0; c < C; ++c) {
             x[NDIMS - 1] = c;
@@ -84,7 +86,7 @@ __kernel void ref_lnorm_fwd(__global DATA_T *src, __global float *mean,
 
     if (CALCULATE_STATS) {
         if (SAVE_STATS) {
-            mean[s_off] = convert_float(v_mean);
+            if (!SKIP_MEAN) mean[s_off] = convert_float(v_mean);
             variance[s_off] = convert_float(v_variance);
         }
     }
@@ -122,7 +124,8 @@ __kernel void ref_lnorm_bwd_scaleshift(__global SRC_DATA_T *src,
                             = rsqrt(variance[s_off] + eps);
                     const float dd = DST_TO_REF(diff_dst[dst_off]);
 
-                    diff_gamma += (SRC_TO_REF(src[src_off]) - mean[s_off]) * dd
+                    const float mean_val = SKIP_MEAN ? 0 : mean[s_off];
+                    diff_gamma += (SRC_TO_REF(src[src_off]) - mean_val) * dd
                             * inv_sqrt_variance;
                     diff_beta += dd;
                 }
@@ -146,7 +149,7 @@ __kernel void ref_lnorm_bwd(__global SRC_DATA_T *src, __global float *mean,
     x[3] = GWS_GET_X3();
 
     const int s_off = STAT_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
-    const ACC_DATA_T mean_val = mean[s_off];
+    const ACC_DATA_T mean_val = SKIP_MEAN ? 0 : mean[s_off];
 
     const ACC_DATA_T inv_sqrt_variance = rsqrt(variance[s_off] + eps);
     ACC_DATA_T dd_gamma = 0;

--- a/src/gpu/intel/ocl/ref_layer_normalization.cpp
+++ b/src/gpu/intel/ocl/ref_layer_normalization.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/ref_layer_normalization.cpp
+++ b/src/gpu/intel/ocl/ref_layer_normalization.cpp
@@ -49,6 +49,7 @@ static status_t init_conf_common(lnorm_conf_t &conf,
     conf.dst_md_info = memory_desc_info_t::create(dst_mdw);
     conf.stat_md_info = memory_desc_info_t::create(stat_mdw);
     conf.is_fwd = pd->is_fwd();
+    conf.skip_mean = pd->skip_mean();
 
     if (conf.use_shift || conf.use_scale) {
         memory_desc_wrapper weights_mdw(
@@ -98,6 +99,7 @@ static status_t init_kernel_ctx_common(
     kernel_ctx.define_int("IS_FWD", conf.is_fwd);
     kernel_ctx.define_int("IS_BWD", !conf.is_fwd);
     kernel_ctx.define_int("VECT_DT_N", conf.vect_dt_n);
+    kernel_ctx.define_int("SKIP_MEAN", conf.skip_mean);
 
     def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC");
     def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");

--- a/src/gpu/intel/ocl/ref_layer_normalization.hpp
+++ b/src/gpu/intel/ocl/ref_layer_normalization.hpp
@@ -72,8 +72,6 @@ struct ref_layer_normalization_fwd_t : public gpu_primitive_t {
             VDISPATCH_LNORM(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
 
             VDISPATCH_LNORM_SC(init_conf(engine), "init_conf()");
             return status::success;
@@ -154,8 +152,6 @@ struct ref_layer_normalization_bwd_t : public gpu_primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
 
             VDISPATCH_LNORM_SC(init_conf(engine), "init_conf()");
             return status::success;

--- a/src/gpu/intel/ocl/reusable_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_lnorm.cl
@@ -43,7 +43,7 @@ __kernel void lnorm_reusable_calc_var(__global SRC_STAT_DT *src,
     mean = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, mean);
     variance = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, variance);
 
-    float mean_val = load(mean_val, mean);
+    float mean_val = SKIP_MEAN ? 0 : load(mean_val, mean);
     float sum = 0.0f;
     for (off_t i = 0; i < reduce_size; i++) {
         ACC_DT src_val = load(src_val, src + i * (off_t)reduce_stride);
@@ -75,7 +75,7 @@ __kernel void lnorm_reusable_fwd(__global SRC_DT *src, __global float *mean,
     if (USE_SHIFT) load(&sv, shift);
     float src_val = load(src_val, src);
     float var_val = load(var_val, variance);
-    float mean_val = load(mean_val, mean);
+    float mean_val = SKIP_MEAN ? 0 : load(mean_val, mean);
     float sqrt_variance = 1.0f / sqrt(var_val + eps);
     float res = sm * (src_val - mean_val) * sqrt_variance + sv;
 
@@ -112,7 +112,7 @@ __kernel void lnorm_reusable_bwd_scaleshift(__global SRC_SS_DT *src,
         off_t off = i * stat_stride;
         ACC_BWD_DT dst_val = load(dst_val, diff_dst + off);
         ACC_DT src_val = load(src_val, src + off);
-        float mean_val = load(mean_val, mean + i);
+        float mean_val = SKIP_MEAN ? 0 : load(mean_val, mean + i);
         float var_val = load(var_val, variance + i);
 
         beta += dst_val;
@@ -140,7 +140,7 @@ __kernel void lnorm_reusable_bwd(__global SRC_STAT_DT *src,
     mean = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, mean);
     variance = GWS_GET_BUFFER_POS_NAMED(STAT, STAT, gws_params, variance);
 
-    float mean_val = load(mean_val, mean);
+    float mean_val = SKIP_MEAN ? 0 : load(mean_val, mean);
     float var_val = load(var_val, variance);
 
     float inv_var = rsqrt(var_val + eps);

--- a/src/gpu/intel/ocl/reusable_lnorm.cpp
+++ b/src/gpu/intel/ocl/reusable_lnorm.cpp
@@ -48,6 +48,8 @@ static status_t init_conf_common(const layer_normalization_pd_t *pd,
     conf->src_dt = src_buf.data_type;
     conf->dst_dt = dst_buf.data_type;
 
+    conf->skip_mean = pd->skip_mean();
+
     const auto &scales = pd->attr()->scales_;
     conf->with_src_scale = !scales.has_default_values(DNNL_ARG_SRC);
     conf->with_dst_scale = !scales.has_default_values(DNNL_ARG_DST);
@@ -185,6 +187,7 @@ compute::kernel_ctx_t reusable_lnorm_params_t::get_kernel_ctx() const {
 
     kernel_ctx.define_int("USE_SCALE", use_scale);
     kernel_ctx.define_int("USE_SHIFT", use_shift);
+    kernel_ctx.define_int("SKIP_MEAN", skip_mean);
 
     kernel_ctx.define_int("WITH_SRC_SCALES", with_src_scale);
     kernel_ctx.define_int("WITH_DST_SCALES", with_dst_scale);

--- a/src/gpu/intel/ocl/reusable_lnorm.hpp
+++ b/src/gpu/intel/ocl/reusable_lnorm.hpp
@@ -57,7 +57,8 @@ struct reusable_lnorm_params_t
     data_type_t dst_dt = data_type::undef;
     bool use_scale = false;
     bool use_shift = false;
-    uint8_t padding[4] = {0};
+    bool skip_mean = false;
+    uint8_t padding[3] = {0};
 
     // Not used by bwd impl, but would be padding otherwise
     bool with_src_scale = false;
@@ -113,8 +114,6 @@ struct reusable_layer_normalization_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
 
             VDISPATCH_LNORM_SC(init_conf(engine), "Failed init_conf");
             if (stats_are_tmp()) init_scratchpad();
@@ -192,8 +191,6 @@ struct reusable_layer_normalization_bwd_t : public gpu_primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
 
             VDISPATCH_LNORM_SC(init_conf(engine), "Failed init_conf");
 

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cl
@@ -65,9 +65,11 @@ lnorm_reusable_vectorized(__global SRC_DATA_T *src, __global float *mean,
         }
         local_variance = sub_group_reduce_add(sumsq) * rrs;
     } else {
-        mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
+        if (!SKIP_MEAN) {
+            mean = GWS_GET_BUFFER_POS(STAT, gws_params, mean);
+            local_mean = *mean;
+        }
         variance = GWS_GET_BUFFER_POS(STAT, gws_params, variance);
-        local_mean = *mean;
         local_variance = *variance;
     }
 

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.cpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.cpp
@@ -96,6 +96,7 @@ static status_t init_conf_common(const layer_normalization_pd_t *pd,
     conf->ss_dt = ss_buf.data_type;
     conf->calculate_stats = !pd->stats_are_src();
     conf->save_stats = pd->is_training();
+    conf->skip_mean = pd->skip_mean();
 
     // We require that the lnorm axis is a single dense block, so that it can
     // be represented by a stride + size alone.
@@ -212,7 +213,7 @@ reusable_vectorized_lnorm_params_t::get_kernel_ctx() const {
 
     kernel_ctx.define_int("USE_SCALE", use_scale);
     kernel_ctx.define_int("USE_SHIFT", use_shift);
-
+    kernel_ctx.define_int("SKIP_MEAN", skip_mean);
     kernel_ctx.define_int("CALCULATE_STATS", calculate_stats);
     kernel_ctx.define_int("SAVE_STATS", save_stats && calculate_stats);
 

--- a/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/reusable_vectorized_lnorm.hpp
@@ -68,6 +68,7 @@ struct reusable_vectorized_lnorm_params_t
 
     bool use_scale = false;
     bool use_shift = false;
+    bool skip_mean = false;
 
     /// If true calculate the mean and variance values. Otherwise reads from global memory
     bool calculate_stats = false;
@@ -75,7 +76,7 @@ struct reusable_vectorized_lnorm_params_t
     /// Saves the mean and variance to memory
     bool save_stats = false;
 
-    uint8_t padding[4] = {false};
+    uint8_t padding[3] = {false};
 };
 
 struct reusable_vectorized_lnorm_runtime_params_t {
@@ -123,9 +124,6 @@ struct reusable_vectorized_layer_normalization_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
 
             VDISPATCH_LNORM_SC(init_conf(engine), "Failed init_conf");
 

--- a/src/gpu/intel/ocl/simple_layer_normalization.cl
+++ b/src/gpu/intel/ocl/simple_layer_normalization.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/simple_layer_normalization.cl
+++ b/src/gpu/intel/ocl/simple_layer_normalization.cl
@@ -41,7 +41,7 @@ __kernel void simple_lnorm_fwd(__global DATA_T *src, __global float *mean,
 
     int s_off = STAT_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
 
-    float v_mean = CALCULATE_STATS ? 0 : mean[s_off];
+    float v_mean = (CALCULATE_STATS || SKIP_MEAN) ? 0 : mean[s_off];
     float v_variance = CALCULATE_STATS ? 0 : variance[s_off];
 
     if (CALCULATE_STATS) {
@@ -52,6 +52,7 @@ __kernel void simple_lnorm_fwd(__global DATA_T *src, __global float *mean,
             v_acc += CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(VECT_BLOCK_READ(
                     (const __global BLOCK_DATA_T *)&src[src_off])));
         }
+#if !SKIP_MEAN
 #if VECT_DT_N == 1
         v_mean = v_acc;
 #else // VECT_DT_N == 1
@@ -60,10 +61,9 @@ __kernel void simple_lnorm_fwd(__global DATA_T *src, __global float *mean,
             v_mean += v_acc[i];
         }
 #endif // VECT_DT_N == 1
-
         float total_sum = sub_group_reduce_add(v_mean);
         v_mean = total_sum / C;
-
+#endif // SKIP_MEAN
         v_acc = 0;
         VECT_FLOAT_T m = 0;
 
@@ -112,7 +112,7 @@ __kernel void simple_lnorm_fwd(__global DATA_T *src, __global float *mean,
 
     if (CALCULATE_STATS) {
         if (SAVE_STATS) {
-            mean[s_off] = v_mean;
+            if (!SKIP_MEAN) mean[s_off] = v_mean;
             variance[s_off] = v_variance;
         }
     }
@@ -139,7 +139,7 @@ __kernel void simple_lnorm_bwd_scaleshift(__global SRC_DATA_T *src,
     vector_float diff_beta_vect = 0;
 
     for (int n_off = n_start; n_off < n_end; n_off += VECTOR_SIZE_SCALESHIFT) {
-        const vector_float mean_vect = vector_load(mean[n_off]);
+        const vector_float mean_vect = SKIP_MEAN ? 0 : vector_load(mean[n_off]);
         const vector_float variance_vect = vector_load(variance[n_off]);
         const vector_float inv_sqrt_variance = rsqrt(variance_vect + eps);
 #if NDIMS == 2
@@ -215,7 +215,7 @@ __kernel void simple_lnorm_bwd(__global DATA_T *src, __global float *mean,
     x[3] = GWS_GET_X3();
 
     const int s_off = STAT_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
-    const float mean_val = mean[s_off];
+    const float mean_val = SKIP_MEAN ? 0 : mean[s_off];
     const float inv_sqrt_variance = rsqrt(variance[s_off] + eps);
 
     float dd_gamma = 0, dd_gamma_x = 0;

--- a/src/gpu/intel/ocl/simple_layer_normalization.cpp
+++ b/src/gpu/intel/ocl/simple_layer_normalization.cpp
@@ -53,6 +53,7 @@ static status_t init_conf_common(lnorm_conf_t &conf,
     conf.is_fwd = pd->is_fwd();
     conf.vect_dt_n = 1;
     conf.sub_group_size = 1;
+    conf.skip_mean = pd->skip_mean();
 
     if (conf.use_scale || conf.use_shift) {
         memory_desc_wrapper weights_mdw(
@@ -252,6 +253,7 @@ static status_t init_kernel_ctx_common(
             "VECTOR_SIZE_SCALESHIFT", conf.vector_size_scaleshift);
     kernel_ctx.define_int("N_CHUNK_SIZE", conf.n_chunk_size);
     kernel_ctx.define_int("N_CHUNKS", conf.n_chunks);
+    kernel_ctx.define_int("SKIP_MEAN", conf.skip_mean);
 
     def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC");
     def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");

--- a/src/gpu/intel/ocl/simple_layer_normalization.hpp
+++ b/src/gpu/intel/ocl/simple_layer_normalization.hpp
@@ -72,8 +72,6 @@ struct simple_layer_normalization_fwd_t : public gpu_primitive_t {
             VDISPATCH_LNORM(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
             VDISPATCH_LNORM_SC(init_conf(engine), "init_conf()");
             return status::success;
         }
@@ -154,9 +152,6 @@ struct simple_layer_normalization_bwd_t : public gpu_primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
-
             VDISPATCH_LNORM_SC(init_conf(engine), "init_conf()");
             init_scratchpad();
             return status::success;

--- a/src/gpu/intel/ocl/vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/vectorized_lnorm.cl
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2024 Intel Corporation
+* Copyright 2019-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/gpu/intel/ocl/vectorized_lnorm.cl
+++ b/src/gpu/intel/ocl/vectorized_lnorm.cl
@@ -65,7 +65,7 @@ __kernel void vectorized_lnorm_fwd(__global DATA_T *src, __global float *mean,
 
     int s_off = STAT_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
 
-    float v_mean = CALCULATE_STATS ? 0 : mean[s_off];
+    float v_mean = (CALCULATE_STATS || SKIP_MEAN) ? 0 : mean[s_off];
     float v_variance = CALCULATE_STATS ? 0 : variance[s_off];
 
     const float rC = 1.f / C;
@@ -86,8 +86,10 @@ __kernel void vectorized_lnorm_fwd(__global DATA_T *src, __global float *mean,
     for (int c = 0; c < VLEN_C_BLOCK; c++) {
         v_acc += v_src[c];
     }
+#if !SKIP_MEAN
     CALC_V_STAT(v_mean, v_acc);
     v_mean = GROUP_REDUCE_ADD(v_mean) * rC;
+#endif // SKIP_MEAN
     v_acc = 0;
     VECT_FLOAT_T m = 0;
     for (int c = 0; c < VLEN_C_BLOCK; c++) {
@@ -140,8 +142,10 @@ __kernel void vectorized_lnorm_fwd(__global DATA_T *src, __global float *mean,
         v_acc += CONVERT_VECT_FLOAT_T(AS_VECT_DATA_T(
                 VECT_BLOCK_READ((const __global BLOCK_DATA_T *)&src[src_off])));
     }
+#if !SKIP_MEAN
     CALC_V_STAT(v_mean, v_acc);
     v_mean = GROUP_REDUCE_ADD(v_mean) * rC;
+#endif // SKIP_MEAN
     v_acc = 0;
     VECT_FLOAT_T m = 0;
     for (int c = 0; c < C_BLOCK; c += SUB_GROUP_SIZE * VECT_DT_N) {
@@ -191,7 +195,7 @@ __kernel void vectorized_lnorm_fwd(__global DATA_T *src, __global float *mean,
 
 #if CALCULATE_STATS && SAVE_STATS
     if (get_local_linear_id() == 0) {
-        mean[s_off] = v_mean;
+        if (!SKIP_MEAN) mean[s_off] = v_mean;
         variance[s_off] = v_variance;
     }
 #endif
@@ -232,7 +236,7 @@ __kernel void vectorized_lnorm_bwd_scaleshift(__global DATA_T *src,
     VECT_FLOAT_T diff_beta_vect = 0;
 
     for (int n_off = n_start; n_off < n_end; n_off++) {
-        const float mean_vect = mean[n_off];
+        const float mean_vect = SKIP_MEAN ? 0 : mean[n_off];
         const float variance_vect = variance[n_off];
         const float inv_sqrt_variance = rsqrt(variance_vect + eps);
 #if NDIMS == 2
@@ -305,7 +309,7 @@ __kernel void vectorized_lnorm_bwd(__global DATA_T *src, __global float *mean,
     x[3] = GWS_GET_X3();
 
     const int s_off = STAT_OFF(x[0], x[1], x[2], x[3], x[4], x[5]);
-    const float mean_val = mean[s_off];
+    const float mean_val = SKIP_MEAN ? 0 : mean[s_off];
     const float inv_sqrt_variance = rsqrt(variance[s_off] + eps);
 
     float dd_gamma = 0, dd_gamma_x = 0;

--- a/src/gpu/intel/ocl/vectorized_lnorm.cpp
+++ b/src/gpu/intel/ocl/vectorized_lnorm.cpp
@@ -201,6 +201,7 @@ static status_t init_conf_common(lnorm_conf_t &conf,
     conf.calculate_stats = !pd->stats_are_src();
     conf.save_stats = pd->is_training();
     conf.eps = pd->desc()->layer_norm_epsilon;
+    conf.skip_mean = pd->skip_mean();
 
     if (conf.use_scale || conf.use_shift) {
         memory_desc_wrapper weights_mdw(
@@ -501,6 +502,7 @@ static status_t init_kernel_ctx_common(
     kernel_ctx.define_int("N_CHUNKS", conf.n_chunks);
     kernel_ctx.define_int("FINALIZE_N_CHUNKS", conf.finalize_n_chunks);
     kernel_ctx.define_int("USE_SRC_BUFFER", conf.use_src_buffer);
+    kernel_ctx.define_int("SKIP_MEAN", conf.skip_mean);
 
     kernel_ctx.add_option("-cl-std=CL2.0");
     def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC");

--- a/src/gpu/intel/ocl/vectorized_lnorm.hpp
+++ b/src/gpu/intel/ocl/vectorized_lnorm.hpp
@@ -70,8 +70,6 @@ struct vectorized_lnorm_fwd_t : public gpu_primitive_t {
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
 
             VDISPATCH_LNORM_SC(init_conf(engine), "init_conf()");
             return status::success;
@@ -150,8 +148,7 @@ struct vectorized_lnorm_bwd_t : public gpu_primitive_t {
                     attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_LNORM(
                     set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_LNORM(!skip_mean(), VERBOSE_UNSUPPORTED_FEATURE,
-                    "rms normalization is not supported");
+
             VDISPATCH_LNORM_SC(init_conf(engine), "init_conf()");
             init_scratchpad();
             return status::success;

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -399,6 +399,7 @@ struct lnorm_conf_t {
     dim_t n_chunks;
     int vector_size_scaleshift;
     bool use_src_buffer;
+    bool skip_mean;
 
     compute::dispatch_t dispatch_scaleshift;
     compute::dispatch_t dispatch_scaleshift_finalize;

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -464,6 +464,15 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
         res->reason = skip_reason::case_not_supported;
         return;
     }
+
+    if ((is_nvidia_gpu() || is_amd_gpu() || is_generic_gpu())
+            && prb->skip_mean()) {
+        // non-intel GPU does not support rms normalization
+        // todo: remove the check once supported
+        res->state = SKIPPED;
+        res->reason = skip_reason::case_not_supported;
+        return;
+    }
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -464,13 +464,6 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
         res->reason = skip_reason::case_not_supported;
         return;
     }
-    if (is_gpu() && prb->skip_mean()) {
-        // GPU does not support rms normalization
-        // todo: remove the check once supported
-        res->state = SKIPPED;
-        res->reason = skip_reason::case_not_supported;
-        return;
-    }
 }
 
 void skip_invalid_prb(const prb_t *prb, res_t *res) {

--- a/tests/gtests/test_layer_normalization.cpp
+++ b/tests/gtests/test_layer_normalization.cpp
@@ -100,23 +100,32 @@ protected:
         Forward(training, flags::use_scale | flags::use_shift);
         Forward(training,
                 flags::use_scale | flags::use_shift | flags::use_global_stats);
-        Forward(training, flags::rms_norm);
-        Forward(training,
-                flags::rms_norm | flags::use_scale | flags::use_shift);
-        Forward(training,
-                flags::rms_norm | flags::use_scale | flags::use_shift
-                        | flags::use_global_stats);
+
+        // RMS normalization on GPU is currently limited to Intel GPUs only
+        // todo: remove the vendor check once supported
+        if (!is_nvidia_gpu(eng) && !is_amd_gpu(eng)) {
+            Forward(training, flags::rms_norm);
+            Forward(training,
+                    flags::rms_norm | flags::use_scale | flags::use_shift);
+            Forward(training,
+                    flags::rms_norm | flags::use_scale | flags::use_shift
+                            | flags::use_global_stats);
+        }
 
         Forward(inference);
         Forward(inference, flags::use_global_stats);
         Forward(inference, flags::use_scale | flags::use_shift);
 
-        Forward(inference, flags::rms_norm);
-        Forward(inference,
-                flags::rms_norm | flags::use_scale | flags::use_shift);
-        Forward(inference,
-                flags::rms_norm | flags::use_scale | flags::use_shift
-                        | flags::use_global_stats);
+        // RMS normalization on GPU is currently limited to Intel GPUs only
+        // todo: remove the vendor check once supported
+        if (!is_nvidia_gpu(eng) && !is_amd_gpu(eng)) {
+            Forward(inference, flags::rms_norm);
+            Forward(inference,
+                    flags::rms_norm | flags::use_scale | flags::use_shift);
+            Forward(inference,
+                    flags::rms_norm | flags::use_scale | flags::use_shift
+                            | flags::use_global_stats);
+        }
 
         if (!impl::utils::one_of(p.dst_dt, memory::data_type::f16,
                     memory::data_type::s8, memory::data_type::u8)) {
@@ -132,9 +141,9 @@ protected:
                     flags::use_scale | flags::use_shift
                             | flags::use_global_stats);
 
-            // RMS normalization is currently supported only on CPU.
-            // todo: remove the CPU check once other engines are supported
-            if (get_test_engine_kind() == engine::kind::cpu) {
+            // RMS normalization on GPU is currently limited to Intel GPUs only
+            // todo: remove the vendor check once supported
+            if (!is_nvidia_gpu(eng) && !is_amd_gpu(eng)) {
                 Backward(prop_kind::backward, flags::rms_norm);
                 Backward(prop_kind::backward,
                         flags::rms_norm | flags::use_scale | flags::use_shift);

--- a/tests/gtests/test_layer_normalization.cpp
+++ b/tests/gtests/test_layer_normalization.cpp
@@ -100,32 +100,23 @@ protected:
         Forward(training, flags::use_scale | flags::use_shift);
         Forward(training,
                 flags::use_scale | flags::use_shift | flags::use_global_stats);
-
-        // RMS normalization is currently supported only on CPU.
-        // todo: remove the CPU check once other engines are supported
-        if (get_test_engine_kind() == engine::kind::cpu) {
-            Forward(training, flags::rms_norm);
-            Forward(training,
-                    flags::rms_norm | flags::use_scale | flags::use_shift);
-            Forward(training,
-                    flags::rms_norm | flags::use_scale | flags::use_shift
-                            | flags::use_global_stats);
-        }
+        Forward(training, flags::rms_norm);
+        Forward(training,
+                flags::rms_norm | flags::use_scale | flags::use_shift);
+        Forward(training,
+                flags::rms_norm | flags::use_scale | flags::use_shift
+                        | flags::use_global_stats);
 
         Forward(inference);
         Forward(inference, flags::use_global_stats);
         Forward(inference, flags::use_scale | flags::use_shift);
 
-        // RMS normalization is currently supported only on CPU.
-        // todo: remove the CPU check once other engines are supported
-        if (get_test_engine_kind() == engine::kind::cpu) {
-            Forward(inference, flags::rms_norm);
-            Forward(inference,
-                    flags::rms_norm | flags::use_scale | flags::use_shift);
-            Forward(inference,
-                    flags::rms_norm | flags::use_scale | flags::use_shift
-                            | flags::use_global_stats);
-        }
+        Forward(inference, flags::rms_norm);
+        Forward(inference,
+                flags::rms_norm | flags::use_scale | flags::use_shift);
+        Forward(inference,
+                flags::rms_norm | flags::use_scale | flags::use_shift
+                        | flags::use_global_stats);
 
         if (!impl::utils::one_of(p.dst_dt, memory::data_type::f16,
                     memory::data_type::s8, memory::data_type::u8)) {


### PR DESCRIPTION


Implements: https://jira.devtools.intel.com/browse/MFDNN-13581 
- Added GPU support for RMS normalization in layer norm.
- Added skip_mean bool parameter to invoke RMS.
- Extended testing [gtests & benchdnn] with GPU cases.

Following: https://github.com/uxlfoundation/oneDNN/pull/3068