### PR TITLE
missing block2d definitions sdpa 

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa_configs.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa_configs.cpp
@@ -606,8 +606,8 @@ sdpa_config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size,
     if (arch == compute::gpu_arch_t::xe_hpg && is_fma && !is_f32
             && is_quantized)
         return nullptr;
-    // f32 fma on MTL requires too many registers for head sizes >= 256
-    if (arch == compute::gpu_arch_t::xe_hpg && is_fma && is_f32
+    // f32 and fma on MTL requires too many registers for head sizes >= 256
+    if (arch == compute::gpu_arch_t::xe_hpg && (is_fma || is_f32)
             && head_size > 256)
         return nullptr;
     // no valid quantized configs w/head size = 512 on xe2

--- a/src/gpu/intel/ocl/tile_ops.h
+++ b/src/gpu/intel/ocl/tile_ops.h
@@ -236,6 +236,10 @@ DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 8, 16, u16_m8k16v1, 16, 8)
 DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 8, 16, u16_m4k32v1, 32, 4)
 DEF_BLOCK2D_LOAD_STORE(ushort, ushort, 16, 16, u16_m8k32v1, 32, 8)
 
+DEF_BLOCK2D_LOAD_STORE(float, uint, 8, 16, u32_m8k16v1, 16, 8)
+DEF_BLOCK2D_LOAD_STORE(float, uint, 8, 16, u32_m4k32v1, 32, 4)
+DEF_BLOCK2D_LOAD_STORE(float, uint, 16, 16, u32_m8k32v1, 32, 8)
+
 #define tile_fill(t, v) \
     do { \
         _Pragma("unroll") for (int i = 0; i < sizeof(t.x) / sizeof(t.x[0]); \


### PR DESCRIPTION
# Description
This PR addresses a few minor sdpa fixes :
* adds missing block2d definitions for f32
* further restricts head size 512 on MTL

These changes enable graph support for f32 as part of #3538. 
