### PR TITLE
ci: aarch64: ignore fp16 fastmath tests

### DIFF
--- a/.github/automation/performance/benchdnn_comparison.py
+++ b/.github/automation/performance/benchdnn_comparison.py
@@ -111,7 +111,7 @@ def compare_two_benchdnn(file1, file2, tolerance=0.05):
             )
         if ctime_regressed:
             ctime_failures.append(
-                f"ctime: {r1_med_ctime:.3g} → {r2_med_ctime:.3g}"
+                f"{prb} ctime: {r1_med_ctime:.3g} → {r2_med_ctime:.3g}"
                 f"(p={ctime_ttest.pvalue:.3g})"
             )
 

--- a/.github/automation/performance/inputs/matmul_nightly
+++ b/.github/automation/performance/inputs/matmul_nightly
@@ -26,6 +26,7 @@
 --bia_mask=4
 --batch=shapes_3d
 
+--reset
 --dt=f32
 --bia_dt=f32,undef
 --bia_mask=2
@@ -35,6 +36,7 @@
 --batch=shapes_3d
 
 #f16
+--reset
 --dt=f16:f16:f16
 --bia_dt=undef
 --bia_mask=2


### PR DESCRIPTION
# Description

fp16 fastmath matmul tests are accidentally running on the performance tests, these have been disabled. The ctime regression output has also been modified to also show the problem it failed on.

