### PR TITLE
ci: aarch64: Fix nightly performance tests

### DIFF
--- a/.github/automation/performance/benchdnn_comparison.py
+++ b/.github/automation/performance/benchdnn_comparison.py
@@ -56,10 +56,15 @@ def compare_two_benchdnn(file1, file2, tolerance=0.05):
     r2_ctime = defaultdict(list)
 
     for key, exec_time, ctime in r1:
+        # Older versions of benchdnn outputs underscores
+        # instead of hyphens for some ops leading to
+        # mismatches in problems with newer versions
+        key = key.replace("_", "-")
         r1_exec[key].append(float(exec_time))
         r1_ctime[key].append(float(ctime))
 
     for key, exec_time, ctime in r2:
+        key = key.replace("_", "-")
         r2_exec[key].append(float(exec_time))
         r2_ctime[key].append(float(ctime))
 

--- a/.github/automation/performance/inputs/matmul_nightly
+++ b/.github/automation/performance/inputs/matmul_nightly
@@ -20,14 +20,14 @@
 # Plain cases
 --reset
 --dt=f32,s8:s8:f32
---bia-dt=f32,undef
+--bia_dt=f32,undef
 --bia_mask=2
 --batch=shapes_2d_ci
 --bia_mask=4
 --batch=shapes_3d
 
 --dt=f32
---bia-dt=f32,undef
+--bia_dt=f32,undef
 --bia_mask=2
 --attr-fpmath=bf16
 --batch=shapes_2d_ci
@@ -36,7 +36,7 @@
 
 #f16
 --dt=f16:f16:f16
---bia-dt=undef
+--bia_dt=undef
 --bia_mask=2
 --batch=shapes_2d_ci
 --bia_mask=4


### PR DESCRIPTION
The nightly performance tests are failing due to benchdnn no longer accepting underscores for the matmul operator