### PR TITLE
ci: enforce failure on ACL cache miss

### DIFF
--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -150,6 +150,7 @@ jobs:
         with:
           key: ${{ steps.get_system_name.outputs.SystemName }}-acl-${{ matrix.config.toolset }}-${{ matrix.config.build }}-${{ steps.get_acl_commit_hash.outputs.ACLCommitHash }}
           path: ${{ github.workspace }}/ComputeLibrary/build
+          fail-on-cache-miss: true
 
       - name: Configure oneDNN
         run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/build.sh


### PR DESCRIPTION
CI should not proceed if ACL is not already in cache.