### PR TITLE
xe: softmax: drop 32 subgroup size due to accuracy issues

### DIFF
--- a/src/gpu/intel/ocl/reusable_softmax.hpp
+++ b/src/gpu/intel/ocl/reusable_softmax.hpp
@@ -178,7 +178,7 @@ struct reusable_softmax_fwd_t : public gpu_primitive_t {
 
             // utilize largest supported subgroup size
             conf.subgroup_size = [=] {
-                for (int size : {32, 16, 8}) {
+                for (int size : {16, 8}) {
                     if (compute_engine->mayiuse_sub_group(size)
                             && compute_engine
                                        ->mayiuse_block_reads_writes_with_sub_group(


### PR DESCRIPTION
Utilizing subgroup size 32 for softmax leads to unexpected incorrect behavior in some circumstances. Reverting back to 16 for the time being until size 32 is investigated.