### PR TITLE
cpu: x64: matmul: Adjust heuristics for postops bound layers

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -215,6 +215,7 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
     float strip_mid_size_shared, strip_mid_size_private;
     float num_tmuls_per_strip, strip_mid_share_coef, num_strip, nt_mat_l1_miss;
     float l1_reuse;
+    float num_postop_cache_lines;
 
     if (is_horizontal) {
         // Amount of C/D bytes that are written per core
@@ -248,6 +249,9 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
         // share_coeff - the cores that share A
         strip_mid_share_coef = std::max((size_t)1, nthr_n_);
 
+        // Calculate the number of cache lines to be processed in AVX postops
+        num_postop_cache_lines = m_decomposition * div_up(n_per_thread, n_tmul);
+
     } else {
         // Amount of C/D bytes that are written per core
         size_t strip_dst_size = n_decomposition * m_per_thread
@@ -279,6 +283,9 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
         strip_mid_size_private = strip_dst_size;
         // share_coeff - the cores that share B
         strip_mid_share_coef = std::max((size_t)1, nthr_m_);
+
+        // Calculate the number of cache lines to be processed in AVX postops
+        num_postop_cache_lines = m_per_thread * div_up(n_decomposition, n_tmul);
     }
     // There are 2 L1 misses for the L1 matrix:
     //   1. For the prefetch to the L2 (==L1 miss)
@@ -326,8 +333,11 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
     float strip_mid_llc = (strip_mid_size_private + strip_mid_size_shared)
             / bw_interpulator.llc_bw;
     float strip_tmul = num_tmuls_per_strip * num_cycles_per_tmul;
-    float strip_mid_cycles
-            = std::max({strip_mid_dram, strip_mid_llc, l1_cycles, strip_tmul});
+
+    float strip_avx
+            = this->postops_inst_count * num_postop_cache_lines / avx_ipc;
+    float strip_mid_cycles = std::max(
+            {strip_mid_dram, strip_mid_llc, l1_cycles, strip_tmul, strip_avx});
 
     float gemm_cycles = strip_1_cycles + (num_strip - 1) * strip_mid_cycles;
 
@@ -631,7 +641,7 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
     dim_t k_blk_h = calc_k_blk(m_decomposition);
     calc_horizontal(k_blk_h);
 
-    auto calc_vertical = [&](size_t k_blk_v) {
+    auto calc_vertical = [&](size_t k_blk_v, dim_t min_k_chunk_size = 0) {
         if (rnd_up(n_per_thread, n_decomposition) * (nthr_n_ - 1) > (size_t)N) {
             vertical_not_possible = true;
         } else if (rnd_up(k_per_thread, k_blk_v) * (nthr_k_ - 1) > (size_t)K) {
@@ -648,7 +658,7 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
                         it_k != k_candidates_v.rend(); it_k++) {
                     float cur_score = evaluate_single_core_blocking(
                             *it_k, *it_m * m_decomposition, k_blk_v, false);
-                    if (cur_score > best_score_v) {
+                    if (cur_score > best_score_v && *it_k >= min_k_chunk_size) {
                         best_score_v = cur_score;
                         best_k_v = *it_k;
                         best_m_v = *it_m;
@@ -716,6 +726,13 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
     is_horizontal = is_horizontal_selected(horizontal_not_possible,
             vertical_not_possible, best_m_v, best_k_v, k_blk_v);
 
+    auto is_postops_bound = [&](size_t k_blk) {
+        // If the number of cycles for postops per cache line is larger than
+        // the number of AMX cycles per cache line, then the calculation is
+        // postops bound.
+        return postops_inst_count / avx_ipc > div_up(k_blk, k_tmul);
+    };
+
     if (is_horizontal) {
         size_t l1_eff_factor = div_up(K, k_blk_h);
         // This works for M > 32 in this case k_blk_h << 4096 =~ 512
@@ -726,9 +743,11 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
         size_t d_post = m_decomposition * rnd_up(n_decomposition * c_dt_sz, 64);
         is_a_nt_ = false;
         is_b_nt_ = true;
+        bool l1_set_issues = k_blk_h < K
+                && l1_eff_factor * a_l1 + 2 * c_l1 + d_post > L1_threshold();
 
-        if (k_blk_h < K
-                && l1_eff_factor * a_l1 + 2 * c_l1 + d_post > L1_threshold()) {
+        if (l1_set_issues || is_postops_bound(k_blk_h)) {
+            // Give up on the L1 blocking
             best_score_h = 0;
             // Calculate k_blk_h and n_blk_h that can fit in the L2 when k_blk is wei_k_blk
             calc_horizontal(wei_k_blk, k_blk_h / wei_k_blk);
@@ -752,6 +771,17 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
         m_blk_ = m_decomposition;
         m_chunk_size_ = div_up(m_per_thread, m_blk_);
     } else {
+        if (is_postops_bound(k_blk_v)) {
+            // Give up on the L1 blocking
+            best_score_v = 0;
+            // Calculate k_blk_h and n_blk_h that can fit in the L2 when k_blk is wei_k_blk
+            calc_vertical(wei_k_blk, k_blk_v / wei_k_blk);
+            // Give up on the L1.
+            k_blk_v = nstl::min(wei_k_blk * best_k_v, K);
+            best_k_v = 1;
+            is_b_nt_ = true;
+        }
+
         k_blk_ = k_blk_v;
         k_chunk_size_ = best_k_v;
         n_blk_ = n_decomposition;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -84,7 +84,7 @@ protected:
     bool extendable_k_ {false};
     size_t blocking_chunk_mem_size_ {0};
     float efficiency_score_ {0.0};
-
+    static constexpr float avx_ipc {1.2f};
     bool is_buffer_c_required() const;
 };
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -112,6 +112,7 @@ struct brgemm_matmul_conf_t {
     bool packed_sparse_weights;
     bool req_transpose_scales;
     bool with_wei_decompression;
+    int postops_inst_count;
     brgemm_broadcast_t src_zp_type;
     brgemm_broadcast_t wei_zp_type;
     brgemm_broadcast_t dst_zp_type;

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_MATMUL_POSTOPS_ESTIMATOR_HPP
+#define CPU_X64_MATMUL_POSTOPS_ESTIMATOR_HPP
+
+#include "cpu/x64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace matmul {
+
+// The postops estimator JIT-compiles post-operation code for a single
+// cache line result produced by the GEMM. The size of the generated code
+// serves as a metric to help blocking heuristics account for the impact
+// of post-operations on execution performance. Note: the generated code
+// is not executed.
+
+class postops_estimator_t : public jit_generator_t {
+public:
+    static status_t estimate_insts_per_cacheline(memory_desc_t &dst_md,
+            primitive_attr_t &attr, int &estimated_vec_insts) {
+        postops_estimator_t post_ops_gen(dst_md, attr);
+        status_t res = post_ops_gen.check_status();
+        if (res != status::success) return res;
+        post_ops_gen.generate();
+        res = post_ops_gen.check_status();
+        if (res != status::success) return res;
+
+        size_t code_size = post_ops_gen.getSize();
+        size_t estimated_vec_code_size = (size_t)nstl::max(
+                (int)code_size - (int)mean_none_vec_code_bytes, 0);
+        estimated_vec_insts = estimated_vec_code_size / mean_vec_inst_bytes;
+        return status::success;
+    }
+
+private:
+    using po_injector_t = injector::jit_uni_postops_injector_base_t<Xbyak::Zmm>;
+    std::unique_ptr<po_injector_t> postops_injector_;
+    static constexpr size_t mean_none_vec_code_bytes = 8;
+    static constexpr size_t mean_vec_inst_bytes = 7;
+
+    postops_estimator_t(memory_desc_t &dst_md, primitive_attr_t &attr)
+        : jit_generator_t("dummy_generator") {
+        auto dsc = memory_desc_wrapper(dst_md);
+        const dnnl::impl::cpu::x64::binary_injector::rhs_arg_static_params_t
+                rhs_sp(static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
+                        this->r15, this->r13, false, false,
+                        static_cast<size_t>(0), static_cast<size_t>(0), dsc,
+                        static_cast<size_t>(0), Xbyak::Opmask(0), false);
+
+        const dnnl::impl::cpu::x64::binary_injector::static_params_t bsp(
+                this->param1,
+                dnnl::impl::cpu::x64::binary_injector::
+                        get_all_strategies_supported_by_injector(),
+                rhs_sp, nullptr, nullptr);
+
+        dnnl::impl::cpu::x64::eltwise_injector::static_params_t esp;
+        esp.preserve_vmm = false;
+        esp.preserve_p_table = false;
+
+        auto st = safe_ptr_assign(postops_injector_,
+                po_injector_t::create(this,
+                        impl::cpu::x64::cpu_isa_t::avx512_core_amx,
+                        attr.post_ops_, bsp, esp));
+        if (st != status::success) {
+            assert(!"postops_injector creation failed");
+        }
+    }
+
+    const char *name() const final {
+        assert(!"postops_estimator_t name function is not expected to be "
+                "called. The jitted code is not to be registered or used");
+        return nullptr;
+    }
+    const char *source_file() const final {
+        assert(!"postops_estimator_t source_file function is not expected to be"
+                " called. The jitted code is not to be registered or used");
+        return nullptr;
+    }
+
+    status_t check_status() {
+        if (postops_injector_ == nullptr) return status::out_of_memory;
+        int err_code = Xbyak::GetError();
+        if (err_code == Xbyak::ERR_CANT_ALLOC) return status::out_of_memory;
+        if (err_code != Xbyak::ERR_NONE) return status::runtime_error;
+        return status::success;
+    }
+
+    void generate() final { postops_injector_->compute_vector(0); }
+};
+
+} // namespace matmul
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+#endif


### PR DESCRIPTION
Estimate the size of the post-operation for the blocking heuristics. Avoid splitting dimension K if bound on post-processing , and incorporate post-processing information into the core work partitioning algorithm.