### PR TITLE
xe: fix ref_inner_product call to APPLY_POST_OPS

### DIFF
--- a/src/gpu/intel/ref_inner_product.cl
+++ b/src/gpu/intel/ref_inner_product.cl
@@ -67,7 +67,7 @@ __kernel void ref_inner_product_fwd(__global SRC_DATA_T *src,
     dest_data = DST_TO_REF(dst[mb * OC + oc]);
 #endif
 
-    APPLY_POST_OPS_SERIAL(tmp, dest_data, mb, oc, 0, 0, 0);
+    APPLY_POST_OPS_SERIAL(tmp, dest_data, mb, oc, 0, 0, 0, 0);
 
 #if WITH_DST_SCALES
     tmp /= dst_scales[0];


### PR DESCRIPTION
#3558 missed adding one of the unused dimension arguments to APPLY_POST_OPS_SERIAL.
