### PR TITLE
jit: simplify ir codegen dependencies

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -58,7 +58,7 @@ public:
         : host_(host)
         , expr_binding_(expr_binding)
         , simd_size_(host->getSIMD())
-        , with_atomic_fp64_(host->exec_cfg().hw().has_fp64_atomic_support()) {}
+        , with_atomic_fp64_(host->hw_info().has_fp64_atomic_support()) {}
 
     ~ir_to_ngen_t() override
 #ifdef DNNL_DEV_MODE

--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -220,6 +220,7 @@ public:
 
     const kernel_iface_t &kernel_iface() const { return kernel_iface_; }
     const exec_config_t &exec_cfg() const { return exec_cfg_; }
+    const hw_t &hw_info() const { return exec_cfg_.hw(); }
 
     reg_allocator_t &ra() { return ra_; };
     const reg_allocator_t &ra() const { return ra_; };

--- a/src/gpu/intel/jit/codegen/reduce.hpp
+++ b/src/gpu/intel/jit/codegen/reduce.hpp
@@ -92,7 +92,7 @@ public:
             bool s_is_hf = src_type.is_f16();
             bool s_is_fp8 = src_type.is_fp8();
             bool d_is_f = dst_type.is_f32();
-            bool native_bf = host->exec_cfg().hw().systolic_support();
+            bool native_bf = host->hw_info().systolic_support();
             bool sd_aligned = (tile_elems == 1
                     || (dst_stride * ngen::getBytes(d.type())
                             == src_stride * ngen::getBytes(s.type())));

--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -291,7 +291,7 @@ void emit_reorder_1d_tile(ngen::HW hw, GeneratorT *host,
     bool src_f4_e3m0 = (src_type == ngen_f4_e3m0());
     bool src_f4 = src_f4_e2m1 || src_f4_e3m0;
     bool f_to_xf = (src_f && (dst_bf || dst_hf));
-    bool native_bf16 = host->exec_cfg().hw().systolic_support();
+    bool native_bf16 = host->hw_info().systolic_support();
     op_plan_t plan = grf_size;
     ngen_register_scope_t lex_scope {scope.register_allocator()};
 

--- a/src/gpu/intel/jit/codegen/send.hpp
+++ b/src/gpu/intel/jit/codegen/send.hpp
@@ -194,7 +194,7 @@ private:
                 gpu_error_not_expected();
             }
         } else if (send_.is_a64()) {
-            *lsc_spec |= get_cache_settings(send_, host->exec_cfg_.hw());
+            *lsc_spec |= get_cache_settings(send_, host->hw_info());
             if (send_.is_load() || send_.is_prefetch()) {
                 host->load.ugm(mod, data, *lsc_spec, host->A64, header);
             } else if (send_.is_store()) {
@@ -223,7 +223,7 @@ private:
         if (info.vnni) data_spec |= host->vnni;
         if (info.transpose) data_spec |= host->transpose;
         ngen::block_2d spec(data_spec, info.width, info.height, info.count);
-        spec |= get_cache_settings(send_, host->exec_cfg_.hw());
+        spec |= get_cache_settings(send_, host->hw_info());
         if (send_.is_load_2d() || send_.is_prefetch_2d()) {
             host->load(mod, data, spec, host->A64, header);
         } else if (send_.is_store_2d()) {

--- a/src/gpu/intel/jit/conv/config.cpp
+++ b/src/gpu/intel/jit/conv/config.cpp
@@ -1199,7 +1199,6 @@ status_t init_pd_time_cfg(const conv_problem_t &prb, conv_config_t &cfg,
     cfg.set_exec_cfg(exec_config_t(hw));
     cfg.maybe_override_from_env();
 
-    cfg.set_require_signal_header(true);
     CHECK(init_fma_kind(cfg, pd, engine));
     CHECK(init_simd(cfg));
     CHECK(init_vec_size(cfg));

--- a/src/gpu/intel/jit/conv/config.hpp
+++ b/src/gpu/intel/jit/conv/config.hpp
@@ -599,12 +599,6 @@ public:
         set_exec_cfg(tmp);
     }
 
-    void set_require_signal_header(bool r) {
-        auto tmp = exec_cfg();
-        tmp.set_require_signal_header(r);
-        set_exec_cfg(tmp);
-    }
-
     void set_tiler(const std::shared_ptr<conv_tiler_t> &tiler);
     const conv_tiler_t &tiler() const;
     conv_tiler_t &tiler();

--- a/src/gpu/intel/jit/ir/config.hpp
+++ b/src/gpu/intel/jit/ir/config.hpp
@@ -124,13 +124,12 @@ public:
     bool is_default(const std::string &key) const override {
         if (key == "regs") return false;
         if (key == "simd") return false;
-        if (key == "vec") return value_.vec_size() == value_.simd();
         gpu_error_not_expected() << key;
         return false;
     }
 
     std::vector<std::string> accepted_keys() const override {
-        return {"regs", "simd", "vec"};
+        return {"regs", "simd"};
     }
 
     void set_from_str(
@@ -139,8 +138,6 @@ public:
             value_.set_regs(std::stoi(value));
         } else if (key == "simd") {
             value_.set_simd(std::stoi(value));
-        } else if (key == "vec") {
-            value_.set_vec_size(std::stoi(value));
         } else {
             gpu_error_not_expected() << key;
         }
@@ -152,8 +149,6 @@ public:
             oss << "regs=" << value_.regs();
         } else if (key == "simd") {
             oss << "simd=" << value_.simd();
-        } else if (key == "vec") {
-            if (!is_default("vec")) oss << "vec=" << value_.vec_size();
         }
         return oss.str();
     }
@@ -323,23 +318,6 @@ public:
 
         set_params_id(params.id());
         set_bufs_hint(params.bufs_hint());
-    }
-
-    blocking_params_t params(
-            int bufs_hint = blocking_params_t::bufs_hint_undef) const {
-        blocking_t blocking;
-        for (auto &d : index_dims()) {
-            dim_t loop = loop_dim(d);
-            dim_t tg = thread_group_dim(d);
-            dim_t iter = iter_dim(d);
-            if (loop != 1) blocking.set_loop(d, loop);
-            if (tg != 1) blocking.set_thread_group(d, tg);
-            if (iter != 1) blocking.set_iter(d, iter);
-        }
-        blocking.set_simd(exec_cfg().vec_size());
-        blocking_params_t ret(blocking, bufs_hint);
-        ret.set_id(params_id_);
-        return ret;
     }
 
     static int get_max_threadgroups_per_wave(

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -157,23 +157,17 @@ class exec_config_t {
 public:
     exec_config_t() = default;
     exec_config_t(const hw_t &hw) : hw_(hw) {}
-    exec_config_t(const hw_t &hw, int regs, int simd,
-            bool require_signal_header = false)
-        : hw_(hw)
-        , regs_(regs)
-        , simd_(simd)
-        , require_signal_header_(require_signal_header) {}
+    exec_config_t(const hw_t &hw, int regs, int simd)
+        : hw_(hw), regs_(regs), simd_(simd) {}
 
     const hw_t &hw() const { return hw_; }
     int regs() const { return regs_; }
     int simd() const { return simd_; }
     int vec_size() const { return vec_size_; }
     int grf_size() const { return hw_.grf_size(); }
-    bool require_signal_header() const { return require_signal_header_; }
     void set_regs(int regs) { regs_ = regs; }
     void set_simd(int simd) { simd_ = simd; }
     void set_vec_size(int vec_size) { vec_size_ = vec_size; }
-    void set_require_signal_header(bool r) { require_signal_header_ = r; }
 
     std::string str() const {
         std::ostringstream oss;
@@ -189,7 +183,6 @@ private:
     int regs_ = 0;
     int simd_ = 0;
     int vec_size_ = 0;
-    bool require_signal_header_ = false;
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -163,17 +163,14 @@ public:
     const hw_t &hw() const { return hw_; }
     int regs() const { return regs_; }
     int simd() const { return simd_; }
-    int vec_size() const { return vec_size_; }
     int grf_size() const { return hw_.grf_size(); }
     void set_regs(int regs) { regs_ = regs; }
     void set_simd(int simd) { simd_ = simd; }
-    void set_vec_size(int vec_size) { vec_size_ = vec_size; }
 
     std::string str() const {
         std::ostringstream oss;
         oss << hw_.str();
         oss << ", SIMD: " << simd();
-        if (vec_size() != simd()) oss << " (" << vec_size() << ")";
         oss << ", regs: " << regs();
         return oss.str();
     }
@@ -182,7 +179,6 @@ private:
     hw_t hw_;
     int regs_ = 0;
     int simd_ = 0;
-    int vec_size_ = 0;
 };
 
 } // namespace jit

--- a/src/gpu/intel/jit/ir/ir.cpp
+++ b/src/gpu/intel/jit/ir/ir.cpp
@@ -929,22 +929,6 @@ int get_peak_regs(
     return utils::div_up(visitor.peak_regs(), grf_size);
 }
 
-class has_send_atomics_visitor_t : public ir_visitor_t {
-public:
-    void _visit(const func_call_t &obj) override {
-        auto *send = obj.func.as_ptr<send_t>();
-        if (send && send->is_atomic()) found = true;
-    }
-
-    bool found = false;
-};
-
-bool has_send_atomics(const stmt_t &s) {
-    has_send_atomics_visitor_t visitor;
-    visitor.visit(s);
-    return visitor.found;
-}
-
 bool relation_t::implies(const relation_t &other) const {
     gpu_assert(var().is_same(other.var()));
 

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -680,8 +680,6 @@ stmt_t replace_stmt_body(const stmt_t &stmt, const stmt_t &new_body);
 int get_peak_regs(const stmt_t &stmt, int grf_size, int external_regs = 0,
         bool skip_let = false);
 
-bool has_send_atomics(const stmt_t &s);
-
 struct mem_usage_guard_t {
     mem_usage_guard_t(int *usage, int *peak_usage, int size)
         : usage(usage), peak_usage(peak_usage), size(size) {

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.hpp
@@ -347,7 +347,7 @@ public:
     std::string kernel_name() const override { return "gen_conv_v2"; }
 
     exec_config_t exec_cfg(const impl::engine_t *engine) const override {
-        return exec_config_t(hw_t(engine), regs, simd, true);
+        return exec_config_t(hw_t(engine), regs, simd);
     }
 
     compute::range_t local_range() const override;


### PR DESCRIPTION
This PR removes 3 dependencies from IR code generation. In particular, this PR replaces the generation of hardcoded dpas meta data, atomic send meta data, and signal header generation with an IR pass which automatically determines their necessity. In addition, this removes the v1:conv configuration parameter `vec_size` out of shared structure `exec_config_t`, and removes the codegen dependency on `exec_config_t`, as `exec_config_t` is only necessary for the interface setup.