### PR TITLE
xe: sdpa: fix undefined behavior warning in internal sdpa tests

### DIFF
--- a/tests/gtests/internals/test_utils.cpp
+++ b/tests/gtests/internals/test_utils.cpp
@@ -283,7 +283,7 @@ void transpose_strides(const dnnl::engine &eng, memory &out, memory &in) {
             auto &val = mapped_ptr[offset];
             auto &val_t = mapped_ptr_t[offset_t];
 
-            char bits;
+            uint8_t bits;
             if (is_odd) {
                 bits = val & 0xf0;
                 bits >>= 4;


### PR DESCRIPTION
# Description

This PR addresses an undefined behavior sanitizer warning found in a recently nightly job. 