### PR TITLE
[GPU] Fix build error after compiler update

### DIFF
--- a/src/gpu/intel/jit/CMakeLists.txt
+++ b/src/gpu/intel/jit/CMakeLists.txt
@@ -30,17 +30,7 @@ foreach(d ${DIRS})
     list(APPEND SOURCES "${d_sources}")
 endforeach()
 
-if(DNNL_EXPERIMENTAL)
-    list(REMOVE_ITEM SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/v2/conv/planner/planner_main.cpp")
-else()
-    file(GLOB planner_sources
-        ${CMAKE_CURRENT_SOURCE_DIR}/v2/conv/planner/*.hpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/v2/conv/planner/*.cpp
-        )
-    foreach(s ${planner_sources})
-        list(REMOVE_ITEM SOURCES "${s}")
-    endforeach()
-endif()
+list(FILTER SOURCES EXCLUDE REGEX "planner")
 
 add_subdirectory(gemm)
 
@@ -49,7 +39,7 @@ add_library(${OBJ_LIB} OBJECT ${SOURCES})
 set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
     $<TARGET_OBJECTS:${OBJ_LIB}>)
 
-if(DNNL_EXPERIMENTAL)
+if(DNNL_EXPERIMENTAL AND DNNL_DEV_MODE)
     add_subdirectory(v2/conv/planner)
 endif()
 

--- a/src/gpu/intel/jit/v2/conv/planner/CMakeLists.txt
+++ b/src/gpu/intel/jit/v2/conv/planner/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2023-2024 Intel Corporation
+# Copyright 2023-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,5 +14,19 @@
 # limitations under the License.
 #===============================================================================
 
-add_executable(gpu_conv_planner planner_main.cpp)
+file(GLOB SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+    )
+
+set(planner_main "${CMAKE_CURRENT_SOURCE_DIR}/planner_main.cpp")
+list(REMOVE_ITEM SOURCES ${planner_main})
+
+set(OBJ_LIB ${LIB_PACKAGE_NAME}_gpu_intel_jit_v2_conv_planner)
+add_library(${OBJ_LIB} OBJECT ${SOURCES})
+
+set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
+    $<TARGET_OBJECTS:${OBJ_LIB}>)
+
+add_executable(gpu_conv_planner EXCLUDE_FROM_ALL ${planner_main})
 target_link_libraries(gpu_conv_planner ${LIB_PACKAGE_NAME})

--- a/src/gpu/intel/jit/v2/conv/planner/bench.cpp
+++ b/src/gpu/intel/jit/v2/conv/planner/bench.cpp
@@ -51,6 +51,13 @@ namespace v2 {
 namespace conv {
 namespace planner {
 
+bench_manager_t::bench_manager_t()
+    : engine_(engine::kind::gpu, 0)
+    , stream_(engine_,
+              static_cast<stream::flags>(
+                      stream_flags::in_order | stream_flags::profiling))
+    , hw_(engine_.get()) {}
+
 bench_manager_t::~bench_manager_t() {
     dump_plan_registry();
 }

--- a/src/gpu/intel/jit/v2/conv/planner/bench.hpp
+++ b/src/gpu/intel/jit/v2/conv/planner/bench.hpp
@@ -36,19 +36,13 @@ namespace planner {
 
 class bench_manager_t {
 public:
-    bench_manager_t()
-        : engine_(engine::kind::gpu, 0)
-        , stream_(engine_, _stream_flags)
-        , hw_(engine_.get()) {}
+    bench_manager_t();
     const engine &get_engine() const { return engine_; }
     const stream &get_stream() const { return stream_; }
     const hw_t &hw() const { return hw_; }
     ~bench_manager_t();
 
 private:
-    static const stream::flags _stream_flags = static_cast<stream::flags>(
-            stream_flags::in_order | stream_flags::profiling);
-
     engine engine_;
     stream stream_;
     hw_t hw_;


### PR DESCRIPTION
Jira: [MFDNN-13920](https://jira.devtools.intel.com/browse/MFDNN-13920)

PR fixes a build error with after compiler update. PR also excludes all v2 conv planner sources from the build, unless built with `ONEDNN_DEV_MODE`.