### PR TITLE
ngen: rename ELFCodeGenerator::interface

### DIFF
--- a/third_party/ngen/ngen_elf.hpp
+++ b/third_party/ngen/ngen_elf.hpp
@@ -37,7 +37,7 @@ public:
     explicit ELFCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : BinaryCodeGenerator<hw>(stepping_, debugConfig) {}
     explicit ELFCodeGenerator(DebugConfig debugConfig) : ELFCodeGenerator(0, debugConfig) {}
 
-    const NEOInterfaceHandler &interface() {return interface_;}
+    const NEOInterfaceHandler &getInterface() {return interface_;}
 
     void externalName(const std::string &name)                           { interface_.externalName(name); }
 


### PR DESCRIPTION
The windows.h header contains the following define:

```
#define interface                   struct
```

This adversely interacts with the ELFCodeGenerator::interface function and produces a compilation error. To avoid this interaction, the function is renamed.