### PR TITLE
cpu: x64: fix brgemm_1x1_convolution core dump

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -49,6 +49,8 @@ bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
+    const int ref_size = refs_.size();
+    if (idx > ref_size - 1) { refs_.resize(idx + 1); }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
     if (!ret.second) {

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Intel Corporation
+* Copyright 2023-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -179,8 +179,8 @@ private:
         return jcp.is_reduced_rtus && (!get_extra_m_kernel_req(jcp));
     }
 
-    brgemm_containers::brgemm_kernel_container_t brg_kernels_ {32};
-    brgemm_containers::brgemm_palette_container_t brgemm_palettes_ {32};
+    brgemm_containers::brgemm_kernel_container_t brg_kernels_ {64};
+    brgemm_containers::brgemm_palette_container_t brgemm_palettes_ {64};
 
     std::unique_ptr<jit_avx512_core_brgemm_conv_trans_kernel::
                     jit_avx512_core_brgemm_conv_rtus_kernel_t>


### PR DESCRIPTION
# Description

[MFDNN-13801](https://jira.devtools.intel.com/browse/MFDNN-13801)
[CPU] Fixed two core dump issues in primitives brgemm_1x1_convolution_fwd_t: 
1. Core dump at model compilation stage
2. Core dump at kernel execution stage


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

