### PR TITLE
[Benchdnn] Move GEMM attr tests

### DIFF
--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -224,3 +224,6 @@
 
 # fp4
 --batch=test_matmul_fp4
+
+# test batch reshape with attributes
+--batch=harness_matmul_3d_bcast

--- a/tests/benchdnn/inputs/matmul/test_matmul_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_gpu
@@ -60,9 +60,6 @@
 --attr-post-ops=sum+add:f32+add:u8:per_dim_01+mul:f32:per_dim_0+add:s8:per_tensor+add:f32:per_dim_01+linear:2:-1
 3x30x1:3x1x20
 
-# test batch reshape with attributes
---batch=harness_matmul_3d_bcast
-
 # test regressions
 --batch=harness_matmul_regression_f32
 


### PR DESCRIPTION
# Description

- ~~Add skip in `skip_unimplemented_prb` to cover GPU ref gaps, CPU unimplemented in CI~~
- Add batched gemm with reshape, per_tensor attributes tests to CI to avoid escapes. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
