### PR TITLE
Backport: cpu: x64: matmul: correct bf16 conversion in copy_b_transpose

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -4304,6 +4304,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Ymm>::copy_row_x_col(
                 vcvtph2ps(vmm_src, Xmm(vmm_src.getIdx()));
             } else if (use_bf16_instructions_) {
                 // Upconvert: move loaded 16 bits left.
+                uni_vpmovzxwd(vmm_src, vmm_src);
                 uni_vpslld(vmm_src, vmm_src, 16);
             }
         } else {


### PR DESCRIPTION
Backport of #3589 
