### PR TITLE
xe: gemm: refactor post ops and quantization

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.cpp
@@ -34,6 +34,16 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
+namespace {
+dim_t quant_entry_group_prod(const quant_entry_t &attr) {
+    dim_t ret = 1;
+    if (attr.has_default_groups()) return ret;
+    for (int i = 0; i < 2; ++i)
+        ret *= attr.get_group(i);
+    return ret;
+}
+} // anonymous namespace
+
 status_t gen_gemm_t::launch_nocopy(const gemm_exec_ctx_t &ctx,
         compute::compute_stream_t *compute_stream, zero_pool_t *zero_pool,
         const memory_storage_t &a, const memory_storage_t &b,
@@ -145,14 +155,14 @@ status_t gen_gemm_t::launch_nocopy(const gemm_exec_ctx_t &ctx,
             if (problem->asPtrDims > 2) {
                 dim_t scale_stride = pd()->stride_scale(i, DNNL_ARG_A);
                 auto scale_stride_a = int32_t(scale_stride
-                        / pd()->quant_entry_group_prod(
+                        / quant_entry_group_prod(
                                 pd()->attr()->scales_.get(DNNL_ARG_A)));
                 arg_list.set(argn++, scale_stride_a);
             }
             if (problem->bsPtrDims > 2) {
                 dim_t scale_stride = pd()->stride_scale(i, DNNL_ARG_B);
                 auto scale_stride_b = int32_t(scale_stride
-                        / pd()->quant_entry_group_prod(
+                        / quant_entry_group_prod(
                                 pd()->attr()->scales_.get(DNNL_ARG_B)));
                 arg_list.set(argn++, scale_stride_b);
             }

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -212,14 +212,6 @@ int jit_gemm_pd_t::quant_entry_ndims(
     return count;
 }
 
-int jit_gemm_pd_t::quant_entry_group_prod(const quant_entry_t &attr) const {
-    int ret = 1;
-    if (attr.has_default_groups()) return ret;
-    for (int i = 0; i < 2; ++i)
-        ret *= attr.get_group(i);
-    return ret;
-}
-
 bool jit_gemm_pd_t::dy_quant_enabled() {
     const auto d = desc();
     using namespace data_type;

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
@@ -167,7 +167,6 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     bool quant_entry_2d(int arg, const quant_entries_t &entry) const;
     int quant_entry_ndims(
             const quant_entry_t &entry, const memory_desc_t &md) const;
-    int quant_entry_group_prod(const quant_entry_t &attr) const;
 
     bool dy_quant_enabled();
     bool wei_decomp();

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
@@ -164,10 +164,6 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     bool wei_scales_2d() const { return asc_dims_ > 1; }
     bool src_scales_2d() const { return bsc_dims_ > 1; }
 
-    bool quant_entry_2d(int arg, const quant_entries_t &entry) const;
-    int quant_entry_ndims(
-            const quant_entry_t &entry, const memory_desc_t &md) const;
-
     bool dy_quant_enabled();
     bool wei_decomp();
     bool quant_enabled();

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
@@ -105,7 +105,7 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     const int mask_per_ic = 1 << 2;
 
     const int idx_a = DNNL_ARG_WEIGHTS;
-    memory_desc_t wei_scales_md, src_scales_md, c_scales_md, prelu_wei_md;
+    memory_desc_t prelu_wei_md;
     bool swap_ab_ = false;
     bool a_zp_ = false, b_zp_ = false;
     dim_t eff_lda_ = 0, eff_ldb_ = 0;


### PR DESCRIPTION
Post-ops for A/B/C each have their own handling code, potentially leading to bug escapes. This PR refactors post-op initialization to simplify the related logic, and so that A/B/C scales are handled in one block and can easily be extended for future features. Additionally refactors a few functions to be defined where they're used and to reduce type conversions.

The first commit is from #3498 and will be dropped upon merging (that PR, then this one).