### PR TITLE
WIP: xe: jit: refactor layout_t to support pvar_t dimensions

### DIFF
--- a/src/gpu/intel/jit/codegen/reduce.hpp
+++ b/src/gpu/intel/jit/codegen/reduce.hpp
@@ -128,7 +128,7 @@ private:
         auto &a0 = a.blocks()[0];
         auto &b0 = b.blocks()[0];
 
-        bool ok = (a0.dim_idx == b0.dim_idx && a0.block == b0.block);
+        bool ok = (a0.dim == b0.dim && a0.block == b0.block);
         if (!ok) {
             // Try to match strided layout.
             if (a0.block == 2) {
@@ -160,7 +160,7 @@ private:
         }
 
         std::vector<dim_t> tile_dims(src_layout_.ndims(), 1);
-        tile_dims[a0.dim_idx]
+        tile_dims[a0.dim]
                 = ir_utils::max_divisor(int(a0.block), {min_step, max_step});
 
         return tile_t(tile_dims);

--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -1762,8 +1762,8 @@ private:
                 if (i > min_log_bytes) {
                     gpu_assert(!layout.blocks().empty());
                     gpu_assert(!v.layout.blocks().empty());
-                    int dim_idx0 = layout.blocks()[0].dim_idx;
-                    int dim_idx1 = v.layout.blocks()[0].dim_idx;
+                    int dim_idx0 = layout.blocks()[0].dim;
+                    int dim_idx1 = v.layout.blocks()[0].dim;
                     if (dim_idx0 != dim_idx1) continue;
                 }
                 min_cost = cur_cost;
@@ -1968,14 +1968,14 @@ private:
     static std::vector<layout_t> generate_all_layouts(
             const type_t &type, int a, int b) {
         std::vector<layout_t> ret;
-        std::vector<block_t> blocks;
+        std::vector<layout_block_t> blocks;
         generate_all_layouts_impl(ret, blocks, type, a, b, 1);
         return ret;
     }
 
     static void generate_all_layouts_impl(std::vector<layout_t> &layouts,
-            std::vector<block_t> &blocks, const type_t &type, int a, int b,
-            int stride) {
+            std::vector<layout_block_t> &blocks, const type_t &type, int a,
+            int b, int stride) {
         if (a == 1 && b == 1) {
             layouts.emplace_back(type, 2, 0, blocks);
             return;
@@ -1986,8 +1986,8 @@ private:
         // Avoid repeating indices to keep only unique layouts.
         if (!blocks.empty()) {
             auto &last = blocks.back();
-            iterate_a &= (last.dim_idx != 0);
-            iterate_b &= (last.dim_idx != 1);
+            iterate_a &= (last.dim != 0);
+            iterate_b &= (last.dim != 1);
         }
 
         if (iterate_a) {
@@ -2074,12 +2074,12 @@ private:
             int non_one_dims = 0;
             int count = 0;
             std::unordered_set<int> seen;
-            return [=](const block_t &b) mutable {
+            return [=](const layout_block_t &b) mutable {
                 if ((dim_t)b.stride != stride) return false;
                 if (b.block != 1) {
                     count++;
                     stride *= b.block;
-                    auto ret = seen.insert(b.dim_idx);
+                    auto ret = seen.insert(b.dim);
                     if (ret.second) non_one_dims++;
                 }
                 return non_one_dims <= 2 && count <= max_tile_blocks;
@@ -2190,7 +2190,7 @@ private:
         for (int i = 0; i < min_blocks; i++) {
             auto &ab = a_blocks[i];
             auto &bb = b_blocks[i];
-            if (ab.dim_idx != bb.dim_idx || ab.block != bb.block) break;
+            if (ab.dim != bb.dim || ab.block != bb.block) break;
 
             // Strides are supported for the innermost block only.
             if (src_cur_stride != int(ab.stride)) break;
@@ -2198,7 +2198,7 @@ private:
 
             src_cur_stride = int(ab.block * ab.stride);
             dst_cur_stride = int(bb.block * bb.stride);
-            tile_dims[ab.dim_idx] *= ab.block;
+            tile_dims[ab.dim] *= ab.block;
         }
         return tile_t(tile_dims);
     }

--- a/src/gpu/intel/jit/conv/normalization.cpp
+++ b/src/gpu/intel/jit/conv/normalization.cpp
@@ -24,42 +24,42 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
-layout_t insert_dimension(const layout_t &layout, dim_idx_t dim_idx) {
+layout_t insert_dimension(const layout_t &layout, const pvar_t &dim) {
     auto new_blocks = layout.blocks();
     for (auto &b : new_blocks) {
-        if (b.dim_idx >= dim_idx) b.dim_idx++;
+        if (b.dim.index() >= dim.index()) b.dim = pvar_t((dim_idx_t)b.dim + 1);
     }
     return layout_t(layout.type(), layout.ndims() + 1, layout.offset(),
             new_blocks,
             /*do_normalize=*/false);
 }
 
-layout_t remove_size_1_dimension(const layout_t &layout, dim_idx_t dim_idx) {
-    gpu_assert(dim_idx != dim_idx::invalid && dim_idx < layout.ndims());
-    gpu_assert(layout.dim(dim_idx) == 1);
+layout_t remove_size_1_dimension(const layout_t &layout, const pvar_t &dim) {
+    gpu_assert(dim < layout.ndims());
+    gpu_assert(layout.dim(dim) == 1);
     dim_assignment_t a(layout.ndims(), layout.ndims() - 1);
     for (dim_idx_t i = 0; i < layout.ndims(); i++) {
-        if (i == dim_idx) continue;
-        a.assign(i, i < dim_idx ? i : i - 1);
+        if (i == dim.index()) continue;
+        a.assign(i, i < dim.index() ? i : i - 1);
     }
     return a.map(layout);
 }
 
 layout_t split_dimension(
-        const layout_t &_layout, dim_idx_t dim_idx, dim_t outer_block) {
+        const layout_t &_layout, const pvar_t &dim, dim_t outer_block) {
     dim_t rem_inner_block
-            = ir_utils::safe_divide(_layout.dim(dim_idx), outer_block);
-    auto layout = insert_dimension(_layout, dim_idx);
-    std::vector<block_t> new_blocks;
+            = ir_utils::safe_divide(_layout.dim(dim), outer_block);
+    auto layout = insert_dimension(_layout, dim);
+    std::vector<layout_block_t> new_blocks;
     for (auto &eb : layout.enumerated_blocks()) {
         auto &b = eb.second;
-        if (b.dim_idx != dim_idx + 1) {
+        if (b.dim != dim + 1) {
             new_blocks.push_back(b);
             continue;
         }
         if (b.block % rem_inner_block == 0) {
-            new_blocks.emplace_back(dim_idx + 1, rem_inner_block, b.stride);
-            new_blocks.emplace_back(dim_idx, b.block / rem_inner_block,
+            new_blocks.emplace_back(dim + 1, rem_inner_block, b.stride);
+            new_blocks.emplace_back(dim, b.block / rem_inner_block,
                     dim_t(b.stride) * rem_inner_block);
             rem_inner_block = 1;
         } else {
@@ -69,12 +69,12 @@ layout_t split_dimension(
     }
 
     // Remove inner blocks with size one.
-    std::vector<block_t> _new_blocks;
+    std::vector<layout_block_t> _new_blocks;
     std::vector<bool> seen(layout.ndims());
     for (auto it = new_blocks.rbegin(); it != new_blocks.rend(); ++it) {
-        if (it->block == 1 && seen[it->dim_idx]) continue;
+        if (it->block == 1 && seen[it->dim]) continue;
         _new_blocks.push_back(*it);
-        seen[it->dim_idx] = true;
+        seen[it->dim] = true;
     }
     std::reverse(_new_blocks.begin(), _new_blocks.end());
     return layout_t(layout.type(), layout.ndims(), layout.offset(), _new_blocks,
@@ -94,7 +94,7 @@ layout_t normalize_conv_groups(const layout_t &layout, bool with_groups,
     gpu_assert(!with_groups) << "Unexpected groups in source/destination.";
     if (is_dw) groups = layout.dim(1);
     if (layout.dim(1) == 1) groups = 1;
-    return split_dimension(layout, /*dim_idx=*/1, groups);
+    return split_dimension(layout, /*dim=*/1, groups);
 }
 
 layout_t normalize_conv_layout(const layout_t &_layout, bool with_groups,
@@ -215,12 +215,12 @@ view_t conv_post_op_view_mapper_t::create_src_zp_view(uint32_t mask) const {
     gpu_assert((vars.size() == 6) && (dst.ndims() == 6));
 
     bool non_1_spatials[3] = {false, false, false};
-    std::vector<block_t> new_blk;
+    std::vector<layout_block_t> new_blk;
     for (auto &b : dst.blocks()) {
-        if ((b.dim_idx >= 3) && (b.dim_idx <= 5)) {
+        if ((b.dim >= 3) && (b.dim <= 5)) {
             if (b.block > 1)
-                non_1_spatials[b.dim_idx - 3] = true;
-            else if (non_1_spatials[b.dim_idx - 3])
+                non_1_spatials[b.dim - 3] = true;
+            else if (non_1_spatials[b.dim - 3])
                 continue;
         }
         new_blk.emplace_back(b);
@@ -277,8 +277,8 @@ view_t conv_post_op_view_mapper_t::try_create_bias_view(uint32_t mask) const {
     return {};
 }
 
-bool conv_post_op_view_mapper_t::is_spurious_spatial(dim_idx_t dim_idx) const {
-    auto &var = cp_view().vvars()[dim_idx].as<var_t>();
+bool conv_post_op_view_mapper_t::is_spurious_spatial(const pvar_t &dim) const {
+    auto &var = cp_view().vvars()[dim].as<var_t>();
 
     int sp_idx = -1;
     if (utils::one_of(var.name, "od", "id")) {

--- a/src/gpu/intel/jit/conv/normalization.hpp
+++ b/src/gpu/intel/jit/conv/normalization.hpp
@@ -56,7 +56,7 @@ public:
     // bounds) convolution computes an out-of-bound element which is not
     // generally zero. This requires special handling if there are post-ops
     // followed the convolution.
-    bool is_spurious_spatial(dim_idx_t dim_idx) const override;
+    bool is_spurious_spatial(const pvar_t &dim) const override;
     bool need_to_restore_zero_padding() const override;
     bool use_dst_in_sum_post_op() const override;
     bool can_use_scales() const override;

--- a/src/gpu/intel/jit/conv/plan.cpp
+++ b/src/gpu/intel/jit/conv/plan.cpp
@@ -91,7 +91,7 @@ static dim_tile_t create_tile(gemm_schedule_t &gemm_schedule,
                           : get_kernel_grid_conv_dims(cfg);
         for (auto &tile : grid)
             for (auto &d : tile)
-                if (dim_name == d.name()) return true;
+                if (dim_name == d.str()) return true;
         return false;
     };
 
@@ -817,8 +817,8 @@ bool x2r_plan_t::can_split(abc_kind_t abc, int factor) const {
     auto &reorder = (is_a ? a_reorder : b_reorder);
     auto &layout = (is_a ? a_layout : b_layout);
     if (!layout.has_outer_block(factor)) return false;
-    int dim_idx = layout.blocks().back().dim_idx;
-    if (reorder && !reorder.src.has_outer_block(factor, dim_idx)) return false;
+    auto &dim = layout.blocks().back().dim;
+    if (reorder && !reorder.src.has_outer_block(factor, dim)) return false;
     if (!load.can_split(factor)) return false;
     if (!x_reduce.can_split(factor)) return false;
     return true;
@@ -876,14 +876,14 @@ std::string x2r_plan_t::str() const {
     return add_indent("x2r_plan", oss.str());
 }
 
-int get_dpas_block_rcount(const layout_t &layout, dim_idx_t dim_idx) {
+int get_dpas_block_rcount(const layout_t &layout, const pvar_t &dim) {
     if (layout.nblocks() < 2) return 1;
 
     auto &b0 = layout.blocks()[0];
     if (b0.block * layout.type().size() > 32) return 1;
 
     auto &b1 = layout.blocks()[1];
-    if (b1.dim_idx != dim_idx) return 1;
+    if (b1.dim != dim) return 1;
 
     int block_rcount = (int)b1.block;
     int max_rcount = 8;
@@ -906,7 +906,7 @@ bool fma_plan_t::can_split(abc_kind_t abc, int factor) const {
     auto &blocks = layout.blocks();
     if (blocks.empty()) return false;
     auto &b = blocks.back();
-    if (b.dim_idx != mn_idx) return false;
+    if (b.dim != mn_idx) return false;
     if ((int)b.block % factor != 0) return false;
     return true;
 }
@@ -1324,7 +1324,7 @@ struct fma_context_t {
         if (is_dpas) {
             int sdepth = 8;
             int dword_size = 4;
-            std::vector<std::pair<int, dim_t>> blocks;
+            std::vector<std::pair<pvar_t, dim_t>> blocks;
             auto bmnks = get_bmnk_kinds(abc);
             if (is_a) {
                 // A -> src2
@@ -1356,7 +1356,7 @@ struct fma_context_t {
             auto ret = maybe_retype_layout_for_mad(is_a, layout);
             auto &hint = layout_hint(abc);
             if (hint.is_empty()) return ret;
-            std::vector<std::pair<int, dim_t>> blocks;
+            std::vector<std::pair<pvar_t, dim_t>> blocks;
             blocks.emplace_back(hint.vec_dim_idx, vec_size);
             auto bmnks = get_bmnk_kinds(abc, /*with_batch=*/true);
             auto bmnk_layout = mapper.map_to_bmnk(abc, bmnks, ret);
@@ -1613,11 +1613,11 @@ layout_t to_reduce_layout(
         const conv_config_t &cfg, const layout_t &layout, uint32_t mask) {
     int reduce_ndims = layout.ndims();
     auto map = get_reduce_dim_map(mask, reduce_ndims);
-    std::vector<block_t> reduce_blocks;
+    std::vector<layout_block_t> reduce_blocks;
     for (auto &b : layout.blocks()) {
-        if (map[b.dim_idx] == -1) continue;
+        if (map[b.dim] == -1) continue;
         auto bb = b;
-        bb.dim_idx = map[b.dim_idx];
+        bb.dim = map[b.dim];
         reduce_blocks.push_back(bb);
     }
     auto type = get_accumulation_type(cfg, layout.type(), layout.type());
@@ -1644,14 +1644,14 @@ public:
     layout_t transform(const layout_t &layout) const {
         gpu_assert((bool)*this);
         gpu_assert(fused_tidx_ != dim_idx::invalid);
-        std::vector<block_t> blocks;
+        std::vector<layout_block_t> blocks;
         bool seen = false;
         for (auto &b : layout.blocks()) {
             if (b.block == 1) continue;
-            auto &tdim = view_.tdim(b.dim_idx);
-            if (b.dim_idx != fused_tidx_) {
+            auto &tdim = view_.tdim(b.dim);
+            if (b.dim != fused_tidx_) {
                 auto vb = b;
-                vb.dim_idx = tdim.vidx(0);
+                vb.dim = tdim.vidx(0);
                 blocks.push_back(vb);
                 continue;
             }
@@ -1661,7 +1661,7 @@ public:
                 int vidx = tdim.vidx(i);
                 dim_t vstride = (dim_t)tdim.vstride(i);
                 auto vb = b;
-                vb.dim_idx = vidx;
+                vb.dim = vidx;
                 vb.block = view_.vdims()[vidx];
                 vb.stride = b.stride * vstride;
                 blocks.push_back(vb);
@@ -1761,7 +1761,7 @@ private:
 layout_t add_batch(const layout_t &layout) {
     auto blocks = layout.blocks();
     for (auto &b : blocks) {
-        b.dim_idx++;
+        b.dim = b.dim + 1;
     }
     return layout_t(layout.type(), layout.ndims(), layout.offset(), blocks);
 }
@@ -1794,17 +1794,17 @@ bool is_dpas_src2_compatible(int simd, bool transpose, const layout_t &layout) {
 
 layout_t get_c_layout(const layout_t &a_layout, const layout_t &b_layout,
         const layout_t &c_blk_layout) {
-    std::vector<block_t> blocks;
+    std::vector<layout_block_t> blocks;
     const bmnk_kind_t a_bmnks[3]
             = {bmnk_kind_t::b, bmnk_kind_t::m, bmnk_kind_t::k};
     const bmnk_kind_t b_bmnks[3]
             = {bmnk_kind_t::b, bmnk_kind_t::k, bmnk_kind_t::n};
     for (auto &b : a_layout.blocks()) {
-        if (a_bmnks[b.dim_idx] == bmnk_kind_t::k) continue;
+        if (a_bmnks[b.dim] == bmnk_kind_t::k) continue;
         blocks.push_back(b);
     }
     for (auto &b : b_layout.blocks()) {
-        if (utils::one_of(b_bmnks[b.dim_idx], bmnk_kind_t::b, bmnk_kind_t::k))
+        if (utils::one_of(b_bmnks[b.dim], bmnk_kind_t::b, bmnk_kind_t::k))
             continue;
         blocks.push_back(b);
     }
@@ -2243,7 +2243,7 @@ private:
                 if (b.block % j != 0) continue;
                 if (outer * j > k_tg) break;
                 if (outer * j == k_tg || j == b.block) {
-                    rem_dims[b.dim_idx] /= j;
+                    rem_dims[b.dim] /= j;
                     outer *= j;
                     break;
                 }
@@ -2274,9 +2274,9 @@ private:
             layout_t k_layout = layout_t(type_t::u8(), 0,
                     std::vector<dim_t>(layout_t::max_ndims, 1));
             for (auto &b : l.blocks()) {
-                auto bmnk_kind = bmnk_mapper.bmnk_kind(abc_kind, b.dim_idx);
+                auto bmnk_kind = bmnk_mapper.bmnk_kind(abc_kind, b.dim);
                 if (bmnk_kind != bmnk_kind_t::k) continue;
-                auto &var = bmnk_mapper.var(abc_kind, b.dim_idx);
+                auto &var = bmnk_mapper.var(abc_kind, b.dim);
                 auto ret = k_vars.emplace(var, (int)k_vars.size());
                 k_layout = k_layout.add_outer_block(ret.first->second, b.block);
             }
@@ -2293,16 +2293,14 @@ private:
             auto &a1 = a_k.blocks()[1];
             auto &b0 = b_k.blocks()[0];
             auto &b1 = b_k.blocks()[1];
-            bool dims_ok
-                    = (a0.dim_idx == b1.dim_idx) && (a1.dim_idx == b0.dim_idx);
+            bool dims_ok = (a0.dim == b1.dim) && (a1.dim == b0.dim);
             bool blocks_ok = (a0.block == b1.block) && (a1.block == b0.block);
             if (dims_ok && blocks_ok) {
                 auto a_blocks = a.blocks();
                 int i0 = -1;
                 int i1 = -1;
                 for (int i = 0; i < a.nblocks(); i++) {
-                    if (bmnk_mapper.bmnk_kind(
-                                abc_kind_t::a, a_blocks[i].dim_idx)
+                    if (bmnk_mapper.bmnk_kind(abc_kind_t::a, a_blocks[i].dim)
                             == bmnk_kind_t::k) {
                         if (i0 == -1) {
                             i0 = i;

--- a/src/gpu/intel/jit/conv/tiler.cpp
+++ b/src/gpu/intel/jit/conv/tiler.cpp
@@ -166,7 +166,7 @@ int get_layout_unit(const conv_config_t &cfg, const layout_t &layout,
 
     std::vector<dim_t> blocks;
     for (auto &b : layout.blocks()) {
-        if (b.dim_idx == dim_idx) blocks.push_back(b.block);
+        if (b.dim == dim_idx) blocks.push_back(b.block);
     }
     if (blocks.size() <= 1) return 1;
     blocks.resize(blocks.size() - 1);
@@ -451,7 +451,7 @@ dim_t inner_stride(const conv_config_t &cfg, tensor_kind_t tensor_kind,
     gpu_assert(dim_idx != dim_idx::invalid);
     auto &layout = compute_layout(cfg, tensor_kind);
     for (auto &b : layout.blocks()) {
-        if (b.dim_idx == dim_idx) return (dim_t)b.stride;
+        if (b.dim == dim_idx) return (dim_t)b.stride;
     }
     return 0;
 }
@@ -808,7 +808,7 @@ private:
         if (dim_idx == dim_idx::invalid) return true;
         std::vector<dim_t> blocks;
         for (auto &b : layout.blocks()) {
-            if (b.dim_idx == dim_idx) blocks.push_back(b.block);
+            if (b.dim == dim_idx) blocks.push_back(b.block);
         }
         if (blocks.size() <= 1) return true;
         blocks.resize(blocks.size() - 1);

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -91,7 +91,7 @@ layout_t dpas_t::a_layout() const {
     int m_blk = exec_size;
     int inner_blk = 4 / src1_type.size();
     int outer_blk = sdepth;
-    std::vector<std::pair<int, dim_t>> blocks
+    std::vector<std::pair<pvar_t, dim_t>> blocks
             = {{1, outer_blk}, {0, m_blk}, {1, inner_blk}};
     return layout_t(src1_type, 0, 2, blocks);
 }

--- a/src/gpu/intel/jit/ir/gemm_schedule.cpp
+++ b/src/gpu/intel/jit/ir/gemm_schedule.cpp
@@ -31,9 +31,9 @@ layout_t bmnk_mapper_t::map_to_bmnk(abc_kind_t abc_kind,
 layout_t bmnk_mapper_t::map_to_bmnk(abc_kind_t abc_kind,
         const std::vector<bmnk_kind_t> &bmnk_kinds,
         const layout_t &layout) const {
-    std::vector<block_t> blocks;
+    std::vector<layout_block_t> blocks;
     for (auto &b : layout.blocks()) {
-        auto b_bmnk_kind = bmnk_kind(abc_kind, b.dim_idx);
+        auto b_bmnk_kind = bmnk_kind(abc_kind, b.dim);
         bool found = false;
         for (int i = 0; i < int(bmnk_kinds.size()); i++) {
             if (bmnk_kinds[i] == b_bmnk_kind) {
@@ -55,8 +55,8 @@ layout_t bmnk_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
     return m.map_from_bmnk(abc_kind, bmnk_kinds, bmnk_layout);
 }
 
-void bmnk_block_mapper_t::push_block(abc_kind_t abc_kind, const block_t &b) {
-    auto bmnk_kind = bmnk_mapper_.bmnk_kind(abc_kind, b.dim_idx);
+void bmnk_block_mapper_t::push_block(abc_kind_t abc_kind, const layout_block_t &b) {
+    auto bmnk_kind = bmnk_mapper_.bmnk_kind(abc_kind, b.dim);
     switch (bmnk_kind) {
         case bmnk_kind_t::b:
             if (abc_kind == abc_kind_t::a) b_blocks_.emplace_back(abc_kind, b);
@@ -73,8 +73,8 @@ layout_t bmnk_block_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
         const layout_t &bmnk_layout) const {
     gpu_assert(bmnk_layout.ndims() <= 3);
     gpu_assert(bmnk_layout.has_zero_offset());
-    std::vector<block_t> blocks;
-    std::vector<std::vector<block_t>> tmp_blocks(
+    std::vector<layout_block_t> blocks;
+    std::vector<std::vector<layout_block_t>> tmp_blocks(
             static_cast<int>(bmnk_kind_t::k) + 1);
     tmp_blocks[static_cast<int>(bmnk_kind_t::b)]
             = create_prb_blocks(abc_kind, b_blocks_);
@@ -85,7 +85,7 @@ layout_t bmnk_block_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
     tmp_blocks[static_cast<int>(bmnk_kind_t::k)]
             = create_prb_blocks(abc_kind, k_blocks_);
     for (auto &b : bmnk_layout.blocks()) {
-        auto &bmnk_blocks = tmp_blocks[static_cast<int>(bmnk_kinds[b.dim_idx])];
+        auto &bmnk_blocks = tmp_blocks[static_cast<int>(bmnk_kinds[b.dim])];
         bool ok = pop_block(bmnk_blocks, blocks, b);
         gpu_assert(ok) << "Can't map from bmnk layout to problem layout.";
         MAYBE_UNUSED(ok);
@@ -107,8 +107,9 @@ layout_t bmnk_block_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
             bmnk_layout.type(), bmnk_mapper_.ndims(abc_kind), 0, blocks);
 }
 
-bool bmnk_block_mapper_t::pop_block(std::vector<block_t> &bmnk_blocks,
-        std::vector<block_t> &prb_blocks, const block_t &bmnk_block) const {
+bool bmnk_block_mapper_t::pop_block(std::vector<layout_block_t> &bmnk_blocks,
+        std::vector<layout_block_t> &prb_blocks,
+        const layout_block_t &bmnk_block) const {
     if (bmnk_block.block == 1) return true;
 
     pop_size_1_blocks(bmnk_blocks);
@@ -118,13 +119,13 @@ bool bmnk_block_mapper_t::pop_block(std::vector<block_t> &bmnk_blocks,
     dim_t common_block = math::gcd(next_block.block, bmnk_block.block);
     if (common_block == bmnk_block.block) {
         prb_blocks.emplace_back(
-                next_block.dim_idx, common_block, next_block.stride);
+                next_block.dim, common_block, next_block.stride);
         next_block.block /= common_block;
         next_block.stride *= common_block;
         return true;
     } else if (common_block == next_block.block) {
         prb_blocks.emplace_back(
-                next_block.dim_idx, common_block, next_block.stride);
+                next_block.dim, common_block, next_block.stride);
         bmnk_blocks.erase(bmnk_blocks.begin());
         auto tmp_block = bmnk_block;
         tmp_block.block /= common_block;

--- a/src/gpu/intel/jit/ir/gemm_schedule.hpp
+++ b/src/gpu/intel/jit/ir/gemm_schedule.hpp
@@ -140,48 +140,48 @@ public:
     bmnk_block_mapper_t(const bmnk_mapper_t &bmnk_mapper)
         : bmnk_mapper_(bmnk_mapper) {}
 
-    void push_blocks(abc_kind_t abc_kind, const std::vector<block_t> &blocks) {
+    void push_blocks(abc_kind_t abc_kind, const std::vector<layout_block_t> &blocks) {
         for (auto &b : blocks)
             push_block(abc_kind, b);
     }
 
-    void push_block(abc_kind_t abc_kind, const block_t &b);
+    void push_block(abc_kind_t abc_kind, const layout_block_t &b);
 
     layout_t map_from_bmnk(abc_kind_t abc_kind,
             const std::vector<bmnk_kind_t> &bmnk_kinds,
             const layout_t &bmnk_layout) const;
 
 private:
-    static void pop_size_1_blocks(std::vector<block_t> &blocks) {
+    static void pop_size_1_blocks(std::vector<layout_block_t> &blocks) {
         while (!blocks.empty() && blocks.front().block == 1) {
             blocks.erase(blocks.begin());
         }
     }
 
-    std::vector<block_t> create_prb_blocks(abc_kind_t abc_kind,
-            const std::vector<std::pair<abc_kind_t, block_t>> &mn_blocks)
+    std::vector<layout_block_t> create_prb_blocks(abc_kind_t abc_kind,
+            const std::vector<std::pair<abc_kind_t, layout_block_t>> &mn_blocks)
             const {
-        std::vector<block_t> ret;
+        std::vector<layout_block_t> ret;
         ret.reserve(mn_blocks.size());
         for (auto &p : mn_blocks) {
             auto b = p.second;
-            const auto &var = bmnk_mapper_.var(p.first, b.dim_idx);
-            b.dim_idx = bmnk_mapper_.dim_idx(abc_kind, var);
+            const auto &var = bmnk_mapper_.var(p.first, b.dim);
+            b.dim = bmnk_mapper_.dim_idx(abc_kind, var);
             ret.push_back(b);
         }
         return ret;
     }
 
-    bool pop_block(std::vector<block_t> &bmnk_blocks,
-            std::vector<block_t> &prb_blocks, const block_t &bmnk_block) const;
+    bool pop_block(std::vector<layout_block_t> &bmnk_blocks,
+            std::vector<layout_block_t> &prb_blocks, const layout_block_t &bmnk_block) const;
 
     bmnk_mapper_t bmnk_mapper_;
 
     // Ordered from innermost to outermost.
-    std::vector<std::pair<abc_kind_t, block_t>> b_blocks_;
-    std::vector<std::pair<abc_kind_t, block_t>> m_blocks_;
-    std::vector<std::pair<abc_kind_t, block_t>> n_blocks_;
-    std::vector<std::pair<abc_kind_t, block_t>> k_blocks_;
+    std::vector<std::pair<abc_kind_t, layout_block_t>> b_blocks_;
+    std::vector<std::pair<abc_kind_t, layout_block_t>> m_blocks_;
+    std::vector<std::pair<abc_kind_t, layout_block_t>> n_blocks_;
+    std::vector<std::pair<abc_kind_t, layout_block_t>> k_blocks_;
 };
 
 enum class loop_kind_t : uint32_t {

--- a/src/gpu/intel/jit/ir/message.cpp
+++ b/src/gpu/intel/jit/ir/message.cpp
@@ -327,7 +327,7 @@ private:
         std::vector<dim_t> dims(l.ndims(), 1);
         for (auto &b : l.blocks()) {
             if (b.stride != stride) break;
-            dims[b.dim_idx] *= b.block;
+            dims[b.dim] *= b.block;
             stride = b.block * b.stride;
         }
         tile_t tile(dims);
@@ -578,7 +578,7 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
 
     auto &b0 = blocks[0];
     auto &b1 = blocks[1];
-    gpu_assert(b0.dim_idx != b1.dim_idx);
+    gpu_assert(b0.dim != b1.dim);
     if (b0.stride != stride_t(1)) return false;
     if (!b1.stride.is_fixed()) return false;
 
@@ -599,8 +599,8 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
 
     int w_tstride = 0;
     int h_tstride = 0;
-    dim_idx_t w_dim_idx = get_tdim_idx(b0.dim_idx, w_tstride);
-    dim_idx_t h_dim_idx = get_tdim_idx(b1.dim_idx, h_tstride);
+    dim_idx_t w_dim_idx = get_tdim_idx(b0.dim, w_tstride);
+    dim_idx_t h_dim_idx = get_tdim_idx(b1.dim, h_tstride);
 
     if (w_tstride != 1) return false;
 
@@ -658,42 +658,41 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
         return false;
 
     std::vector<dim_t> dims(vlayout.ndims(), 1);
-    dims[b0.dim_idx] = count * width;
-    dims[b1.dim_idx] = height;
+    dims[b0.dim] = count * width;
+    dims[b1.dim] = height;
     tile_t tile(dims);
 
     reg_layout_ = layout_t(type_factor == 1 ? mem_type_ : send_type, 0,
             std::vector<dim_t>(vlayout.ndims(), 1));
     int h_inner = vnni ? 4 / send_type.size() : 1;
     int h_outer = ir_utils::safe_divide(height, h_inner);
-    reg_layout_ = reg_layout_.add_outer_block(b1.dim_idx, h_inner);
+    reg_layout_ = reg_layout_.add_outer_block(b1.dim, h_inner);
     if (transpose) {
-        reg_layout_ = reg_layout_.add_outer_block(b1.dim_idx, h_outer);
-        reg_layout_ = reg_layout_.add_outer_block(b0.dim_idx, width);
+        reg_layout_ = reg_layout_.add_outer_block(b1.dim, h_outer);
+        reg_layout_ = reg_layout_.add_outer_block(b0.dim, width);
     } else {
-        reg_layout_ = reg_layout_.add_outer_block(b0.dim_idx, width);
-        reg_layout_ = reg_layout_.add_outer_block(b1.dim_idx, h_outer);
+        reg_layout_ = reg_layout_.add_outer_block(b0.dim, width);
+        reg_layout_ = reg_layout_.add_outer_block(b1.dim, h_outer);
     }
-    reg_layout_ = reg_layout_.add_outer_block(b0.dim_idx, count);
+    reg_layout_ = reg_layout_.add_outer_block(b0.dim, count);
 
-    int w_outermost
-            = ir_utils::safe_divide(vlayout.dim(b0.dim_idx), count * width);
-    int h_outermost = ir_utils::safe_divide(vlayout.dim(b1.dim_idx), height);
-    reg_layout_ = reg_layout_.add_outer_block(b0.dim_idx, w_outermost);
-    reg_layout_ = reg_layout_.add_outer_block(b1.dim_idx, h_outermost);
+    int w_outermost = ir_utils::safe_divide(vlayout.dim(b0.dim), count * width);
+    int h_outermost = ir_utils::safe_divide(vlayout.dim(b1.dim), height);
+    reg_layout_ = reg_layout_.add_outer_block(b0.dim, w_outermost);
+    reg_layout_ = reg_layout_.add_outer_block(b1.dim, h_outermost);
 
     if (type_factor != 1) {
         auto blocks = reg_layout_.blocks();
         reg_layout_ = layout_t(
                 mem_type_, 0, std::vector<dim_t>(vlayout.ndims(), 1));
-        reg_layout_ = reg_layout_.add_outer_block(b0.dim_idx, type_factor);
+        reg_layout_ = reg_layout_.add_outer_block(b0.dim, type_factor);
         for (auto &b : blocks)
-            reg_layout_ = reg_layout_.add_outer_block(b.dim_idx, b.block);
+            reg_layout_ = reg_layout_.add_outer_block(b.dim, b.block);
     }
 
     for (auto &b : blocks) {
-        if (utils::one_of(b.dim_idx, b0.dim_idx, b1.dim_idx)) continue;
-        reg_layout_ = reg_layout_.add_outer_block(b.dim_idx, b.block);
+        if (utils::one_of(b.dim, b0.dim, b1.dim)) continue;
+        reg_layout_ = reg_layout_.add_outer_block(b.dim, b.block);
     }
 
     reg_layout_walker_
@@ -743,7 +742,7 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
         auto vstart = vstart0;
         for (dim_idx_t i = 0; i < into<dim_idx_t>(vlayout.ndims()); i++) {
             if (start[i] == 0) continue;
-            int factor = (i == b0.dim_idx ? type_factor : 1);
+            int factor = (i == b0.dim ? type_factor : 1);
             vstart[i] += factor * start[i];
         }
         auto tstart
@@ -763,7 +762,7 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
 
             if (h_tstride != 1) {
                 if (!stride_dimension_ok(
-                            mem_view_, h_dim_idx, b1.dim_idx, vstart)) {
+                            mem_view_, h_dim_idx, b1.dim, vstart)) {
                     if (send.is_prefetch_2d()) {
                         skip_send = true;
                     } else {
@@ -1117,7 +1116,7 @@ bool send_2d_vlayout_ok(const layout_t &vlayout) {
 
     const auto &b0 = blocks[0];
     const auto &b1 = blocks[1];
-    if (b0.dim_idx == b1.dim_idx) return false;
+    if (b0.dim == b1.dim) return false;
     if (b0.stride != stride_t(1)) return false;
     if (b1.stride.is_unknown()) return false;
     return true;
@@ -1164,8 +1163,8 @@ send_2d_hint_t get_send_2d_hint(const exec_config_t &exec_cfg,
         int mn_blk = (is_dpas_src1 ? m_blk : n_blk);
         int k_blk = 32 / view.type().size();
         auto &bmnk_mapper = gemm_schedule.bmnk_mapper();
-        bool is_b0_k = (bmnk_mapper.bmnk_kind(abc_kind, b0.dim_idx)
-                == bmnk_kind_t::k);
+        bool is_b0_k
+                = (bmnk_mapper.bmnk_kind(abc_kind, b0.dim) == bmnk_kind_t::k);
         bool transpose = (is_dpas_src1 == is_b0_k);
         int b0_blk = is_b0_k ? k_blk : mn_blk;
         int b1_blk = !is_b0_k ? k_blk : mn_blk;

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -263,7 +263,7 @@ public:
 
     virtual view_t try_create_bias_view(uint32_t mask) const { return {}; }
 
-    virtual bool is_spurious_spatial(dim_idx_t dim_idx) const { return false; };
+    virtual bool is_spurious_spatial(const pvar_t &dim) const { return false; };
     virtual bool need_to_restore_zero_padding() const { return false; }
     virtual bool use_dst_in_sum_post_op() const { return true; }
     virtual bool can_use_scales() const { return true; }

--- a/src/gpu/intel/jit/ir/problem.cpp
+++ b/src/gpu/intel/jit/ir/problem.cpp
@@ -40,16 +40,58 @@ std::string to_string(tensor_kind_t tensor) {
     return {};
 }
 
+void str_to_u64(const std::string &s, uint64_t *u64) {
+    if (s.empty()) return;
+    size_t pos = 0;
+    size_t bit = 0;
+    for (size_t i = s.size(); i > 0; i--) {
+        u64[pos] |= (s[i - 1] << bit);
+        bit += 8;
+        if (bit == 64) {
+            pos += 1;
+            bit = 0;
+        }
+    }
+}
+
+std::string u64_to_str(const uint64_t *u64) {
+    std::string s;
+    size_t pos = 0;
+    size_t bit = 0;
+    for (;;) {
+        char c = into<char>((u64[pos] >> bit) & 0xFF);
+        if (c == 0) break;
+        s += c;
+        bit += 8;
+        if (bit == 64) {
+            pos += 1;
+            bit = 0;
+        }
+    }
+    std::reverse(s.begin(), s.end());
+    return s;
+}
+
+pvar_name_t::pvar_name_t(const std::string &s) {
+    gpu_assert(!s.empty() && s.size() <= max_len);
+    str_to_u64(s, data_.data());
+}
+
+std::string pvar_name_t::str() const {
+    return u64_to_str(data_.data());
+}
+
 const expr_t &pvar_t::index_var() const {
     static thread_local pvar_map_t<expr_t> vars;
     if (!vars.has(*this))
-        vars[*this] = var_t::make(type_t::s32(), name_ + "_idx");
+        vars[*this] = var_t::make(type_t::s32(), name_.str() + "_idx");
     return vars[*this];
 }
 
 const expr_t &pvar_t::var() const {
     static thread_local pvar_map_t<expr_t> vars;
-    if (!vars.has(*this)) vars[*this] = const_var_t::make(type_t::s32(), name_);
+    if (!vars.has(*this))
+        vars[*this] = const_var_t::make(type_t::s32(), name_.str());
     return vars[*this];
 }
 
@@ -72,9 +114,10 @@ pvar_t pvar_t::from_index_var(const expr_t &index_var) {
 }
 
 char pvar_t::to_spatial() const {
-    if (name_.size() != 2) return ' ';
-    char c0 = name_[0];
-    char c1 = name_[1];
+    auto s = name_.str();
+    if (s.size() != 2) return ' ';
+    char c0 = s[0];
+    char c1 = s[1];
     if (!std::strchr("dikops", c0)) return ' ';
     if (!std::strchr("dhw", c1)) return ' ';
     return c1;
@@ -121,9 +164,10 @@ pvar_t k("k");
 } // namespace pvars
 
 bool is_spatial(const pvar_t &pvar, char prefix) {
-    if (pvar.name().size() != 2) return false;
-    char c0 = pvar.name()[0];
-    char c1 = pvar.name()[1];
+    auto s = pvar.str();
+    if (s.size() != 2) return false;
+    char c0 = s[0];
+    char c1 = s[1];
     return (c0 == prefix) && utils::one_of(c1, 'd', 'h', 'w');
 }
 bool is_input_spatial(const pvar_t &pvar) {

--- a/src/gpu/intel/jit/ir/problem.hpp
+++ b/src/gpu/intel/jit/ir/problem.hpp
@@ -41,17 +41,72 @@ enum class tensor_kind_t {
 
 std::string to_string(tensor_kind_t tensor);
 
+class pvar_name_t {
+public:
+    pvar_name_t() = default;
+    pvar_name_t(dim_idx_t idx) { data_[0] = 'a' + idx; }
+    pvar_name_t(const std::string &s);
+
+    bool operator==(const pvar_name_t &other) const {
+        return data_ == other.data_;
+    }
+    bool operator!=(const pvar_name_t &other) const {
+        return !operator==(other);
+    }
+    bool operator<(const pvar_name_t &other) const {
+        for (size_t i = 0; i < max_chunks; i++) {
+            if (data_[i] < other.data_[i]) return true;
+            if (data_[i] > other.data_[i]) return false;
+        }
+        return false;
+    }
+    dim_idx_t index() const {
+        for (size_t i = 1; i < max_chunks; i++) {
+            gpu_assert(data_[i] == 0);
+        }
+        dim_idx_t idx = into<dim_idx_t>(data_[0]);
+        gpu_assert('a' <= idx && idx <= 'z');
+        return into<dim_idx_t>(idx - 'a');
+    }
+
+    bool is_empty() const {
+        for (size_t i = 0; i < max_chunks; i++) {
+            if (data_[i] != 0) return false;
+        }
+        return true;
+    }
+
+    size_t get_hash() const { return ir_utils::get_hash(data_); }
+    std::string str() const;
+
+    IR_DEFINE_DUMP()
+
+private:
+    static const size_t max_chunks = 2;
+    static const size_t max_len = max_chunks * sizeof(uint64_t) - 1;
+
+    std::array<uint64_t, max_chunks> data_ = {};
+};
+
 class pvar_t {
 public:
     pvar_t() = default;
-    pvar_t(const std::string &name) : name_(name) { gpu_assert(!name.empty()); }
-    const std::string &name() const { return name_; }
-    bool is_undef() const { return name_.empty(); }
+    pvar_t(dim_idx_t idx) : name_(idx) {}
+    pvar_t(const std::string &name) : name_(name) {}
+    bool is_undef() const { return name_.is_empty(); }
     bool operator==(const pvar_t &other) const { return name_ == other.name_; }
     bool operator!=(const pvar_t &other) const { return name_ != other.name_; }
     bool operator<(const pvar_t &other) const { return name_ < other.name_; }
+    bool operator==(dim_idx_t idx) const { return *this == pvar_t(idx); }
+    bool operator!=(dim_idx_t idx) const { return !operator==(idx); }
+    bool operator<(dim_idx_t idx) const { return *this < pvar_t(idx); }
+    bool operator==(int idx) const { return operator==(into<dim_idx_t>(idx)); }
+    bool operator!=(int idx) const { return operator!=(into<dim_idx_t>(idx)); }
+    bool operator<(int idx) const { return operator<(into<dim_idx_t>(idx)); }
+    dim_idx_t index() const { return name_.index(); }
+    operator dim_idx_t() const { return index(); }
     size_t get_hash() const { return ir_utils::get_hash(name_); }
-    std::string str() const { return name_; }
+    std::string str() const { return name_.str(); }
 
     IR_DEFINE_DUMP()
 
@@ -64,7 +119,7 @@ public:
     int spatial_index() const;
 
 private:
-    std::string name_;
+    pvar_name_t name_;
 };
 
 namespace pvars {
@@ -202,7 +257,7 @@ public:
     std::unordered_map<std::string, dim_t> to_string_map() const {
         std::unordered_map<std::string, dim_t> ret;
         for (auto &kv : map_)
-            ret[kv.first.name()] = kv.second;
+            ret[kv.first.str()] = kv.second;
         return ret;
     }
 
@@ -475,7 +530,7 @@ namespace std {
 template <>
 struct hash<dnnl::impl::gpu::intel::jit::pvar_t> {
     size_t operator()(const dnnl::impl::gpu::intel::jit::pvar_t &pvar) const {
-        return std::hash<std::string>()(pvar.name());
+        return pvar.get_hash();
     }
 };
 } // namespace std

--- a/src/gpu/intel/jit/ir/reduce.cpp
+++ b/src/gpu/intel/jit/ir/reduce.cpp
@@ -53,7 +53,7 @@ stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
 
         auto dst_blocks = dst.blocks();
         for (auto &b : dst_blocks)
-            b.dim_idx = dst2src[b.dim_idx];
+            b.dim = dst2src[b.dim];
 
         // Create final layout.
         dst_aligned = layout_t(dst.type(), ndims, dst.offset(), dst_blocks);

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -363,7 +363,7 @@ public:
 
     int64_t size() const { return size_; }
 
-    int vidx(int i) const { return vidxs_[i]; }
+    const pvar_t &vidx(int i) const { return vidxs_[i]; }
 
     dim_t vstride(int i) const { return vstrides_[i]; }
 
@@ -386,11 +386,11 @@ public:
         return mask && !mask.is_equal(expr_t(true));
     }
 
-    bool has_vidx(int vidx) const {
+    bool has_vidx(const pvar_t &vidx) const {
         return utils::one_of(vidx, vidxs_[0], vidxs_[1]);
     }
 
-    int64_t vstride_by_vidx(int vidx) const {
+    int64_t vstride_by_vidx(const pvar_t &vidx) const {
         for (int i = 0; i < 2; i++) {
             if (vidxs_[i] == vidx) return vstrides_[i];
         }
@@ -402,7 +402,7 @@ public:
     T offset(const std::vector<T> &voff, const T &base = T()) const {
         T ret = base;
         for (int i = 0; i < 2; i++) {
-            if (vidxs_[i] == -1) continue;
+            if (vidxs_[i].is_undef()) continue;
             ret += voff[vidxs_[i]] * vstrides_[i];
         }
         if (block_ != 1) ret /= block_;
@@ -413,7 +413,8 @@ public:
         std::ostringstream oss;
         oss << "tdim(idx = " << tidx_;
         oss << ", size = " << size_;
-        oss << ", vidxs = [" << vidxs_[0] << ", " << vidxs_[1] << "]";
+        oss << ", vidxs = [" << vidxs_[0].str() << ", " << vidxs_[1].str()
+            << "]";
         oss << ", vstrides = [" << vstrides_[0] << ", " << vstrides_[1] << "]";
         oss << ", block = " << block_ << ")";
         return oss.str();
@@ -450,7 +451,7 @@ private:
     int tidx_ = -1;
     int64_t size_ = 0;
     modulus_t base_mod_;
-    int vidxs_[2] = {-1, -1};
+    pvar_t vidxs_[2];
     int64_t vstrides_[2] = {0, 0};
     int64_t block_ = 1;
     const tdim_t *dim_ = nullptr;
@@ -487,7 +488,7 @@ public:
     void set_base(const expr_t &base) {
         base_ = base;
         dim_t factor = 1;
-        if (tdim_.vidx(1) == -1) {
+        if (tdim_.vidx(1).is_undef()) {
             factor = get_max_const_factor(base_, constraint_set_t());
             factor = math::gcd(factor, a_ * tdim_.block());
             factor = math::gcd(factor, b_ * tdim_.block());
@@ -707,8 +708,8 @@ struct send_2d_params_t {
         for (int i = 0; i < nblocks; i++) {
             auto &b = blocks[i];
             if (use_xy) {
-                if (w_tdim.has_vidx(b.dim_idx)) continue;
-                if (h_tdim.has_vidx(b.dim_idx)) continue;
+                if (w_tdim.has_vidx(b.dim)) continue;
+                if (h_tdim.has_vidx(b.dim)) continue;
             }
             ret += (int64_t)b.stride * vblock_off[i];
         }
@@ -1158,7 +1159,7 @@ public:
         for (auto &eb : layout.enumerated_blocks()) {
             auto &b = eb.second;
             if (b.block == 1) continue;
-            auto &m = mods[b.dim_idx];
+            auto &m = mods[b.dim];
             ret += (m % b.block) * (int64_t)b.stride;
             if (!layout.is_outermost(eb)) m /= (int64_t)b.block;
         }
@@ -1201,24 +1202,25 @@ struct layout_2d_wrapper_t {
         int ret = 0;
         for (auto &b : l.blocks()) {
             if (b.block == 1) continue;
-            if (idx == dim_idx::invalid || b.dim_idx == idx) ret++;
+            if (idx == dim_idx::invalid || b.dim == idx) ret++;
         }
         return ret;
     }
-    const block_t &w_block() const {
+    const layout_block_t &w_block() const {
         gpu_assert(nblocks() >= 2);
         return l.blocks()[0];
     }
-    const block_t &h_block() const {
+    const layout_block_t &h_block() const {
         gpu_assert(nblocks() >= 2);
         return l.blocks()[1];
     }
     int64_t w_stride() const { return w_block().stride; }
     int64_t h_stride() const { return h_block().stride; }
+    // TODO: Rename.
     dim_t w_dim() const { return w_block().block; }
     dim_t h_dim() const { return h_block().block; }
-    dim_idx_t w_idx() const { return w_block().dim_idx; }
-    dim_idx_t h_idx() const { return h_block().dim_idx; }
+    const pvar_t &w_idx() const { return w_block().dim; }
+    const pvar_t &h_idx() const { return h_block().dim; }
 
     const layout_t &l;
 };
@@ -1268,7 +1270,7 @@ public:
         return ret;
     }
 
-    const tdim_info_t &vidx_to_tdim(int vidx) const {
+    const tdim_info_t &vidx_to_tdim(const pvar_t &vidx) const {
         for (dim_idx_t i = 0; i < view_.ntdims(); i++) {
             auto &tdim = tdims_[i];
             if (utils::one_of(vidx, tdim.vidx(0), tdim.vidx(1))) return tdim;
@@ -1441,8 +1443,8 @@ private:
                 break;
             }
             dim_t factor;
-            if (has_vidx_mask(mask_descs_, b.dim_idx, dims[b.dim_idx], b.block,
-                        factor)) {
+            if (has_vidx_mask(
+                        mask_descs_, b.dim, dims[b.dim], b.block, factor)) {
                 inner_idx = eb.first;
                 if (factor == 1) return layout;
                 inner_idx++;
@@ -1450,7 +1452,7 @@ private:
                     return layout.split_block(eb, factor, b.block / factor);
             }
             stride *= b.block;
-            dims[b.dim_idx] *= b.block;
+            dims[b.dim] *= b.block;
         }
         return layout;
     }
@@ -1646,8 +1648,8 @@ public:
         auto &w_tdim = info_.vidx_to_tdim(lw.w_idx());
         auto &h_tdim = info_.vidx_to_tdim(lw.h_idx());
 
-        int w_vidx = lw.w_idx();
-        int h_vidx = lw.h_idx();
+        auto &w_vidx = lw.w_idx();
+        auto &h_vidx = lw.h_idx();
         dim_idx_t w_tidx = w_tdim.tidx();
         dim_idx_t h_tidx = h_tdim.tidx();
         bool use_xy = true;
@@ -1655,8 +1657,8 @@ public:
         int w_tcount = 0;
         int h_tcount = 0;
         for (auto &b : info_.view().tlayout().blocks()) {
-            w_tcount += (b.dim_idx == w_tidx);
-            h_tcount += (b.dim_idx == h_tidx);
+            w_tcount += (b.dim == w_tidx);
+            h_tcount += (b.dim == h_tidx);
         }
 
         if (w_tcount > 1 || h_tcount > 1) use_xy = false;
@@ -1838,8 +1840,8 @@ public:
         std::vector<int> dims(info_.vlayout().ndims(), 1);
         for (int i = 0; i < nblocks(); i++) {
             auto &b = blocks()[i];
-            block_dims_[i] = dims[b.dim_idx];
-            dims[b.dim_idx] *= (int)b.block;
+            block_dims_[i] = dims[b.dim];
+            dims[b.dim] *= (int)b.block;
         }
     }
 
@@ -1864,7 +1866,7 @@ public:
 
     int nblocks() const { return (int)blocks().size(); }
 
-    const std::vector<block_t> &blocks() const {
+    const std::vector<layout_block_t> &blocks() const {
         return info_.vlayout().blocks();
     }
 
@@ -1882,7 +1884,7 @@ public:
         off_.assign(info_.vlayout().ndims(), 0);
         for (int i = 0; i < nblocks(); i++) {
             auto &b = blocks()[i];
-            off_[b.dim_idx] += block_off_[i] * block_dims_[i];
+            off_[b.dim] += block_off_[i] * block_dims_[i];
         }
         mask.merge(get_mask(mask_bits, slots));
         addr.merge(get_addr(slots, slot_size));
@@ -2512,7 +2514,7 @@ send_group_t init_block(const view_info_t &info, view_iterator_t &it,
     auto &vlayout = info.vlayout();
     auto &blocks = vlayout.blocks();
     reg_layout = layout_t(vlayout.type(), vlayout.ndims(), 0,
-            std::vector<block_t>(
+            std::vector<layout_block_t>(
                     blocks.begin(), blocks.begin() + info.outer_idx()));
     return ret;
 }
@@ -2548,7 +2550,7 @@ send_group_t init_scattered(const view_info_t &info,
     ret.addr_inc = std::move(addr_base);
     ret.mask_inc = std::move(mask_base);
     reg_layout = layout_t(vlayout.type(), vlayout.ndims(), 0,
-            std::vector<block_t>(
+            std::vector<layout_block_t>(
                     blocks.begin(), blocks.begin() + info.outer_idx()));
     reg_layout = reg_layout.make_dense();
     if (slot_stride != slot_size) {
@@ -2712,7 +2714,7 @@ send_plan_t create_send_plan(const exec_config_t &exec_cfg, const view_t &view,
             stride, base_group.pad_bytes * type.packing() / type.size());
     for (int i = outer_idx; i < (int)blocks.size(); i++) {
         auto &b = blocks[i];
-        reg_layout = reg_layout.add_outer_block(b.dim_idx, b.block, stride);
+        reg_layout = reg_layout.add_outer_block(b.dim, b.block, stride);
         stride *= b.block;
     }
 

--- a/src/gpu/intel/jit/ir/tensor.cpp
+++ b/src/gpu/intel/jit/ir/tensor.cpp
@@ -26,17 +26,35 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
+std::vector<layout_block_t> normalize_blocks(
+        const std::vector<layout_block_t> &blocks, bool remove_size_1_blocks) {
+    if (blocks.empty()) return {};
+    std::vector<layout_block_t> res;
+
+    for (const layout_block_t &block : blocks) {
+        if (remove_size_1_blocks && block.block == 1) continue;
+
+        if (!res.empty() && res.back().can_merge(block)) {
+            res.back().block *= block.block;
+        } else {
+            res.emplace_back(block);
+        }
+    }
+
+    return res;
+}
+
 layout_t::layout_t(const type_t &type, const expr_t &offset, dim_idx_t ndims,
-        const std::vector<std::pair<int, dim_t>> &parts,
+        const std::vector<std::pair<pvar_t, dim_t>> &parts,
         const std::vector<dim_t> &dims, bool do_normalize)
     : type_(type), ndims_(ndims), offset_(offset) {
     if (!dims.empty() && ndims_ != dims.size()) {
         gpu_error_not_expected() << "Format and dimensions do not match.";
     }
     for (auto &p : parts) {
-        dim_idx_t dim_idx = p.first;
+        pvar_t dim = p.first;
         dim_t block = p.second;
-        gpu_assert(dim_idx < ndims_);
+        gpu_assert(dim < ndims_);
         if (block == 0 && dims.empty())
             gpu_error_not_expected()
                     << "Dimensions are missing. Can't deduce them from "
@@ -46,17 +64,17 @@ layout_t::layout_t(const type_t &type, const expr_t &offset, dim_idx_t ndims,
     dim_t stride = 1;
     // Iterate from right to left (innermost to outermost).
     for (auto it = parts.rbegin(); it != parts.rend(); ++it) {
-        dim_idx_t dim_idx = it->first;
+        auto &dim = it->first;
         dim_t block = it->second;
         if (block == 0) {
             dim_t full_block = 1;
             for (auto &b : blocks_)
-                if (b.dim_idx == dim_idx) full_block *= b.block;
+                if (b.dim == dim) full_block *= b.block;
 
-            block = utils::div_up(dims[dim_idx], full_block);
+            block = utils::div_up(dims[dim], full_block);
         }
 
-        blocks_.emplace_back(dim_idx, block, stride);
+        blocks_.emplace_back(dim, block, stride);
         stride = block * stride;
     }
 
@@ -76,7 +94,7 @@ layout_t::layout_t(const memory_desc_wrapper &mdw, bool do_normalize)
     // TODO: Switch blocks_ from std::vector<block_t> to block_layout_t
     // to avoid this copy
     for (const auto &block : layout) {
-        blocks_.emplace_back(block);
+        blocks_.emplace_back(block.dim_idx, block.block, block.stride);
     }
 
     sanity_check();
@@ -98,16 +116,16 @@ memory_desc_t layout_t::to_dnnl(const dim_t *dims_hint) const {
 
     for (auto it = blocks_.rbegin(); it != blocks_.rend(); ++it) {
         auto &b = *it;
-        if (!seen[b.dim_idx]) {
+        if (!seen[b.dim]) {
             // Outer block.
             gpu_assert(!in_inner_block);
             MAYBE_UNUSED(in_inner_block);
-            blk.strides[b.dim_idx] = b.stride;
-            md.padded_dims[b.dim_idx] = b.block;
+            blk.strides[b.dim] = b.stride;
+            md.padded_dims[b.dim] = b.block;
         } else {
             // Inner block.
-            md.padded_dims[b.dim_idx] *= b.block;
-            blk.inner_idxs[blk.inner_nblks] = b.dim_idx;
+            md.padded_dims[b.dim] *= b.block;
+            blk.inner_idxs[blk.inner_nblks] = b.dim;
             blk.inner_blks[blk.inner_nblks] = b.block;
             blk.inner_nblks++;
             if (prev_stride > 0) {
@@ -117,7 +135,7 @@ memory_desc_t layout_t::to_dnnl(const dim_t *dims_hint) const {
             prev_stride = b.stride;
             in_inner_block = true;
         }
-        seen[b.dim_idx] = true;
+        seen[b.dim] = true;
     }
 
     for (dim_idx_t i = 0; i < ndims(); i++) {
@@ -135,19 +153,19 @@ layout_t layout_t::map(const tile_t &tile, const coord_t &start) const {
         gpu_error_not_expected() << "Dimensions do not match.";
 
     std::vector<dim_t> remaining_dims = tile.values();
-    std::vector<block_t> mapped_blocks;
+    std::vector<layout_block_t> mapped_blocks;
 
     for (auto &eb : enumerated_blocks()) {
-        block_t &b = eb.second;
+        layout_block_t &b = eb.second;
         bool b_is_outermost = is_outermost(eb);
 
         dim_t block = b.block;
-        dim_t &rem_dim = remaining_dims[b.dim_idx];
+        dim_t &rem_dim = remaining_dims[b.dim];
         if (rem_dim == 1) {
             if (b_is_outermost) {
                 // This is to have similarity between the current and
                 // mapped layouts.
-                mapped_blocks.emplace_back(b.dim_idx, 1, b.stride);
+                mapped_blocks.emplace_back(b.dim, 1, b.stride);
             }
             continue;
         }
@@ -164,7 +182,7 @@ layout_t layout_t::map(const tile_t &tile, const coord_t &start) const {
             gpu_except_not_implemented("Can't map tensor layout.");
         }
         rem_dim /= block;
-        mapped_blocks.emplace_back(b.dim_idx, block, b.stride);
+        mapped_blocks.emplace_back(b.dim, block, b.stride);
     }
 
     for (auto &d : remaining_dims) {
@@ -238,7 +256,7 @@ layout_t layout_t::reinterpret(
 }
 
 layout_t layout_t::split_block(
-        const std::pair<int, block_t> &eb, dim_t block0, dim_t block1) const {
+        const std::pair<int, layout_block_t> &eb, dim_t block0, dim_t block1) const {
     int block_idx = eb.first;
     auto &b = eb.second;
     gpu_assert(b.block == block0 * block1) << "Incompatible block sizes.";
@@ -246,8 +264,8 @@ layout_t layout_t::split_block(
 
     auto new_blocks = blocks_;
 
-    block_t &b0 = new_blocks[block_idx];
-    block_t b1 = b0;
+    layout_block_t &b0 = new_blocks[block_idx];
+    layout_block_t b1 = b0;
 
     b0.block = block0;
     b1.block = block1;
@@ -305,7 +323,7 @@ tile_t layout_t::split_into_max_tile(
                 dense_stride = b.block * b.stride;
             }
             cur_elems *= b.block;
-            tile_dims[b.dim_idx] *= b.block;
+            tile_dims[b.dim] *= b.block;
             continue;
         }
         dim_t max_block = utils::max_div(b.block, max_tile_elems / cur_elems);
@@ -327,9 +345,9 @@ void layout_t::align_layouts(layout_t &a, layout_t &b) {
         int b_idx = 0;
 
         for (;;) {
-            while (a_idx < a_max && a_blocks[a_idx].dim_idx != i)
+            while (a_idx < a_max && a_blocks[a_idx].dim != i)
                 a_idx++;
-            while (b_idx < b_max && b_blocks[b_idx].dim_idx != i)
+            while (b_idx < b_max && b_blocks[b_idx].dim != i)
                 b_idx++;
 
             if (a_idx >= a_max || b_idx >= b_max) break;
@@ -378,7 +396,7 @@ std::vector<std::pair<char, dim_t>> layout_t::parse_letter_blocks(
     return ret;
 }
 
-std::vector<std::pair<int, dim_t>> layout_t::parse_format(
+std::vector<std::pair<pvar_t, dim_t>> layout_t::parse_format(
         const std::string &format, int ndims_hint) {
     bool seen_letters[DNNL_MAX_NDIMS] = {};
     int letter_ndims = 0;
@@ -396,7 +414,7 @@ std::vector<std::pair<int, dim_t>> layout_t::parse_format(
 
     auto letter_blocks = parse_letter_blocks(format);
 
-    std::vector<std::pair<int, dim_t>> parts;
+    std::vector<std::pair<pvar_t, dim_t>> parts;
     for (auto &p : letter_blocks) {
         char letter = p.first;
         dim_t block = p.second;
@@ -504,14 +522,14 @@ layout_t view_t::create_pseudo_vlayout(
     gpu_assert(!tlayout.is_empty());
 
     std::vector<dim_t> rem_vdims = vdims_.values();
-    std::vector<block_t> blocks;
+    std::vector<layout_block_t> blocks;
 
     for (auto &teb : tlayout.enumerated_blocks()) {
-        block_t &tb = teb.second;
+        layout_block_t &tb = teb.second;
         bool tb_is_outermost = tlayout.is_outermost(teb);
         dim_t tblock = tb.block;
 
-        auto &tinfo = tdims_[tb.dim_idx];
+        auto &tinfo = tdims_[tb.dim];
         if (tb_is_outermost) {
             // Use innermost dimension with maximum remaining size for first
             // block
@@ -564,7 +582,7 @@ layout_t view_t::create_pseudo_vlayout(
             // TODO: Remove exception usage.
             gpu_except_not_implemented("Can't create pseudo-layout.");
         }
-        blocks.emplace_back(tb.dim_idx, tblock, tb.stride);
+        blocks.emplace_back(tb.dim, tblock, tb.stride);
     }
 
     for (auto &d : rem_vdims) {
@@ -581,12 +599,12 @@ layout_t view_t::create_pseudo_vlayout(
 }
 
 layout_t dim_assignment_t::map(const layout_t &layout) const {
-    std::vector<block_t> new_blocks;
+    std::vector<layout_block_t> new_blocks;
     for (auto &b : layout.blocks()) {
-        int new_idx = assignments_[b.dim_idx];
+        int new_idx = assignments_[b.dim];
         if (new_idx == -1) continue; // Drop this block.
         auto new_b = b;
-        new_b.dim_idx = new_idx;
+        new_b.dim = new_idx;
         new_blocks.push_back(new_b);
     }
     new_blocks = normalize_blocks(new_blocks,

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -214,6 +214,45 @@ private:
     dim_t cur_stride_;
 };
 
+struct layout_block_t {
+    layout_block_t() = default;
+
+    layout_block_t(const pvar_t &dim, dim_t block, const stride_t &stride)
+        : dim(dim), block(block), stride(stride) {}
+
+    bool can_merge(const layout_block_t &other, bool same_dim_only = true) const {
+        bool dim_ok = !same_dim_only || (dim == other.dim);
+        bool is_dense = (stride * block == other.stride);
+        return dim_ok && is_dense;
+    }
+
+    bool operator==(const layout_block_t &other) const {
+        return (dim == other.dim) && (block == other.block)
+                && (stride == other.stride);
+    }
+    bool operator!=(const layout_block_t &other) const { return !(*this == other); }
+
+    size_t get_hash() const { return 0; }
+
+    std::string str() const {
+        std::ostringstream oss;
+        oss << "block_t(dim = " << dim;
+        oss << ", block = " << block;
+        oss << ", stride = " << stride.str();
+        oss << ")";
+        return oss.str();
+    }
+
+    bool is_empty() const { return dim.is_undef(); }
+
+    pvar_t dim;
+    dim_t block = 1; // Block size.
+    stride_t stride; // Stride between elements of the block.
+};
+
+std::vector<layout_block_t> normalize_blocks(
+        const std::vector<layout_block_t> &blocks, bool remove_size_1_blocks = true);
+
 class layout_t {
 public:
     static const dim_idx_t max_ndims = 16;
@@ -223,7 +262,7 @@ public:
     }
 
     layout_t(const type_t &type, const expr_t &offset, dim_idx_t ndims,
-            const std::vector<std::pair<int, dim_t>> &parts,
+            const std::vector<std::pair<pvar_t, dim_t>> &parts,
             const std::vector<dim_t> &dims = {}, bool do_normalize = true);
 
     layout_t(const type_t &type, const expr_t &offset,
@@ -258,7 +297,7 @@ public:
     }
 
     layout_t(const type_t &type, dim_idx_t ndims, const expr_t &offset,
-            const std::vector<block_t> &blocks, bool do_normalize = true)
+            const std::vector<layout_block_t> &blocks, bool do_normalize = true)
         : type_(type), ndims_(ndims), offset_(offset), blocks_(blocks) {
         if (do_normalize) blocks_ = normalize_blocks(blocks_);
         sanity_check();
@@ -315,7 +354,7 @@ public:
         auto _args = args;
         for (auto &eb : enumerated_blocks()) {
             auto &b = eb.second;
-            auto &idx = _args[b.dim_idx];
+            auto &idx = _args[b.dim];
             if (is_zero(idx)) continue;
 
             // Do not use modulus for outermost blocks.
@@ -329,31 +368,34 @@ public:
 
     const type_t &type() const { return type_; }
 
+    // TODO: Rename.
     std::vector<dim_t> dims() const {
         std::vector<dim_t> dims(ndims(), 1);
         for (auto &b : blocks_) {
-            dims[b.dim_idx] *= b.block;
+            dims[b.dim] *= b.block;
         }
         return dims;
     }
 
-    dim_t dim(dim_idx_t dim_idx) const {
+    dim_t dim(const pvar_t &dim) const {
         dim_t ret = 1;
         for (auto &b : blocks_) {
-            if (b.dim_idx == dim_idx) ret *= b.block;
+            if (b.dim == dim) ret *= b.block;
         }
         return ret;
     }
 
+    dim_t dim(dim_idx_t dim_idx) const { return dim(pvar_t(dim_idx)); }
+
     int nblocks() const { return (int)blocks().size(); }
 
-    const std::vector<block_t> &blocks() const { return blocks_; }
+    const std::vector<layout_block_t> &blocks() const { return blocks_; }
 
-    dim_t inner_block(dim_idx_t dim_idx, bool skip_outer = true,
+    dim_t inner_block(const pvar_t &dim, bool skip_outer = true,
             bool inner_only = true) const {
         std::vector<dim_t> dim_blocks;
         for (auto &b : blocks_) {
-            if (b.dim_idx == dim_idx) dim_blocks.push_back(b.block);
+            if (b.dim == dim) dim_blocks.push_back(b.block);
         }
         dim_t ret = 1;
         int nblocks = (int)dim_blocks.size();
@@ -375,7 +417,7 @@ public:
         for (size_t i = 0; i < blocks_.size(); i++) {
             auto &b0 = blocks_[i];
             auto &b1 = other.blocks_[i];
-            if (b0.dim_idx != b1.dim_idx) return false;
+            if (b0.dim != b1.dim) return false;
             if (b0.block != b1.block) return false;
             if (compare_strides && b0.stride != b1.stride) return false;
         }
@@ -396,7 +438,7 @@ public:
         for (; i < (int)self_blocks.size() - 1; i++) {
             if (self_blocks[i] != other_blocks[i]) return false;
         }
-        return (self_blocks[i].dim_idx == other_blocks[i].dim_idx
+        return (self_blocks[i].dim == other_blocks[i].dim
                 && self_blocks[i].stride == other_blocks[i].stride
                 && other_blocks[i].block % self_blocks[i].block == 0);
     }
@@ -430,10 +472,10 @@ public:
             auto &b = eb.second;
             std::string b_str;
             if (dnnl_style && is_outermost(eb)) {
-                b_str.append(1, dim_idx::as_tag(b.dim_idx, seen[b.dim_idx]));
+                b_str.append(1, dim_idx::as_tag(b.dim, seen[b.dim]));
             } else {
                 b_str = std::to_string(b.block);
-                b_str.append(1, dim_idx::as_tag(b.dim_idx));
+                b_str.append(1, dim_idx::as_tag(b.dim));
             }
             if (!dnnl_style) {
                 if (b.stride.is_unknown()) {
@@ -445,7 +487,7 @@ public:
             b_str += ret;
             std::swap(ret, b_str);
             dense_stride = b.stride * b.block;
-            seen[b.dim_idx] = true;
+            seen[b.dim] = true;
         }
         ret += ":" + type().str();
         return ret;
@@ -465,8 +507,8 @@ public:
 
     // Returns a vector of <block index, block> pairs.
     // The innermost block (first) has index 0.
-    std::vector<std::pair<int, block_t>> enumerated_blocks() const {
-        std::vector<std::pair<int, block_t>> ret;
+    std::vector<std::pair<int, layout_block_t>> enumerated_blocks() const {
+        std::vector<std::pair<int, layout_block_t>> ret;
         ret.reserve(blocks_.size());
         for (int i = 0; i < int(blocks_.size()); i++) {
             ret.emplace_back(i, blocks_[i]);
@@ -474,23 +516,23 @@ public:
         return ret;
     }
 
-    std::vector<dim_t> strides(dim_idx_t dim_idx) const {
+    std::vector<dim_t> strides(const pvar_t &dim) const {
         std::vector<dim_t> ret;
         for (auto &b : blocks_)
-            if (b.dim_idx == dim_idx) ret.push_back(b.stride);
+            if (b.dim == dim) ret.push_back(b.stride);
         return ret;
     }
 
     // eb is <block index, block> pair, see enumerated_blocks().
-    bool is_outermost(const std::pair<int, block_t> &eb) const {
+    bool is_outermost(const std::pair<int, layout_block_t> &eb) const {
         return is_outermost(eb, blocks_);
     }
 
     bool is_plain() const {
         std::vector<bool> seen(ndims());
         for (auto &b : blocks_) {
-            if (seen[b.dim_idx]) return false;
-            seen[b.dim_idx] = true;
+            if (seen[b.dim]) return false;
+            seen[b.dim] = true;
         }
         return true;
     }
@@ -514,10 +556,20 @@ public:
     layout_t transpose() const {
         if (ndims() != 2) gpu_error_not_expected();
 
+        pvar_t pdims[2];
+        for (auto &b : blocks_) {
+            int idx = (pdims[0].is_undef() ? 0 : 1);
+            if (pdims[idx].is_undef()) {
+                pdims[idx] = b.dim;
+                continue;
+            }
+            gpu_assert(pdims[idx] == b.dim);
+        }
+
         // Flip: 0 -> 1, 1 -> 0.
         auto blocks = blocks_;
         for (auto &b : blocks)
-            b.dim_idx ^= 1;
+            b.dim = (b.dim == pdims[0] ? pdims[1] : pdims[0]);
 
         return layout_t(type(), ndims(), offset(), blocks);
     }
@@ -551,11 +603,11 @@ public:
         return true;
     }
 
-    bool is_blocked_by(dim_idx_t dim_idx, int block) const {
+    bool is_blocked_by(const pvar_t &dim, int block) const {
         if (block == 1) return true;
         if (nblocks() == 0) return false;
         auto &b0 = blocks()[0];
-        if (b0.dim_idx != dim_idx) return false;
+        if (b0.dim != dim) return false;
         if (b0.block % block != 0) return false;
         return true;
     }
@@ -563,17 +615,17 @@ public:
     layout_t innermost_block_layout() const {
         int block_count[layout_t::max_ndims] = {0};
         for (auto &b : blocks_)
-            block_count[b.dim_idx]++;
+            block_count[b.dim]++;
 
-        std::vector<block_t> inner_blocks;
+        std::vector<layout_block_t> inner_blocks;
 
         stride_t stride = 1;
         for (auto &b : blocks_) {
             if (b.stride != stride) break; // Not dense anymore.
-            if (block_count[b.dim_idx] == 1) break; // Outer block.
+            if (block_count[b.dim] == 1) break; // Outer block.
             stride *= b.block;
-            gpu_assert(block_count[b.dim_idx] > 0);
-            block_count[b.dim_idx]--;
+            gpu_assert(block_count[b.dim] > 0);
+            block_count[b.dim]--;
             inner_blocks.push_back(b);
         }
         return layout_t(type(), ndims(), 0, inner_blocks);
@@ -623,12 +675,12 @@ public:
             rem_tile[i] = ir_utils::safe_divide(dim(i), inner.dim(i));
         auto ret = inner;
         for (auto &b : blocks()) {
-            auto &d = cur_dims[b.dim_idx];
-            auto &r = rem_tile[b.dim_idx];
+            auto &d = cur_dims[b.dim];
+            auto &r = rem_tile[b.dim];
             d = ir_utils::safe_divide(d, b.block);
             if (r <= d) continue;
             auto blk = ir_utils::safe_divide(r, d);
-            ret = ret.add_outer_block(b.dim_idx, blk);
+            ret = ret.add_outer_block(b.dim, blk);
             r = ir_utils::safe_divide(r, blk);
         }
         for (dim_idx_t i = 0; i < ndims(); i++)
@@ -639,7 +691,7 @@ public:
     // Returns an equivalent layout where the specified block is split into two.
     // block0 - inner block size.
     // block1 - outer block size.
-    layout_t split_block(const std::pair<int, block_t> &eb, dim_t block0,
+    layout_t split_block(const std::pair<int, layout_block_t> &eb, dim_t block0,
             dim_t block1) const;
 
     // Splits blocks so that they can be used to form `multi_blocks` without
@@ -718,7 +770,7 @@ public:
         for (auto &b : blocks()) {
             dim_t block
                     = std::min(b.block, elems_per_tile / cur_elems_per_tile);
-            tile[b.dim_idx] *= block;
+            tile[b.dim] *= block;
             cur_elems_per_tile *= block;
         }
         if (cur_elems_per_tile != elems_per_tile) return {};
@@ -731,7 +783,7 @@ public:
         if (elems() % factor != 0) return {};
         dim_t cur_elems = 1;
         dim_t split_elems = elems() / factor;
-        std::vector<block_t> split_blocks;
+        std::vector<layout_block_t> split_blocks;
         for (auto &b : blocks()) {
             if (cur_elems * b.block > split_elems) {
                 if (split_elems % cur_elems != 0) return {};
@@ -747,12 +799,12 @@ public:
         }
         tile_t split_tile(ndims());
         for (auto &b : split_blocks)
-            split_tile[b.dim_idx] *= b.block;
+            split_tile[b.dim] *= b.block;
         return tile_coord_t(split_tile);
     }
 
     tile_coord_t split(const tile_t &tile, const grid_info_t &grid,
-            std::vector<block_t> *outer_blocks = nullptr) const {
+            std::vector<layout_block_t> *outer_blocks = nullptr) const {
         gpu_assert(ndims() == tile.size())
                 << "Number of dimensions doesn't match.";
 
@@ -776,7 +828,7 @@ public:
             auto &b = eb.second;
             if (b.block == 1) continue;
 
-            dim_t &e = rem_tile[b.dim_idx];
+            dim_t &e = rem_tile[b.dim];
             if (e > 1) {
                 if (e % b.block == 0) {
                     e /= b.block;
@@ -791,7 +843,7 @@ public:
                         = math::gcd(b.block, grid_splitter.cur_block());
                 if (b.block == next_chunk) {
                     auto idx = grid_splitter.pop_block(next_chunk);
-                    start[b.dim_idx] += idx * dims[b.dim_idx];
+                    start[b.dim] += idx * dims[b.dim];
                     if (outer_blocks) outer_blocks->push_back(b);
                 } else if (b.block % next_chunk == 0 && next_chunk != 1) {
                     auto tmp_layout
@@ -801,7 +853,7 @@ public:
                     return {};
                 }
             }
-            dims[b.dim_idx] *= b.block;
+            dims[b.dim] *= b.block;
         }
         return tile_coord_t(tile, start);
     }
@@ -825,7 +877,7 @@ public:
             dim_t dim = tile[i];
             for (auto &eb : enumerated_blocks()) {
                 auto &b = eb.second;
-                if (b.dim_idx != i) continue;
+                if (b.dim != i) continue;
                 int block_idx = eb.first;
                 if (b.block >= dim) {
                     gpu_assert(b.block % dim == 0);
@@ -849,8 +901,8 @@ public:
                 auto &b = blocks()[j];
                 dim_t k = sub_block_idxs[j]
                         * (blocks()[j].block / sub_blocks[j]);
-                start[b.dim_idx] += dims[b.dim_idx] * k;
-                dims[b.dim_idx] *= b.block;
+                start[b.dim] += dims[b.dim] * k;
+                dims[b.dim] *= b.block;
             }
 
             // Pass dimension offsets to the callback.
@@ -872,7 +924,7 @@ public:
         if (block == 1) return true;
         if (blocks().empty()) return false;
         auto &b = blocks().back();
-        if (dim_idx != dim_idx::invalid && b.dim_idx != dim_idx) return false;
+        if (dim_idx != dim_idx::invalid && b.dim != dim_idx) return false;
         if (b.block % block != 0) return false;
         return true;
     }
@@ -883,11 +935,11 @@ public:
     }
 
     // eb is <block index, block> pair, see enumerated_blocks().
-    static bool is_outermost(const std::pair<int, block_t> &eb,
-            const std::vector<block_t> &blocks) {
-        dim_idx_t dim_idx = eb.second.dim_idx;
+    static bool is_outermost(const std::pair<int, layout_block_t> &eb,
+            const std::vector<layout_block_t> &blocks) {
+        dim_idx_t dim_idx = eb.second.dim;
         for (int i = 0; i < int(blocks.size()); i++) {
-            if (blocks[i].dim_idx == dim_idx && i > eb.first) return false;
+            if (blocks[i].dim == dim_idx && i > eb.first) return false;
         }
         return true;
     }
@@ -905,7 +957,7 @@ public:
 
         auto &s0 = src.blocks()[0];
         auto &d0 = dst.blocks()[0];
-        if (s0.dim_idx != d0.dim_idx) return false;
+        if (s0.dim != d0.dim) return false;
         if (int(s0.stride) != 1) return false;
         if (int(d0.stride) != 1) return false;
 
@@ -920,7 +972,7 @@ public:
         auto tile_ok = [&](const layout_t &l) {
             if (tile.is_empty()) return true;
             int factor = new_size / old_size;
-            if (tile[l.blocks()[0].dim_idx] % factor != 0) return false;
+            if (tile[l.blocks()[0].dim] % factor != 0) return false;
             return true;
         };
 
@@ -951,7 +1003,7 @@ public:
 
 private:
     // Returns vector of <dimension index, block size> pairs.
-    static std::vector<std::pair<int, dim_t>> parse_format(
+    static std::vector<std::pair<pvar_t, dim_t>> parse_format(
             const std::string &format, int ndims_hint);
 
     // Returns vector of <dimension letter, block size> pairs.
@@ -970,7 +1022,7 @@ private:
     expr_t offset_;
 
     // Blocks ordered from innermost to outermost.
-    std::vector<block_t> blocks_;
+    std::vector<layout_block_t> blocks_;
 };
 
 // Helper class to incrementally increase a sub-layout of the given layout.
@@ -1016,7 +1068,7 @@ public:
             auto &b = l_.blocks()[i];
             dim_t b_block = b.block;
             if (i == block_idx_) b_block /= block_;
-            dims[b.dim_idx] *= b_block;
+            dims[b.dim] *= b_block;
         }
         return tile_t(dims);
     }
@@ -1025,7 +1077,7 @@ public:
 
     layout_t outer_layout() const {
         auto &blocks = l_.blocks();
-        std::vector<block_t> outer_blocks;
+        std::vector<layout_block_t> outer_blocks;
         if (block_ > 1) {
             auto &b = blocks[block_idx_];
             outer_blocks.push_back(b);
@@ -1215,7 +1267,7 @@ public:
         return ret;
     }
 
-    dim_idx_t vidx(dim_idx_t arg_idx) const {
+    const pvar_t &vidx(dim_idx_t arg_idx) const {
         gpu_assert(arg_idx < nvargs());
         return vidxs_[arg_idx];
     }
@@ -1234,7 +1286,7 @@ public:
         return vstrides_[arg_idx].is_fixed();
     }
 
-    void add_vvar(dim_idx_t vidx, const expr_t &varg) {
+    void add_vvar(const pvar_t &vidx, const expr_t &varg) {
         gpu_assert(nvargs_ + 1 <= max_nvargs);
         vidxs_[nvargs_] = vidx;
         vstrides_[nvargs_] = compute_stride(expr_, nvargs_, varg);
@@ -1265,7 +1317,7 @@ private:
 
     dim_idx_t nvargs_ = 0;
     std::array<stride_t, max_nvargs> vstrides_;
-    std::array<dim_idx_t, max_nvargs> vidxs_;
+    std::array<pvar_t, max_nvargs> vidxs_;
     expr_t mask_;
 };
 
@@ -1347,7 +1399,8 @@ public:
 
         tdim_t tdim(texpr, mask);
         for (dim_idx_t i = 0; i < nvdims(); i++) {
-            if (contains_object(texpr, vvars_[i])) tdim.add_vvar(i, vvars_[i]);
+            if (contains_object(texpr, vvars_[i]))
+                tdim.add_vvar(pvar_t(i), vvars_[i]);
         }
         if (!is_const(texpr)) {
             gpu_assert(tdim.nvargs() > 0)
@@ -1746,11 +1799,11 @@ private:
         }
     }
 
-    std::vector<block_t> move_size_1_blocks_outer() const {
-        std::vector<block_t> new_blocks;
-        std::vector<block_t> size_1_blocks;
+    std::vector<layout_block_t> move_size_1_blocks_outer() const {
+        std::vector<layout_block_t> new_blocks;
+        std::vector<layout_block_t> size_1_blocks;
         for (auto &b : tlayout_.blocks()) {
-            if (b.block == 1 && vdims_[b.dim_idx] == 1) {
+            if (b.block == 1 && vdims_[b.dim] == 1) {
                 size_1_blocks.emplace_back(b);
             } else {
                 new_blocks.emplace_back(b);

--- a/src/gpu/intel/jit/pass/slm.cpp
+++ b/src/gpu/intel/jit/pass/slm.cpp
@@ -206,7 +206,7 @@ private:
         auto &d0 = dst_blocks[0];
         auto &d1 = dst_blocks[1];
 
-        if (s0.dim_idx != d1.dim_idx || s1.dim_idx != d0.dim_idx) return false;
+        if (s0.dim != d1.dim || s1.dim != d0.dim) return false;
         gpu_assert(s0.block == d1.block);
         gpu_assert(s1.block == d0.block);
 

--- a/src/gpu/intel/jit/pooling/config.hpp
+++ b/src/gpu/intel/jit/pooling/config.hpp
@@ -70,7 +70,7 @@ public:
 
         // only allow SIMD-aligned channel-first layouts
         const auto &oc_blk = src.blocks()[0];
-        if ((oc_blk.dim_idx != dim_idx_t(1)) || (oc_blk.block % exec.simd()))
+        if ((oc_blk.dim != dim_idx_t(1)) || (oc_blk.block % exec.simd()))
             return false;
 
         // for some reason 3D pooling works poorly on PVC at the moment
@@ -197,7 +197,7 @@ public:
 
     bool is_blocked_by_mb() const {
         const auto &blk = src_layout().user().blocks();
-        return (blk.size() > 1) && (blk[1].dim_idx == 0);
+        return (blk.size() > 1) && (blk[1].dim == 0);
     }
 
     type_t acc_type(int len) const {

--- a/src/gpu/intel/jit/reorder/gen_reorder.cpp
+++ b/src/gpu/intel/jit/reorder/gen_reorder.cpp
@@ -155,8 +155,8 @@ status_t gen_reorder_t::pd_t::init(impl::engine_t *engine,
         for (auto &eb : l.enumerated_blocks()) {
             auto &b = eb.second;
             if (l.is_outermost(eb)) {
-                dim_t inner = l.dim(b.dim_idx) / b.block;
-                if (dims[b.dim_idx] % inner) return false;
+                dim_t inner = l.dim(b.dim) / b.block;
+                if (dims[b.dim] % inner) return false;
             }
         }
         return true;
@@ -184,13 +184,13 @@ status_t gen_reorder_t::pd_t::init(impl::engine_t *engine,
         for (auto &b : layout.blocks()) {
             if (b.block == 1) continue;
             if ((dim_t)b.stride != contiguous_inner_elems) break;
-            if (b.block > dims[b.dim_idx]) {
-                if (b.block % dims[b.dim_idx] == 0)
-                    contiguous_inner_elems *= dims[b.dim_idx];
+            if (b.block > dims[b.dim]) {
+                if (b.block % dims[b.dim] == 0)
+                    contiguous_inner_elems *= dims[b.dim];
                 break;
             }
             contiguous_inner_elems *= b.block;
-            dims[b.dim_idx] /= b.block;
+            dims[b.dim] /= b.block;
         }
         return contiguous_inner_elems;
     };

--- a/src/gpu/intel/jit/reorder/ir_builder.cpp
+++ b/src/gpu/intel/jit/reorder/ir_builder.cpp
@@ -88,7 +88,7 @@ bool reorder_ir_builder_t::try_build(
     std::vector<expr_t> vars;
     vars.reserve(ndims);
     for (auto &d : padded_dims) {
-        auto var = var_t::make(type_t::s32(), d.name());
+        auto var = var_t::make(type_t::s32(), d.str());
         vars.emplace_back(var);
     }
 

--- a/src/gpu/intel/jit/reorder/normalization.cpp
+++ b/src/gpu/intel/jit/reorder/normalization.cpp
@@ -27,7 +27,7 @@ namespace reorder {
 
 struct normalization_stage_t {
     int idx;
-    block_t curr, last;
+    layout_block_t curr, last;
     std::array<dim_t, 2> tile;
 
     bool is_dense() const { return curr.stride == last.stride * last.block; }
@@ -35,12 +35,12 @@ struct normalization_stage_t {
     dim_t elems() const { return tile[0]; }
 
     normalization_stage_t() = default;
-    normalization_stage_t(int idx, const block_t &curr, const block_t &last,
-            std::vector<dim_t> tile)
+    normalization_stage_t(int idx, const layout_block_t &curr,
+            const layout_block_t &last, std::vector<dim_t> tile)
         : idx(idx)
         , curr(curr)
         , last(last)
-        , tile({tile[curr.dim_idx], tile[last.dim_idx]}) {}
+        , tile({tile[curr.dim], tile[last.dim]}) {}
 };
 
 struct merge_info_t {
@@ -56,8 +56,8 @@ struct merge_info_t {
 merge_info_t::merge_direction_t merge_direction(
         const normalization_stage_t &l, const normalization_stage_t &r) {
     using direction_t = merge_info_t::merge_direction_t;
-    if (l.curr.dim_idx != r.curr.dim_idx) return direction_t::none;
-    if (l.last.dim_idx != r.last.dim_idx) return direction_t::none;
+    if (l.curr.dim != r.curr.dim) return direction_t::none;
+    if (l.last.dim != r.last.dim) return direction_t::none;
     if (l.tile[0] != r.tile[0]) return direction_t::none;
     if (l.curr.block == r.curr.block
             && l.tile[1] * l.last.block == r.tile[1] * r.last.block)
@@ -68,7 +68,7 @@ merge_info_t::merge_direction_t merge_direction(
 }
 
 struct layout_normalization_t {
-    using blocks_t = std::vector<block_t>;
+    using blocks_t = std::vector<layout_block_t>;
     using block_iterator_t = typename blocks_t::const_iterator;
     using stage_t = normalization_stage_t;
 
@@ -79,7 +79,7 @@ struct layout_normalization_t {
         iterator_t &operator++() {
             if (curr_ == end_) return *this;
             auto blk = *last_;
-            tile_[blk.dim_idx] *= blk.block;
+            tile_[blk.dim] *= blk.block;
             last_ = curr_;
             ++curr_;
             ++idx_;
@@ -103,9 +103,9 @@ struct layout_normalization_t {
     const blocks_t &blocks() const { return blocks_; }
 
     bool empty() const { return begin() == end(); }
-    bool contains_dim(dim_idx_t dim_idx) const {
+    bool contains_dim(const pvar_t &dim) const {
         for (auto &blk : blocks_)
-            if (blk.dim_idx == dim_idx) return true;
+            if (blk.dim == dim) return true;
         return false;
     }
 
@@ -122,12 +122,12 @@ struct layout_normalization_t {
                 });
         auto merge_it = merges.begin();
         auto merge_end = merges.end();
-        std::vector<block_t> blocks;
-        block_t last = (*begin()).last;
+        std::vector<layout_block_t> blocks;
+        layout_block_t last = (*begin()).last;
         for (auto s : *this) {
             if (merge_it != merge_end && merge_it->iter_idx == s.idx) {
                 if (merge_it->direction == direction_t::backward)
-                    s.curr.dim_idx = last.dim_idx;
+                    s.curr.dim = last.dim;
                 s.curr.block *= last.block;
                 s.curr.stride = last.stride;
                 ++merge_it;
@@ -142,7 +142,7 @@ struct layout_normalization_t {
     void reindex(int ndims, const std::vector<int> &map) {
         ndims_ = ndims;
         for (auto &blk : blocks_)
-            blk.dim_idx = map[blk.dim_idx];
+            blk.dim = map[blk.dim];
     }
 
     layout_t layout() const {
@@ -162,23 +162,24 @@ struct layout_normalization_t {
         , blocks_(normalized_blocks(layout, dim_empty)) {}
 
 private:
-    static bool can_combine(const block_t &last, const block_t &next) {
-        if (last.dim_idx != next.dim_idx) return false;
+    static bool can_combine(
+            const layout_block_t &last, const layout_block_t &next) {
+        if (last.dim != next.dim) return false;
         if (last.stride * last.block != next.stride) return false;
         return true;
     }
 
-    static std::vector<block_t> normalized_blocks(
+    static std::vector<layout_block_t> normalized_blocks(
             const layout_t &layout, std::vector<bool> dim_empty) {
-        std::vector<block_t> normalized_blocks;
+        std::vector<layout_block_t> normalized_blocks;
         for (auto &eb : layout.enumerated_blocks()) {
             auto &blk = eb.second;
             if (blk.block != 1
-                    || (layout.is_outermost(eb) && !dim_empty[blk.dim_idx])) {
+                    || (layout.is_outermost(eb) && !dim_empty[blk.dim])) {
                 if (normalized_blocks.empty()
                         || !can_combine(normalized_blocks.back(), blk)) {
                     normalized_blocks.push_back(blk);
-                    dim_empty[blk.dim_idx] = true;
+                    dim_empty[blk.dim] = true;
                 } else {
                     normalized_blocks.back().block *= blk.block;
                 }
@@ -214,17 +215,17 @@ void normalize(layout_t &a, layout_t &b) {
                        const normalization_stage_t &b) {
         return a.elems() <= b.elems();
     };
-    auto dim_blocks = [](dim_idx_t dim_idx) {
+    auto dim_blocks = [](const pvar_t &dim) {
         return [=](const normalization_stage_t &s) {
-            return s.curr.dim_idx == dim_idx;
+            return s.curr.dim == dim;
         };
     };
 
     std::vector<bool> empty_dimension(ndims, true);
     for (auto &blk : a.blocks())
-        if (blk.block != 1) empty_dimension[blk.dim_idx] = false;
+        if (blk.block != 1) empty_dimension[blk.dim] = false;
     for (auto &blk : b.blocks())
-        if (blk.block != 1) empty_dimension[blk.dim_idx] = false;
+        if (blk.block != 1) empty_dimension[blk.dim] = false;
 
     layout_normalization_t a_normalization {a, empty_dimension};
     layout_normalization_t b_normalization {b, empty_dimension};

--- a/src/gpu/intel/jit/utils/iterator.hpp
+++ b/src/gpu/intel/jit/utils/iterator.hpp
@@ -32,9 +32,9 @@ namespace jit {
 //
 // E.g.
 //
-//   std::vector<block_t> blocks = {...};
-//   auto block_filter = [](const block_t &blk) { return blk.block != 1; };
-//   filter_t<std::vector<block_t>> non_size_1_blocks(blocks, block_filter);
+//   std::vector<layout_block_t> blocks = {...};
+//   auto block_filter = [](const layout_block_t &blk) { return blk.block != 1; };
+//   filter_t<std::vector<layout_block_t>> non_size_1_blocks(blocks, block_filter);
 //   for (const auto &blk : non_size_1_blocks) {
 //       // blk is a value from blocks, skipping those with blk.block == 1
 //       ...
@@ -206,8 +206,8 @@ class inner_tiles_t {
     using inner_iter_t = decltype(std::declval<const IterT>().begin());
     using iter_value_t = decltype(*std::declval<inner_iter_t>());
     using decayed_iter_value_t = typename std::decay<iter_value_t>::type;
-    static_assert(std::is_same<decayed_iter_value_t, block_t>::value,
-            "inner_tiles_t only accepts iterables with block_t values");
+    static_assert(std::is_same<decayed_iter_value_t, layout_block_t>::value,
+            "inner_tiles_t only accepts iterables with layout_block_t values");
 
 public:
     class iterator_t {
@@ -228,7 +228,7 @@ public:
                 if (size % factor_ == 0) return *this;
             }
 
-            dims_[(*it_).dim_idx] *= block;
+            dims_[(*it_).dim] *= block;
             ++it_;
             factor_ = 1;
             log2scale_ = 0;
@@ -237,7 +237,7 @@ public:
 
         tile_t operator*() const {
             auto dims = dims_;
-            dims[(*it_).dim_idx] *= factor();
+            dims[(*it_).dim] *= factor();
             return tile_t(dims);
         }
 

--- a/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
+++ b/src/gpu/intel/jit/v2/conv/kernel_desc.cpp
@@ -120,8 +120,8 @@ void specialization_t::parse(std::istream &in) {
         if (found) continue;
         auto tile = jit::parse<tile_t>(p);
         for (auto &d : tile) {
-            if (d.name().back() == '@') {
-                dim_mods[pvar_t(d.name().substr(0, d.name().size() - 1))]
+            if (d.str().back() == '@') {
+                dim_mods[pvar_t(d.str().substr(0, d.str().size() - 1))]
                         = tile[d];
             } else {
                 dim_values[d] = tile[d];

--- a/src/gpu/intel/jit/v2/conv/plan.cpp
+++ b/src/gpu/intel/jit/v2/conv/plan.cpp
@@ -338,7 +338,7 @@ private:
         for (auto &b : layout.blocks()) {
             dim_t block = b.block;
             while (block > 1) {
-                auto dim_block = dims[b.dim_idx].pop(block);
+                auto dim_block = dims[b.dim].pop(block);
                 ret.add_block(dim_block.first, dim_block.second);
             }
         }
@@ -446,7 +446,7 @@ private:
         for (auto &d : conv_index_dims(desc_.prop)) {
             auto gemm_d = to_gemm(d, desc_.prop);
             gpu_assert(!gemm_d.is_undef());
-            ret[d] = gemm_d.name()[0];
+            ret[d] = gemm_d.str()[0];
         }
         return ret;
     }

--- a/src/gpu/intel/jit/v2/ir/bridge.hpp
+++ b/src/gpu/intel/jit/v2/ir/bridge.hpp
@@ -71,7 +71,7 @@ inline jit::send_op_t to_ir(send_op_t op, bool is_2d = false) {
 inline jit::layout_t to_ir(const layout_t &layout) {
     gpu_assert(layout.has_const_sizes());
     gpu_assert(layout.has_const_strides());
-    std::vector<gpu::intel::block_t> blocks;
+    std::vector<layout_block_t> blocks;
     for (auto &b : layout.blocks()) {
         int dim_idx = layout.desc().dim_index(b.dim);
         blocks.emplace_back(dim_idx, b.int_size(), b.int_stride());


### PR DESCRIPTION
PR for early feedback.

This is to prepare for DSL support. Two main changes:

- `jit::layout_t` is refactored to use `pvar_t` for dimension identification: [link](https://github.com/uxlfoundation/oneDNN/blob/echeresh/layout/src/gpu/intel/jit/ir/tensor.hpp#L217)
    - I had to bring the block structure from `gpu/intel/block_structure.hpp` at cost of some duplication
-  `pvar_t` is extended and improved to behave like `dim_idx_t` where indices are used as dimensions: [link](https://github.com/uxlfoundation/oneDNN/blob/echeresh/layout/src/gpu/intel/jit/ir/problem.hpp#L44)