### PR TITLE
example: graph: sdpa: use host-side scale value

### DIFF
--- a/include/oneapi/dnnl/dnnl_graph.h
+++ b/include/oneapi/dnnl/dnnl_graph.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -192,6 +192,17 @@ dnnl_status_t DNNL_API dnnl_graph_logical_tensor_is_equal(
 dnnl_status_t DNNL_API dnnl_graph_tensor_create(dnnl_graph_tensor_t *tensor,
         const dnnl_graph_logical_tensor_t *logical_tensor, dnnl_engine_t engine,
         void *handle);
+
+/// Creates a scalar tensor with logical tensor and scalar data handle.
+///
+/// @param tensor Output scalar tensor.
+/// @param logical_tensor Description for this tensor.
+/// @param handle Handle of the memory buffer to use as an underlying storage.
+/// @returns #dnnl_success on success or a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_graph_tensor_create_host_scalar(
+        dnnl_graph_tensor_t *tensor,
+        const dnnl_graph_logical_tensor_t *logical_tensor, void *handle);
 
 /// Destroys a tensor.
 ///

--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -575,6 +575,8 @@ private:
 /// A tensor object
 class tensor : public tensor_handle {
 public:
+    using tensor_handle::handle;
+
     /// Default constructor. Constructs an empty object.
     tensor() = default;
 
@@ -606,6 +608,22 @@ public:
     /// @param aengine Engine to store the data on.
     tensor(const logical_tensor &lt, const engine &aengine)
         : tensor(lt, aengine, DNNL_MEMORY_ALLOCATE) {}
+
+    /// Creates a tensor object for host-side scalar value. The data type contained
+    /// in the logical tensor parameter will be used to interpret the scalar
+    /// pointer. The property type in the logical tensor must be `host_scalar`.
+    ///
+    /// @param lt The logical tensor describing the host scalar
+    /// @param scalar The pointer to scalar value
+    /// @returns Created tensor object
+    static tensor make_scalar_tensor(const logical_tensor &lt, void *scalar) {
+        dnnl_graph_tensor_t t = nullptr;
+        error::wrap_c_api(
+                dnnl_graph_tensor_create_host_scalar(&t, &(lt.data), scalar),
+                "could not create a scalar tensor object");
+
+        return tensor(t);
+    }
 
     /// Returns the underlying memory buffer.
     ///

--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -164,6 +164,11 @@ dnnl::engine make_dnnl_engine(const engine_t &g_engine) {
     return engine;
 }
 
+// The function will throw expect if cpu runtime is none.
+dnnl::engine make_host_engine() {
+    return dnnl::engine(dnnl::engine::kind::cpu, 0);
+}
+
 dnnl::stream make_dnnl_stream(
         const dnnl::engine &p_engine, const stream_t &g_stream) {
     UNUSED(p_engine);

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -81,6 +81,8 @@ dims group_dims(const dims &adims, dim groups);
 
 engine make_dnnl_engine(const engine_t &g_engine);
 
+engine make_host_engine();
+
 stream make_dnnl_stream(const engine &p_engine, const stream_t &g_stream);
 
 memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt);

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -170,9 +170,17 @@ void larger_partition_kernel_t::setup_pipeline(pass_pipeline_t &pipeline,
 void larger_partition_kernel_t::prepare_host_scalar_args(
         execution_args_set_t *res, const std::vector<tensor_t> &inputs) {
     for (const auto &host_scalar_info : res->get_host_scalar_infos()) {
-        auto mem = make_dnnl_memory(host_scalar_info.md,
-                make_dnnl_engine(
-                        *(inputs[host_scalar_info.input_idx].get_engine())),
+        const engine_t *eng_ptr
+                = inputs[host_scalar_info.input_idx].get_engine();
+        // For host scalar tensor, if it contains an egine, use it. Otherwise,
+        // create a host engine for it. This can be changed once dnnl::memory
+        // supports host scalar memory creation without engine and also supports
+        // reorder from a host scalar memory to a gpu device memory.
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_NONE
+        assert(eng_ptr);
+#endif
+        auto eng = eng_ptr ? make_dnnl_engine(*eng_ptr) : make_host_engine();
+        auto mem = make_dnnl_memory(host_scalar_info.md, eng,
                 inputs[host_scalar_info.input_idx].get_data_handle());
         auto args = res->get_exec_args()[host_scalar_info.exec_idx];
         args.insert({host_scalar_info.arg, mem});

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -250,6 +250,17 @@ status_t sdp_primitive_config_t::initial_check(
                 // Scale exists, update post_op and traverse to next op
                 scale = post_op;
                 post_op = get_post_op(post_op);
+                // Sdpa primitive does not support host scale. Check both inputs
+                // as we are not sure which one is the scale input.
+                const auto &lt_s0
+                        = scale->get_input_value(0)->get_logical_tensor();
+                const auto &lt_s1
+                        = scale->get_input_value(1)->get_logical_tensor();
+                if (ltw(lt_s0).property_type() == property_type::host_scalar
+                        || ltw(lt_s1).property_type()
+                                == property_type::host_scalar)
+                    return status::unimplemented;
+
                 const auto &lt_ss
                         = scale->get_output_value(0)->get_logical_tensor();
                 f32_inter = f32_inter

--- a/src/graph/interface/tensor.cpp
+++ b/src/graph/interface/tensor.cpp
@@ -150,6 +150,25 @@ status_t DNNL_API dnnl_graph_tensor_create(tensor_t **tensor,
     return status::success;
 }
 
+status_t DNNL_API dnnl_graph_tensor_create_host_scalar(tensor_t **tensor,
+        const logical_tensor_t *logical_tensor, void *handle) {
+    if (utils::any_null(tensor, logical_tensor))
+        return status::invalid_arguments;
+
+    if (logical_tensor->property != property_type::host_scalar)
+        return status::invalid_arguments;
+
+    // TODO(xxx): extend for library allocated host scalar?
+    if (nullptr == handle || DNNL_MEMORY_ALLOCATE == handle) {
+        return status::invalid_arguments;
+    }
+
+    *tensor = new tensor_t {*logical_tensor, nullptr, handle};
+    if (*tensor == nullptr) return status::out_of_memory;
+
+    return status::success;
+}
+
 status_t DNNL_API dnnl_graph_tensor_destroy(tensor_t *tensor) {
     delete tensor;
     return status::success;

--- a/src/graph/interface/tensor.cpp
+++ b/src/graph/interface/tensor.cpp
@@ -123,6 +123,9 @@ dnnl_graph_tensor::dnnl_graph_tensor(
         if (lt.data_type == data_type::s32) {
             scalar_.s32_value = *static_cast<int32_t *>(handle);
             handle_.reset(&scalar_.s32_value, dummy_destructor);
+        } else if (lt.data_type == data_type::f32) {
+            scalar_.f32_value = *static_cast<float *>(handle);
+            handle_.reset(&scalar_.f32_value, dummy_destructor);
         } else {
             assertm(false, "Unsupported data type for host scalar");
         }

--- a/src/graph/interface/tensor.hpp
+++ b/src/graph/interface/tensor.hpp
@@ -50,6 +50,9 @@ public:
             if (lt_.data_type == dnnl::impl::graph::data_type::s32) {
                 scalar_.s32_value = *static_cast<int32_t *>(handle);
                 handle_.reset(&scalar_.s32_value, dummy_destructor);
+            } else if (lt_.data_type == dnnl::impl::graph::data_type::f32) {
+                scalar_.f32_value = *static_cast<float *>(handle);
+                handle_.reset(&scalar_.f32_value, dummy_destructor);
             } else {
                 assertm(false, "Unsupported data type for host scalar");
             }
@@ -93,6 +96,7 @@ private:
         // this field is valid when logical tensor's
         // property is host_scalar
         int32_t s32_value = 0;
+        float f32_value;
         // TODO: add more dtype support
     } scalar_;
 };

--- a/tests/gtests/graph/api/test_cpp_api_tensor.cpp
+++ b/tests/gtests/graph/api/test_cpp_api_tensor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -155,5 +155,22 @@ TEST(APITensor, CreateWithLogicalTensorS8) {
 
     ASSERT_EQ(t.get_data_handle(), nullptr);
     ASSERT_EQ(t.get_engine().get_kind(), dnnl::engine::kind::cpu);
+}
+
+TEST(APITensor, CreateScalarTensor) {
+    using namespace dnnl::graph;
+
+    auto lt = logical_tensor(0, logical_tensor::data_type::f32, 0,
+            logical_tensor::layout_type::strided,
+            logical_tensor::property_type::host_scalar);
+
+    float scalar = 0.25f;
+    // success
+    EXPECT_NO_THROW(tensor::make_scalar_tensor(lt, &scalar));
+
+    // fail
+    lt = logical_tensor(0, logical_tensor::data_type::f32, 0,
+            logical_tensor::layout_type::strided);
+    EXPECT_THROW(tensor::make_scalar_tensor(lt, &scalar), dnnl::error);
 }
 #endif


### PR DESCRIPTION
- Modified the SDPA example to use host-side scale value on GPU.
- Added check in the backend to fallback the case to primitive based implementation. It can be removed once host-side scale is supported by ukernel SDPA.