### PR TITLE
cpu: aarch64: perf: increase 3d matmul shape for perf tests

### DIFF
--- a/.github/automation/performance/inputs/matmul_nightly
+++ b/.github/automation/performance/inputs/matmul_nightly
@@ -24,7 +24,7 @@
 --bia_mask=2
 --batch=shapes_2d_ci
 --bia_mask=4
---batch=shapes_3d
+--batch=shapes_3d_perf
 
 --reset
 --dt=f32
@@ -33,7 +33,7 @@
 --attr-fpmath=bf16
 --batch=shapes_2d_ci
 --bia_mask=4
---batch=shapes_3d
+--batch=shapes_3d_perf
 
 #f16
 --reset
@@ -42,4 +42,4 @@
 --bia_mask=2
 --batch=shapes_2d_ci
 --bia_mask=4
---batch=shapes_3d
+--batch=shapes_3d_perf

--- a/.github/automation/performance/inputs/shapes_3d_perf
+++ b/.github/automation/performance/inputs/shapes_3d_perf
@@ -1,0 +1,10 @@
+# random batched shapes for correctness testing
+128x80x110:128x110x1
+111x310x1:111x1x210
+1x110x110:1x110x100
+
+# batch broadcast shapes
+7x32x16:1x16x8
+1x128x8:2x8x16
+2x16x73:1x73x8
+1x26x17:5x17x65


### PR DESCRIPTION
Increasing the size of 3d shapes for the nightly matmul performance tests as it is causing a false positive in the ci
