### PR TITLE
src: gpu: intel: sycl: remove additional OCL dependencies

### DIFF
--- a/src/gpu/intel/sycl/l0/utils.cpp
+++ b/src/gpu/intel/sycl/l0/utils.cpp
@@ -208,6 +208,17 @@ status_t func_zeKernelCreate(ze_module_handle_t hModule,
     return status::success;
 }
 
+#ifdef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
+status_t func_zeGetKernelBinary(
+        ze_kernel_handle_t hKernel, size_t *pSize, uint8_t *pKernelBinary) {
+    static auto f = find_ze_symbol<decltype(&zeKernelGetBinaryExp)>(
+            "zeKernelGetBinaryExp");
+
+    if (!f) return status::runtime_error;
+    ZE_CHECK(f(hKernel, pSize, pKernelBinary));
+    return status::success;
+}
+#else
 status_t func_zeModuleGetNativeBinary(ze_module_handle_t hModule, size_t *pSize,
         uint8_t *pModuleNativeBinary) {
     static auto f = find_ze_symbol<decltype(&zeModuleGetNativeBinary)>(
@@ -217,6 +228,7 @@ status_t func_zeModuleGetNativeBinary(ze_module_handle_t hModule, size_t *pSize,
     ZE_CHECK(f(hModule, pSize, pModuleNativeBinary));
     return status::success;
 }
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 // FIXME: Currently SYCL doesn't provide any API to get device UUID so
 // we query it directly from Level0 with the zeDeviceGetProperties function.

--- a/src/gpu/intel/sycl/l0/utils.hpp
+++ b/src/gpu/intel/sycl/l0/utils.hpp
@@ -42,8 +42,13 @@ status_t sycl_create_kernels_with_level_zero(
 
 bool compare_ze_devices(const ::sycl::device &lhs, const ::sycl::device &rhs);
 
+#ifdef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
+status_t func_zeGetKernelBinary(
+        ze_kernel_handle_t hKernel, size_t *pSize, uint8_t *pKernelBinary);
+#else
 status_t func_zeModuleGetNativeBinary(ze_module_handle_t hModule, size_t *pSize,
         uint8_t *pModuleNativeBinary);
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 status_t init_gpu_hw_info(impl::engine_t *engine, ze_device_handle_t device,
         ze_context_handle_t context, uint32_t &ip_version,

--- a/src/gpu/intel/sycl/utils.hpp
+++ b/src/gpu/intel/sycl/utils.hpp
@@ -32,6 +32,7 @@ class engine_t;
 ::sycl::nd_range<3> to_sycl_nd_range(
         const gpu::intel::compute::nd_range_t &range);
 
+#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 status_t sycl_dev2ocl_dev(cl_device_id *ocl_dev, const ::sycl::device &dev);
 
 status_t create_ocl_engine(
@@ -39,12 +40,13 @@ status_t create_ocl_engine(
                 *ocl_engine,
         const gpu::intel::sycl::engine_t *engine);
 
-status_t get_kernel_binary(const ::sycl::kernel &kernel, xpu::binary_t &binary);
-
 status_t create_ocl_engine(
         std::unique_ptr<gpu::intel::ocl::engine_t, engine_deleter_t>
                 *ocl_engine,
         const gpu::intel::sycl::engine_t *engine);
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
+
+status_t get_kernel_binary(const ::sycl::kernel &kernel, xpu::binary_t &binary);
 
 gpu_utils::device_id_t device_id(const ::sycl::device &dev);
 

--- a/src/xpu/ocl/utils.cpp
+++ b/src/xpu/ocl/utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -317,6 +317,7 @@ status_t create_program(ocl::wrapper_t<cl_program> &ocl_program,
     return status::success;
 }
 
+#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 status_t get_device_uuid(xpu::device_uuid_t &uuid, cl_device_id ocl_dev) {
     // This function is used only with SYCL that works with OpenCL 3.0
     // that supports `cl_khr_device_uuid` extension.
@@ -339,6 +340,7 @@ status_t get_device_uuid(xpu::device_uuid_t &uuid, cl_device_id ocl_dev) {
 #endif
     return status::runtime_error;
 }
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 status_t check_device(
         engine_kind_t eng_kind, cl_device_id dev, cl_context ctx) {

--- a/src/xpu/ocl/utils.hpp
+++ b/src/xpu/ocl/utils.hpp
@@ -287,7 +287,9 @@ cl_platform_id get_platform(engine_t *engine);
 status_t create_program(ocl::wrapper_t<cl_program> &ocl_program,
         cl_device_id dev, cl_context ctx, const xpu::binary_t &binary);
 
+#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 status_t get_device_uuid(xpu::device_uuid_t &uuid, cl_device_id ocl_dev);
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 // Check for three conditions:
 // 1. Device and context are compatible, i.e. the device belongs to

--- a/src/xpu/utils.cpp
+++ b/src/xpu/utils.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,10 +23,12 @@ namespace dnnl {
 namespace impl {
 namespace xpu {
 
+#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 size_t device_uuid_hasher_t::operator()(const device_uuid_t &uuid) const {
     const size_t seed = hash_combine(0, std::get<0>(uuid));
     return hash_combine(seed, std::get<1>(uuid));
 }
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 } // namespace xpu
 } // namespace impl

--- a/src/xpu/utils.hpp
+++ b/src/xpu/utils.hpp
@@ -32,9 +32,11 @@ namespace xpu {
 using binary_t = std::vector<uint8_t>;
 using device_uuid_t = std::tuple<uint64_t, uint64_t>;
 
+#ifndef DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 struct device_uuid_hasher_t {
     size_t operator()(const device_uuid_t &uuid) const;
 };
+#endif // DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER
 
 struct runtime_version_t {
     int major;


### PR DESCRIPTION
All changes are guarded by `DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER` build option:
1. Add L0 native kernel binary retrieval
2. Use SYCL kernel compiler for microkernels check
3. Remove OCL-L0 device mapping
4. Remove OCL engine creation from SYCL code