### PR TITLE
xe: jit: refactor tensor/tile/coord usage

### DIFF
--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -1623,7 +1623,7 @@ class reorder_2d_impl_t {
     struct reorder_step_t;
 
 public:
-    reorder_2d_impl_t(ngen::HW hw, tensor_t tile, const layout_t &src_layout,
+    reorder_2d_impl_t(ngen::HW hw, tile_t tile, const layout_t &src_layout,
             const layout_t &dst_layout)
         : hw_(hw), tile_(std::move(tile)) {
         gpu_assert(src_layout.type() == dst_layout.type());
@@ -1645,7 +1645,7 @@ public:
         path_ = find_min_cost_path(hw_, src_ab, dst_ab, tile_a, tile_b);
     }
 
-    const tensor_t &tile() const { return tile_; }
+    const tile_t &tile() const { return tile_; }
     const std::vector<reorder_step_t> &path() const { return path_; }
 
     template <typename GeneratorT>
@@ -1684,17 +1684,16 @@ public:
             int x_stride = (x_blocks.empty() ? 1 : int(x_blocks[0].stride));
             int y_stride = (y_blocks.empty() ? 1 : int(y_blocks[0].stride));
             int width = int(tile.elems()) * orig_type.size() / type.size();
-            next_layout->for_each_tile(
-                    tile, [&](const std::vector<dim_t> &start) {
-                        int prev_off = int(prev_layout->offset(start))
-                                * orig_type.bitsize() / type.bitsize();
-                        int next_off = int(next_layout->offset(start))
-                                * orig_type.bitsize() / type.bitsize();
-                        auto x_sub = prev_rd.format(prev_off, to_ngen(type));
-                        auto y_sub = next_rd.format(next_off, to_ngen(type));
-                        emit_reorder_1d_tile(hw_, host, scope, width, x_sub,
-                                x_stride, y_sub, y_stride);
-                    });
+            next_layout->for_each_tile(tile, [&](const icoord_t &start) {
+                int prev_off = prev_layout->offset<int>(start)
+                        * orig_type.bitsize() / type.bitsize();
+                int next_off = next_layout->offset<int>(start)
+                        * orig_type.bitsize() / type.bitsize();
+                auto x_sub = prev_rd.format(prev_off, to_ngen(type));
+                auto y_sub = next_rd.format(next_off, to_ngen(type));
+                emit_reorder_1d_tile(hw_, host, scope, width, x_sub, x_stride,
+                        y_sub, y_stride);
+            });
             prev_layout = next_layout;
             prev_rd = std::move(next_rd);
         }
@@ -1708,7 +1707,7 @@ private:
         edge_t() = default;
         edge_t(int idx, int a, int b) : idx(idx), a(a), b(b) {}
 
-        tensor_t tile() const { return tensor_t({a, b}); }
+        tile_t tile() const { return tile_t(std::vector<dim_t> {a, b}); }
 
         std::string str() const {
             std::ostringstream oss;
@@ -1764,7 +1763,7 @@ private:
         // - Assume at most one block (maybe with non-dense stride)
         // - Horizontal stride must be <= 4 for GRF region
         // - GRF region can't span more than 2 registers
-        bool can_reorder(const tensor_t &tile, const type_t &type) const {
+        bool can_reorder(const tile_t &tile, const type_t &type) const {
             auto ab_layout = layout.map(tile).reinterpret(type);
             int nblocks = int(ab_layout.blocks().size());
             if (nblocks == 0) return true;
@@ -1837,23 +1836,23 @@ private:
     // Represents a reorder step.
     struct reorder_step_t {
         reorder_step_t() = default;
-        reorder_step_t(const layout_t &layout, const tensor_t &tile,
-                const type_t &type)
+        reorder_step_t(
+                const layout_t &layout, const tile_t &tile, const type_t &type)
             : layout(layout), tile(tile), type(type) {}
 
         layout_t layout; // Destination layout.
-        tensor_t tile; // Tile corresponding to one instruction.
+        tile_t tile; // Tile corresponding to one instruction.
         type_t type; // Registers should be reinterpreted to `type` for reorder.
     };
 
     // Extracts dimension sizes and their indices from a multidimensional
     // tensor.
-    static void tile_to_2d_dims(const tensor_t &tile, dim_idx_t &a_idx,
+    static void tile_to_2d_dims(const tile_t &tile, dim_idx_t &a_idx,
             dim_idx_t &b_idx, int &a, int &b) {
         a_idx = dim_idx::invalid;
         b_idx = dim_idx::invalid;
-        for (dim_idx_t i = 0; i < tile.ndims(); i++) {
-            if (tile.dims()[i] == 1) continue;
+        for (dim_idx_t i = 0; i < tile.size(); i++) {
+            if (tile[i] == 1) continue;
             if (a_idx == dim_idx::invalid) {
                 a_idx = i;
                 continue;
@@ -1865,7 +1864,7 @@ private:
             gpu_error_not_expected();
         }
 
-        for (dim_idx_t i = 0; i < tile.ndims(); i++) {
+        for (dim_idx_t i = 0; i < tile.size(); i++) {
             if (utils::one_of(i, a_idx, b_idx)) continue;
             if (a_idx == dim_idx::invalid) {
                 a_idx = i;
@@ -1879,8 +1878,8 @@ private:
 
         if (a_idx > b_idx) std::swap(a_idx, b_idx);
 
-        a = tile.dims()[a_idx];
-        b = tile.dims()[b_idx];
+        a = tile[a_idx];
+        b = tile[b_idx];
     }
 
     // Finds the optimal sequence of reorders between src and dst layouts.
@@ -2062,7 +2061,7 @@ private:
     }
 
     ngen::HW hw_;
-    tensor_t tile_;
+    tile_t tile_;
     layout_t src_;
     layout_t dst_;
     std::vector<reorder_step_t> path_;
@@ -2103,9 +2102,9 @@ private:
         int tile_elems = int(tile.elems());
         auto &src_type = src_layout_.type();
         auto &dst_type = dst_layout_.type();
-        dst_layout_.for_each_tile(tile, [&](const std::vector<dim_t> &start) {
-            int src_off = src_layout_(start);
-            int dst_off = dst_layout_(start);
+        dst_layout_.for_each_tile(tile, [&](const icoord_t &start) {
+            int src_off = src_layout_.offset<int>(start);
+            int dst_off = dst_layout_.offset<int>(start);
             auto sub_src = src_rd.format(src_off, to_ngen(src_type));
             auto sub_dst = dst_rd.format(dst_off, to_ngen(dst_type));
 
@@ -2115,9 +2114,9 @@ private:
         });
     }
 
-    static std::vector<tensor_t> find_2d_dense_tiles(
+    static std::vector<tile_t> find_2d_dense_tiles(
             const layout_t &a, const layout_t &b) {
-        using tile_pair_t = std::array<tensor_t, 2>;
+        using tile_pair_t = std::array<tile_t, 2>;
         static constexpr int max_tile_blocks
                 = reorder_2d_impl_t::max_tile_blocks;
         auto dense_2d_blocks = []() {
@@ -2137,17 +2136,16 @@ private:
             };
         };
 
-        auto take_smaller = [](const tensor_t &a, const tensor_t &b) {
+        auto take_smaller = [](const tile_t &a, const tile_t &b) {
             return a.elems() <= b.elems();
         };
 
-        auto equal_tiles
-                = [](const tile_pair_t &p) { return p[0].is_equal(p[1]); };
+        auto equal_tiles = [](const tile_pair_t &p) { return p[0] == p[1]; };
 
         auto to_single_tile = [](const tile_pair_t &p) { return p[0]; };
 
-        auto all_dims_pow2 = [](const tensor_t &tile) {
-            for (auto d : tile.dims())
+        auto all_dims_pow2 = [](const tile_t &tile) {
+            for (auto d : tile.values())
                 if (!math::is_pow2(d)) return false;
             return true;
         };
@@ -2158,7 +2156,7 @@ private:
                 b.blocks() | filter(dense_2d_blocks()), b.ndims());
         auto tiles = merge(a_tiles, b_tiles, take_smaller) | filter(equal_tiles)
                 | transform(to_single_tile) | filter(all_dims_pow2);
-        std::vector<tensor_t> ret;
+        std::vector<tile_t> ret;
         for (const auto &tile : tiles)
             ret.insert(ret.begin(), tile);
         return ret;
@@ -2177,7 +2175,7 @@ private:
 
         const auto type = to_ngen(src_layout_.type());
         for (const auto &tile : find_2d_dense_tiles(src_layout_, dst_layout_)) {
-            if (tile.ndims() < 2) continue;
+            if (tile.size() < 2) continue;
             if (tile.elems() < 4) break;
             auto src_tile_layout = src_layout_.map(tile);
             auto dst_tile_layout = dst_layout_.map(tile);
@@ -2207,23 +2205,21 @@ private:
             // Skip any 2d reorder that attempts scalar moves
             if (!tile_ok) continue;
 
-            src_layout_.for_each_tile(
-                    tile, [&](const std::vector<dim_t> &start) {
-                        auto src_off = src_layout_.offset<dim_t>(start);
-                        auto dst_off = dst_layout_.offset<dim_t>(start);
-                        auto src_tile_rd = src_rd.format(int(src_off), type);
-                        auto dst_tile_rd = dst_rd.format(int(dst_off), type);
+            src_layout_.for_each_tile(tile, [&](const icoord_t &start) {
+                auto src_off = src_layout_.offset<dim_t>(start);
+                auto dst_off = dst_layout_.offset<dim_t>(start);
+                auto src_tile_rd = src_rd.format(int(src_off), type);
+                auto dst_tile_rd = dst_rd.format(int(dst_off), type);
 
-                        ngen_register_scope_t tile_scope(
-                                scope.register_allocator());
-                        r.emit(host, tile_scope, src_tile_rd, dst_tile_rd);
-                    });
+                ngen_register_scope_t tile_scope(scope.register_allocator());
+                r.emit(host, tile_scope, src_tile_rd, dst_tile_rd);
+            });
             return true;
         }
         return false;
     }
 
-    static tensor_t find_max_tile_with_fixed_stride(const layout_t &src,
+    static tile_t find_max_tile_with_fixed_stride(const layout_t &src,
             const layout_t &dst, int &src_stride, int &dst_stride) {
         // 1. Split layouts to have aligned blocks.
         auto a = src;
@@ -2254,7 +2250,7 @@ private:
             dst_cur_stride = int(bb.block * bb.stride);
             tile_dims[ab.dim_idx] *= ab.block;
         }
-        return tensor_t(tile_dims);
+        return tile_t(tile_dims);
     }
 
     ngen::HW hw_;

--- a/src/gpu/intel/jit/conv/config.hpp
+++ b/src/gpu/intel/jit/conv/config.hpp
@@ -523,7 +523,7 @@ public:
     const std::vector<pvar_t> &index_dims() const override {
         return conv_index_dims(prb().prop_kind());
     }
-    pvar_tile_t shape(bool pad) const override;
+    tile_t shape(bool pad) const override;
 
     std::string blocking_brief_str() const;
 
@@ -661,9 +661,9 @@ public:
     dim_t loop_dim(const pvar_t &d) const { return gemm_loop_.get(d, 1); }
 
 private:
-    pvar_tile_t gemm_iter_;
-    pvar_tile_t gemm_thread_group_;
-    pvar_tile_t gemm_loop_;
+    tile_t gemm_iter_;
+    tile_t gemm_thread_group_;
+    tile_t gemm_loop_;
 };
 
 status_t init_pd_time_cfg(const conv_problem_t &prb, conv_config_t &cfg,
@@ -683,9 +683,8 @@ void init_walk_order(conv_config_t &cfg);
 void init_thread_group_grid(conv_config_t &cfg);
 void prepare_zp_precompute_conv(const conv_problem_t &prb, dim_t *idhw,
         dim_t *odhw, dim_t *pdhw, dim_t *ddhw);
-std::array<pvar_tile_t, 3> get_kernel_grid_conv_dims(const conv_config_t &cfg);
-std::array<pvar_tile_t, 3> get_thread_group_grid_conv_dims(
-        const conv_config_t &cfg);
+std::array<tile_t, 3> get_kernel_grid_conv_dims(const conv_config_t &cfg);
+std::array<tile_t, 3> get_thread_group_grid_conv_dims(const conv_config_t &cfg);
 
 } // namespace jit
 } // namespace intel

--- a/src/gpu/intel/jit/conv/plan.hpp
+++ b/src/gpu/intel/jit/conv/plan.hpp
@@ -88,7 +88,7 @@ struct slm_plan_t : public base_plan_t {
     layout_t b_layout;
     send_plan_t a_g2s_load;
     send_plan_t b_g2s_load;
-    tensor_t x_reduce_tile;
+    tile_coord_t x_reduce_tile_coord;
     reduce_plan_t x_reduce;
     reorder_plan_t a_reorder;
     reorder_plan_t b_reorder;
@@ -131,7 +131,7 @@ struct prefetch_plan_t : public base_plan_t {
 struct x2r_plan_t : public base_plan_t {
     send_plan_t a_load;
     send_plan_t b_load;
-    tensor_t x_reduce_tile;
+    tile_coord_t x_reduce_tile_coord;
     reduce_plan_t x_reduce;
     reorder_plan_t a_reorder;
     reorder_plan_t b_reorder;
@@ -233,11 +233,11 @@ struct conv_plan_t : public base_plan_t {
     conv_plan_t(const hw_t &hw)
         : base_plan_t(hw), slm(hw), prefetch(hw), x2r(hw), fma(hw), zp(hw) {}
 
-    const tensor_t &x_reduce_tile() const {
-        if (!x2r.x_reduce_tile.is_empty()) return x2r.x_reduce_tile;
-        if (!slm.x_reduce_tile.is_empty()) return slm.x_reduce_tile;
+    const tile_coord_t &x_reduce_tile_coord() const {
+        if (!x2r.x_reduce_tile_coord.is_empty()) return x2r.x_reduce_tile_coord;
+        if (!slm.x_reduce_tile_coord.is_empty()) return slm.x_reduce_tile_coord;
         gpu_error_not_expected();
-        return x2r.x_reduce_tile;
+        return x2r.x_reduce_tile_coord;
     }
 
     bool can_split(abc_kind_t abc, int factor) const;

--- a/src/gpu/intel/jit/conv/plan_utils.hpp
+++ b/src/gpu/intel/jit/conv/plan_utils.hpp
@@ -49,9 +49,9 @@ inline std::string add_indent(const std::string &tag, const std::string &s) {
 }
 
 inline layout_t split(const layout_t &layout, int factor) {
-    auto tile = layout.split_exact(factor);
-    if (tile.is_empty()) return layout_t();
-    return layout.map(tile);
+    auto tile_coord = layout.split_exact(factor);
+    if (tile_coord.is_empty()) return layout_t();
+    return layout.map(tile_coord.tile, tile_coord.coord);
 }
 
 } // namespace jit

--- a/src/gpu/intel/jit/conv/problem.cpp
+++ b/src/gpu/intel/jit/conv/problem.cpp
@@ -434,8 +434,8 @@ pvar_t to_gemm(const pvar_t &d, prop_kind_t prop, bool is_transpose) {
     return pvar_t();
 }
 
-pvar_tile_t to_gemm(const pvar_tile_t &t, prop_kind_t prop, bool is_transpose) {
-    pvar_tile_t ret;
+tile_t to_gemm(const tile_t &t, prop_kind_t prop, bool is_transpose) {
+    tile_t ret;
     ret[pvars::b] = 1;
     ret[pvars::m] = 1;
     ret[pvars::n] = 1;

--- a/src/gpu/intel/jit/conv/problem.hpp
+++ b/src/gpu/intel/jit/conv/problem.hpp
@@ -290,12 +290,11 @@ private:
 };
 
 pvar_t to_gemm(const pvar_t &d, prop_kind_t prop, bool is_transpose = false);
-pvar_tile_t to_gemm(
-        const pvar_tile_t &t, prop_kind_t prop, bool is_transpose = false);
+tile_t to_gemm(const tile_t &t, prop_kind_t prop, bool is_transpose = false);
 inline pvar_t to_gemm(const pvar_t &d, const conv_problem_t &prb) {
     return to_gemm(d, prb.prop_kind(), prb.ab_swap_transpose);
 }
-inline pvar_tile_t to_gemm(const pvar_tile_t &t, const conv_problem_t &prb) {
+inline tile_t to_gemm(const tile_t &t, const conv_problem_t &prb) {
     return to_gemm(t, prb.prop_kind(), prb.ab_swap_transpose);
 }
 

--- a/src/gpu/intel/jit/ir/blocking.cpp
+++ b/src/gpu/intel/jit/ir/blocking.cpp
@@ -361,7 +361,7 @@ const tiler_params_t &tiler_params() {
     return params;
 }
 
-tile_to_vec_t::tile_to_vec_t(const std::vector<std::vector<pvar_tile_t>> &tiles,
+tile_to_vec_t::tile_to_vec_t(const std::vector<std::vector<tile_t>> &tiles,
         const std::vector<int> &_ids) {
     if (tiles.empty()) return;
     int ntiles = (int)tiles.size();

--- a/src/gpu/intel/jit/ir/blocking.hpp
+++ b/src/gpu/intel/jit/ir/blocking.hpp
@@ -32,9 +32,9 @@ namespace jit {
 class blocking_t {
 public:
     int simd() const { return simd_; }
-    const pvar_tile_t &loop() const { return loop_; }
-    const pvar_tile_t &thread_group() const { return thread_group_; }
-    const pvar_tile_t &iter() const { return iter_; }
+    const tile_t &loop() const { return loop_; }
+    const tile_t &thread_group() const { return thread_group_; }
+    const tile_t &iter() const { return iter_; }
 
     dim_t loop_dim(const pvar_t &d) const { return loop_[d]; }
     dim_t thread_group_dim(const pvar_t &d) const { return thread_group_[d]; }
@@ -110,7 +110,7 @@ public:
     }
 
     // Returns the ratio of all operations (with padding) to "useful" operations
-    double get_efficiency(const pvar_tile_t &shape) const {
+    double get_efficiency(const tile_t &shape) const {
         double ret = 1;
         for (auto &d : shape) {
             dim_t loop = loop_.get(d, 1);
@@ -127,9 +127,9 @@ public:
 
 private:
     int simd_ = 0;
-    pvar_tile_t loop_;
-    pvar_tile_t thread_group_;
-    pvar_tile_t iter_;
+    tile_t loop_;
+    tile_t thread_group_;
+    tile_t iter_;
 };
 
 struct blocking_hash_t {
@@ -301,7 +301,7 @@ public:
     }
 
     virtual level_tile_set_t make_level_tile_set(
-            const pvar_tile_t &padded_shape) const {
+            const tile_t &padded_shape) const {
         const auto all_dims = dims();
         const int ndims = int(all_dims.size());
         const std::vector<int> deps(ndims, -1);
@@ -398,9 +398,9 @@ private:
     }
 
 protected:
-    pvar_tile_t loop_;
-    pvar_tile_t thread_group_;
-    pvar_tile_t iter_;
+    tile_t loop_;
+    tile_t thread_group_;
+    tile_t iter_;
     std::map<pvar_t, tile_info_t> tile_infos_;
 };
 
@@ -639,7 +639,7 @@ const tiler_params_t &tiler_params();
 class tile_to_vec_t {
 public:
     tile_to_vec_t() = default;
-    tile_to_vec_t(const std::vector<std::vector<pvar_tile_t>> &tiles,
+    tile_to_vec_t(const std::vector<std::vector<tile_t>> &tiles,
             const std::vector<int> &ids = {});
 
     float dist(int id0, int id1) const {
@@ -689,7 +689,7 @@ private:
             dim_mappers_[d].add(value);
         }
 
-        void add(const pvar_tile_t &t) {
+        void add(const tile_t &t) {
             for (auto &d : t) {
                 add(d, t[d]);
             }
@@ -704,7 +704,7 @@ private:
             return dim_mappers_.at(d).to_index(value);
         }
 
-        std::vector<dim_idx_t> to_index(const pvar_tile_t &t) const {
+        std::vector<dim_idx_t> to_index(const tile_t &t) const {
             std::vector<dim_idx_t> ret;
             for (auto &kv : dim_mappers_) {
                 auto &m = kv.second;

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -184,7 +184,7 @@ public:
 
 class tile_param_t : public param_t {
 public:
-    using value_t = pvar_tile_t;
+    using value_t = tile_t;
 
     const value_t &get() const { return tile_; }
 
@@ -195,7 +195,7 @@ public:
     dim_t operator()(const pvar_t &pvar) const { return get(pvar); }
 
     void set_from_str(const std::string &s) override {
-        tile_ = pvar_tile_t();
+        tile_ = tile_t();
         for (auto &kv : ir_utils::to_string_int_pairs(s)) {
             tile_[pvar_t(kv.first)] = kv.second;
         }
@@ -287,7 +287,7 @@ public:
     ~prim_config_t() override = default;
     std::string str() const override = 0;
 
-    virtual pvar_tile_t shape(bool pad) const = 0;
+    virtual tile_t shape(bool pad) const = 0;
     virtual const std::vector<pvar_t> &index_dims() const = 0;
     virtual int pad_block(const pvar_t &d) const = 0;
 
@@ -434,12 +434,12 @@ public:
                 loop_dim(dim) * thread_group_dim(dim) * iter_dim(dim));
     }
 
-    pvar_tile_t dims() const { return shape(/* pad = */ false); }
+    tile_t dims() const { return shape(/* pad = */ false); }
     dim_t dim(const pvar_t &d) const { return dims().get(d); }
 
     int sort_key(const param_t *param) const override;
 
-    void init_kernel_grid(const std::array<pvar_tile_t, 3> &grid) {
+    void init_kernel_grid(const std::array<tile_t, 3> &grid) {
         std::vector<dim_t> dims(grid.size(), 1);
         for (dim_idx_t i = 0; i < grid.size(); i++) {
             for (auto &d : grid[i]) {
@@ -451,7 +451,7 @@ public:
         set_kernel_grid(grid_info_t(dims, ir_builder_t::tg_idx));
     }
 
-    void init_thread_group_grid(const std::array<pvar_tile_t, 3> &grid) {
+    void init_thread_group_grid(const std::array<tile_t, 3> &grid) {
         std::vector<dim_t> dims(grid.size(), 1);
         for (dim_idx_t i = 0; i < grid.size(); i++) {
             for (auto &d : grid[i])

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -1032,8 +1032,18 @@ private:
 
 // Helper functions.
 inline bool is_const(const expr_t &e);
+inline bool is_const(const expr_t &e, int value);
 inline bool is_var(const expr_t &e);
 inline bool all_of(const expr_t &e, const expr_t &value);
+inline bool is_zero(const expr_t &e) {
+    return is_const(e, 0);
+}
+inline bool is_one(const expr_t &e) {
+    return is_const(e, 1);
+}
+inline bool is_minus_one(const expr_t &e) {
+    return is_const(e, -1);
+}
 
 // Unary and binary operators.
 enum class op_kind_t {
@@ -1855,6 +1865,11 @@ inline bool is_binary_cmp_op(const expr_t &e) {
 
 inline bool is_const(const expr_t &e) {
     return e.is<bool_imm_t>() || e.is<int_imm_t>() || e.is<float_imm_t>();
+}
+
+inline bool is_const(const expr_t &e, int value) {
+    if (!is_const(e)) return false;
+    return e.is_equal(to_expr(value, e.type()));
 }
 
 inline bool all_of(const expr_t &e, const expr_t &value) {

--- a/src/gpu/intel/jit/ir/epilogue.hpp
+++ b/src/gpu/intel/jit/ir/epilogue.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ namespace jit {
 
 stmt_t create_epilogue_stmt(const exec_config_t &exec_cfg, ir_context_t &ir_ctx,
         const gemm_schedule_t &gemm_schedule, bool force_c_reorder,
-        const post_op_context_t &post_op_ctx, const tensor_t &thr_tile,
-        const layout_t &c_reg_layout, const expr_t &c_mem_buf,
-        const expr_t &c_reg_buf, int &c_reg_buf_size);
+        const post_op_context_t &post_op_ctx,
+        const tile_coord_t &thr_tile_coord, const layout_t &c_reg_layout,
+        const expr_t &c_mem_buf, const expr_t &c_reg_buf, int &c_reg_buf_size);
 
 } // namespace jit
 } // namespace intel

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -120,8 +120,10 @@ bool dpas_t::matches(const multiply_desc_t &desc) const {
 
     if (desc.m() % m_blk != 0 || desc.k() % k_blk != 0) return false;
 
-    auto a_blk_layout = desc.a_layout().map(tensor_t({m_blk, k_blk}));
-    auto b_blk_layout = desc.b_layout().map(tensor_t({k_blk, n_blk}));
+    auto a_blk_layout
+            = desc.a_layout().map(tile_t(std::vector<dim_t> {m_blk, k_blk}));
+    auto b_blk_layout
+            = desc.b_layout().map(tile_t(std::vector<dim_t> {k_blk, n_blk}));
 
     if (a_blk_layout != a_layout()) return false;
     if (b_blk_layout != b_layout()) return false;

--- a/src/gpu/intel/jit/ir/ir.cpp
+++ b/src/gpu/intel/jit/ir/ir.cpp
@@ -745,24 +745,6 @@ expr_t cast(const expr_t &e, const type_t &type, bool saturate) {
     return const_fold(cast_t::make(type, e, saturate));
 }
 
-bool is_zero(const expr_t &e) {
-    if (e.is_empty()) return false;
-    if (!e.type().is_scalar() || e.type().is_ptr()) return false;
-    return e.is_equal(to_expr(0, e.type()));
-}
-
-bool is_one(const expr_t &e) {
-    if (e.is_empty()) return false;
-    if (!e.type().is_scalar() || e.type().is_ptr()) return false;
-    return e.is_equal(to_expr(1, e.type()));
-}
-
-bool is_minus_one(const expr_t &e) {
-    if (e.is_empty()) return false;
-    if (!e.type().is_scalar() || e.type().is_ptr()) return false;
-    return e.is_equal(to_expr(-1, e.type()));
-}
-
 bool is_const_broadcast(const expr_t &e) {
     auto *shuffle = e.as_ptr<shuffle_t>();
     if (!shuffle) return false;

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -504,12 +504,6 @@ expr_t min(const expr_t &a, const expr_t &b);
 
 expr_t cast(const expr_t &e, const type_t &type, bool saturate = false);
 
-bool is_zero(const expr_t &e);
-
-bool is_one(const expr_t &e);
-
-bool is_minus_one(const expr_t &e);
-
 bool is_const_broadcast(const expr_t &e);
 
 bool is_const_broadcast(const expr_t &e, const expr_t &value);

--- a/src/gpu/intel/jit/ir/message.hpp
+++ b/src/gpu/intel/jit/ir/message.hpp
@@ -495,8 +495,9 @@ private:
             bool transpose, bool use_xy, int &W, int &H, int &P, int &w, int &h,
             int &c, int &vnni_permute_factor);
 
-    bool check_2d_mask(const tensor_t &tile, bool use_virtual_surface,
-            dim_idx_t w_idx, dim_idx_t h_idx, expr_t &mask) const;
+    bool check_2d_mask(const tile_t &tile, const coord_t &coord,
+            bool use_virtual_surface, dim_idx_t w_idx, dim_idx_t h_idx,
+            expr_t &mask) const;
 
     std::vector<layout_t> candidate_payload_layouts() const;
     stmt_t create_send_stmt(

--- a/src/gpu/intel/jit/ir/post_ops.cpp
+++ b/src/gpu/intel/jit/ir/post_ops.cpp
@@ -277,9 +277,9 @@ bool post_op_context_t::init_need_to_restore_zero_padding(
                                 alg_kind::binary_max, alg_kind::binary_gt,
                                 alg_kind::binary_lt, alg_kind::binary_ne);
 
-                uint32_t rhs_mask
-                        = utils::get_dims_mask(cp_view().vdims().data(),
-                                po.binary.src1_desc.dims, cp_ndims());
+                uint32_t rhs_mask = utils::get_dims_mask(
+                        cp_view().vdims().values().data(),
+                        po.binary.src1_desc.dims, cp_ndims());
                 if ((rhs_mask & (1 << j)) == 0 && !zero_op_x_ok) return true;
                 if (!zero_op_zero_ok) return true;
             }

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -192,9 +192,10 @@ public:
 
     bool do_convert() const { return do_convert_; }
 
-    post_op_tensor_info_t create_sub_tensor(const tensor_t &tile) const {
+    post_op_tensor_info_t create_sub_tensor(
+            const tile_t &tile, const coord_t &coord) const {
         auto ret = *this;
-        ret.view_ = ret.view_.create_sub_view(tile);
+        ret.view_ = ret.view_.create_sub_view(tile, coord);
         return ret;
     }
 
@@ -238,7 +239,7 @@ public:
     const view_t &cp_view() const { return cp_view_; };
 
     virtual view_t create_view(const type_t &type, uint32_t rhs_mask) const {
-        std::vector<dim_t> rhs_dims = cp_view_.vdims();
+        std::vector<dim_t> rhs_dims = cp_view_.vdims().values();
         uint32_t bound_check_mask = 0;
         for (int i = 0; i < int(rhs_dims.size()); i++) {
             if ((rhs_mask & (1 << i)) == 0) {

--- a/src/gpu/intel/jit/ir/problem.hpp
+++ b/src/gpu/intel/jit/ir/problem.hpp
@@ -269,12 +269,7 @@ private:
 
 class pvar_tile_t : public pvar_map_t<dim_t> {
 public:
-    using pvar_map_t<dim_t>::at;
     using pvar_map_t<dim_t>::pvar_map_t;
-    using pvar_map_t<dim_t>::has;
-    using pvar_map_t<dim_t>::operator[];
-    using pvar_map_t<dim_t>::str_impl;
-    using pvar_map_t<dim_t>::get_hash;
 
     dim_t elems() const {
         dim_t ret = 1;

--- a/src/gpu/intel/jit/ir/reduce.hpp
+++ b/src/gpu/intel/jit/ir/reduce.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -56,8 +56,9 @@ private:
 };
 
 stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
-        const expr_t &src_buf, const expr_t &dst_buf, const tensor_t &_subtile,
-        uint32_t reduction_mask, bool drop_dims = true);
+        const expr_t &src_buf, const expr_t &dst_buf,
+        const tile_coord_t &_sub_tile_coord, uint32_t reduction_mask,
+        bool drop_dims = true);
 
 stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
         const expr_t &src_buf, const expr_t &dst_buf);

--- a/src/gpu/intel/jit/ir/slm_reduce_builder.hpp
+++ b/src/gpu/intel/jit/ir/slm_reduce_builder.hpp
@@ -36,13 +36,13 @@ public:
 
     slm_reduce_builder_t(ir_context_t &ir_ctx, const grid_info_t &tg_grid,
             const expr_t &reg_buf, const layout_t &reg_layout,
-            const tensor_t &thr_tile, dim_idx_t dim = 2);
+            const tile_coord_t &thr_tile_coord, dim_idx_t dim = 2);
 
     bool is_empty() const { return reg_buf_.is_empty(); }
 
     const layout_t &reg_layout() const { return reg_layout_; }
 
-    const tensor_t &thr_tile() const { return thr_tile_; }
+    const tile_coord_t &thr_tile_coord() const { return thr_tile_coord_; }
 
     const stmt_t &store_stmt() const { return store_stmt_; }
 
@@ -79,7 +79,7 @@ private:
 
     expr_t reg_buf_;
     layout_t reg_layout_;
-    tensor_t thr_tile_;
+    tile_coord_t thr_tile_coord_;
 
     dim_idx_t dim_ = -1;
 

--- a/src/gpu/intel/jit/ir/walk_order.hpp
+++ b/src/gpu/intel/jit/ir/walk_order.hpp
@@ -139,7 +139,7 @@ public:
         return false;
     }
 
-    void finalize(const pvar_tile_t &grid_tile) {
+    void finalize(const tile_t &grid_tile) {
         for (auto &d : grid_tile) {
             int inner_block = 1;
             for (auto &b : blocks_) {

--- a/src/gpu/intel/jit/pass/slm.cpp
+++ b/src/gpu/intel/jit/pass/slm.cpp
@@ -119,11 +119,11 @@ private:
         layout_iterator_t src_it(src);
         layout_iterator_t dst_it(dst);
 
-        tensor_t max_tile;
+        tile_t max_tile;
         for (;;) {
             auto src_tile = src_it.tile();
             auto dst_tile = dst_it.tile();
-            if (src_tile.is_equal(dst_tile)) {
+            if (src_tile == dst_tile) {
                 auto s = src.map(src_it.tile());
                 auto d = dst.map(dst_it.tile());
                 if (s.is_dense() && d.is_dense()
@@ -151,7 +151,7 @@ private:
         return create_slm_reorder(max_tile, src, dst, src_buf, dst_buf);
     }
 
-    stmt_t create_slm_reorder(const tensor_t &tile, const layout_t &src,
+    stmt_t create_slm_reorder(const tile_t &tile, const layout_t &src,
             const layout_t &dst, const expr_t &src_buf, const expr_t &dst_buf) {
         auto src_tile = src.map(tile);
         auto &src_tile_blocks = src_tile.blocks();
@@ -182,8 +182,8 @@ private:
 
         stmt_t store_stmt;
         stmt_t load_stmt;
-        src.for_each_tile(tile, [&](const std::vector<dim_t> &start) {
-            expr_t off = (int)src.offset_in_bytes(start);
+        src.for_each_tile(tile, [&](const icoord_t &start) {
+            expr_t off = src.offset_in_bytes(start);
             auto store = store_send.call({slm_base_,
                     shuffle_t::make_broadcast(off0 + off, simd) + vec_off,
                     src_buf + off, expr_t()});

--- a/src/gpu/intel/jit/pooling/config.hpp
+++ b/src/gpu/intel/jit/pooling/config.hpp
@@ -127,14 +127,14 @@ public:
         set_exec_cfg(ec);
     }
 
-    pvar_tile_t shape(bool pad) const override {
+    tile_t shape(bool pad) const override {
 #define SET(g_name, l_name) \
     ret[pvars::g_name] = (pad) \
             ? utils::rnd_up(prb.l_name, pad_block(pvars::g_name)) \
             : prb.l_name
 
         const auto &prb = pooling_problem();
-        pvar_tile_t ret;
+        tile_t ret;
         SET(mb, mb);
         SET(oc, c);
         if (is_fwd()) {

--- a/src/gpu/intel/jit/reorder/config.cpp
+++ b/src/gpu/intel/jit/reorder/config.cpp
@@ -48,17 +48,17 @@ reorder_config_t::reorder_config_t(
     dim_idx_t ndims = src.ndims();
     const auto &thr_tile = tiles_.front();
 
-    pvar_tile_t iter_tile;
-    pvar_tile_t loop_tile;
-    pvar_tile_t tg_tile;
+    tile_t iter_tile;
+    tile_t loop_tile;
+    tile_t tg_tile;
 
-    pvar_tile_t dims;
+    tile_t dims;
     dim_idx_t grid_idx = 0;
 
     for (dim_idx_t i = 0; i < ndims; ++i) {
         pvar_t &d = reorder::pvars[i];
 
-        dim_t tg_dim = thr_tile(i);
+        dim_t tg_dim = thr_tile[i];
         dim_t outer = utils::div_up(dst.dim(i), tg_dim);
         iter_tile[d] = tg_dim;
         loop_tile[d] = 1;
@@ -70,7 +70,7 @@ reorder_config_t::reorder_config_t(
 
     for (dim_idx_t i = 0; i < ndims; ++i) {
         pvar_t &d = reorder::pvars[i];
-        dim_t tg_dim = thr_tile(i);
+        dim_t tg_dim = thr_tile[i];
         dim_t outer = utils::div_up(dims[d], tg_dim);
 
         if (outer % 2 == 0) {

--- a/src/gpu/intel/jit/reorder/config.hpp
+++ b/src/gpu/intel/jit/reorder/config.hpp
@@ -43,7 +43,7 @@ public:
         return ss.str();
     }
 
-    pvar_tile_t shape(bool pad) const override { return {}; };
+    tile_t shape(bool pad) const override { return {}; };
 
     const std::vector<pvar_t> &index_dims() const override {
         static const std::vector<pvar_t> null {};
@@ -54,14 +54,14 @@ public:
 
     int simd() const { return exec_cfg().simd(); }
     compute::nd_range_t nd_range() const;
-    const std::vector<tensor_t> &tiles() const { return tiles_; }
-    const std::array<pvar_tile_t, 3> &grid() const { return grid_; }
+    const std::vector<tile_t> &tiles() const { return tiles_; }
+    const std::array<tile_t, 3> &grid() const { return grid_; }
 
     reorder_config_t(const exec_config_t &ec, layout_t src, layout_t dst);
 
 private:
-    std::vector<tensor_t> tiles_;
-    std::array<pvar_tile_t, 3> grid_;
+    std::vector<tile_t> tiles_;
+    std::array<tile_t, 3> grid_;
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -180,7 +180,7 @@ status_t gen_reorder_t::pd_t::init(impl::engine_t *engine,
     cfg->set_zp_cfg(zp_cfg);
 
     auto count_inner_elems = [&](const layout_t &layout) {
-        auto dims = cfg->tiles().front().dims();
+        auto dims = cfg->tiles().front().values();
         dim_t contiguous_inner_elems = 1;
         for (auto &b : layout.blocks()) {
             if (b.block == 1) continue;

--- a/src/gpu/intel/jit/reorder/ir_builder.hpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.hpp
@@ -46,7 +46,7 @@ public:
 
 private:
     void build() override;
-    bool try_build(const pvar_tile_t &iter_tile, const pvar_tile_t &loop_tile);
+    bool try_build(const tile_t &iter_tile, const tile_t &loop_tile);
 
     const reorder_config_t &cfg_;
     const kernel_info_t &kernel_info_;

--- a/src/gpu/intel/jit/reorder/tiler.hpp
+++ b/src/gpu/intel/jit/reorder/tiler.hpp
@@ -28,7 +28,7 @@ namespace intel {
 namespace jit {
 namespace reorder {
 
-std::vector<tensor_t> tiles(const hw_t &hw, layout_t a, layout_t b);
+std::vector<tile_t> tiles(const hw_t &hw, layout_t a, layout_t b);
 
 } // namespace reorder
 } // namespace jit

--- a/src/gpu/intel/jit/utils/iterator.hpp
+++ b/src/gpu/intel/jit/utils/iterator.hpp
@@ -235,10 +235,10 @@ public:
             return operator++();
         }
 
-        tensor_t operator*() const {
+        tile_t operator*() const {
             auto dims = dims_;
             dims[(*it_).dim_idx] *= factor();
-            return tensor_t(dims);
+            return tile_t(dims);
         }
 
         iterator_t(const inner_iter_t &it, const inner_iter_t &end, int ndims)

--- a/src/gpu/intel/jit/v2/conv/bridge.hpp
+++ b/src/gpu/intel/jit/v2/conv/bridge.hpp
@@ -34,8 +34,8 @@ namespace jit {
 namespace v2 {
 namespace conv {
 
-inline pvar_tile_t to_shape(const convolution_pd_t *pd) {
-    pvar_tile_t shape;
+inline tile_t to_shape(const convolution_pd_t *pd) {
+    tile_t shape;
     shape[pvars::mb] = pd->MB();
     shape[pvars::ic] = ir_utils::safe_div(pd->IC(), pd->G());
     shape[pvars::oc] = ir_utils::safe_div(pd->OC(), pd->G());
@@ -166,7 +166,7 @@ inline jit::layout_t to_conv_layout(const layout_tag_t &_tag,
 }
 
 inline jit::layout_t to_conv_layout(
-        const layout_tag_t &_tag, const pvar_tile_t &shape) {
+        const layout_tag_t &_tag, const tile_t &shape) {
     int ndims = _tag.desc().ndims();
     const auto &tag = _tag.raw_tag();
     std::vector<dim_t> dims(ndims);
@@ -177,8 +177,7 @@ inline jit::layout_t to_conv_layout(
     return jit::layout_t(_tag.type(), expr_t(0), tag.str(), dims);
 }
 
-inline jit::grid_info_t to_grid_info(
-        const grid_t &grid, const pvar_tile_t &tile) {
+inline jit::grid_info_t to_grid_info(const grid_t &grid, const tile_t &tile) {
     std::vector<dim_t> dims;
     std::vector<expr_t> idxs;
     for (int i = 0; i < grid_t::N; i++) {

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -81,9 +81,9 @@ GPU_DEFINE_PARSE_ENUM(specialization_mode_t, specialization_mode_names)
 struct specialization_t {
     specialization_mode_t mode = specialization_mode_t::none;
     // Dimension values to specialize (e.g. kw1).
-    pvar_tile_t dim_values;
+    tile_t dim_values;
     // Dimension modulus to specialize (e.g. oc@64)
-    pvar_tile_t dim_mods;
+    tile_t dim_mods;
 
     // Whether the specialization depends on the problem dimensions, meaning
     // that specialize() must be called.
@@ -283,9 +283,9 @@ public:
     fma_kind_t fma = fma_kind_t::undef;
     int simd = 0;
     int regs = 0;
-    pvar_tile_t iter_tile;
-    pvar_tile_t iter_outer_tile;
-    pvar_tile_t thread_group_tile;
+    tile_t iter_tile;
+    tile_t iter_outer_tile;
+    tile_t thread_group_tile;
     loop_desc_t loop_desc;
 
     bool use_stream_k = false;
@@ -455,7 +455,7 @@ public:
         return ret;
     }
 
-    size_t size(size_t idx, const pvar_tile_t &tile) const {
+    size_t size(size_t idx, const tile_t &tile) const {
         gpu_assert(idx < N);
         size_t ret = 1;
         for (auto &d : entries_[idx].dims) {

--- a/src/gpu/intel/jit/v2/conv/kernel_desc_2d_reqs.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc_2d_reqs.cpp
@@ -96,9 +96,9 @@ struct block_2d_params_t {
 };
 
 block_2d_params_t to_block_2d_params(const prop_kind_t &prop,
-        const tensor_kind_t &tensor_kind, int type_size,
-        const pvar_tile_t &tg_tile, const pvar_tile_t &iter_tile,
-        const pvar_map_t<stride_t> &strides, const prb_reqs_t &reqs) {
+        const tensor_kind_t &tensor_kind, int type_size, const tile_t &tg_tile,
+        const tile_t &iter_tile, const pvar_map_t<stride_t> &strides,
+        const prb_reqs_t &reqs) {
     bool is_fwd = (prop == prop_kind::forward);
     bool is_bwd_d = (prop == prop_kind::backward_data);
     bool is_bwd_w = (prop == prop_kind::backward_weights);

--- a/src/gpu/intel/jit/v2/conv/model.cpp
+++ b/src/gpu/intel/jit/v2/conv/model.cpp
@@ -73,8 +73,8 @@ std::vector<std::string> feature_names(model_kind_t kind) {
     return std::vector<std::string>();
 }
 
-void to_bmnk(prop_kind_t prop, const pvar_tile_t &tile, dim_t &b, dim_t &m,
-        dim_t &n, dim_t &k) {
+void to_bmnk(prop_kind_t prop, const tile_t &tile, dim_t &b, dim_t &m, dim_t &n,
+        dim_t &k) {
     const auto t = to_gemm(tile, prop);
     b = t[pvars::b];
     m = t[pvars::m];
@@ -122,7 +122,7 @@ struct bmnk_helper_t {
 dim_t layout_size(const layout_tag_t &tag, const problem_t &prb) {
     gpu_assert(!tag.is_any() && !tag.is_empty())
             << "Unexpected tag: " << tag.str();
-    pvar_tile_t tile;
+    tile_t tile;
     for (auto &d : tag.desc().letter_map())
         tile[d] = prb.shape().at(d);
     dim_t elems = 1;

--- a/src/gpu/intel/jit/v2/conv/plan.hpp
+++ b/src/gpu/intel/jit/v2/conv/plan.hpp
@@ -97,9 +97,9 @@ public:
         return entries_.at(dim).loop_idx;
     }
 
-    pvar_coord_t<expr_t> iter_coord() const;
-    pvar_coord_t<expr_t> tg_iter_coord() const;
-    pvar_tile_t tg_iter_tile() const;
+    coord_t iter_coord() const;
+    coord_t tg_iter_coord() const;
+    tile_t tg_iter_tile() const;
 
     std::string str() const {
         std::ostringstream oss;
@@ -231,7 +231,7 @@ struct fma_plan_t : public base_plan_t {
     layout_t a_layout;
     layout_t b_layout;
     layout_t c_layout;
-    pvar_tile_t inst_tile;
+    tile_t inst_tile;
     fma_kind_t fma = fma_kind_t::undef;
     int simd = 0;
 
@@ -279,7 +279,7 @@ struct x2r_fma_plan_t : public base_plan_t {
         }
     };
 
-    pvar_tile_t outer;
+    tile_t outer;
     layout_t c_layout;
     layout_t bias_layout;
     std::vector<stage_t> stages;
@@ -334,7 +334,7 @@ struct slm_reduce_plan_t : public base_plan_t {
     // C layout and tile coordinate after reduction and redistribution in
     // threadgroup.
     layout_t c_layout;
-    pvar_coord_t<expr_t> c_coord;
+    coord_t c_coord;
 
     using base_plan_t::base_plan_t;
 
@@ -364,7 +364,7 @@ struct slm_reduce_plan_t : public base_plan_t {
 };
 
 struct epilogue_store_plan_t : public base_plan_t {
-    pvar_tile_t tile;
+    tile_t tile;
     reorder_plan_t reorder;
     reorder_plan_t bias_reorder;
     send_plan_t c_store;
@@ -390,7 +390,7 @@ struct epilogue_store_plan_t : public base_plan_t {
 struct epilogue_plan_t : public base_plan_t {
     slm_reduce_plan_t slm_reduce;
     layout_t c_reg_layout;
-    pvar_coord_t<expr_t> c_coord;
+    coord_t c_coord;
     layout_t bias_layout;
     expr_t bias_reduce_cond;
 

--- a/src/gpu/intel/jit/v2/conv/planner/bench.hpp
+++ b/src/gpu/intel/jit/v2/conv/planner/bench.hpp
@@ -65,7 +65,7 @@ struct bench_input_params_t {
     prb_reqs_t reqs;
     bool is_dw = false;
     type_t bias_type;
-    pvar_tile_t tile;
+    tile_t tile;
     int nprbs = 0;
 
     bench_input_params_t() = default;

--- a/src/gpu/intel/jit/v2/conv/problem.cpp
+++ b/src/gpu/intel/jit/v2/conv/problem.cpp
@@ -42,7 +42,7 @@ const type_t &problem_t::out_type() const {
 
 void problem_t::set_shape(const std::string &s) {
     gpu_assert(prop_ != prop_kind::undef);
-    pvar_tile_t s_tile(s);
+    tile_t s_tile(s);
     bool has_d = has_spatial(s_tile, 'd');
     bool has_h = has_spatial(s_tile, 'h');
     bool has_w = has_spatial(s_tile, 'w');
@@ -184,9 +184,9 @@ std::string problem_t::csv_str() const {
     return oss.str();
 }
 
-pvar_tile_t problem_t::default_shape() {
-    static pvar_tile_t _default_shape = []() {
-        static pvar_tile_t ret;
+tile_t problem_t::default_shape() {
+    static tile_t _default_shape = []() {
+        static tile_t ret;
         ret[pvars::g] = 1;
         ret[pvars::mb] = 1;
         ret[pvars::id] = ret[pvars::ih] = ret[pvars::iw] = 1;
@@ -203,7 +203,7 @@ pvar_tile_t problem_t::default_shape() {
     return _default_shape;
 }
 
-double problem_t::ops(prop_kind_t prop, const pvar_tile_t &shape) {
+double problem_t::ops(prop_kind_t prop, const tile_t &shape) {
 #define GET(name) shape[pvars::name]
     double ret = 2.0;
     ret *= (double)GET(g) * GET(mb) * GET(oc) * GET(ic);

--- a/src/gpu/intel/jit/v2/conv/problem.hpp
+++ b/src/gpu/intel/jit/v2/conv/problem.hpp
@@ -51,7 +51,7 @@ public:
         }
         return src_tag_;
     }
-    const pvar_tile_t &shape() const { return shape_; }
+    const tile_t &shape() const { return shape_; }
     bool with_groups() const { return with_groups_; }
     bool with_scales() const { return with_scales_; }
     bool with_post_ops() const { return with_post_ops_; }
@@ -72,7 +72,7 @@ public:
     void set_wei_tag(const layout_tag_t &tag) { wei_tag_ = tag; }
     void set_dst_tag(const layout_tag_t &tag) { dst_tag_ = tag; }
     void set_bias_type(const type_t &bias_type) { bias_type_ = bias_type; }
-    void set_shape(const pvar_tile_t &shape) { shape_ = shape; }
+    void set_shape(const tile_t &shape) { shape_ = shape; }
     void set_with_groups(bool value) { with_groups_ = value; }
     void set_with_scales(bool value) { with_scales_ = value; }
     void set_with_post_ops(bool value) { with_post_ops_ = value; }
@@ -93,8 +93,8 @@ public:
 
     IR_DEFINE_DUMP()
 
-    static pvar_tile_t default_shape();
-    static double ops(prop_kind_t prop, const pvar_tile_t &shape);
+    static tile_t default_shape();
+    static double ops(prop_kind_t prop, const tile_t &shape);
 
 private:
     hw_t hw_;
@@ -103,7 +103,7 @@ private:
     layout_tag_t wei_tag_;
     layout_tag_t dst_tag_;
     type_t bias_type_;
-    pvar_tile_t shape_;
+    tile_t shape_;
     std::array<int, 3> dhw_map_ = {0};
     bool with_groups_ = false;
     bool with_scales_ = false;

--- a/src/gpu/intel/jit/v2/conv/tensor_utils.cpp
+++ b/src/gpu/intel/jit/v2/conv/tensor_utils.cpp
@@ -410,7 +410,7 @@ dim_mapper_t extend_mapper(
 }
 
 std::vector<pvar_t> skip_mask(
-        const view_t &view, const pvar_tile_t &tile, const prb_reqs_t &reqs) {
+        const view_t &view, const tile_t &tile, const prb_reqs_t &reqs) {
     std::vector<pvar_t> ret;
     auto &mask_desc = view.mask_desc();
     auto dim_sizes = view.base_layout().dim_sizes();

--- a/src/gpu/intel/jit/v2/conv/tensor_utils.hpp
+++ b/src/gpu/intel/jit/v2/conv/tensor_utils.hpp
@@ -75,7 +75,7 @@ dim_mapper_t extend_mapper(
         const dim_mapper_t &mapper, const pvar_t &extra_dim, char letter);
 
 std::vector<pvar_t> skip_mask(
-        const view_t &view, const pvar_tile_t &tile, const prb_reqs_t &reqs);
+        const view_t &view, const tile_t &tile, const prb_reqs_t &reqs);
 
 } // namespace conv
 } // namespace v2

--- a/src/gpu/intel/jit/v2/ir/builder.cpp
+++ b/src/gpu/intel/jit/v2/ir/builder.cpp
@@ -152,8 +152,8 @@ type_t to_send_type(const send_1d_desc_t &desc) {
 }
 
 stmt_t create_stmt(const send_1d_plan_t &plan, const expr_t &mem_buf,
-        const expr_t &reg_buf, offset_ctx_t &off_ctx,
-        const pvar_coord_t<dim_t> &coord, const pvar_tile_t &tile) {
+        const expr_t &reg_buf, offset_ctx_t &off_ctx, const coord_t &coord,
+        const tile_t &tile) {
     for (auto &d : plan.entry_tile) {
         gpu_assert(tile.at(d) % plan.entry_tile.at(d) == 0);
     }
@@ -165,7 +165,7 @@ stmt_t create_stmt(const send_1d_plan_t &plan, const expr_t &mem_buf,
             plan.hw, op, address, type, slots, /*zero_out=*/true);
     auto &send = send_func.as<send_t>();
     stmt_t ret;
-    for_each(tile, plan.entry_tile, [&](const pvar_coord_t<dim_t> &sub_coord) {
+    for_each(tile, plan.entry_tile, [&](const coord_t &sub_coord) {
         int entry_idx = plan.reg_layout.to_linear_index(
                 plan.entry_tile, coord + sub_coord);
         auto &e = plan.entries[entry_idx];
@@ -186,8 +186,8 @@ stmt_t create_stmt(const send_1d_plan_t &plan, const expr_t &mem_buf,
 }
 
 stmt_t create_stmt(const send_2d_plan_t &plan, const expr_t &mem_buf,
-        const expr_t &reg_buf, offset_ctx_t &off_ctx,
-        const pvar_coord_t<dim_t> &coord, const pvar_tile_t &tile) {
+        const expr_t &reg_buf, offset_ctx_t &off_ctx, const coord_t &coord,
+        const tile_t &tile) {
     auto op = to_ir(plan.desc.op, /*is_2d=*/true);
     auto &type = plan.desc.type;
     auto &desc = plan.desc;
@@ -195,7 +195,7 @@ stmt_t create_stmt(const send_2d_plan_t &plan, const expr_t &mem_buf,
             desc.c, desc.vnni, desc.transpose, /*zero_out=*/true);
     auto &send = send_func.as<send_t>();
     stmt_t ret;
-    for_each(tile, plan.entry_tile, [&](const pvar_coord_t<dim_t> &sub_coord) {
+    for_each(tile, plan.entry_tile, [&](const coord_t &sub_coord) {
         int entry_idx = plan.reg_layout.to_linear_index(
                 plan.entry_tile, coord + sub_coord);
         auto &e = plan.entries[entry_idx];
@@ -215,8 +215,8 @@ stmt_t create_stmt(const send_2d_plan_t &plan, const expr_t &mem_buf,
 }
 
 stmt_t create_stmt(const send_plan_t &plan, const expr_t &mem_buf,
-        const expr_t &reg_buf, offset_ctx_t &off_ctx,
-        const pvar_coord_t<dim_t> &coord, const pvar_tile_t &tile) {
+        const expr_t &reg_buf, offset_ctx_t &off_ctx, const coord_t &coord,
+        const tile_t &tile) {
     if (plan.is_1d())
         return create_stmt(plan._1d, mem_buf, reg_buf, off_ctx, coord, tile);
     if (plan.is_2d())

--- a/src/gpu/intel/jit/v2/ir/builder.hpp
+++ b/src/gpu/intel/jit/v2/ir/builder.hpp
@@ -441,12 +441,12 @@ inline stmt_t create_stmt(const reorder_plan_t &plan, const expr_t &src_buf,
 }
 
 stmt_t create_stmt(const send_plan_t &plan, const expr_t &mem_buf,
-        const expr_t &reg_buf, offset_ctx_t &off_ctx,
-        const pvar_coord_t<dim_t> &coord, const pvar_tile_t &tile);
+        const expr_t &reg_buf, offset_ctx_t &off_ctx, const coord_t &coord,
+        const tile_t &tile);
 
 inline stmt_t create_stmt(const send_plan_t &plan, const expr_t &mem_buf,
         const expr_t &reg_buf, offset_ctx_t &off_ctx) {
-    return create_stmt(plan, mem_buf, reg_buf, off_ctx, pvar_coord_t<dim_t>(),
+    return create_stmt(plan, mem_buf, reg_buf, off_ctx, coord_t(),
             plan.reg_layout().int_dim_sizes());
 }
 
@@ -572,8 +572,7 @@ public:
     }
 
     void store(const send_plan_t &plan, const expr_t &mem_buf,
-            const expr_t &reg_buf, const pvar_coord_t<dim_t> &coord,
-            const pvar_tile_t &tile) {
+            const expr_t &reg_buf, const coord_t &coord, const tile_t &tile) {
         auto store_stmt
                 = create_stmt(plan, mem_buf, reg_buf, off_ctx_, coord, tile);
         emit(store_stmt);
@@ -603,7 +602,7 @@ public:
     void reduce(const layout_t &src, const layout_t &dst, const expr_t &src_buf,
             const expr_t &dst_buf, uint32_t mask) {
         auto stmt = create_reduce_stmt(
-                to_ir(src), to_ir(dst), src_buf, dst_buf, tensor_t(), mask);
+                to_ir(src), to_ir(dst), src_buf, dst_buf, tile_t(), mask);
         emit(stmt);
     }
 

--- a/src/gpu/intel/jit/v2/ir/send.cpp
+++ b/src/gpu/intel/jit/v2/ir/send.cpp
@@ -55,8 +55,8 @@ bool process_coef_y_stride(
     return false;
 }
 
-bool adjust_for_non_unit_y_stride(plane_t &plane,
-        const pvar_coord_t<expr_t> &coord, const prover_t &prover) {
+bool adjust_for_non_unit_y_stride(
+        plane_t &plane, const coord_t &coord, const prover_t &prover) {
     if (is_one(plane.y_stride)) return true;
     auto y_stride_dim = pvar_t::from_var(plane.y_stride);
     if (y_stride_dim.is_undef()) return false;

--- a/src/gpu/intel/jit/v2/ir/send.hpp
+++ b/src/gpu/intel/jit/v2/ir/send.hpp
@@ -408,7 +408,7 @@ struct send_1d_entry_t {
     expr_t addr_inc;
     std::vector<expr_t> mask_incs; // Per dimension mask.
     int reg_off = 0;
-    pvar_coord_t<dim_t> coord;
+    coord_t coord;
 
     std::string str() const {
         using namespace ir_utils;
@@ -426,7 +426,7 @@ struct send_1d_plan_t : public base_plan_t {
     mask_t mask;
     std::vector<send_1d_entry_t> entries;
     layout_t reg_layout;
-    pvar_tile_t entry_tile;
+    tile_t entry_tile;
 
     using base_plan_t::base_plan_t;
 
@@ -618,7 +618,7 @@ struct send_2d_entry_t {
     expr_t x_inc;
     expr_t y_inc;
     int reg_off = 0;
-    pvar_coord_t<dim_t> coord;
+    coord_t coord;
 
     std::string str() const {
         std::ostringstream oss;
@@ -639,15 +639,14 @@ struct send_2d_plan_t : public base_plan_t {
     mask_t mask;
     std::vector<send_2d_entry_t> entries;
     layout_t reg_layout;
-    pvar_tile_t entry_tile;
+    tile_t entry_tile;
 
     using base_plan_t::base_plan_t;
 
     int nentries() const { return static_cast<int>(entries.size()); }
     explicit operator bool() const { return (bool)desc; }
 
-    bool add_entry(const pvar_coord_t<dim_t> &coord, int reg_off,
-            const prover_t &prover) {
+    bool add_entry(const coord_t &coord, int reg_off, const prover_t &prover) {
         entries.emplace_back();
         auto &e = entries.back();
         e.x_inc = coord.at(desc.w_dim);
@@ -710,7 +709,7 @@ struct send_plan_t : public base_plan_t {
         return _2d.reg_layout;
     }
 
-    const pvar_tile_t &entry_tile() const {
+    const tile_t &entry_tile() const {
         if (is_1d()) return _1d.entry_tile;
         return _2d.entry_tile;
     }
@@ -886,7 +885,7 @@ private:
         int reg_off = 0;
         for (int h = 0; h < plane.h; h += desc.h) {
             for (int w = 0; w < plane.w; w += desc.w * desc.c) {
-                pvar_coord_t<dim_t> coord;
+                coord_t coord;
                 coord[plane.w_dim] = w;
                 coord[plane.h_dim] = h;
                 if (!plan_2d.add_entry(coord, reg_off, prover))


### PR DESCRIPTION
PR includes the following changes:

- Converted `pvar_coord_t` to a non-template class storing expression coordinates (and renamed to `coord_t`)
- Introduced `icoord_t` to store constant, `dim_t` coordinates (the naming is up for dicussion)
    - Unified most of code to use `coord_t` (expressions)
    - `icoord_t` is reserved for some specific usage when absolutely needed, otherwise `coord_t` is preferred for consistency
    - Added implicit constructors to convert between `coord_t` and `icoord_t`
- Renamed `pvar_coord_t` -> `coord_t` and `pvar_tile_t` -> `tile_t`
- Introduced `tile_coord_t` to represent a tile with a coordinate. This is a replacement for `tensor_t`
- Dropped `tensor_t` abstraction. It will be reintroduced later as part of DSL to represent a buffer with its layout
