### PR TITLE
xe: gemm: remove incorrect assertion

### DIFF
--- a/src/gpu/gpu_sdpa_list.cpp
+++ b/src/gpu/gpu_sdpa_list.cpp
@@ -18,8 +18,10 @@
 
 #include "gpu/gpu_impl_list.hpp"
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
 #include "gpu/intel/ocl/micro_sdpa.hpp"
 #include "gpu/intel/ocl/ref_sdpa.hpp"
+#endif
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -190,7 +190,6 @@ status_t jit_gemm_pd_t::init_post_ops() {
         bool converted;
         CHECK(maybe_convert_scales_to_postop(
                 dims, DNNL_ARG_C, c_scales.get_data_type(), converted));
-        gpu_assert(converted) << "Unable to convert dst scales to a post op";
     }
 
     return status::success;


### PR DESCRIPTION
Removes an overzealous assertion from #3521. After this PR, will be equivalent to the old behaviour. This is a temporary fix until a more robust solution is implemented.

Edit: Also includes an `#include` fix, where intel-specific dependencies are leaking into generic builds (causing build failures).