### PR TITLE
common: fix alignment for nested scratchpads

### DIFF
--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -492,7 +492,8 @@ struct registrar_t {
 
     void book(const key_t &key, const registry_t &registry,
             size_t perf_align = default_alignment) {
-        registry_.book(make_key(prefix_, key), registry.size(), 1, perf_align);
+        registry_.book(make_key(prefix_, key), registry.size(),
+                default_alignment, perf_align);
     }
 
     size_t size() const { return registry_.size(); }


### PR DESCRIPTION
PR fixes this assertion on PVC with debug build:

```
$ ./build/tests/benchdnn/benchdnn --matmul --engine=gpu --dt=f16:f16:u8 --stag=bac --wtag=abc --dtag=bac --skip-impl=ref 1x425x183:1x183x7189
benchdnn: ../src/xpu/ocl/buffer_memory_storage.cpp:124: virtual std::unique_ptr<dnnl::impl::memory_storage_t> dnnl::impl::xpu::ocl::buffer_memory_storage_t::get_sub_storage(size_t, size_t) const: Assertion `offset % ocl_engine_impl->get_buffer_alignment() == 0' failed.
Aborted (core dumped)

```