### PR TITLE
xe: jit: codegen: remove unnecessary emul workaround

### DIFF
--- a/src/gpu/intel/jit/codegen/kernel.hpp
+++ b/src/gpu/intel/jit/codegen/kernel.hpp
@@ -533,26 +533,6 @@ public:
                 }
             }
         } else {
-            auto &src1_imm = src1.immediate();
-            if (ngen_is_qw(dst.type()) || ngen_is_w(src1_imm.getType())) {
-                emul(mod, dst.reg_data(), src0.reg_data(), src1.immediate());
-                return;
-            }
-            if (ngen_is_dw(src1_imm.getType())) {
-                gpu_assert(mod.getExecSize() == 1);
-                auto tmp = ra_.alloc_sub<int64_t>();
-                if (ngen_is_w(src0.type())) {
-                    auto tmp_src1 = ra_.alloc_sub<int32_t>();
-                    emov(mod, tmp_src1.d(0), src0.reg_data());
-                    emul(mod, tmp.q(0), tmp_src1.d(0), src1_imm);
-                    ra_.safeRelease(tmp_src1);
-                } else {
-                    emul(mod, tmp.q(0), src0.reg_data(), src1_imm);
-                }
-                emov(mod, dst.reg_data(), tmp.reinterpret(0, dst.type()));
-                ra_.safeRelease(tmp);
-                return;
-            }
             emul(mod, dst.reg_data(), src0.reg_data(), src1.immediate());
         }
     }


### PR DESCRIPTION
The ngen::emul functionality has be signficantly increased since the removed branch was added. This PR removes this complexity so that we can just rely on ngen::emul directly. Additionally, this provides a workaround for [MFDNN-13917](https://jira.devtools.intel.com/browse/MFDNN-13917).