### PR TITLE
[rls-v3.9] xe: jit: codegen: limit comparison binary op SIMD

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -999,6 +999,12 @@ public:
                 auto src0_op = eval(obj.a, a_out_op);
                 auto src1_op = eval(obj.b, b_out_op);
 
+                if ((src0_op.is_reg_buf_data()
+                            && src0_op.reg_buf_data().hs() != 0)
+                        || (src1_op.is_reg_buf_data()
+                                && src1_op.reg_buf_data().hs() != 0))
+                    mod.setExecSize(obj.type.elems());
+
                 ebinary(obj, mod, dst_op, src0_op, src1_op);
                 break;
             }


### PR DESCRIPTION
Comparison operations use a flag register which forces SIMD16. This is problematic when padding to 16 elements exceeds the size of the allocated register buffer.

Addresses [MFDNN-13970](https://jira.devtools.intel.com/browse/MFDNN-13970).

This is not a backport per se, as the issue does not reproduce on main.