### PR TITLE
examples: remove description of outdated concept

### DIFF
--- a/examples/getting_started.cpp
+++ b/examples/getting_started.cpp
@@ -349,7 +349,7 @@ void getting_started_tutorial(engine::kind engine_kind) {
     /// and no suffix for primitives themselves.
     ///
     /// It is worth mentioning that we specified the exact tensor and its
-    /// memory format when we were initializing the `relu_d`. That means
+    /// memory format when we were initializing the `relu_pd`. That means
     /// `relu` primitive would perform computations with memory objects that
     /// correspond to this description. This is the one and only one way of
     /// creating non-compute-intensive primitives like @ref dev_guide_eltwise,

--- a/examples/getting_started.cpp
+++ b/examples/getting_started.cpp
@@ -345,7 +345,7 @@ void getting_started_tutorial(engine::kind engine_kind) {
     // [Create a ReLU primitive]
 
     /// A note about variable names. Similar to the `_md` suffix used for
-    /// memory descriptor, we use `_pd` for the primitive descriptors,
+    /// memory descriptors, we use `_pd` for the primitive descriptors,
     /// and no suffix for primitives themselves.
     ///
     /// It is worth mentioning that we specified the exact tensor and its

--- a/examples/getting_started.cpp
+++ b/examples/getting_started.cpp
@@ -345,9 +345,8 @@ void getting_started_tutorial(engine::kind engine_kind) {
     // [Create a ReLU primitive]
 
     /// A note about variable names. Similar to the `_md` suffix used for
-    /// memory descriptor, we use `_d` for the operation descriptor names,
-    /// `_pd` for the primitive descriptors, and no suffix for primitives
-    /// themselves.
+    /// memory descriptor, we use `_pd` for the primitive descriptors,
+    /// and no suffix for primitives themselves.
     ///
     /// It is worth mentioning that we specified the exact tensor and its
     /// memory format when we were initializing the `relu_d`. That means

--- a/examples/gpu_opencl_interop.cpp
+++ b/examples/gpu_opencl_interop.cpp
@@ -31,7 +31,7 @@
 ///   - Access a GPU memory via OpenCL interoperability interface
 ///   - Access a GPU command queue via OpenCL interoperability interface
 ///   - Execute a OpenCL kernel with related GPU command queue and GPU memory
-///   - Create primitives descriptor/primitive
+///   - Create primitive descriptor/primitive
 ///   - Execute the primitive with the initialized GPU memory
 ///   - Validate the result by mapping the OpenCL memory via OpenCL interoperability
 ///     interface

--- a/examples/gpu_opencl_interop.cpp
+++ b/examples/gpu_opencl_interop.cpp
@@ -31,7 +31,7 @@
 ///   - Access a GPU memory via OpenCL interoperability interface
 ///   - Access a GPU command queue via OpenCL interoperability interface
 ///   - Execute a OpenCL kernel with related GPU command queue and GPU memory
-///   - Create operation descriptor/operation primitives descriptor/primitive .
+///   - Create primitives descriptor/primitive
 ///   - Execute the primitive with the initialized GPU memory
 ///   - Validate the result by mapping the OpenCL memory via OpenCL interoperability
 ///     interface
@@ -195,18 +195,15 @@ void gpu_opencl_interop_tutorial() {
     // [oclexecution]
 
     /// @subsection gpu_opencl_interop_cpp_sub4 Create and execute a primitive
-    /// There are three steps to create an operation primitive in oneDNN:
-    /// 1. Create an operation descriptor.
-    /// 2. Create a primitive descriptor.
-    /// 3. Create a primitive.
+    /// There are two steps to create an operation primitive in oneDNN:
+    /// 1. Create a primitive descriptor.
+    /// 2. Create a primitive.
     ///
     /// Let's create the primitive to perform the ReLU (rectified linear unit)
-    /// operation: x = max(0, x). An operation descriptor has no dependency on a
-    /// specific engine - it just describes some operation. On the contrary,
-    /// primitive descriptors are attached to a specific engine and represent
-    /// some implementation for this engine. A primitive object is a realization
-    /// of a primitive descriptor, and its construction is usually much
-    /// "heavier".
+    /// operation: x = max(0, x). Primitive descriptors are attached to a specific
+    /// engine and represent some implementation for this engine.
+    /// A primitive object is a realization of a primitive descriptor,
+    /// and its construction is usually much "heavier".
     /// @snippet gpu_opencl_interop.cpp relu creation
     //  [relu creation]
     auto relu_pd = eltwise_forward::primitive_desc(eng, prop_kind::forward,

--- a/examples/primitives/batch_normalization.cpp
+++ b/examples/primitives/batch_normalization.cpp
@@ -26,7 +26,7 @@
 /// Key optimizations included in this example:
 /// - In-place primitive execution;
 /// - Source memory format for an optimized primitive implementation;
-/// - Fused post-ops via operation descriptor flags;
+/// - Fused post-ops via primitive descriptor flags;
 ///
 /// @page batch_normalization_example_cpp Batch Normalization Primitive Example
 /// @copydetails batch_normalization_example_cpp_short

--- a/examples/primitives/lrn.cpp
+++ b/examples/primitives/lrn.cpp
@@ -76,12 +76,11 @@ void lrn_example(dnnl::engine::kind engine_kind) {
     // Write data to memory object's handle.
     write_to_dnnl_memory(src_data.data(), src_mem);
 
-    // Create operation descriptor.
+    // Create primitive descriptor.
     const memory::dim local_size = 5;
     const float alpha = 1.e-4f;
     const float beta = 0.75f;
     const float k = 1.f;
-    // Create primitive descriptor.
     auto lrn_pd = lrn_forward::primitive_desc(engine,
             prop_kind::forward_training, algorithm::lrn_across_channels, src_md,
             dst_md, local_size, alpha, beta, k);

--- a/examples/sycl_interop_buffer.cpp
+++ b/examples/sycl_interop_buffer.cpp
@@ -29,7 +29,7 @@
 ///   - Access a SYCL buffer via SYCL interoperability interface.
 ///   - Access a SYCL queue via SYCL interoperability interface.
 ///   - Execute a SYCL kernel with related SYCL queue and SYCL buffer
-///   - Create operation descriptor/operation primitives descriptor/primitive.
+///   - Create primitives descriptor/primitive.
 ///   - Execute the primitive with the initialized memory.
 ///   - Validate the result through a host accessor.
 ///
@@ -161,18 +161,15 @@ void sycl_interop_buffer_tutorial(engine::kind engine_kind) {
     // [sycl kernel exec]
 
     /// @subsection sycl_interop_buffer_cpp_sub4 Create and execute a primitive
-    /// There are three steps to create an operation primitive in oneDNN:
-    /// 1. Create an operation descriptor.
-    /// 2. Create a primitive descriptor.
-    /// 3. Create a primitive.
+    /// There are two steps to create an operation primitive in oneDNN:
+    /// 1. Create a primitive descriptor.
+    /// 2. Create a primitive.
     ///
     /// Let's create the primitive to perform the ReLU (rectified linear unit)
-    /// operation: x = max(0, x). An operation descriptor has no dependency on a
-    /// specific engine - it just describes some operation. On the contrary,
-    /// primitive descriptors are attached to a specific engine and represent
-    /// some implementation for this engine. A primitive object is a realization
-    /// of a primitive descriptor, and its construction is usually much
-    /// "heavier".
+    /// operation: x = max(0, x). Primitive descriptors are attached to a
+    /// specific engine and represent some implementation for this engine.
+    /// A primitive object is a realization of a primitive descriptor,
+    /// and its construction is usually much "heavier".
     /// @snippet sycl_interop_buffer.cpp relu creation
     //  [relu creation]
     auto relu_pd = eltwise_forward::primitive_desc(eng, prop_kind::forward,

--- a/examples/sycl_interop_usm.cpp
+++ b/examples/sycl_interop_usm.cpp
@@ -27,7 +27,7 @@
 ///   - Access a SYCL USM pointer via SYCL interoperability interface.
 ///   - Access a SYCL queue via SYCL interoperability interface.
 ///   - Execute a SYCL kernel with related SYCL queue and SYCL USM pointer
-///   - Create operation descriptor/operation primitives descriptor/primitive.
+///   - Create primitives descriptor/primitive.
 ///   - Execute the primitive with the initialized memory.
 ///   - Validate the result.
 ///


### PR DESCRIPTION
Another minor observation corrected (seems like at least examples/doc/include don't have other mentions of operation desc).