### PR TITLE
[GPU] various quantization fixes

### DIFF
--- a/src/gpu/gpu_sdpa_list.cpp
+++ b/src/gpu/gpu_sdpa_list.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@
 
 #include "gpu/gpu_impl_list.hpp"
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
 #include "gpu/intel/ocl/micro_sdpa.hpp"
 #include "gpu/intel/ocl/ref_sdpa.hpp"
+#endif
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/jit/gemm/gen_gemm.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.cpp
@@ -99,7 +99,6 @@ status_t gen_gemm_t::launch_nocopy(const gemm_exec_ctx_t &ctx,
         int32_t ldaq = isColMajor(layout)
                 ? pd()->eff_m()
                 : utils::div_up(pd()->desc()->k(), problem->aqGroupK);
-        if (pd()->src_po_sc_ && swapab) ldaq = 0;
         arg_list.set(argn++, ldaq);
     }
     if (problem->boPtrDims == 2 || problem->bScale2D()) {
@@ -108,7 +107,6 @@ status_t gen_gemm_t::launch_nocopy(const gemm_exec_ctx_t &ctx,
         int32_t ldbq = !isColMajor(layout)
                 ? pd()->eff_n()
                 : utils::div_up(pd()->desc()->k(), problem->bqGroupK);
-        if (pd()->src_po_sc_ && !swapab) ldbq = 0;
         arg_list.set(argn++, ldbq);
     }
     if (pd()->with_c_zero_points() || pd()->with_bias()
@@ -401,9 +399,9 @@ status_t gen_gemm_t::execute(const gemm_exec_ctx_t &ctx) const {
         if (swapab) std::swap(ao, bo);
     }
 
-    if (pd()->wei_scales_2d()) { a_scales = &GEMM_CTX_ARG_STORAGE(a_scales); }
+    if (pd()->a_scales_2d()) { a_scales = &GEMM_CTX_ARG_STORAGE(a_scales); }
 
-    if (pd()->src_scales_2d()) { b_scales = &GEMM_CTX_ARG_STORAGE(b_scales); }
+    if (pd()->b_scales_2d()) { b_scales = &GEMM_CTX_ARG_STORAGE(b_scales); }
     if (swapab) std::swap(a_scales, b_scales);
 
     if (swapab) {

--- a/src/gpu/intel/jit/gemm/gen_gemm.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm.hpp
@@ -245,7 +245,7 @@ struct gen_gemm_t : public gpu_gemm_t {
                     ? attr_zps.get_data_type(swap_ab_ ? DNNL_ARG_A : DNNL_ARG_B)
                     : data_type::s32;
             bool int_acc = utils::one_of(eff_a_type(), s8, u8);
-            int_acc &= !wei_scales_2d();
+            int_acc &= !a_scales_2d();
             auto co_type = with_bias() ? d->bias_type()
                     : with_sum_ab()    ? d->sum_ab_type
                     : int_acc          ? s32
@@ -312,13 +312,13 @@ struct gen_gemm_t : public gpu_gemm_t {
                     dev_info_->eu_count(), has_systolic, is_integrated, mode,
                     batch_dims(), eff_transa(), eff_transb(), eff_trans_bias(),
                     swap_ab(), ao_dims_, bo_dims_, asc_dims_, bsc_dims_,
-                    with_sround_, wei_q2d_group_k_, src_q2d_group_k_,
+                    with_sround_, a_q2d_group_k_, b_q2d_group_k_,
                     with_c_zero_points(), with_bias(), eff_sum_ab(), alpha(),
                     beta(), eff_a_type(), eff_b_type(), desc()->c_type(),
-                    ao_type, bo_type, wei_scales_type_, src_scales_type_,
-                    co_type, acc_type, eff_align_a(), eff_align_b(), align_c(),
-                    eff_m(), eff_n(), d->k(), eff_lda(), eff_ldb(), d->ldc(),
-                    d->batch(), std::move(gpu_post_ops)));
+                    ao_type, bo_type, a_scales_type_, b_scales_type_, co_type,
+                    acc_type, eff_align_a(), eff_align_b(), align_c(), eff_m(),
+                    eff_n(), d->k(), eff_lda(), eff_ldb(), d->ldc(), d->batch(),
+                    std::move(gpu_post_ops)));
 
             // Global k-parallel kernels don't support post-ops or non-f32/s32
             //   accumulation unless fusion is enabled.

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -359,11 +359,11 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
         int stepping, int eu_count, bool has_systolic, bool is_integrated,
         compute_mode mode, int batch_dims, bool trans_a, bool trans_b,
         bool trans_co, bool swap_ab, int ao_dims, int bo_dims, int asc_dims,
-        int bsc_dims, bool dst_sround, int wei_q2d_group_k, int src_q2d_group_k,
+        int bsc_dims, bool dst_sround, int a_q2d_group_k, int b_q2d_group_k,
         bool c_offset, bool bias, sum_ab_t reduce_ab, float alpha, float beta,
         data_type_t a_type, data_type_t b_type, data_type_t c_type,
-        data_type_t ao_type, data_type_t bo_type, data_type_t wei_scales_type,
-        data_type_t src_scales_type, data_type_t co_type, data_type_t acc_type,
+        data_type_t ao_type, data_type_t bo_type, data_type_t a_scales_type,
+        data_type_t b_scales_type, data_type_t co_type, data_type_t acc_type,
         int align_a, int align_b, int align_c, dim_t m, dim_t n, dim_t k,
         dim_t lda, dim_t ldb, dim_t ldc, dim_t batch,
         gpu_post_ops_t &&post_ops) {
@@ -438,34 +438,34 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
     if (!swap_ab) {
         problem_.asPtrDims = asc_dims;
         problem_.bsPtrDims = bsc_dims;
-        problem_.aqGroupK = wei_q2d_group_k;
-        problem_.bqGroupK = src_q2d_group_k;
-        if (wei_scales_type != data_type::undef) {
-            problem_.Ta_scale = convert_dnnl_to_kernel_type(wei_scales_type);
+        problem_.aqGroupK = a_q2d_group_k;
+        problem_.bqGroupK = b_q2d_group_k;
+        if (a_scales_type != data_type::undef) {
+            problem_.Ta_scale = convert_dnnl_to_kernel_type(a_scales_type);
             problem_.A_scale.setAlignment(
-                    int(types::data_type_size(wei_scales_type)));
+                    int(types::data_type_size(a_scales_type)));
         }
-        if (src_scales_type != data_type::undef) {
-            problem_.Tb_scale = convert_dnnl_to_kernel_type(src_scales_type);
+        if (b_scales_type != data_type::undef) {
+            problem_.Tb_scale = convert_dnnl_to_kernel_type(b_scales_type);
             problem_.B_scale.layout = MatrixLayout::N;
             problem_.B_scale.setAlignment(
-                    int(types::data_type_size(src_scales_type)));
+                    int(types::data_type_size(b_scales_type)));
         }
     } else {
         problem_.bsPtrDims = asc_dims;
         problem_.asPtrDims = bsc_dims;
-        problem_.bqGroupK = wei_q2d_group_k;
-        problem_.aqGroupK = src_q2d_group_k;
-        if (wei_scales_type != data_type::undef) {
-            problem_.Tb_scale = convert_dnnl_to_kernel_type(wei_scales_type);
+        problem_.bqGroupK = a_q2d_group_k;
+        problem_.aqGroupK = b_q2d_group_k;
+        if (a_scales_type != data_type::undef) {
+            problem_.Tb_scale = convert_dnnl_to_kernel_type(a_scales_type);
             problem_.B_scale.setAlignment(
-                    int(types::data_type_size(wei_scales_type)));
+                    int(types::data_type_size(a_scales_type)));
         }
-        if (src_scales_type != data_type::undef) {
-            problem_.Ta_scale = convert_dnnl_to_kernel_type(src_scales_type);
+        if (b_scales_type != data_type::undef) {
+            problem_.Ta_scale = convert_dnnl_to_kernel_type(b_scales_type);
             problem_.A_scale.layout = MatrixLayout::T;
             problem_.A_scale.setAlignment(
-                    int(types::data_type_size(src_scales_type)));
+                    int(types::data_type_size(b_scales_type)));
         }
     }
 

--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.hpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.hpp
@@ -129,11 +129,11 @@ struct gen_gemm_nocopy_kernel_desc_t : public gen_gemm_kernel_desc_t {
             bool has_systolic, bool is_integrated, compute_mode mode,
             int batch_dims, bool trans_a, bool trans_b, bool trans_co,
             bool swap_ab, int ao_dims, int bo_dims, int asc_dims, int bsc_dims,
-            bool dst_sround, int wei_q2d_group_k, int src_q2d_group_k,
+            bool dst_sround, int a_q2d_group_k, int b_q2d_group_k,
             bool c_offset, bool bias, sum_ab_t reduce_ab, float alpha,
             float beta, data_type_t a_type, data_type_t b_type,
             data_type_t c_type, data_type_t ao_type, data_type_t bo_type,
-            data_type_t wei_scales_type, data_type_t src_scales_type,
+            data_type_t a_scales_type, data_type_t b_scales_type,
             data_type_t co_type, data_type_t acc_type, int align_a, int align_b,
             int align_c, dim_t m, dim_t n, dim_t k, dim_t lda, dim_t ldb,
             dim_t ldc, dim_t batch, gpu_post_ops_t &&post_ops);

--- a/src/gpu/intel/jit/gemm/generator/pieces/map.hpp
+++ b/src/gpu/intel/jit/gemm/generator/pieces/map.hpp
@@ -105,8 +105,12 @@ static inline void map(ngen::HW hw, ngen::DataType dt, const GRFMultirange &regs
             int regOff = curOff & (GRF::bytes(hw) - 1);
             if (regOff != 0)
                 maxBytes = GRF::bytes(hw) - regOff;
-            else
-                maxBytes = (canDualGRF(hw, dt, strategy) ? 2 : 1) * GRF::bytes(hw);
+            else {
+                int nr = 1;
+                if (canDualGRF(hw, dt, strategy) && regs.contiguous(curOff >> GRF::log2Bytes(hw), 2))
+                    nr = 2;
+                maxBytes = nr * GRF::bytes(hw);
+            }
 
             auto nbytes = ngen::utils::rounddown_pow2(std::min(maxBytes, curBytes));
             auto ne = std::min<int>(32, nbytes / ebytes);

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.cpp
@@ -344,25 +344,6 @@ bool jit_gemm_pd_t::scales_ok() {
             return false;
     }
 
-    if (a_scales_2d()) {
-        if (a_q2d_group_k_ != a_scales_group_k_) return false;
-        // Non-trivial N group unsupported.
-        if (a_scales.get_group(1) != 1) return false;
-    }
-
-    if (b_scales_2d()) {
-        int cmask_b_sc_ = attr()->scales_.get_mask(DNNL_ARG_B);
-        if (!dy_quant_enabled_
-                || (!utils::one_of(eff_a_type(), s4, u4)
-                        && ((cmask_b_sc_ != full_tensor_mask())
-                                || bsc_dims_ > 2)))
-            return false;
-    } else {
-        if (!b_scales.has_default_values() && b_scales.get_mask() != 0
-                && a_scales_group_k_ > desc()->k())
-            return false;
-    }
-
     return true;
 }
 

--- a/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
+++ b/src/gpu/intel/jit/gemm/jit_gemm_pd.hpp
@@ -79,26 +79,22 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     bool wei_decomp_ = false;
     bool dy_quant_enabled_ = false;
     bool quant_enabled_ = false;
-    int wei_q2d_group_k_ = 0;
-    int src_q2d_group_k_ = 0;
-    bool src_po_sc_ = false;
-    data_type_t wei_scales_type_ = data_type::undef;
-    data_type_t src_scales_type_ = data_type::undef;
+    int a_q2d_group_k_ = 0;
+    int b_q2d_group_k_ = 0;
+    data_type_t a_scales_type_ = data_type::undef;
+    data_type_t b_scales_type_ = data_type::undef;
 
     int ao_dims_ = -1, bo_dims_ = -1;
     int asc_dims_ = -1, bsc_dims_ = -1;
     post_ops_t post_ops_;
     std::vector<binary_src_t> binary_srcs_;
 
-    int zp_group_k_a_ = -1;
-    int zp_group_k_b_ = -1;
-
     int cmask_a_ = INT_MIN;
     int cmask_b_ = INT_MIN;
     int cmask_c_ = INT_MIN;
 
-    int src_scales_group_k_ = -1;
-    int wei_scales_group_k_ = -1;
+    int b_scales_group_k_ = -1;
+    int a_scales_group_k_ = -1;
 
     const int mask_scalar = 1 << 0;
     const int mask_per_oc = 1 << 1;
@@ -107,7 +103,6 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     const int idx_a = DNNL_ARG_WEIGHTS;
     memory_desc_t prelu_wei_md;
     bool swap_ab_ = false;
-    bool a_zp_ = false, b_zp_ = false;
     dim_t eff_lda_ = 0, eff_ldb_ = 0;
     bool eff_transa_ = false, eff_transb_ = false;
     bool with_sround_ = false;
@@ -135,8 +130,8 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
         return sum_ab();
     }
 
-    bool wei_zp_2d() const { return ao_dims_ == 2; }
-    bool src_zp_2d() const { return bo_dims_ == 2; }
+    bool a_zp_2d() const { return ao_dims_ == 2; }
+    bool b_zp_2d() const { return bo_dims_ == 2; }
 
     bool with_sum_ab() const { return sum_ab() != sum_ab::sum_none; }
 
@@ -161,8 +156,8 @@ struct jit_gemm_pd_t : public gpu_gemm_pd_t {
     }
     bool with_sround() const { return with_sround_; }
 
-    bool wei_scales_2d() const { return asc_dims_ > 1; }
-    bool src_scales_2d() const { return bsc_dims_ > 1; }
+    bool a_scales_2d() const { return asc_dims_ > 1; }
+    bool b_scales_2d() const { return bsc_dims_ > 1; }
 
     bool dy_quant_enabled();
     bool wei_decomp();

--- a/src/gpu/intel/ocl/gemm_matmul.hpp
+++ b/src/gpu/intel/ocl/gemm_matmul.hpp
@@ -287,6 +287,8 @@ struct gemm_matmul_t : public gpu_primitive_t {
                                 orig_dims - reshape_size, 0));
                         CHECK(adjust_scales(new_scales, DNNL_ARG_B,
                                 orig_dims - reshape_size, a_dim_ratio));
+                        CHECK(adjust_scales(new_scales, DNNL_ARG_C,
+                                orig_dims - reshape_size, 0));
                     }
                     if (!attr()->zero_points_.has_default_values()) {
                         CHECK(map_gemm_zp(DNNL_ARG_WEIGHTS, true,


### PR DESCRIPTION
Fixes several issues in quantization code, each with their own commit. Also renames variables used in gemm code to rely on A/B names instead of SRC/WEI whenever possible, to ensure variable naming consistency.

High-impact bugs fixed:
- In some cases, common scales/zero-points were emitting invalid instructions leading to accuracy issues. They now generate correctly.
- Some valid cases were getting skipped without reason, which now go to the optimized implementation.
- When reshaping GEMM layers to reduce dimensions, dst scales were not getting reshaped with the other scales.
- Reduced strictness of dst scales support via jit:gemm:any, which was overly-restrictive.
- Some `per_ocic` quantization cases with M=1 or N=1 were treated as 1D, although gemmstone requires these to be labeled as 2D.

Also included a build fix for generic builds, sequestering intel-specific code from these configurations.