### PR TITLE
graph: backend: dnnl: enable f32 sdpa with gpu ukernel opt

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -174,17 +174,28 @@ status_t sdp_primitive_config_t::initial_check(
     VCHECK_SDP_PRIMITIVE(inputs.size() >= 3, status::invalid_arguments,
             "At least 3 inputs are required");
 
+    const bool is_f32 = inputs[0].data_type == data_type::f32;
+    bool has_genindex = false;
+
     // Note: sdpa_primitive_v1 kernel currently don't support legacy GQA pattern.
     if (v1_kernel) {
         for (auto &cur_op : sg->get_ops()) {
-            if (cur_op->get_kind() == graph::op_kind::StaticReshape) {
+            const auto opk = cur_op->get_kind();
+            if (opk == graph::op_kind::StaticReshape) {
                 auto in = cur_op->get_input_value(0)->get_logical_tensor();
                 auto out = cur_op->get_output_value(0)->get_logical_tensor();
                 if (ltw(in).ndims() == 5 || ltw(out).ndims() == 5) {
                     return status::unimplemented;
                 }
+            } else if (opk == graph::op_kind::GenIndex) {
+                has_genindex = true;
             }
         }
+    }
+    // Dispatch f32 implicit causal mask cases into the f32 ukernel impl.
+    if (is_f32 && !has_genindex) {
+        VCHECK_SDP_PRIMITIVE(false, status::unimplemented,
+                "only implicit causal mask for f32 sdpa");
     }
 
     // step1(pattern check): Not support sdpa variants with select as mask

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -174,11 +174,6 @@ status_t sdp_primitive_config_t::initial_check(
     VCHECK_SDP_PRIMITIVE(inputs.size() >= 3, status::invalid_arguments,
             "At least 3 inputs are required");
 
-    // Ukernel doesn't support f32 datatype now
-    VCHECK_SDP_PRIMITIVE(inputs[0].data_type != dnnl_data_type_t::dnnl_f32,
-            status::invalid_arguments,
-            "SDPA ukernel doesn't support f32 datatype now");
-
     // Note: sdpa_primitive_v1 kernel currently don't support legacy GQA pattern.
     if (v1_kernel) {
         for (auto &cur_op : sg->get_ops()) {


### PR DESCRIPTION
Local test results:

```bash
$ ./tests/benchdnn/benchdnn --graph --engine=gpu --mode=P --case=complex_fusion/mha/gqa-plain-implicit-causal-mask-fp32-bs1.json
Output template: perf,%engine%,%prb%,%-time%,%0time%
perf,gpu,--mode=P --graph --engine=gpu --case=complex_fusion/mha/gqa-plain-implicit-causal-mask-fp32-bs1.json,0.08016,0.0902972
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):0.08016 avg(ms):0.0902972
total: 5.07s; create_pd: 0.00s (0%); create_prim: 0.65s (13%); fill: 0.00s (0%); execute: 0.00s (0%);

$ _ONEDNN_GRAPH_SDPA_FORCE_PRIMITIVE=1 ./tests/benchdnn/benchdnn --graph --engine=gpu --mode=P --case=complex_fusion/mha/gqa-plain-implicit-ca
usal-mask-fp32-bs1.json
Output template: perf,%engine%,%prb%,%-time%,%0time%
perf,gpu,--mode=P --graph --engine=gpu --case=complex_fusion/mha/gqa-plain-implicit-causal-mask-fp32-bs1.json,0.34448,0.377469
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):0.34448 avg(ms):0.377469
total: 6.36s; create_pd: 0.00s (0%); create_prim: 0.69s (11%); fill: 0.00s (0%); execute: 0.00s (0%);
```