### PR TITLE
[backport] cpu: x64: brgemm: enable per_oc_d broadcast strategy for AMX

### DIFF
--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -107,13 +107,15 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
 
             using namespace dnnl::impl::cpu::binary_injector_utils;
             std::tie(with_binary_per_oc_bcast_, with_binary_per_oc_sp_bcast_,
-                    with_binary_per_mb_bcast_, with_binary_channel_bcast_,
-                    with_binary_per_mb_w_bcast_, with_binary_per_w_bcast_,
-                    with_binary_spatial_bcast_, with_binary_batch_bcast_,
-                    with_binary_spatial_bcast_, with_binary_no_bcast_)
+                    with_binary_per_oc_d_bcast_, with_binary_per_mb_bcast_,
+                    with_binary_channel_bcast_, with_binary_per_mb_w_bcast_,
+                    with_binary_per_w_bcast_, with_binary_spatial_bcast_,
+                    with_binary_batch_bcast_, with_binary_spatial_bcast_,
+                    with_binary_no_bcast_)
                     = bcast_strategies_present_tup(brg.attr()->post_ops_.entry_,
                             dst_md_wrapper, broadcasting_strategy_t::per_oc,
                             broadcasting_strategy_t::per_oc_spatial,
+                            broadcasting_strategy_t::per_oc_d,
                             broadcasting_strategy_t::per_mb,
                             broadcasting_strategy_t::per_mb_spatial,
                             broadcasting_strategy_t::per_mb_w,
@@ -123,7 +125,8 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
                             broadcasting_strategy_t::spatial,
                             broadcasting_strategy_t::no_broadcast);
             handle_binary_po_offset_ = with_binary_per_oc_bcast_
-                    || with_binary_per_oc_sp_bcast_ || with_binary_per_mb_bcast_
+                    || with_binary_per_oc_sp_bcast_
+                    || with_binary_per_oc_d_bcast_ || with_binary_per_mb_bcast_
                     || with_binary_channel_bcast_ || with_binary_per_mb_w_bcast_
                     || with_binary_per_w_bcast_ || with_binary_per_hw_bcast_
                     || with_binary_batch_bcast_ || with_binary_spatial_bcast_
@@ -205,6 +208,7 @@ private:
     bool handle_binary_po_offset_ = false;
     bool with_binary_per_oc_bcast_ = false;
     bool with_binary_per_oc_sp_bcast_ = false;
+    bool with_binary_per_oc_d_bcast_ = false;
     bool with_binary_channel_bcast_ = false;
     bool with_binary_per_mb_bcast_ = false;
     bool with_binary_per_mb_w_bcast_ = false;

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
@@ -13,6 +13,13 @@
 --attr-post-ops=add:bf16:13:abcd
 2x2x32x16:2x2x16x64_n"small_shape_with_binary_po_and_mask_13"
 
+# Binary post-op with mask 6 to test broadcasting strategy per_oc_d for non-f32.
+--reset
+--dt=bf16:bf16:f32
+--stag=abcd --wtag=abdc --dtag=abcd
+--attr-post-ops=binary_sub:f32:6
+1x16x384x64:1x16x64x384_n"binary_po_and_mask_6_and_bf16"
+
 # Shape to reach parallel reduction.
 --reset
 --dt=bf16:bf16:bf16


### PR DESCRIPTION
Backport of #3532