### PR TITLE
tests: benchdnn: Fixup attribute dim count

### DIFF
--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -986,8 +986,9 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
             const int exec_sc_arg = DNNL_ARG_ATTR_SCALES | exec_arg;
             dims_t dims = {};
             int64_t ndims = 1;
+            const auto &arg_md = query_md(const_pd, exec_arg);
             const auto mask = sc.get_mask(exec_arg, prim_kind,
-                    query_md_ndims(wei_md), has_channel_groups);
+                    query_md_ndims(arg_md), has_channel_groups);
             const auto &groups = sc.get(exec_arg).groups;
 
             if (mask > 0) {
@@ -1029,15 +1030,14 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
     if (!prb->attr.zero_points.is_def()) {
         const auto &zp = prb->attr.zero_points;
 
-        const auto &wei_md = query_md(const_pd, DNNL_ARG_WEIGHTS);
-
         const auto append_zero_points = [&](int exec_arg) {
             const int exec_zp_arg = DNNL_ARG_ATTR_ZERO_POINTS | exec_arg;
             const auto &e = zp.get(exec_arg);
             int64_t ndims = 1;
             dims_t dims = {};
+            const auto &arg_md = query_md(const_pd, exec_arg);
             const auto mask
-                    = zp.get_mask(exec_arg, prim_kind, query_md_ndims(wei_md));
+                    = zp.get_mask(exec_arg, prim_kind, query_md_ndims(arg_md));
             const auto &groups = e.groups;
 
             if (mask > 0) {


### PR DESCRIPTION
# Description

Correct argument used to get dim count during attribute initialization. Using weights was invalid for primitives without weights. 

Fixes # [MFDNN-13881](https://jira.devtools.intel.com/browse/MFDNN-13881)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

