### PR TITLE
fixups: kernel dump for SYCL and benchdnn matmul reference

### DIFF
--- a/src/gpu/intel/gpu_primitive.hpp
+++ b/src/gpu/intel/gpu_primitive.hpp
@@ -98,14 +98,14 @@ struct gpu_primitive_t : public gpu::primitive_t {
                             *kernel, jitter ? jitter->kernel_name() : nullptr),
                     VERBOSE_KERNEL_CREATION_FAIL,
                     jitter ? jitter->kernel_name() : "cached");
-            kernel->hash_dump(engine, "blob");
+            kernel->hash_dump("blob");
             CHECK(register_kernels({*kernel}));
             return status::success;
         }
         VCHECK_KERNEL(compute_engine->create_kernel(kernel, jitter),
                 VERBOSE_KERNEL_CREATION_FAIL,
                 jitter ? jitter->kernel_name() : "");
-        kernel->hash_dump(engine, "real");
+        kernel->hash_dump("real");
         if (register_kernel) CHECK(register_kernels({*kernel}));
         return status::success;
     }
@@ -120,14 +120,14 @@ struct gpu_primitive_t : public gpu::primitive_t {
             CHECK(compute_engine->create_kernels_from_cache_blob(
                     cache_blob(), *kernels, kernel_names));
             for (auto &k : *kernels)
-                k.hash_dump(engine, "blob");
+                k.hash_dump("blob");
             CHECK(register_kernels(*kernels));
             return status::success;
         }
         CHECK(compute_engine->create_kernels(
                 kernels, kernel_names, kernel_ctx));
         for (auto &k : *kernels)
-            k.hash_dump(engine, "real");
+            k.hash_dump("real");
         CHECK(register_kernels(*kernels));
         return status::success;
     }
@@ -152,7 +152,7 @@ struct gpu_primitive_t : public gpu::primitive_t {
             CHECK(compute_engine->create_kernels_from_cache_blob(
                     cache_blob(), kernels, kernel_names));
             for (auto &k : kernels)
-                k.hash_dump(engine, "blob");
+                k.hash_dump("blob");
             CHECK(register_kernels(kernels));
             return status::success;
         }
@@ -170,7 +170,7 @@ struct gpu_primitive_t : public gpu::primitive_t {
         }
 
         for (auto &k : kernels)
-            k.hash_dump(engine, "real");
+            k.hash_dump("real");
         CHECK(register_kernels(kernels));
 
         return status::success;

--- a/src/gpu/intel/ocl/kernel.cpp
+++ b/src/gpu/intel/ocl/kernel.cpp
@@ -105,6 +105,10 @@ status_t kernel_t::get_binary(
     return get_ocl_program_binary(ocl_kernel(), ocl_engine->device(), binary);
 }
 
+status_t kernel_t::get_kernel_binary(xpu::binary_t &binary) const {
+    return get_ocl_kernel_binary(ocl_kernel(), binary);
+}
+
 status_t kernel_t::get_binary_size(
         const impl::engine_t *engine, size_t *binary_size) const {
     auto *ocl_engine = utils::downcast<const engine_t *>(engine);
@@ -237,7 +241,7 @@ status_t kernel_t::parallel_for(impl::stream_t &stream,
 
 status_t kernel_t::dump() const {
     xpu::binary_t binary;
-    CHECK(get_ocl_kernel_binary(ocl_kernel(), binary));
+    CHECK(get_kernel_binary(binary));
     CHECK(gpu_utils::dump_kernel_binary(binary, name()));
     return status::success;
 }

--- a/src/gpu/intel/ocl/kernel.hpp
+++ b/src/gpu/intel/ocl/kernel.hpp
@@ -40,6 +40,7 @@ public:
 
     status_t get_binary(
             const impl::engine_t *engine, xpu::binary_t &binary) const override;
+    status_t get_kernel_binary(xpu::binary_t &binary) const override;
     status_t get_binary_size(
             const impl::engine_t *engine, size_t *binary_size) const override;
 

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -772,7 +772,7 @@ status_t simple_rnn_common_t<aprop>::pd_t::init(impl::engine_t *engine) {
             auto t = 0;
             CHECK(gemm_pd->query(query::preferred_gpu_threads_per_eu, 0, &t));
             if (t != threads_per_eu)
-                verbose_printf("[WARNING] GEMM grf modes are inconsistent");
+                verbose_printf("[WARNING] GEMM grf modes are inconsistent\n");
         }
         return status::success;
     };

--- a/src/gpu/intel/sycl/interop_kernel.cpp
+++ b/src/gpu/intel/sycl/interop_kernel.cpp
@@ -183,9 +183,13 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
     return status::success;
 }
 
+status_t interop_kernel_t::get_kernel_binary(xpu::binary_t &binary) const {
+    return gpu::intel::sycl::get_kernel_binary(sycl_kernel(), binary);
+}
+
 status_t interop_kernel_t::dump() const {
     xpu::binary_t binary;
-    CHECK(gpu::intel::sycl::get_kernel_binary(sycl_kernel(), binary));
+    CHECK(get_kernel_binary(binary));
     return gpu::intel::gpu_utils::dump_kernel_binary(binary, name());
 }
 

--- a/src/gpu/intel/sycl/interop_kernel.hpp
+++ b/src/gpu/intel/sycl/interop_kernel.hpp
@@ -41,6 +41,7 @@ public:
         return arg_types_;
     }
 
+    status_t get_kernel_binary(xpu::binary_t &binary) const override;
     status_t dump() const override;
     std::string name() const override {
         return sycl_kernel_.get_info<::sycl::info::kernel::function_name>();

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -92,17 +92,17 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
 
     const int64_t src_scale_group = !src_scale_groups.empty()
             ? src_scale_groups[1]
-            : (src_scale_mask << (src_m.ndims() - 1)) > 0 ? 1
-                                                          : K;
+            : ((src_scale_mask >> (src_m.ndims() - 1)) % 2) > 0 ? 1
+                                                                : K;
     const int64_t wei_scale_group = !wei_scale_groups.empty()
             ? wei_scale_groups[0]
-            : ((wei_scale_mask << (wei_m.ndims() - 2)) % 2) > 0 ? 1
+            : ((wei_scale_mask >> (wei_m.ndims() - 2)) % 2) > 0 ? 1
                                                                 : K;
-    const int64_t src_zp_group = !src_zp_groups.empty() ? src_zp_groups[1]
-            : (src_zp_mask << (src_m.ndims() - 1)) > 0  ? 1
-                                                        : K;
+    const int64_t src_zp_group = !src_zp_groups.empty()      ? src_zp_groups[1]
+            : ((src_zp_mask >> (src_m.ndims() - 1)) % 2) > 0 ? 1
+                                                             : K;
     const int64_t wei_zp_group = !wei_zp_groups.empty()      ? wei_zp_groups[0]
-            : ((wei_zp_mask << (wei_m.ndims() - 2)) % 2) > 0 ? 1
+            : ((wei_zp_mask >> (wei_m.ndims() - 2)) % 2) > 0 ? 1
                                                              : K;
 
     const auto smallest_k_group = std::min(


### PR DESCRIPTION
[MFDNN-13649](https://jira.devtools.intel.com/browse/MFDNN-13649)

Kernel dump error was reported by @rjoursler (thank you!) and the fix was picked up from https://github.com/uxlfoundation/oneDNN/pull/3180 (@rjoursler, thanks again!).

Checked that both backends now report hashes. They did, and I found a difference in generated kernels for OCL and SYCL backends for RNN problems for which a cache skew issue was reported.