### PR TITLE
benchdnn: fixes to cold cache and perf mode filling

### DIFF
--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -287,8 +287,11 @@ private:
         // only 1 GB so far to check if it proves working well.
         const bool is_total_size_big = total_size_ >= 1024 * 1024 * 1024;
         const bool is_total_size_unexpected = total_size_ > expected_max_;
-        if (!has_warned_ && is_max_set && is_total_size_big
-                && is_total_size_unexpected) {
+        // Perf mode might have cold-cache enabled which potentially allocates
+        // unaccounted memory. To avoid a dependency on a cold-cache in this
+        // file, just rely on perf mode.
+        if (!has_bench_mode_bit(mode_bit_t::perf) && !has_warned_ && is_max_set
+                && is_total_size_big && is_total_size_unexpected) {
             BENCHDNN_PRINT(0,
                     "[CHECK_MEM][ERROR]: Memory use is underestimated. Current "
                     "allocation size: %s; expected size: %s.\n",


### PR DESCRIPTION
[MFDNN-13874](https://jira.devtools.intel.com/browse/MFDNN-13874)
Here there was only one config which was static, which captured the first data type in it and used it for any further data types.

@yair-obodovsky reported that cold-cache is not working on CPU which has become a victim of memory prefilling optimization when number of buffers for the problem exceeded 100.

Also using cold-cache might trigger a report of misconducted memory which is expected. It was disabled.