### PR TITLE
cpu: aarch64: Fix nightly test crash caused by PR #3552

### DIFF
--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024-2025 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -534,6 +535,9 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     if (jcp_.with_scales)
         book_precomputed_scales(scratchpad, attr()->scales_, OC(),
                 jcp_.scale_adjust_factor != 1.0f);
+
+    // temporary fix for large l_pad failing test caused by PR #3552
+    if (2 * jcp_.l_pad > jcp_.ow_block) return status::unimplemented;
 
     return status::success;
 }


### PR DESCRIPTION
# Description

This PR aims to create a workaround for a test failure caused by PR #3552 until a definitive solution is developed. To reproduce the test failure, you need to run:

`DNNL_VERBOSE=all OMP_NUM_THREADS=1 ./tests/benchdnn/benchdnn --conv --dt=u8:s8:f32 --skip-impl=ref,x64:gemm mb1ic64ih1iw33oc1oh1ow33kh1kw24ph0pw23n"l_pad_exceeds_ow_block"`

Fixes #3591 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
