### PR TITLE
benchdnn: add feature to benchmark implementation lists

### DIFF
--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -76,6 +77,7 @@ bool allow_enum_tags_only {true};
 int test_start {0};
 bool attr_same_pd_check {false};
 bool check_ref_impl {false};
+bool bench_list {false};
 
 execution_mode_t execution_mode {execution_mode_t::direct};
 
@@ -185,6 +187,9 @@ int main(int argc, char **argv) {
             benchdnn_stat.mistrusted, benchdnn_stat.unimplemented,
             benchdnn_stat.invalid_arguments, benchdnn_stat.failed,
             benchdnn_stat.listed);
+
+    if (bench_list) std::cout << benchdnn_stat.recommendation;
+
     if (has_bench_mode_bit(mode_bit_t::perf)) {
         const auto &perf_timer
                 = benchdnn_stat.ms.find(timer::names::perf_timer);

--- a/tests/benchdnn/binary/bench_binary.cpp
+++ b/tests/benchdnn/binary/bench_binary.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,11 +39,26 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.prb_vdims, i_sdt, i_ddt, i_stag, i_dtag, i_alg,
-                i_inplace, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.prb_vdims, i_sdt, i_ddt, i_stag, i_dtag, i_alg, i_inplace,
+                i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -117,6 +133,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/bnorm/bench_bnorm.cpp
+++ b/tests/benchdnn/bnorm/bench_bnorm.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -40,12 +41,27 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.desc, i_dir, i_dt, i_tag, i_strides, i_flags,
-                s.check_alg, s.debug_check_ws, i_mb, i_inplace, i_attr,
-                i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.desc, i_dir, i_dt, i_tag, i_strides, i_flags, s.check_alg,
+                s.debug_check_ws, i_mb, i_inplace, i_attr, i_ctx_init,
+                i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -149,6 +165,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -96,6 +97,7 @@ extern bool canonical;
 extern bool mem_check;
 extern bool attr_same_pd_check;
 extern bool check_ref_impl;
+extern bool bench_list;
 extern std::string skip_impl; /* empty or "" means skip nothing */
 extern std::string driver_name;
 
@@ -144,6 +146,7 @@ struct stat_t {
     std::unordered_map<std::string, double[timer::timer_t::mode_t::n_modes]> ms;
     // Key is the number of the test, value is the repro string.
     std::map<int, std::string> failed_cases;
+    std::string recommendation;
 };
 extern stat_t benchdnn_stat;
 

--- a/tests/benchdnn/concat/bench_concat.cpp
+++ b/tests/benchdnn/concat/bench_concat.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -37,11 +38,26 @@ void check_correctness(
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for (const auto &i_ctx_exe : s.ctx_exe) {
-        const prb_t prb(s.prb_vdims, i_sdt, i_ddt, i_stag, i_dtag, i_axis,
-                i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.prb_vdims, i_sdt, i_ddt, i_stag, i_dtag, i_axis, i_attr,
+                i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -89,6 +105,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/conv/bench_conv.cpp
+++ b/tests/benchdnn/conv/bench_conv.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -58,7 +59,7 @@ void check_correctness(
                     || (i_dt.size() > 1 && i_dt[1] == dnnl_f64);
             i_bia_dt = is_f64 ? dnnl_f64 : dnnl_f32;
         }
-        const prb_t prb(s.desc, i_dir, i_dt, i_bia_dt, i_stag, i_wtag, i_dtag,
+        prb_t prb(s.desc, i_dir, i_dt, i_bia_dt, i_stag, i_wtag, i_dtag,
                 i_strides, i_alg, i_mb, i_attr, i_ctx_init, i_ctx_exe,
                 s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
@@ -69,8 +70,25 @@ void check_correctness(
         auto &conv_checkit
                 = has_dw_po ? conv_dw_fusion::checkit : conv::checkit;
         auto &conv_doit = has_dw_po ? conv_dw_fusion::doit : conv::doit;
-        task_executor.submit(
-                prb, s.perf_template, conv_createit, conv_checkit, conv_doit);
+
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(prb, s.perf_template, conv_createit,
+                        conv_checkit, conv_doit);
+                auto res = task_executor.results_[prb.str()].back();
+
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, conv_createit,
+                    conv_checkit, conv_doit);
+        }
     }
 }
 
@@ -155,6 +173,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -951,7 +952,8 @@ std::ostream &dump_global_params(std::ostream &s) {
         s << "--cold-cache=" << cold_cache_input << " ";
     if (canonical || execution_mode != execution_mode_t::direct)
         s << "--execution-mode=" << execution_mode2str(execution_mode) << " ";
-
+    if (canonical || bench_list)
+        s << "--test-list=" << bool2str(bench_list) << " ";
     return s;
 }
 

--- a/tests/benchdnn/eltwise/bench_eltwise.cpp
+++ b/tests/benchdnn/eltwise/bench_eltwise.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,11 +43,27 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.prb_dims, i_dir, i_dt, i_tag, i_alg, i_alpha, i_beta,
-                i_mb, i_inplace, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.prb_dims, i_dir, i_dt, i_tag, i_alg, i_alpha, i_beta, i_mb,
+                i_inplace, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -146,6 +163,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/gnorm/bench_gnorm.cpp
+++ b/tests/benchdnn/gnorm/bench_gnorm.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,11 +39,26 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.desc, i_dir, i_dt, i_tag, i_flags, s.check_alg, i_mb,
+        prb_t prb(s.desc, i_dir, i_dt, i_tag, i_flags, s.check_alg, i_mb,
                 i_inplace, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -111,6 +127,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/ip/bench_ip.cpp
+++ b/tests/benchdnn/ip/bench_ip.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,11 +54,26 @@ void check_correctness(
             i_bia_dt = dnnl_f32;
         }
 
-        const prb_t prb(s.desc, i_dir, i_dt, i_bia_dt, i_stag, i_wtag, i_dtag,
-                i_mb, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.desc, i_dir, i_dt, i_bia_dt, i_stag, i_wtag, i_dtag, i_mb,
+                i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -105,6 +121,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/lnorm/bench_lnorm.cpp
+++ b/tests/benchdnn/lnorm/bench_lnorm.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,12 +44,27 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.prb_dims, i_tag, i_stat_tag, i_ss_dt, i_dir, i_dt,
-                i_flags, s.check_alg, i_inplace, i_attr, i_ctx_init, i_ctx_exe,
+        prb_t prb(s.prb_dims, i_tag, i_stat_tag, i_ss_dt, i_dir, i_dt, i_flags,
+                s.check_alg, i_inplace, i_attr, i_ctx_init, i_ctx_exe,
                 s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -121,6 +137,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/lrn/bench_lrn.cpp
+++ b/tests/benchdnn/lrn/bench_lrn.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,11 +39,27 @@ void check_correctness(
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for (const auto &i_ctx_exe : s.ctx_exe) {
-        const prb_t prb(s.desc, i_dir, i_dt, i_tag, i_alg, i_mb, i_attr,
-                i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.desc, i_dir, i_dt, i_tag, i_alg, i_mb, i_attr, i_ctx_init,
+                i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
         task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -71,6 +88,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/pool/bench_pool.cpp
+++ b/tests/benchdnn/pool/bench_pool.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,11 +39,26 @@ void check_correctness(
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for (const auto &i_ctx_exe : s.ctx_exe) {
-        const prb_t prb(s.desc, i_dir, i_dt, i_tag, i_alg, i_mb, i_attr,
-                i_ctx_init, i_ctx_exe, s.impl_filter);
+        prb_t prb(s.desc, i_dir, i_dt, i_tag, i_alg, i_mb, i_attr, i_ctx_init,
+                i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -88,6 +104,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/prelu/bench_prelu.cpp
+++ b/tests/benchdnn/prelu/bench_prelu.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,11 +36,26 @@ void check_correctness(
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for (const auto &i_ctx_exe : s.ctx_exe) {
-        const prb_t prb(s.prb_vdims, i_dir, i_sdt, i_stag, i_attr, i_ctx_init,
+        prb_t prb(s.prb_vdims, i_dir, i_sdt, i_stag, i_attr, i_ctx_init,
                 i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -100,7 +116,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
-
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
     return parse_last_argument();
 }
 } // namespace prelu

--- a/tests/benchdnn/reorder/bench_reorder.cpp
+++ b/tests/benchdnn/reorder/bench_reorder.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,12 +40,27 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_runtime_dim_mask : s.runtime_dim_mask) {
-        const prb_t prb(s.prb_dims, i_sdt, i_ddt, i_stag, i_dtag, i_strides,
-                i_oflag, i_cross_engine, i_runtime_dim_mask, i_attr, i_ctx_init,
+        prb_t prb(s.prb_dims, i_sdt, i_ddt, i_stag, i_dtag, i_strides, i_oflag,
+                i_cross_engine, i_runtime_dim_mask, i_attr, i_ctx_init,
                 i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -173,7 +189,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
-
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
     return parse_last_argument();
 }
 

--- a/tests/benchdnn/resampling/bench_resampling.cpp
+++ b/tests/benchdnn/resampling/bench_resampling.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -39,11 +40,26 @@ void check_correctness(
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for (const auto &i_ctx_exe : s.ctx_exe) {
-        const prb_t prb(s.desc, i_dir, i_sdt, i_ddt, i_tag, i_alg, i_mb, i_attr,
+        prb_t prb(s.desc, i_dir, i_sdt, i_ddt, i_tag, i_alg, i_mb, i_attr,
                 i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -73,6 +89,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/shuffle/bench_shuffle.cpp
+++ b/tests/benchdnn/shuffle/bench_shuffle.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,11 +39,26 @@ void check_correctness(
     for_(const auto &i_attr : s.attributes)
     for_(const auto &i_ctx_init : s.ctx_init)
     for (const auto &i_ctx_exe : s.ctx_exe) {
-        const prb_t prb(s.prb_dims, i_dir, i_dt, i_tag, i_axis, i_group, i_attr,
+        prb_t prb(s.prb_dims, i_dir, i_dt, i_tag, i_axis, i_group, i_attr,
                 i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -76,6 +92,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/softmax/bench_softmax.cpp
+++ b/tests/benchdnn/softmax/bench_softmax.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,12 +42,27 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.prb_dims, i_dir, i_sdt, i_ddt, i_stag, i_dtag, i_alg,
+        prb_t prb(s.prb_dims, i_dir, i_sdt, i_ddt, i_stag, i_dtag, i_alg,
                 i_axis, s.has_stats[0], i_mb, i_inplace, i_attr, i_ctx_init,
                 i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -93,6 +109,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/sum/bench_sum.cpp
+++ b/tests/benchdnn/sum/bench_sum.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,12 +39,26 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_inplace : s.inplace) {
-        const prb_t prb(s.prb_dims, i_sdt, i_ddt, i_stag, i_dtag,
-                i_input_scales, i_inplace, i_attr, i_ctx_init, i_ctx_exe,
-                s.impl_filter);
+        prb_t prb(s.prb_dims, i_sdt, i_ddt, i_stag, i_dtag, i_input_scales,
+                i_inplace, i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb.str(), s.pattern)) return;
 
-        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        if (bench_list) {
+            bool done = false;
+            while (!done) {
+                task_executor.submit(
+                        prb, s.perf_template, createit, checkit, doit);
+                auto res = task_executor.results_[prb.str()].back();
+                if (res.impl_name.substr(0, 3) == "ref") done = true;
+                if (res.state == res_state_t::SKIPPED) {
+                    done = true;
+                    task_executor.results_[prb.str()].pop_back();
+                }
+                prb.impl_filter.emplace_back(res.impl_name);
+            }
+        } else {
+            task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+        }
     }
 }
 
@@ -112,6 +127,7 @@ int bench(int argc, char **argv) {
     }
 
     task_executor.flush();
+    benchdnn_stat.recommendation = task_executor.get_list_recommendation();
 
     return parse_last_argument();
 }

--- a/tests/benchdnn/utils/impl_filter.hpp
+++ b/tests/benchdnn/utils/impl_filter.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2024-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,6 +34,7 @@ struct impl_filter_t {
     const std::vector<std::string> &get_names() const { return impl_names_; }
     bool use_impl() const { return use_impl_; }
     bool respect_global_filter() const { return respect_global_filter_; }
+    void emplace_back(std::string &name) { impl_names_.emplace_back(name); }
 
 private:
     std::vector<std::string> impl_names_;

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1563,6 +1564,18 @@ static bool parse_execution_mode(
     return parsed;
 }
 
+static bool parse_bench_list(
+        const char *str, const std::string &option_name = "bench-list") {
+    static const std::string help
+            = "Instructs the driver to test "
+              "the implementation list";
+    const std::string pattern = parser_utils::get_pattern(option_name, false);
+    if (!parser_utils::option_matched(pattern, str)) return false;
+    bench_mode = bench_mode_t::perf;
+    bench_list = true;
+    return true;
+}
+
 bool parse_bench_settings(const char *str) {
     last_parsed_is_problem = false; // if start parsing, expect an option
 
@@ -1588,7 +1601,8 @@ bool parse_bench_settings(const char *str) {
             || parse_memory_kind(str) || parse_mode(str)
             || parse_mode_modifier(str) || parse_start(str)
             || parse_stream_kind(str) || parse_summary(str)
-            || parse_verbose(str) || parse_execution_mode(str);
+            || parse_verbose(str) || parse_execution_mode(str)
+            || parse_bench_list(str);
 
     // Last condition makes this help message to be triggered once driver_name
     // is already known.

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2024-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -109,6 +110,14 @@ struct res_t {
     // TODO: fuse `ibytes` and `obytes` into `mem_size_args`.
     size_t ibytes, obytes;
     check_mem_size_args_t mem_size_args;
+
+    bool operator<(const res_t &r) const {
+        timer::timer_map_t &t1 = const_cast<timer::timer_map_t &>(timer_map);
+        timer::timer_map_t &t2 = const_cast<timer::timer_map_t &>(r.timer_map);
+        // Only count as an improvement if faster by 10% or more to account for variability
+        return (t1.perf_timer().ms(timer::timer_t::min) * 1.1
+                < t2.perf_timer().ms(timer::timer_t::min));
+    }
 };
 
 #endif

--- a/tests/benchdnn/utils/task.hpp
+++ b/tests/benchdnn/utils/task.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -91,6 +92,10 @@ struct task_t {
 
         return report();
     }
+
+    res_t res() { return res_; }
+
+    prb_t prb() { return prb_; }
 
 private:
     prb_t prb_;

--- a/tests/benchdnn/utils/task_executor.hpp
+++ b/tests/benchdnn/utils/task_executor.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2023-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -13,9 +14,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+#pragma once
 
 #ifndef UTILS_TASK_EXECUTOR_HPP
 #define UTILS_TASK_EXECUTOR_HPP
+
+#include <map>
 
 #include "utils/parallel.hpp"
 #include "utils/task.hpp"
@@ -41,6 +45,17 @@ template <typename prb_t, typename perf_report_t, typename create_func_t,
         typename check_func_t, typename do_func_t>
 struct task_executor_t {
     virtual ~task_executor_t() { assert(tasks_.empty()); }
+
+    std::string get_impl_names(std::vector<res_t> &results) {
+        std::string s;
+        for (auto r : results) {
+            s += r.impl_name + ": "
+                    + std::to_string(
+                            r.timer_map.perf_timer().ms(timer::timer_t::min))
+                    + ", ";
+        }
+        return s.substr(0, s.size() - 2);
+    }
 
     void submit(const prb_t &prb, const std::string &perf_template,
             const create_func_t &create_func, const check_func_t &check_func,
@@ -72,14 +87,32 @@ struct task_executor_t {
 
         for (auto &t : tasks_) {
             t.exec();
+            if (bench_list) results_[t.prb().str()].emplace_back(t.res());
         }
 
         tasks_.clear();
     }
 
+    std::string get_list_recommendation() {
+        std::stringstream ss;
+        ss << "\n--- New list recommendations ---\n";
+        for (auto r : results_) {
+            std::string original = get_impl_names(r.second);
+            std::sort(r.second.begin(), r.second.end());
+            std::string n = get_impl_names(r.second);
+            if (original != n) {
+                ss << r.first << "\nCurrent list: " << original
+                   << "\nNew list: " << n << "\n";
+            }
+        }
+        ss << "\n";
+        return ss.str();
+    }
+
     std::vector<task_t<prb_t, perf_report_t, create_func_t, check_func_t,
             do_func_t>>
             tasks_;
+    std::map<std::string, std::vector<res_t>> results_;
 
     int get_idx() {
         static int idx = 0;


### PR DESCRIPTION
## Context
There has been some recent cases where we've found that simply shuffling around the implementation list offers some significant performance benefits e.g. aarch64 cpu convolution. Currently, we have to benchmark each implementation manually to see if the implementation lists are up-to-date. This new feature allows users to run a benchdnn test through all available implementations and see if any new ordering should be considered.

## Feature
Adds a --bench-list option to benchdnn which benchmarks all available implementations and gives recommendations where necessary. To minimize variability when running the benchmarks, only performance differences of > 10% are considered significant. This feature also does not work for primitives where --skip-impl currently does not work as intended e.g. reorder, and also does not work for ops not using task_executor in benchdnn i.e. brgemm, graph and rnn.

Usage:
```
benchdnn --eltwise --bench-list --batch=test_eltwise_ci
```

Output:
```
--- New list recommendations ---
--mode=P --eltwise --test-list=true --alg=gelu_erf --alpha=0 --beta=0 512x512
Current list: jit:sve_128: 0.051514, acl: 0.027832, ref:any: 0.180664
New list: acl: 0.027832, jit:sve_128: 0.051514, ref:any: 0.180664
--mode=P --eltwise --test-list=true --alg=logistic --alpha=0 --beta=0 512x512
Current list: jit:sve_128: 0.049316, acl: 0.036133, ref:any: 0.181152
New list: acl: 0.036133, jit:sve_128: 0.049316, ref:any: 0.181152
```

