### PR TITLE
xe: sdpa: compilation error bugfix with non-blocking Q loads

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cl
+++ b/src/gpu/intel/ocl/micro_sdpa.cl
@@ -264,7 +264,8 @@ inline void tile_load_src1(q_tile_type *Q_tile, const global QRY_DATA_T *Q,
     tile_load_block_rem_q(
             Q_tile, (global uint *)Q, n, ldq >> 1, offset_r, offset_c);
 #elif Q_ALIGN >= 4
-        tile_load(Q_tile, (global uint *)Q, (m + 1) >> 1, n, ldq >> 1, offset_r, offset_c;
+    tile_load(Q_tile, (global uint *)Q, (m + 1) >> 1, n, ldq >> 1, offset_r,
+            offset_c);
 #else
     tile_load_packed_vec2(Q_tile, Q, m, n, ldq, offset_r, offset_c);
 #endif


### PR DESCRIPTION
# Description

Bugfix for compilation error happening for aligned non-blocked Q loads. 
Example failure on xe2-bmg: 
```
./tests/benchdnn/benchdnn --graph --engine=gpu --dt=0:f16+1:f16+2:f16+3:f16+7:f16+8:f16 --case=complex_fusion/mha/MHA-stable_diffusion-inf-fp32-bs1.json
```
Tested manually since this test case passes in CI...

# Checklist

## General
- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes
- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
