### PR TITLE
src: gpu: intel: add user-precomputed reductions to gemm

### DIFF
--- a/include/oneapi/dnnl/dnnl_types.h
+++ b/include/oneapi/dnnl/dnnl_types.h
@@ -2469,6 +2469,7 @@ typedef const struct dnnl_primitive *const_dnnl_primitive_t;
 
 /// Undefined argument.
 #define DNNL_ARG_UNDEF 0
+
 /// Source argument #0.
 #define DNNL_ARG_SRC_0 1
 /// A special mnemonic for source argument for primitives that have a
@@ -2670,9 +2671,9 @@ typedef const struct dnnl_primitive *const_dnnl_primitive_t;
 /// Dropout RNG seed value passed via a buffer.
 #define DNNL_ARG_ATTR_DROPOUT_SEED 511
 
-/// Output scaling factors provided at execution time.
-/// Deprecated value.
-#define DNNL_ARG_ATTR_OUTPUT_SCALES 513
+/// The argument marked with this attribute is user-precomputed.
+/// Used exclusively for zero points at the time of writing.
+#define DNNL_ARG_ATTR_USER_PRECOMP 512
 
 /// Starting index for source arguments for primitives that take a variable
 /// number of source arguments.

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -120,6 +120,8 @@ bool primitive_attr_t::has_default_values(dnnl_primitive_attr::skip_mask_t mask,
                     dnnl::impl::accumulation_mode::any)));
     CHECK_ARG(IMPLICATION(
             (bool)(~mask & smask_t::dropout), dropout_.has_default_values()));
+    CHECK_ARG(IMPLICATION((bool)(~mask & smask_t::precomputed_reduction),
+            precomputed_reduction_.has_default_values()));
     CHECK_ARG(IMPLICATION((bool)(~mask & smask_t::rounding_mode),
             rounding_mode_.has_default_values()));
     CHECK_ARG(this->defined(smask_t::none));
@@ -563,6 +565,21 @@ status_t dnnl_primitive_attr_set_scratchpad_mode(
     if (any_null(attr)) return invalid_arguments;
 
     return attr->set_scratchpad_mode(scratchpad_mode);
+}
+
+status_t dnnl_primitive_attr_get_precomputed_reduction(
+        const primitive_attr_t *attr,
+        precomputed_reduction_t *precomputed_reduction) {
+    if (any_null(attr, precomputed_reduction)) return invalid_arguments;
+    *precomputed_reduction = attr->precomputed_reduction_;
+    return success;
+}
+
+status_t dnnl_primitive_attr_set_precomputed_reduction(
+        primitive_attr_t *attr, precomputed_reduction_t precomputed_reduction) {
+    if (any_null(attr)) return invalid_arguments;
+    attr->precomputed_reduction_ = precomputed_reduction;
+    return success;
 }
 
 status_t dnnl_primitive_attr_set_scales_mask(

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -74,6 +74,32 @@ std::ostream &operator<<(std::ostream &s, dnnl_engine_kind_t ek) {
     return s;
 }
 
+precomputed_reduction_t str2pr(const char *str) {
+    precomputed_reduction_t pr = PR_NONE;
+    while (str && *str) {
+        if (*str == 'S') {
+            pr |= PR_SRC;
+        } else if (*str == 'W') {
+            pr |= PR_WEI;
+        } else {
+            BENCHDNN_PRINT(0, "%s \'%c\'\n",
+                    "Error: "
+                    "--use-precomputed-reduction option doesn't support value",
+                    *str);
+            SAFE_V(FAIL);
+        }
+        str++;
+    }
+    return pr;
+}
+
+std::string pr2str(precomputed_reduction_t pr) {
+    std::string str;
+    if (pr & PR_SRC) str += "S";
+    if (pr & PR_WEI) str += "W";
+    return str;
+}
+
 dnnl_prop_kind_t prop2prop_kind(const dir_t dir) {
     if (dir == FWD_I) return dnnl_forward_inference;
     if (dir & FLAG_FWD) return dnnl_forward_training;

--- a/tests/benchdnn/dnn_types.hpp
+++ b/tests/benchdnn/dnn_types.hpp
@@ -41,6 +41,13 @@ extern const char *any;
 extern const char *undef;
 } // namespace tag
 
+using precomputed_reduction_t = unsigned;
+const precomputed_reduction_t PR_NONE = 0u;
+const precomputed_reduction_t PR_SRC = (1u << 0);
+const precomputed_reduction_t PR_WEI = (1u << 1);
+precomputed_reduction_t str2pr(const char *str);
+std::string pr2str(precomputed_reduction_t pr);
+
 /* TODO: merge prop and dir_t (in favor of prop) */
 const char *prop2str(dnnl_prop_kind_t prop);
 dnnl_prop_kind_t prop2prop_kind(dir_t dir);
@@ -425,7 +432,9 @@ struct attr_t {
     void insert(const deterministic_t &d) { this->deterministic = d; }
     void insert(const dropout_t &d) { this->dropout = d; }
     void insert(const rounding_mode_t &rm) { this->rounding_mode = rm; }
-
+    void insert(const precomputed_reduction_t &pr) {
+        this->precomputed_reduction = pr;
+    }
     // When parallel creation modifier is enabled, the library scratchpad mode
     // can't be used unless "-DDNNL_ENABLE_CONCURRENT_EXEC=ON" is enabled at the
     // build time, otherwise scratchpad pointers are invalidated (as were
@@ -444,6 +453,7 @@ struct attr_t {
     fpmath_mode_t fpmath_mode;
     dnnl_accumulation_mode_t acc_mode;
     deterministic_t deterministic;
+    precomputed_reduction_t precomputed_reduction;
     dropout_t dropout;
     rounding_mode_t rounding_mode;
 

--- a/tests/benchdnn/matmul/bench_matmul.cpp
+++ b/tests/benchdnn/matmul/bench_matmul.cpp
@@ -43,6 +43,7 @@ void check_correctness(
     for_(const auto &i_stag : s.stag)
     for_(const auto &i_wtag : s.wtag)
     for_(const auto &i_dtag : s.dtag)
+    for_(const auto &i_precomputed_reduction : s.precomputed_reduction)
     for_(const auto &i_sparse_options : s.sparse_options)
     for_(const auto &i_strides : s.strides)
     for_(const auto &i_rt_dims_masks : s.rt_dims_masks)
@@ -52,7 +53,8 @@ void check_correctness(
     for (const auto &i_bia_cfg : bia_cfg) {
         const prb_t prb(s.prb_vdims, i_dt, i_stag, i_wtag, i_dtag, i_strides,
                 i_bia_cfg.first, i_bia_cfg.second, i_rt_dims_masks,
-                i_sparse_options, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
+                i_precomputed_reduction, i_sparse_options, i_attr, i_ctx_init,
+                i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
         task_executor.submit(prb, s.perf_template, createit, checkit, doit);
@@ -138,6 +140,12 @@ static const std::string help_runtime_dims_masks
           "For tensors with runtime dimensions specified a correspondent "
           "memory format must be specified, too.\n";
 
+static const std::string help_pr
+        = "FLAGS    (Default: not specified)\n    Specifies precomputed "
+          "reduction flags. `FLAGS` values are:\n    * `S` to use precomputed "
+          "reductions on SRC.\n    * `W` to use precomputed reductions on WEI."
+          "\n";
+
 bool parse_legacy_dt(std::vector<dnnl_data_type_t> &dt,
         const std::vector<dnnl_data_type_t> &def_dt, const char *str,
         const std::string &option_name /* = "dt"*/) {
@@ -170,6 +178,9 @@ int bench(int argc, char **argv) {
                 || parse_multivector_option(s.rt_dims_masks, def.rt_dims_masks,
                         atoi, argv[0], "runtime_dims_masks",
                         help_runtime_dims_masks)
+                || parse_vector_option(s.precomputed_reduction,
+                        def.precomputed_reduction, str2pr, argv[0],
+                        "use-precomputed-reduction", help_pr)
                 || parse_driver_shared_settings(s, def, argv[0]);
         if (!parsed_options) {
             catch_unknown_options(argv[0]);

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -202,7 +202,7 @@ int init_prim_ref(benchdnn_dnnl_wrapper_t<dnnl_primitive_t> &prim_ref,
         // modifying prb in place.
         prb_t prb_cpu {*prb, prim_ref_dt_i, tag::any, tag::any, tag::any,
                 {vdims_t(STRIDES_SIZE)}, prim_ref_bia_dt_i, prb->bia_mask,
-                {0, 0, 0}, sparse_options_t(), cpu_attr, prb->ctx_init,
+                {0, 0, 0}, PR_NONE, sparse_options_t(), cpu_attr, prb->ctx_init,
                 prb->ctx_exe, prb->impl_filter};
 
         auto st = init_prim_ref_common(prim_ref, &prb_cpu, res);

--- a/tests/benchdnn/matmul/matmul_aux.cpp
+++ b/tests/benchdnn/matmul/matmul_aux.cpp
@@ -94,6 +94,10 @@ std::string prb_t::set_repro_line() {
             s << "--bia_mask=" << bia_mask << " ";
     }
 
+    if (canonical || precomputed_reduction != def.precomputed_reduction[0])
+        s << "--use-precomputed-reduction=" << pr2str(precomputed_reduction)
+          << " ";
+
     s << attr;
     if (canonical || ctx_init != def.ctx_init[0])
         s << "--ctx-init=" << ctx_init << " ";


### PR DESCRIPTION
This is the new API for #3222 requested by the Arch team.
Addresses [MFDNN-12757](https://jira.devtools.intel.com/browse/MFDNN-12757) and [MFDNN-13500](https://jira.devtools.intel.com/browse/MFDNN-13500).