### PR TITLE
gpu: add guard to vendor specific headers in sdpa list

### DIFF
--- a/src/gpu/gpu_sdpa_list.cpp
+++ b/src/gpu/gpu_sdpa_list.cpp
@@ -18,8 +18,10 @@
 
 #include "gpu/gpu_impl_list.hpp"
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
 #include "gpu/intel/ocl/micro_sdpa.hpp"
 #include "gpu/intel/ocl/ref_sdpa.hpp"
+#endif
 
 namespace dnnl {
 namespace impl {

--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -722,6 +722,10 @@ public:
 #ifdef DNNL_SYCL_HIP
         GTEST_SKIP() << "SDPA primitive tests do not support HIP";
 #endif
+#ifdef DNNL_SYCL_GENERIC
+        GTEST_SKIP() << "no supported generic implementations for SDPA "
+                        "primitive tests";
+#endif
 #ifndef DNNL_TEST_WITH_ENGINE_PARAM
         SKIP_IF(engine::get_count(engine::kind::gpu) == 0,
                 "SDPA tests require gpus.");
@@ -735,6 +739,10 @@ public:
 #endif
 #ifdef DNNL_SYCL_HIP
         GTEST_SKIP() << "SDPA primitive tests do not support HIP";
+#endif
+#ifdef DNNL_SYCL_GENERIC
+        GTEST_SKIP() << "no supported generic implementations for SDPA "
+                        "primitive tests";
 #endif
 #ifdef DNNL_TEST_WITH_ENGINE_PARAM
         SKIP_IF(get_test_engine_kind() != dnnl::engine::kind::gpu,


### PR DESCRIPTION
# Description

Vendor specific headers cause a compilation error in gpu_sdpa_list when building the generic backend. This PR adds a vendor specific guard to avoid the inclusion of these incomplete headers.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?