### PR TITLE
Updated Sphinx version for documentation

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9.5
-  - pip=21.1.2
+  - python=3.9
+  - pip
   - doxyrest=2.1.2
   - doxygen=1.8.14
   - graphviz=2.40.1
-  - sphinx=4.0.2
-  - sphinx-book-theme=0.0.41
+  - sphinx=6.2.1
+  - sphinx-book-theme=1.1.4
   - sphinx-copybutton=0.5.2

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -137,10 +137,14 @@ html_theme = 'sphinx_book_theme'
 html_static_path = ['_static']
 #html_js_files = [('dnnl.js', {'defer': 'defer'})]
 
-html_logo = '_static/oneAPI-rgb-rev-100.png'
 html_favicon = '_static/favicons.png'
 
 html_theme_options = {
+    "logo": {
+        "text": "oneDNN Documentation",
+        "image_light": "_static/oneAPI-rgb-rev-100.png",
+        "image_dark": "_static/oneAPI-rgb-rev-100.png",
+    },
     "repository_url": "https://github.com/uxlfoundation/oneDNN",
     "repository_branch": "main",
     "use_repository_button": True,


### PR DESCRIPTION
This PR fixes errors during documentation deployment.

One thing I did not figure out is how to get project version displayed in the logo section. It happened magically with Sphinx 4.0.