### PR TITLE
xe: refactor microkernels check

### DIFF
--- a/src/gpu/intel/compute/compute_engine.cpp
+++ b/src/gpu/intel/compute/compute_engine.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,6 +19,16 @@
 #include "gpu/intel/compute/compute_engine.hpp"
 
 #include "common/utils.hpp"
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "gpu/intel/ocl/engine.hpp"
+#include "gpu/intel/ocl/utils.hpp"
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+#include "gpu/intel/sycl/engine.hpp"
+#include "gpu/intel/sycl/utils.hpp"
+#endif
 
 namespace dnnl {
 namespace impl {
@@ -81,6 +91,52 @@ status_t compute_engine_t::init(const std::vector<uint8_t> &cache_blob) {
     device_info_cache_set(this, device_info_);
 
     return status::success;
+}
+
+const char *cl_microkernels_check_kernel_code = R""""(
+kernel void igc_check() {
+    __asm__ volatile(
+            ".decl AA0 v_type=G type=ud num_elts=1\n"
+            ".decl AA1 v_type=G type=ud num_elts=1\n"
+            ".implicit_PSEUDO_INPUT AA0 offset=256 size=4\n"
+            ".implicit_PSEUDO_INPUT AA1 offset=256 size=4\n"
+            "mov (M1_NM,1) AA0(0,0)<1> AA1(0,0)<0;1,0>\n"
+    );
+}
+)"""";
+
+bool mayiuse_microkernels(const compute_engine_t *engine) {
+    auto *device_info = engine->device_info();
+    if (device_info->runtime_version() >= xpu::runtime_version_t(24, 22, 29735))
+        return true;
+
+    auto mayiuse_mk = [](const compute_engine_t *engine) {
+        switch (engine->runtime_kind()) {
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+            case runtime_kind::ocl: {
+
+                auto *ocl_engine
+                        = utils::downcast<const ocl::engine_t *>(engine);
+                return ocl::try_building(ocl_engine->context(),
+                        ocl_engine->device(),
+                        cl_microkernels_check_kernel_code);
+            }
+#endif
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+            case runtime_kind::sycl:
+                return sycl::mayiuse_microkernels(
+                        utils::downcast<const sycl::engine_t *>(engine));
+#endif
+            default: return false;
+        }
+    };
+    static std::map<engine_id_t, bool> engine_microkernel_map {
+            {engine->engine_id(), mayiuse_mk(engine)}};
+    static std::mutex map_mutex;
+    std::lock_guard<std::mutex> map_lock(map_mutex);
+    auto it = engine_microkernel_map.find(engine->engine_id());
+    if (it != std::end(engine_microkernel_map)) return it->second;
+    return engine_microkernel_map[engine->engine_id()] = mayiuse_mk(engine);
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/compute_engine.hpp
+++ b/src/gpu/intel/compute/compute_engine.hpp
@@ -196,6 +196,9 @@ private:
     std::once_flag zero_pad_init_;
 };
 
+extern const char *cl_microkernels_check_kernel_code;
+bool mayiuse_microkernels(const compute_engine_t *engine);
+
 } // namespace compute
 } // namespace intel
 } // namespace gpu

--- a/src/gpu/intel/compute/device_info.hpp
+++ b/src/gpu/intel/compute/device_info.hpp
@@ -320,7 +320,8 @@ private:
 };
 
 } // namespace compute
-}} // namespace gpu
+} // namespace intel
+} // namespace gpu
 } // namespace impl
 } // namespace dnnl
 

--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -105,7 +105,7 @@ status_t micro_sdpa_t::pd_t::init_microkernels(impl::engine_t *engine) {
     arch_ = dev_info->gpu_arch();
     auto *d = desc();
 
-    VCHECK_SDPA_COND(mayiuse_microkernels(engine),
+    VCHECK_SDPA_COND(compute::mayiuse_microkernels(compute_engine),
             "Microkernels not supported by the OpenCL driver.");
 
     /* Retrieve pre-tuned kernel configuration */

--- a/src/gpu/intel/ocl/utils.cpp
+++ b/src/gpu/intel/ocl/utils.cpp
@@ -26,10 +26,6 @@
 #include "gpu/intel/ocl/utils.hpp"
 #include "xpu/ocl/utils.hpp"
 
-#ifdef DNNL_WITH_SYCL
-#include "gpu/intel/sycl/engine.hpp"
-#endif
-
 #ifndef CL_KERNEL_BINARY_PROGRAM_INTEL
 #define CL_KERNEL_BINARY_PROGRAM_INTEL 0x407D
 #endif
@@ -84,18 +80,8 @@ namespace ocl {
 
 /// Tries to build a kernel with assembly instructions to check to see if the
 /// OpenCL compiler supports microkernels.
-bool try_building_with_microkernels(cl_context context, cl_device_id device) {
-    const char *kernel_code = R""""(
-        kernel void igc_check() {
-            __asm__ volatile(
-                    ".decl AA0 v_type=G type=ud num_elts=1\n"
-                    ".decl AA1 v_type=G type=ud num_elts=1\n"
-                    ".implicit_PSEUDO_INPUT AA0 offset=256 size=4\n"
-                    ".implicit_PSEUDO_INPUT AA1 offset=256 size=4\n"
-                    "mov (M1_NM,1) AA0(0,0)<1> AA1(0,0)<0;1,0>\n"
-            );
-        }
-        )"""";
+bool try_building(
+        cl_context context, cl_device_id device, const char *kernel_code) {
     cl_int err;
     /// Not using existing build infrastructure to avoid error messages in the CI logs
     xpu::ocl::wrapper_t<cl_program> program(
@@ -103,74 +89,6 @@ bool try_building_with_microkernels(cl_context context, cl_device_id device) {
     if (err != CL_SUCCESS) return false;
     err = clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr);
     return err == CL_SUCCESS;
-}
-
-int get_sycl_ocl_device_and_context(
-        xpu::ocl::wrapper_t<cl_context> &ocl_context,
-        xpu::ocl::wrapper_t<cl_device_id> &ocl_device,
-        const impl::engine_t *engine) {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
-    auto *sycl_engine = utils::downcast<const sycl::engine_t *>(engine);
-    auto &device = sycl_engine->device();
-
-    auto be = xpu::sycl::get_backend(device);
-    if (be == xpu::sycl::backend_t::opencl) {
-        cl_int err = CL_SUCCESS;
-        auto ocl_dev = xpu::sycl::compat::get_native<cl_device_id>(device);
-        ocl_device = xpu::ocl::make_wrapper(ocl_dev, true);
-
-        ocl_context = xpu::ocl::make_wrapper(
-                clCreateContext(nullptr, 1, &ocl_dev, nullptr, nullptr, &err),
-                true);
-        if (err) return -1;
-    } else if (be == xpu::sycl::backend_t::level0) {
-        std::unique_ptr<gpu::intel::ocl::engine_t, engine_deleter_t> ocl_engine;
-        auto err
-                = gpu::intel::sycl::create_ocl_engine(&ocl_engine, sycl_engine);
-        if (err != status::success) return -1;
-        ocl_device = xpu::ocl::make_wrapper(ocl_engine->device(), true);
-        ocl_context = xpu::ocl::make_wrapper(ocl_engine->context(), true);
-    }
-#endif
-    return 0;
-}
-
-bool mayiuse_microkernels(const impl::engine_t *engine) {
-    auto mayiuse_mk = [](const impl::engine_t *engine) {
-        xpu::ocl::wrapper_t<cl_device_id> ocl_device;
-        xpu::ocl::wrapper_t<cl_context> ocl_context;
-
-        switch (engine->runtime_kind()) {
-            case runtime_kind::sycl: {
-                auto err = get_sycl_ocl_device_and_context(
-                        ocl_context, ocl_device, engine);
-                if (err) return false;
-            } break;
-            case runtime_kind::ocl: {
-                const engine_t *eng = utils::downcast<const engine_t *>(engine);
-                ocl_device = xpu::ocl::make_wrapper(eng->device(), true);
-                ocl_context = xpu::ocl::make_wrapper(eng->context(), true);
-            } break;
-            default: return false;
-        }
-
-        bool mayiuse_microkernels = get_driver_version(ocl_device)
-                >= xpu::runtime_version_t(24, 22, 29735);
-        if (!mayiuse_microkernels) {
-            mayiuse_microkernels
-                    = try_building_with_microkernels(ocl_context, ocl_device);
-        }
-        return mayiuse_microkernels;
-    };
-
-    static std::map<engine_id_t, bool> engine_microkernel_map {
-            {engine->engine_id(), mayiuse_mk(engine)}};
-
-    static std::mutex map_mutex;
-    std::lock_guard<std::mutex> map_lock(map_mutex);
-    auto it = engine_microkernel_map.find(engine->engine_id());
-    if (it != std::end(engine_microkernel_map)) { return it->second; }
-    return engine_microkernel_map[engine->engine_id()] = mayiuse_mk(engine);
 }
 
 status_t get_ocl_kernel_arg_type(compute::scalar_type_t *type,

--- a/src/gpu/intel/ocl/utils.hpp
+++ b/src/gpu/intel/ocl/utils.hpp
@@ -40,7 +40,8 @@ namespace ocl {
 
 enum { OCL_BUFFER_ALIGNMENT = 128 };
 
-bool mayiuse_microkernels(const impl::engine_t *engine);
+bool try_building(
+        cl_context context, cl_device_id device, const char *kernel_code);
 
 status_t get_ocl_kernel_arg_type(compute::scalar_type_t *type,
         cl_kernel ocl_kernel, int idx, bool allow_undef = false);

--- a/src/gpu/intel/sycl/utils.hpp
+++ b/src/gpu/intel/sycl/utils.hpp
@@ -48,6 +48,8 @@ status_t create_ocl_engine(
 
 gpu_utils::device_id_t device_id(const ::sycl::device &dev);
 
+bool mayiuse_microkernels(const gpu::intel::sycl::engine_t *engine);
+
 } // namespace sycl
 } // namespace intel
 } // namespace gpu


### PR DESCRIPTION
This is to help [MFDNN-4562](https://jira.devtools.intel.com/browse/MFDNN-4562), and #2988 in particular. PR removes the `intel/ocl` -> `intel/sycl` dependency which will allow to exclude `intel/ocl` directory for SYCL runtime builds in the future.

After the PR OpenCL kernel compilation for SYCL is isolated here:
https://github.com/uxlfoundation/oneDNN/blob/b4b345d3f3ac6814dda2acbc2cdfcfa498ac9c92/src/gpu/intel/sycl/utils.cpp#L307-L315

Tagging @spalicki as this piece also needs proper handling for full transition in #2988.