### PR TITLE
graph: interface: fix namespace of stringstream

### DIFF
--- a/src/graph/interface/graph.cpp
+++ b/src/graph/interface/graph.cpp
@@ -389,7 +389,7 @@ status_t DNNL_API dnnl_graph_graph_filter(
         // deep copy for graph serialization. note that this is for
         // visualization purpose
         graph_t agraph(*graph);
-        stringstream_t filename;
+        dnnl::impl::stringstream_t filename;
         filename << "graph-" << agraph.id() << ".json";
         agraph.serialize(filename.str());
     }
@@ -454,7 +454,7 @@ status_t DNNL_API dnnl_graph_graph_get_partitions(
             aop->set_attr<std::string>(op_attr::backend, bkd_name);
         }
 
-        stringstream_t filename;
+        dnnl::impl::stringstream_t filename;
         filename << "graph-" << agraph.id() << "-partitioning.json";
         agraph.serialize(filename.str());
     }

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -618,7 +618,7 @@ status_t dnnl_graph_partition::compile(compiled_partition_t *cp,
         size_t seed = 0;
         seed = partition_hashing::get_unordered_array_hash(seed, key.ins_);
         seed = partition_hashing::get_unordered_array_hash(seed, key.outs_);
-        stringstream_t filename;
+        dnnl::impl::stringstream_t filename;
         filename << "graph-" << id() << "-" << seed << ".json";
         agraph.serialize(filename.str());
     }


### PR DESCRIPTION
As title, build failure when turn on `ONEDNN_ENABLE_GRAPH_DUMP` which is introduced by #3464