### PR TITLE
Adding fp8 to ukernel documentation

### DIFF
--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -35,7 +35,7 @@ interested in improving application performance on CPUs and GPUs.
    :maxdepth: 1
 
    Key Concepts<dev_guide_basic_concepts>
-   Build oneDNN API Basic Workflow<page_getting_started_cpp>
+   Functional API Basic Workflow<page_getting_started_cpp>
 
 .. toctree::
    :caption: Developer Guide

--- a/doc/ukernel/operations/brgemm.md
+++ b/doc/ukernel/operations/brgemm.md
@@ -33,12 +33,13 @@ is carried in integer arithmetic, C should be of type s32.
 
 The BRGeMM ukernel supports the following combinations of data-types.
 
-| A      | B      | C   | D                           |
-|:-------|:-------|:----|:----------------------------|
-| f32    | f32    | f32 | u8, s8, s32, f32, f16, bf16 |
-| f16    | f16    | f32 | u8, s8, s32, f32, f16, bf16 |
-| bf16   | bf16   | f32 | u8, s8, s32, f32, f16, bf16 |
-| u8, s8 | u8, s8 | s32 | u8, s8, s32, f32, f16, bf16 |
+| A                | B                | C    | D                           |
+|:-----------------|:-----------------|:-----|:----------------------------|
+| f32              | f32              | f32  | u8, s8, s32, f32, f16, bf16 |
+| f16              | f16              | f32  | u8, s8, s32, f32, f16, bf16 |
+| bf16             | bf16             | f32  | u8, s8, s32, f32, f16, bf16 |
+| f8_e4m3, f8_e5m2 | f8_e4m3, f8_e5m2 | f32  | u8, s8, s32, f32, f16, bf16 |
+| u8, s8           | u8, s8           | s32  | u8, s8, s32, f32, f16, bf16 |
 
 ## Data Representation
 

--- a/doc/ukernel/operations/transform.md
+++ b/doc/ukernel/operations/transform.md
@@ -36,13 +36,15 @@ The transform ukernel does not allow data type conversion.
 
 ## Data Representation
 
-| src  | dst  |
-|:-----|:-----|
-| f32  | f32  |
-| f16  | f16  |
-| bf16 | bf16 |
-| s8   | s8   |
-| u8   | u8   |
+| src     | dst     |
+|:------- |:------- |
+| f32     | f32     |
+| f16     | f16     |
+| bf16    | bf16    |
+| f8_e4m3 | f8_e4m3 |
+| f8_e5m2 | f8_e5m2 |
+| s8      | s8      |
+| u8      | u8      |
 
 ## Attributes
 

--- a/src/cpu/x64/cpu_isa_traits.cpp
+++ b/src/cpu/x64/cpu_isa_traits.cpp
@@ -129,10 +129,10 @@ struct isa_info_t {
         switch (isa) {
             case avx10_2_512_amx_2:
                 return "Intel AVX10.2/512 with float16, Intel DL Boost and "
-                       "Intel AMX with bfloat16, float16, float8 and"
+                       "Intel AMX with bfloat16, float16, float8 and "
                        "8-bit integer support";
             case avx10_2_512:
-                return "Intel AVX10.2/512 with float16, Intel DL Boost and"
+                return "Intel AVX10.2/512 with float16, Intel DL Boost and "
                        "bfloat16 support ";
             case avx512_core_amx_fp16:
                 return "Intel AVX-512 with float16, Intel DL Boost and "


### PR DESCRIPTION
This PR documents fp8 support in ukernel API.

Bonus typo fixes:
* Missing spaces in ISA descriptions
* Wording in developer guide index
