### PR TITLE
cpu: riscv: pooling: fix kernel selection and edge case segfault in MaxPooling

### DIFF
--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -49,8 +49,15 @@ void MaxPooling(const float *src, float *dst, const dim_t batch,
                 int od_offset = od * strideD - padFront;
                 int oh_offset = oh * strideH - padTop;
                 int ow_offset = ow * strideW - padLeft;
-                size_t size = std::min(ow_offset + kerW, inW)
-                        - std::max(ow_offset, 0);
+                int iw_start = std::max(ow_offset, 0);
+                int iw_end = std::min(ow_offset + kerW, inW);
+
+                if (iw_start >= iw_end) {
+                    dst[dst_offset] = -__FLT_MAX__;
+                    return;
+                }
+
+                size_t size = iw_end - iw_start;
                 size_t cycleLength = __riscv_vsetvl_e32m1(size);
                 vfloat32m1_t vmax
                         = __riscv_vfmv_v_f_f32m1(-__FLT_MAX__, cycleLength);

--- a/src/cpu/rv64/rvv_nchw_pooling.hpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.hpp
@@ -46,13 +46,13 @@ struct riscv_nchw_pooling_fwd_t : public primitive_t {
                     && utils::one_of(desc()->alg_kind, alg_kind::pooling_max,
                             alg_kind::pooling_avg_include_padding,
                             alg_kind::pooling_avg_exclude_padding)
+                    && set_default_params() == status::success
                     && memory_desc_wrapper(dst_md()).is_dense(false)
                     && utils::everyone_is(
                             d_type, src_md()->data_type, dst_md()->data_type)
                     && platform::has_data_type_support(d_type)
                     && !has_zero_dim_memory() && !is_dilated()
                     && attr()->has_default_values()
-                    && set_default_params() == status::success
                     && memory_desc_matches_tag(*src_md(), desired_fmt_tag)
                     && memory_desc_matches_tag(*dst_md(), desired_fmt_tag)
                     && attr_.set_default_formats(dst_md(0)) == status::success


### PR DESCRIPTION
# Description:

This PR enhances the RISC-V RVV pooling implementation in oneDNN by fixing two key issues: 
- The first change moves set_default_params() earlier in the constraint checks to ensure default memory formats are set before calling is_dense(), allowing the RVV max pooling kernel to be selected for more valid configurations.

- The second fix addresses a segmentation fault in the MaxPooling kernel caused by invalid pooling windows (zero or negative size) due to padding and strides. A guard was added to skip such cases safely, preventing out-of-bounds memory access.

### Fix Kernel Skipping by Reordering `set_default_params()`

Previously, the RVV max pooling kernel was being incorrectly skipped for valid configurations because the is_dense() check in its constraint list was evaluated before the call to `set_default_params()`. Since `dst_md()` could still have an undefined (undef) format tag at that point, `is_dense()` would return false even when the memory layout was actually dense and valid. This premature failure led the kernel to be excluded from execution unnecessarily. By moving the `set_default_params()` call to the top of the condition list, default format tags are now correctly assigned before any layout-dependent checks like `is_dense()` are performed. As a result, the RVV kernel is now correctly selected for a wider range of test cases that it can handle successfully.

### Verifying Kernel Selection with BenchDNN

To test the impact of the fix, the following command was executed:

```sh
./benchdnn --pool --dir=FWD_I --batch=shapes_2d
```
[Before Reordering (RVV kernel not selected).log](https://github.com/user-attachments/files/20837057/Log.Before.Fix.RVV.kernel.not.selected.log)

[After Reordering (RVV kernel selected but segmentation fault occured).log](https://github.com/user-attachments/files/20837059/Log.After.Fix.RVV.kernel.selected.but.segmentation.fault.occured.log)

#### Segmentation Fault Encountered During RVV MaxPooling Execution :
```bash
39:PASSED (33 ms) __REPRO: --pool --dir=FWD_I ic259ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,2x516x19x10,2.33398
onednn_verbose,v1,primitive,exec,cpu,pooling,RISCV64GCV,forward_inference,src:f32::blocked:abcd::f0 dst:f32:a:blocked:abcd::f0,,alg:pooling_max,mb2ic516_ih19oh17kh4sh1dh0ph1_iw10ow3kw2sw4dw0pw0,23.7781
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,2x516x17x3,0.649902
40:PASSED (62 ms) __REPRO: --pool --dir=FWD_I ic516ih19iw10oh17ow3kh4kw2sh1sw4ph1pw0
onednn_verbose,v1,primitive,exec,cpu,reorder,simple:any,undef,src:f32::blocked:abcd::f0 dst:f32::blocked:abcd::f0,,,1x16x10x10,0.0629883
Segmentation fault (core dumped)
```
---


### Fixing Segmentation Fault in MaxPooling Kernel for Edge Cases

In the RVV `MaxPooling` kernel, a segmentation fault occurred when the effective pooling window computed for a given output position had a non-positive width. This situation typically arose due to excessive padding or large strides, which pushed the start index (`iw_start`) beyond the end index (`iw_end`). Since the kernel did not originally check whether `iw_start >= iw_end`, it went on to load and process invalid memory regions, leading to crashes.

To address this, a guard condition was added to skip the computation entirely when `iw_start >= iw_end`, setting the output to `-FLT_MAX` as a placeholder. This prevents unsafe memory access while still maintaining the semantic intent of max pooling with an invalid region.

[Max Pooling Fixed Edge Case.log](https://github.com/user-attachments/files/20837060/Log.After.Fix.In.Max.Pooling.log)
