### PR TITLE
api: graph: fix scalar tensor creation and usage

### DIFF
--- a/doc/graph/fusion_patterns/sdpa.md
+++ b/doc/graph/fusion_patterns/sdpa.md
@@ -150,6 +150,11 @@ demonstrating how to construct a floating-point MQA pattern with the same
 pattern structure as in the SDPA example but different head number in Key and
 Value tensors. In MQA, the head number of Key and Value is always one.
 
+oneDNN also proides an [SDPA with bottom-right implicit causal mask
+example](https://github.com/uxlfoundation/oneDNN/tree/main/examples/graph/sdpa_bottom_right_causal_mask.cpp)
+demonstrating how to construct a floating-point SDPA pattern with implicit
+library-generated attention masks.
+
 ## References
 
 [1] Attention is all you need, https://arxiv.org/abs/1706.03762v7

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -91,6 +91,7 @@ if(NOT ONEDNN_BUILD_GRAPH)
         ${CMAKE_CURRENT_SOURCE_DIR}/graph/gated_mlp.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/graph/gated_mlp_wei_combined.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/graph/gated_mlp_int4.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/graph/sdpa_bottom_right_causal_mask.cpp
         )
 endif()
 

--- a/examples/graph/sdpa_bottom_right_causal_mask.cpp
+++ b/examples/graph/sdpa_bottom_right_causal_mask.cpp
@@ -1,0 +1,363 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cassert>
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "oneapi/dnnl/dnnl.hpp"
+#include "oneapi/dnnl/dnnl_graph.hpp"
+
+#include "graph_example_utils.hpp"
+
+using namespace dnnl;
+
+using namespace dnnl::graph;
+using layout_type = logical_tensor::layout_type;
+using property_type = logical_tensor::property_type;
+using data_type = logical_tensor::data_type;
+using dim = logical_tensor::dim;
+using dims = logical_tensor::dims;
+
+struct sdpa_dims_t {
+    dim mb;
+    dim seq_len;
+    dim head_num;
+    dim head_size;
+    dim query_num;
+};
+
+static const int min_runs = 4;
+
+// this is changed from the fill_random() function in matmul_perf.cpp.
+void fill_random(std::vector<float> &out) {
+    static std::vector<float> random_data_f;
+    constexpr size_t nrand = 1037;
+
+    if (random_data_f.empty()) {
+        std::mt19937 generator;
+        std::uniform_real_distribution<float> dist_f(-1.0f, 1.0f);
+
+        random_data_f.resize(nrand);
+        for (auto &d : random_data_f)
+            d = dist_f(generator);
+    }
+
+    for (size_t i = 0; i < out.size(); i += nrand) {
+        size_t chunk = std::min(nrand, out.size() - i);
+        std::memcpy(&out[i], random_data_f.data(), chunk * sizeof(float));
+    }
+}
+
+void print_test_case(memory::data_type dt, const sdpa_dims_t &p) {
+    std::cout << '[' << std::setw(4) << dnnl_dt2str(memory::convert_to_c(dt));
+    std::cout << " mb = " << p.mb << ", seq_len = " << p.seq_len
+              << ", head_num = " << p.head_num
+              << ", head_size = " << p.head_size
+              << ", query_num = " << p.query_num;
+    std::cout << "] " << std::flush;
+}
+
+const char *get_type_string(logical_tensor::data_type dt) {
+    const char *type_string = "unknown";
+
+#define TYPE_CASE(T) \
+    if (dt == logical_tensor::data_type::T) type_string = #T;
+    TYPE_CASE(f16);
+    TYPE_CASE(f32);
+    TYPE_CASE(bf16);
+#undef TYPE_CASE
+
+    return type_string;
+}
+
+void print_test_case(logical_tensor::data_type dt, const sdpa_dims_t &p) {
+    std::cout << '[' << std::setw(4) << get_type_string(dt);
+    std::cout << " mb = " << p.mb << ", seq_len = " << p.seq_len
+              << ", head_num = " << p.head_num
+              << ", head_size = " << p.head_size
+              << ", query_num = " << p.query_num;
+    std::cout << "] " << std::flush;
+}
+
+void bench_sdpa(engine::kind ekind, logical_tensor::data_type dt,
+        const sdpa_dims_t &p, double time_limit = 0.) {
+    const bool quick_test = (time_limit == 0.);
+    print_test_case(dt, p);
+
+    allocator alloc = create_allocator(ekind);
+
+    // Create execution dnnl::engine.
+    dnnl::engine eng = make_engine_with_allocator(ekind, 0, alloc);
+    // Create dnnl::stream.
+    dnnl::stream strm(eng);
+
+    // Prepare input and output shapes to construct the sdpa graph.
+    const dims qv_sz = {p.mb, p.head_num, p.query_num, p.head_size};
+    const dims k_sz = {p.mb, p.head_num, p.seq_len, p.head_size};
+    const dims score_sz = {p.mb, p.head_num, p.query_num, p.seq_len};
+    const dims scale_sz = {1};
+
+    // Incremental IDs used to create logical tensors and operations.
+    size_t id = 0;
+
+    // Intermediate data type
+    const logical_tensor::data_type dt_inter = logical_tensor::data_type::f32;
+
+    // score = query x key.T
+    auto query = logical_tensor(id++, dt, qv_sz, layout_type::strided);
+    auto key = logical_tensor(id++, dt, k_sz, layout_type::strided);
+    auto score = logical_tensor(id++, dt_inter, score_sz, layout_type::strided);
+    auto bmm1 = op(id++, op::kind::MatMul, "bmm1");
+    bmm1.set_attr<bool>(op::attr::transpose_b, true);
+    bmm1.add_inputs({query, key});
+    bmm1.add_outputs({score});
+
+    // scale_mul_out_lt = score * scale
+    auto scale = logical_tensor(id++, dt, scale_sz, layout_type::strided);
+    auto scaled_score
+            = logical_tensor(id++, dt_inter, score_sz, layout_type::strided);
+    auto scale_mul = op(id++, op::kind::Multiply, "scale_mul");
+    scale_mul.add_inputs({score, scale});
+    scale_mul.add_outputs({scaled_score});
+
+    auto index_row = logical_tensor(
+            id++, data_type::s32, score_sz, layout_type::strided);
+    auto gen_index_row = op(id++, op::kind::GenIndex, "gen_index_row");
+    gen_index_row.set_attr<int64_t>(op::attr::axis, -2);
+    gen_index_row.add_inputs({scaled_score});
+    gen_index_row.add_outputs({index_row});
+
+    auto seq_len_kv = logical_tensor(id++, data_type::s32, 0,
+            layout_type::strided, property_type::host_scalar);
+    auto mask_add_out = logical_tensor(
+            id++, data_type::s32, score_sz, layout_type::strided);
+    auto mask_add = op(id++, op::kind::Add, "mask_add");
+    mask_add.add_inputs({index_row, seq_len_kv});
+    mask_add.add_outputs({mask_add_out});
+
+    auto seq_len_q = logical_tensor(id++, data_type::s32, 0,
+            layout_type::strided, property_type::host_scalar);
+    auto mask_sub_out = logical_tensor(
+            id++, data_type::s32, score_sz, layout_type::strided);
+    auto mask_sub = op(id++, op::kind::Subtract, "mask_sub");
+    mask_sub.add_inputs({mask_add_out, seq_len_q});
+    mask_sub.add_outputs({mask_sub_out});
+
+    auto index_col = logical_tensor(
+            id++, data_type::s32, score_sz, layout_type::strided);
+    auto gen_index_col = op(id++, op::kind::GenIndex, "gen_index_col");
+    gen_index_col.set_attr<int64_t>(op::attr::axis, -1);
+    gen_index_col.add_inputs({scaled_score});
+    gen_index_col.add_outputs({index_col});
+
+    auto mask_ge_out = logical_tensor(
+            id++, data_type::boolean, score_sz, layout_type::strided);
+    auto mask_ge = op(id++, op::kind::GreaterEqual, "mask_ge");
+    mask_ge.add_inputs({mask_sub_out, index_col});
+    mask_ge.add_outputs({mask_ge_out});
+
+    auto neg_inf
+            = logical_tensor(id++, dt_inter, scale_sz, layout_type::strided);
+    auto masked_score
+            = logical_tensor(id++, dt_inter, score_sz, layout_type::strided);
+    auto mask_select = op(id++, op::kind::Select, "mask_select");
+    mask_select.add_inputs({mask_ge_out, scaled_score, neg_inf});
+    mask_select.add_outputs({masked_score});
+
+    // attention_probs = softmax(masked_score)
+    auto probs = logical_tensor(id++, dt, score_sz, layout_type::strided);
+    auto softmax = op(id++, op::kind::SoftMax, "softmax");
+    softmax.set_attr<int64_t>(op::attr::axis, -1);
+    softmax.set_attr<std::string>(op::attr::mode, "inf_as_zero");
+    softmax.add_inputs({masked_score});
+    softmax.add_outputs({probs});
+
+    // attention_output = attention_probs x value
+    auto value = logical_tensor(id++, dt, k_sz, layout_type::strided);
+    auto output = logical_tensor(id++, dt, qv_sz, layout_type::strided);
+    auto bmm2 = op(id++, op::kind::MatMul, "bmm2");
+    bmm2.add_inputs({probs, value});
+    bmm2.add_outputs({output});
+
+    // Construct a sdpa graph with engine kind and operations.
+    dnnl::graph::graph sdpa(ekind);
+    sdpa.add_op(bmm1);
+    sdpa.add_op(scale_mul);
+    sdpa.add_op(gen_index_row);
+    sdpa.add_op(mask_add);
+    sdpa.add_op(mask_sub);
+    sdpa.add_op(gen_index_col);
+    sdpa.add_op(mask_ge);
+    sdpa.add_op(mask_select);
+    sdpa.add_op(softmax);
+    sdpa.add_op(bmm2);
+    sdpa.finalize();
+
+    // Get partitions from the sdpa graph.
+    std::vector<partition> partitions = sdpa.get_partitions();
+    // This is just for oneDNN testing purpose.
+    if (partitions.size() != 1) {
+        std::cout << "unsupported sdpa" << std::endl;
+        return;
+    }
+
+    // Compile the partition with inputs, outputs, and an engine.
+    compiled_partition cp = partitions[0].compile(
+            {query, key, scale, seq_len_kv, seq_len_q, neg_inf, value},
+            {output}, eng);
+
+    int32_t q_len = p.query_num;
+    int32_t kv_len = p.seq_len;
+    auto ts_mask_add = tensor::make_scalar_tensor(seq_len_kv, &kv_len);
+    auto ts_mask_sub = tensor::make_scalar_tensor(seq_len_q, &q_len);
+    // Create tensor objects
+    auto ts_query = tensor(query, eng);
+    auto ts_key = tensor(key, eng);
+    auto ts_scale = tensor(scale, eng);
+    auto ts_neg_inf = tensor(neg_inf, eng);
+    auto ts_value = tensor(value, eng);
+    auto ts_output = tensor(output, eng);
+
+    // Allocate user data.
+    std::vector<float> query_data(product(qv_sz));
+    std::vector<float> key_data(product(k_sz));
+    std::vector<float> scale_data(product(scale_sz), std::sqrt(p.head_size));
+    std::vector<float> neg_inf_data(
+            product(scale_sz), -1 * std::numeric_limits<float>::infinity());
+    std::vector<float> value_data(product(k_sz));
+    std::vector<float> output_data(product(qv_sz));
+
+    fill_random(query_data);
+    fill_random(key_data);
+    fill_random(value_data);
+
+    // Write data to tensor object's handle.
+    write_to_dnnl_tensor(query_data.data(), ts_query);
+    write_to_dnnl_tensor(key_data.data(), ts_key);
+    write_to_dnnl_tensor(scale_data.data(), ts_scale);
+    write_to_dnnl_tensor(neg_inf_data.data(), ts_neg_inf);
+    write_to_dnnl_tensor(value_data.data(), ts_value);
+
+    // Warmup run.
+    // Execute the compiled partition of sdpa.
+    cp.execute(strm,
+            {ts_query, ts_key, ts_scale, ts_mask_add, ts_mask_sub, ts_neg_inf,
+                    ts_value},
+            {ts_output});
+
+    // Wait for the computation to finish.
+    strm.wait();
+
+    // First run.
+    auto start_first = std::chrono::steady_clock::now();
+    cp.execute(strm,
+            {ts_query, ts_key, ts_scale, ts_mask_add, ts_mask_sub, ts_neg_inf,
+                    ts_value},
+            {ts_output});
+    strm.wait();
+    auto end_first = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> dur_first
+            = end_first - start_first;
+
+    if (quick_test) return;
+
+    // Timing runs.
+    const int runs = std::max(min_runs, int(time_limit / dur_first.count()));
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i <= runs; i++)
+        cp.execute(strm,
+                {ts_query, ts_key, ts_scale, ts_mask_add, ts_mask_sub,
+                        ts_neg_inf, ts_value},
+                {ts_output});
+    strm.wait();
+    auto end = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> duration = end - start;
+
+    // Display the results.
+    double avg_time = (duration.count() - dur_first.count()) / runs;
+    std::cout << "graph runs: " << runs + 1 << "; ";
+    std::cout << "avg_time: " << avg_time << " ms" << std::endl;
+}
+
+void bad_args() {
+    std::cerr << "Usage: graph-sdpa-bottom-right-causal-mask-cpp [cpu|gpu]\n"
+                 "       graph-sdpa-bottom-right-causal-mask-cpp [cpu|gpu] "
+                 "<mb> <seq_len> <head_num> <head_size> [<query_num>]\n\n"
+                 "On CPU, it's recommended to test with numactl and memory "
+                 "allocation tools like jemalloc or tcmalloc.\n\n";
+    throw std::invalid_argument("Incorrect input arguments.");
+}
+
+void bench(engine::kind ekind, dnnl_data_type_t dt, const sdpa_dims_t &p,
+        double time_limit = 0.) {
+    try {
+        bench_sdpa(ekind, static_cast<data_type>(dt), p, time_limit);
+        get_mem_pool().clear();
+    } catch (dnnl::error &e) {
+        // Catch and report unimplemented cases.
+        if (e.status == dnnl_unimplemented) {
+            std::cout << "unsupported sdpa" << std::endl;
+        } else
+            throw;
+    }
+}
+
+void sdpa_perf(engine::kind ekind, int argc, char **argv) {
+    // default testing parameters
+    sdpa_dims_t params = {32, 384, 16, 64, 384};
+
+    if (argc > 2) {
+        if (argc == 6) {
+            params.mb = std::atoi(argv[2]);
+            params.seq_len = std::atoi(argv[3]);
+            params.query_num = std::atoi(argv[3]);
+            params.head_num = std::atoi(argv[4]);
+            params.head_size = std::atoi(argv[5]);
+        } else if (argc == 7) {
+            params.mb = std::atoi(argv[2]);
+            params.seq_len = std::atoi(argv[3]);
+            params.head_num = std::atoi(argv[4]);
+            params.head_size = std::atoi(argv[5]);
+            params.query_num = std::atoi(argv[6]);
+        } else {
+            bad_args();
+        }
+
+        if (params.mb <= 0 || params.seq_len <= 0 || params.head_num <= 0
+                || params.head_size <= 0) {
+            bad_args();
+        }
+    }
+
+    bench(ekind, dnnl_f32, params, 2000.0 /*ms*/);
+    bench(ekind, dnnl_bf16, params, 2000.0 /*ms*/);
+    bench(ekind, dnnl_f16, params, 2000.0 /*ms*/);
+}
+
+int main(int argc, char **argv) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_NONE
+    return 0;
+#else
+    return handle_example_errors(
+            sdpa_perf, parse_engine_kind(argc, argv, 5), argc, argv);
+#endif
+}

--- a/include/oneapi/dnnl/dnnl_graph.h
+++ b/include/oneapi/dnnl/dnnl_graph.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -192,6 +192,17 @@ dnnl_status_t DNNL_API dnnl_graph_logical_tensor_is_equal(
 dnnl_status_t DNNL_API dnnl_graph_tensor_create(dnnl_graph_tensor_t *tensor,
         const dnnl_graph_logical_tensor_t *logical_tensor, dnnl_engine_t engine,
         void *handle);
+
+/// Creates a scalar tensor with logical tensor and scalar data handle.
+///
+/// @param tensor Output scalar tensor.
+/// @param logical_tensor Description for this tensor.
+/// @param handle Handle of the memory buffer to use as an underlying storage.
+/// @returns #dnnl_success on success or a status describing the error
+///     otherwise.
+dnnl_status_t DNNL_API dnnl_graph_tensor_create_scalar(
+        dnnl_graph_tensor_t *tensor,
+        const dnnl_graph_logical_tensor_t *logical_tensor, void *handle);
 
 /// Destroys a tensor.
 ///

--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -575,6 +575,8 @@ private:
 /// A tensor object
 class tensor : public tensor_handle {
 public:
+    using tensor_handle::handle;
+
     /// Default constructor. Constructs an empty object.
     tensor() = default;
 
@@ -606,6 +608,22 @@ public:
     /// @param aengine Engine to store the data on.
     tensor(const logical_tensor &lt, const engine &aengine)
         : tensor(lt, aengine, DNNL_MEMORY_ALLOCATE) {}
+
+    /// Creates a tensor object for host-side scalar value. The data type contained
+    /// in the logical tensor parameter will be used to interpret the scalar
+    /// pointer. The property type in the logical tensor must be `host_scalar`.
+    ///
+    /// @param lt The logical tensor describing the host scalar
+    /// @param scalar The pointer to scalar value
+    /// @returns Created tensor object
+    static tensor make_scalar_tensor(const logical_tensor &lt, void *scalar) {
+        dnnl_graph_tensor_t t = nullptr;
+        error::wrap_c_api(
+                dnnl_graph_tensor_create_scalar(&t, &(lt.data), scalar),
+                "could not create a scalar tensor object");
+
+        return tensor(t);
+    }
 
     /// Returns the underlying memory buffer.
     ///

--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -164,6 +164,11 @@ dnnl::engine make_dnnl_engine(const engine_t &g_engine) {
     return engine;
 }
 
+// The function will throw expection if cpu runtime is none.
+dnnl::engine make_host_engine() {
+    return dnnl::engine(dnnl::engine::kind::cpu, 0);
+}
+
 dnnl::stream make_dnnl_stream(
         const dnnl::engine &p_engine, const stream_t &g_stream) {
     UNUSED(p_engine);

--- a/src/graph/backend/dnnl/common.hpp
+++ b/src/graph/backend/dnnl/common.hpp
@@ -81,6 +81,8 @@ dims group_dims(const dims &adims, dim groups);
 
 engine make_dnnl_engine(const engine_t &g_engine);
 
+engine make_host_engine();
+
 stream make_dnnl_stream(const engine &p_engine, const stream_t &g_stream);
 
 memory::desc make_dnnl_memory_desc(const logical_tensor_t &lt);

--- a/src/graph/interface/logical_tensor.hpp
+++ b/src/graph/interface/logical_tensor.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -82,6 +82,10 @@ struct logical_tensor_wrapper_t {
     bool is_strided() const { return lt->layout_type == layout_type::strided; }
     bool is_opaque() const { return lt->layout_type == layout_type::opaque; }
     bool is_constant() const { return lt->property == property_type::constant; }
+    bool is_host_scalar() const {
+        return lt->property == property_type::host_scalar;
+    }
+
     bool is_layout_type_undef() const {
         return lt->layout_type == layout_type::undef;
     }

--- a/src/graph/interface/tensor.hpp
+++ b/src/graph/interface/tensor.hpp
@@ -29,16 +29,14 @@ public:
 
     void *get_data_handle() const { return handle_.get(); }
 
-    void set_data_handle(void *handle) {
-        if (lt_.property == dnnl::impl::graph::property_type::host_scalar) {
-            if (lt_.data_type == dnnl::impl::graph::data_type::s32) {
-                scalar_.s32_value = *static_cast<int32_t *>(handle);
-                handle_.reset(&scalar_.s32_value, dummy_destructor);
-            } else {
-                assertm(false, "Unsupported data type for host scalar");
-            }
+    dnnl::impl::graph::status_t set_data_handle(void *handle) {
+        auto ltw = dnnl::impl::graph::logical_tensor_wrapper_t(lt_);
+
+        if (ltw.is_host_scalar()) {
+            return dnnl::impl::graph::status::invalid_arguments;
         } else {
             handle_.reset(handle, dummy_destructor);
+            return dnnl::impl::graph::status::success;
         }
     }
 

--- a/tests/benchdnn/graph/graph_memory.cpp
+++ b/tests/benchdnn/graph/graph_memory.cpp
@@ -148,12 +148,13 @@ dnnl::graph::tensor dnn_graph_mem_t::make_graph_tensor(
     dnnl_memory_get_data_handle(mem_.m_, &data_handle);
     dnnl::graph::logical_tensor graph_lt(lt.id_, lt.get_data_type(), lt.shape_,
             str2layout(lt.layout_type_), lt.get_property_type());
-    const auto &g_eng = lt.is_host_scalar()
-            ? get_graph_host_engine().operator const dnnl::engine &()
-            : get_graph_engine().operator const dnnl::engine &();
-    dnnl::graph::tensor ret(graph_lt, g_eng, data_handle);
+    const auto &g_eng = get_graph_engine().operator const dnnl::engine &();
 
-    return ret;
+    if (lt.is_host_scalar()) {
+        return dnnl::graph::tensor::make_scalar_tensor(graph_lt, data_handle);
+    } else {
+        return dnnl::graph::tensor(graph_lt, g_eng, data_handle);
+    }
 }
 
 void flush_temp_memory() {

--- a/tests/gtests/graph/api/test_cpp_api_tensor.cpp
+++ b/tests/gtests/graph/api/test_cpp_api_tensor.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2023 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -155,5 +155,25 @@ TEST(APITensor, CreateWithLogicalTensorS8) {
 
     ASSERT_EQ(t.get_data_handle(), nullptr);
     ASSERT_EQ(t.get_engine().get_kind(), dnnl::engine::kind::cpu);
+}
+
+TEST(APITensor, CreateScalarTensor) {
+    using namespace dnnl::graph;
+
+    auto lt = logical_tensor(0, logical_tensor::data_type::s32, 0,
+            logical_tensor::layout_type::strided,
+            logical_tensor::property_type::host_scalar);
+
+    float scalar = 0.25f;
+    // success
+    auto ts = tensor::make_scalar_tensor(lt, &scalar);
+    auto handle = ts.get_data_handle();
+    EXPECT_EQ(handle, nullptr);
+    EXPECT_THROW(ts.set_data_handle(&scalar), dnnl::error);
+
+    // fail
+    lt = logical_tensor(0, logical_tensor::data_type::s32, 0,
+            logical_tensor::layout_type::strided);
+    EXPECT_THROW(tensor::make_scalar_tensor(lt, &scalar), dnnl::error);
 }
 #endif


### PR DESCRIPTION
- Extract the new API changes from #3454 
    - Create scalar tensor with `tensor::make_scalar_tensor(logical_tensor, void*)` instead of the original constructor.
    - `scalar_tensor.get_data_handle()` returns nullptr.
    - `scalar_tensor.set_data_handle()` raises error.
- Benchdnn graph driver is changed accordingly to use the new method to create scalar tensor.
- Fix DNNL backend for creating `dnnl::memory` from a scalar tensor without engine.
- Add an example for SDPA with bottom-right causal mask which requires scalar tensor to define the patter. It's also a new feature for oneDNN v3.9, so I think we may need to backport this one as well.