### PR TITLE
graph: interface: combine fpmath into compiled partition cache key

### DIFF
--- a/src/graph/interface/partition_hashing.cpp
+++ b/src/graph/interface/partition_hashing.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ namespace partition_hashing {
 key_t::key_t(const impl::engine_t *engine,
         const std::vector<std::shared_ptr<op_t>> &ops,
         const std::vector<const logical_tensor_t *> &ins,
-        const std::vector<const logical_tensor_t *> &outs)
+        const std::vector<const logical_tensor_t *> &outs,
+        const impl::graph::fpmath_t &fpmath)
     : ops_(get_raw_ptrs(ops))
     , nthread_(dnnl_get_max_threads())
     // Here we use engine as a member of partition_hashing key_t, because for
@@ -40,6 +41,7 @@ key_t::key_t(const impl::engine_t *engine,
     // engine 2(fail). So we need to use engine as a member of key_t to avoid
     // execution crash.
     , engine_(engine)
+    , fpmath_(fpmath)
     , thread_id_(std::this_thread::get_id()) {
     ins_.reserve(ins.size());
     outs_.reserve(outs.size());
@@ -54,7 +56,8 @@ key_t::key_t(const impl::engine_t *engine,
 key_t::key_t(const partition_t *partition, const impl::engine_t *engine,
         const std::vector<const logical_tensor_t *> &ins,
         const std::vector<const logical_tensor_t *> &outs)
-    : key_t(engine, partition->get_ops(), ins, outs) {}
+    : key_t(engine, partition->get_ops(), ins, outs,
+            partition->get_fpmath_mode()) {}
 
 bool key_t::operator==(const key_t &rhs) const {
     if (this == &rhs) return true;
@@ -68,7 +71,7 @@ bool key_t::operator==(const key_t &rhs) const {
 
     bool ret = true && lhs_num_ops == rhs_num_ops && lhs_num_ins == rhs_num_ins
             && lhs_num_outs == rhs_num_outs && nthread_ == rhs.nthread_
-            && engine_ == rhs.engine_;
+            && engine_ == rhs.engine_ && fpmath_ == rhs.fpmath_;
     if (!ret) return false;
 
     for (size_t i = 0; i < lhs_num_ops; ++i) {

--- a/src/graph/interface/partition_hashing.hpp
+++ b/src/graph/interface/partition_hashing.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 #include "common/engine_id.hpp"
 
 #include "graph/interface/c_types_map.hpp"
+#include "graph/interface/graph_attr.hpp"
 #include "graph/interface/logical_tensor.hpp"
 #include "graph/interface/op.hpp"
 
@@ -56,7 +57,8 @@ struct key_t {
     key_t(const impl::engine_t *engine,
             const std::vector<std::shared_ptr<op_t>> &ops,
             const std::vector<const logical_tensor_t *> &ins,
-            const std::vector<const logical_tensor_t *> &outs);
+            const std::vector<const logical_tensor_t *> &outs,
+            const impl::graph::fpmath_t &fpmath);
     key_t(const partition_t *partition, const impl::engine_t *engine,
             const std::vector<const logical_tensor_t *> &ins,
             const std::vector<const logical_tensor_t *> &outs);
@@ -73,6 +75,7 @@ struct key_t {
     mutable std::vector<logical_tensor_t> outs_;
     int nthread_;
     const impl::engine_t *engine_;
+    const impl::graph::fpmath_t fpmath_;
 
 private:
     // Thread ID is not used as part of the key, it's only used to get
@@ -158,6 +161,12 @@ struct hash<dnnl::impl::graph::partition_hashing::key_t> {
         // Combine hash for input and output ports with the computed hash
         seed = get_array_hash(seed, key.ins_.data(), key.ins_.size());
         seed = get_array_hash(seed, key.outs_.data(), key.outs_.size());
+
+        // Combine hash for fpmath_t
+        seed = dnnl::impl::hash_combine(
+                seed, static_cast<size_t>(key.fpmath_.mode_));
+        seed = dnnl::impl::hash_combine(
+                seed, static_cast<size_t>(key.fpmath_.apply_to_int_));
 
         return seed;
     }

--- a/tests/gtests/graph/unit/interface/test_compiled_partition.cpp
+++ b/tests/gtests/graph/unit/interface/test_compiled_partition.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2024 Intel Corporation
+* Copyright 2021-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -200,6 +200,80 @@ TEST(test_interface_compiled_partition, CacheEngine) {
 #endif
 }
 
+TEST(test_interface_compiled_partition, CacheFpmath) {
+    dnnl::engine::kind ekind;
+    if (get_test_engine_kind() == impl::graph::engine_kind::cpu) {
+        ekind = dnnl::engine::kind::cpu;
+    } else {
+        ekind = dnnl::engine::kind::gpu;
+    }
+
+    impl::graph::op_kind_t kind = impl::graph::op_kind::MatMul;
+
+    const std::vector<impl::graph::fpmath_t> fp_math_vec
+            = {{impl::graph::fpmath_mode::strict, false},
+                    {impl::graph::fpmath_mode::strict, false},
+                    {impl::graph::fpmath_mode::bf16, false},
+                    {impl::graph::fpmath_mode::bf16, false}};
+
+    // Flush the cache
+    set_compiled_partition_cache_capacity(0);
+    set_compiled_partition_cache_capacity(1024);
+
+    dnnl::engine engine = dnnl::engine(ekind, 0);
+    impl::engine_t *eng = engine.get();
+    impl::graph::logical_tensor_t src = utils::logical_tensor_init(0,
+            {1, 1, 1, 1}, impl::graph::data_type::f32,
+            impl::graph::layout_type::strided);
+    impl::graph::logical_tensor_t weight = utils::logical_tensor_init(1,
+            {1, 1, 1, 1}, impl::graph::data_type::f32,
+            impl::graph::layout_type::strided);
+    impl::graph::logical_tensor_t dst = utils::logical_tensor_init(2,
+            {1, 1, 1, 1}, impl::graph::data_type::f32,
+            impl::graph::layout_type::strided);
+    impl::graph::op_t matmul {0, kind, "matmul"};
+    matmul.add_input(src);
+    matmul.add_input(weight);
+    matmul.add_output(dst);
+
+    for (size_t idx = 0; idx < fp_math_vec.size(); ++idx) {
+        // Create graph
+        impl::graph::graph_t g {eng->kind()};
+        g.set_fpmath_mode(
+                fp_math_vec[idx].mode_, fp_math_vec[idx].apply_to_int_);
+        g.add_op(&matmul);
+        g.finalize();
+        // Create single-op partition
+        std::vector<const impl::graph::backend_t *> &backends
+                = impl::graph::backend_registry_t::get_singleton()
+                          .get_registered_backends();
+        for (const auto &cbkd : backends) {
+            impl::graph::backend_t *bkd
+                    = const_cast<impl::graph::backend_t *>(cbkd);
+            bkd->get_partitions(g, impl::graph::partition_policy::fusion);
+        }
+        // wrap into the partition
+        impl::graph::partition_t par = impl::graph::partition_t();
+        std::vector<impl::graph::partition_t *> parts {&par};
+        g.get_ordered_partitions(parts);
+
+        impl::graph::compiled_partition_t cp(par);
+        std::pair<impl::graph::compiled_partition_t *, cache_state_t> cpcache {
+                &cp, cache_state_t::miss};
+        std::vector<const impl::graph::logical_tensor_t *> inputs {
+                &src, &weight};
+        std::vector<const impl::graph::logical_tensor_t *> outputs {&dst};
+        // Partition compilation
+        par.compile(cpcache, inputs, outputs, eng);
+    }
+
+#ifdef DNNL_GRAPH_DISABLE_COMPILED_PARTITION_CACHE
+    ASSERT_EQ(get_compiled_partition_cache_size(), 0);
+#else
+    ASSERT_EQ(get_compiled_partition_cache_size(), fp_math_vec.size() / 2);
+#endif
+}
+
 TEST(test_interface_compiled_partition, CacheMethod) {
     namespace graph = dnnl::impl::graph;
 
@@ -244,7 +318,8 @@ TEST(test_interface_compiled_partition, CacheMethod) {
     par.compile(cpcache, inputs, outputs, &eng);
 
 #ifndef DNNL_GRAPH_DISABLE_COMPILED_PARTITION_CACHE
-    graph::partition_hashing::key_t key {&eng, {elt}, inputs, outputs};
+    graph::partition_hashing::key_t key(
+            &eng, {elt}, inputs, outputs, par.get_fpmath_mode());
     auto &cache_mapper = graph::compiled_partition_cache();
     ASSERT_NO_THROW(cache_mapper.get_partition(key));
 

--- a/tests/gtests/graph/unit/interface/test_partition_hashing.cpp
+++ b/tests/gtests/graph/unit/interface/test_partition_hashing.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ namespace graph = dnnl::impl::graph;
 
 TEST(test_interface_partition_hashing, ThreadId) {
     graph::engine_t &engine = *get_engine();
-    graph::partition_hashing::key_t key {&engine, {}, {}, {}};
+    graph::partition_hashing::key_t key {&engine, {}, {}, {}, {}};
     ASSERT_EQ(std::this_thread::get_id(), key.thread_id());
 }
 


### PR DESCRIPTION
Found in MFDNN-13693, not about solving the MFDNN-13693 itself, but a potential issue.

Different fpmath mode may has different kernel implementation, shouldn't cache hit if fpmath is different. Also following the implementation of primitive hashing([here](https://github.com/uxlfoundation/oneDNN/blob/main/src/common/primitive_hashing.cpp#L226))