### PR TITLE
benchdnn: graph: improve error handling to skip illegal rewrite cases

### DIFF
--- a/tests/benchdnn/graph/bench_graph.cpp
+++ b/tests/benchdnn/graph/bench_graph.cpp
@@ -36,18 +36,28 @@ void check_correctness(const settings_t &s) {
     for (const auto &i_mb : s.mb) {
         deserialized_graph_t dg;
         dg.load(locate_file(s.json_file));
-        flex_rewrite_t fw(i_in_shapes, i_op_attrs, i_fpmath_mode, i_mb, i_dt,
-                i_dt_map, i_op_kind_map);
-        fw.rewrite(dg);
-        BENCHDNN_PRINT(7, "[INFO] Graph dump:\n%s\n", dg.get_string().c_str());
 
-        const prb_t prb(dg, i_expected_n_partition);
+        res_t res {};
         const auto &cpp_pstr = case_to_str(s.json_file, i_in_shapes, i_op_attrs,
                 i_fpmath_mode, i_expected_n_partition, i_mb, i_dt, i_dt_map,
                 i_op_kind_map);
         const char *pstr = cpp_pstr.c_str();
+
+        // rewrite the graph
+        flex_rewrite_t fw(i_in_shapes, i_op_attrs, i_fpmath_mode, i_mb, i_dt,
+                i_dt_map, i_op_kind_map);
+        // TODO(zhitao): use const fw as the parameter of rewrite for the dg
+        // instead, as all the states should the updated in the ctor.
+        if (fw.rewrite(dg) != OK) {
+            res.state = UNTESTED;
+            res.reason = "Rewriting unsupported";
+            parse_result(res, pstr);
+            continue;
+        }
+
+        BENCHDNN_PRINT(7, "[INFO] Graph dump:\n%s\n", dg.get_string().c_str());
+        const prb_t prb(dg, i_expected_n_partition);
         BENCHDNN_PRINT(1, "run: %s\n", pstr);
-        res_t res {};
 
         // A timer for each test case.
         auto &tct = res.timer_map.get_timer(timer::names::test_case_timer);

--- a/tests/benchdnn/graph/flex_rewrite.hpp
+++ b/tests/benchdnn/graph/flex_rewrite.hpp
@@ -40,7 +40,7 @@ struct flex_rewrite_t {
         , dt_map_(dt_map)
         , op_kind_map_(op_kind_map) {}
 
-    void rewrite(deserialized_graph_t &dgraph);
+    int rewrite(deserialized_graph_t &dgraph);
 
 private:
     // input shape info from CML
@@ -54,36 +54,24 @@ private:
             dt_map_; // Updates specific LT with selected dt values.
     std::map<size_t, std::string> op_kind_map_;
 
-    void split_ncx(const std::string &data_format, dims_t &in, int64_t &n,
-            int64_t &c, dims_t &x) const;
-    void merge_ncx(const std::string &data_format, dims_t &out, int64_t n,
-            int64_t c, const dims_t &x) const;
-    void split_oix(const std::string &data_format, dims_t &in, dims_t &oi,
-            dims_t &x) const;
-    void broadcast(const dims_t &x, const dims_t &y, dims_t &z,
-            const std::string &x_str = "", const std::string &y_str = "") const;
-    // Returns `pad_begin` and `pad_end` for each dimension.
-    void cal_pads(dims_t &pads_begin, dims_t &pads_end,
-            const deserialized_op_t &aop, const dims_t &spatial_dims,
-            const dims_t &strides, const dims_t &kernel, bool deconv) const;
-    void infer_output_shape(deserialized_graph_t &dgraph, bool change_stride);
-    void inports_shape_rewrite(
+    int infer_output_shape(deserialized_graph_t &dgraph, bool change_stride);
+    int inports_shape_rewrite(
             deserialized_graph_t &dgraph, bool &change_stride);
     bool get_inport_shape_stride(const std::string &in_shape,
             std::string &shape, std::string &stride, std::string &mtag,
             std::string &msg);
-    void op_attrs_rewrite(deserialized_graph_t &dgraph);
-    void quantized_graph_rewrite(deserialized_graph_t &dgraph);
-    void update_output_info(deserialized_op_t &aop,
-            deserialized_graph_t &dgraph, bool change_stride);
-    void graph_attrs_rewrite(deserialized_graph_t &dgraph);
-    void dt_rewrite(deserialized_graph_t &dgraph);
-    void dt_map_rewrite(deserialized_graph_t &dgraph);
-    void op_kind_rewrite(deserialized_graph_t &dgraph);
+    int op_attrs_rewrite(deserialized_graph_t &dgraph);
+    int quantized_graph_rewrite(deserialized_graph_t &dgraph);
+    int update_output_info(deserialized_op_t &aop, deserialized_graph_t &dgraph,
+            bool change_stride);
+    int graph_attrs_rewrite(deserialized_graph_t &dgraph);
+    int dt_rewrite(deserialized_graph_t &dgraph);
+    int dt_map_rewrite(deserialized_graph_t &dgraph);
+    int op_kind_rewrite(deserialized_graph_t &dgraph);
     // Rewrite some linked attribute and shapes, such as group-shape and
     // scale/zp shape of dynamic dequantization for per-group quantization, to
     // simplify the cml input of rewriting.
-    void rewrite_linked_shape_and_attr(deserialized_graph_t &dgraph);
+    int linked_shape_and_attr_rewrite(deserialized_graph_t &dgraph);
 };
 
 } // namespace graph


### PR DESCRIPTION
## Description

Fix MFDNN-13808. Currently, illegal rewriting in a test batch will terminate the whole program. This PR:
1. Improve error handling in the rewriter to report a SKIPPED instead of terminating directly.
2. Reorganize the functions in the flexible rewriter and add more comments.