### PR TITLE
xe: jit: codegen: limit comparison binary op SIMD

### DIFF
--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -992,6 +992,12 @@ public:
                 auto src0_op = eval(obj.a, a_out_op);
                 auto src1_op = eval(obj.b, b_out_op);
 
+                if ((src0_op.is_reg_buf_data()
+                            && src0_op.reg_buf_data().hs() != 0)
+                        || (src1_op.is_reg_buf_data()
+                                && src1_op.reg_buf_data().hs() != 0))
+                    mod.setExecSize(obj.type.elems());
+
                 ebinary(obj, mod, dst_op, src0_op, src1_op);
                 break;
             }

--- a/tests/benchdnn/inputs/binary/harness_binary_regression
+++ b/tests/benchdnn/inputs/binary/harness_binary_regression
@@ -1,8 +1,9 @@
 # repeated sum with varying scale
 --reset --attr-post-ops=sum+relu+sum:2 8x8x3x5:8x8x3x5_n"multisum"
 
-# Curious edge case in GPU JIT-reorder-based binary
+# Curious edge cases in GPU JIT-reorder-based binary
 --reset --alg=ADD --stag=ABcd32a16b:ABcd32a16b --dtag=acdb --sdt=f16:f16 --ddt=f16 64x168x42x42:64x168x42x42
+--reset --alg=ge --stag=abcde:abcde --dtag=abcde --sdt=f32:f32 --ddt=f32 1x2x6x407x407:1x2x6x407x407
 
 # Mixed src1/post-op src broadcast
 --reset --attr-post-ops=add:f32:2 1x17:1x1


### PR DESCRIPTION
These operations use a flag register which forces SIMD16. This is problematic when padding to 16 elements exceeds the size of the allocated register buffer.

Related to [MFDNN-13970](https://jira.devtools.intel.com/browse/MFDNN-13970), though it does not currently reproduce on main. "Forward-port" of #3648.