### PR TITLE
[GPU] Fixup fp8 weights decomp handling

### DIFF
--- a/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
+++ b/src/gpu/intel/jit/gemm/gen_gemm_kernel.cpp
@@ -560,7 +560,7 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
     add_mode_matches(fpmath_bf16, [](Type dt) -> const char * {
         if (dt == Type::f32) { return "[SB]"; }
         if (dt.isInt8() || dt.isInt4()) return "[OB]";
-        if (dt.isF8()) return "B";
+        if (dt.isF8()) return "[OB]";
         if (dt.isF4()) return "F";
         return nullptr;
     });
@@ -568,7 +568,7 @@ status_t gen_gemm_nocopy_kernel_desc_t::select_kernel(compute::gpu_arch_t arch,
     add_mode_matches(fpmath_f16, [](Type dt) -> const char * {
         if (dt == Type::f32) { return "[SH]"; }
         if (dt.isInt8() || dt.isInt4()) return "[OH]";
-        if (dt.isF8()) return "H";
+        if (dt.isF8()) return "[OH]";
         if (dt.isF4()) return "F";
         return nullptr;
     });


### PR DESCRIPTION
# Description

Use int8 upconversion strategies for fp8 upconversion rather than plain f16/bf16, fixes out of register issues as conversion overhead is similar.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?