### PR TITLE
xe: jit: reorder: prefer word/dword for swizzle

### DIFF
--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -372,21 +372,7 @@ private:
         return layout.size() * type.packing() / type.size();
     }
 
-    type_t intermediate_data_type(const type_t &s, const type_t &d) const {
-        // Force up-/down-convert of small types
-        if (s.is_fp4() || d.is_fp4()) return type_t::f16();
-        // int4 -> fp16 has special conversion paths
-        if (s.is_x4() && (d.is_f16() || d.is_bf16())) return d;
-        if (d.is_x4() && (s.is_f16() || s.is_bf16())) return s;
-        if (s.is_u4() || d.is_u4()) return type_t::u16();
-        if (s.is_s4() || d.is_s4()) return type_t::s16();
-
-        if (s == d) return d; // Swizzle only
-        if (s.is_fp8() || d.is_fp8()) return type_t::f16();
-        if (s.size() > 4) return d;
-        if (d.size() > 4) return s;
-        return s.bitsize() >= d.bitsize() ? s : d;
-    }
+    type_t intermediate_data_type(const type_t &s, const type_t &d) const;
 
     bool needs_saturate(const type_t &ddt, const type_t &sdt) const {
         if (!ddt.is_int() || !sdt.is_int()) return false;


### PR DESCRIPTION
Use the smaller type (if word or dword) to reduce register pressure.

Addresses [MFDNN-13975](https://jira.devtools.intel.com/browse/MFDNN-13975).