### PR TITLE
remove memory type check

### DIFF
--- a/src/xpu/sycl/capi/capi_memory.cpp
+++ b/src/xpu/sycl/capi/capi_memory.cpp
@@ -62,18 +62,6 @@ status_t dnnl_sycl_interop_memory_create_v2(memory_t **memory,
 
     if (is_usm) {
         for (int i = 0; i < nhandles; i++) {
-            if (handles[i] != DNNL_MEMORY_NONE
-                    && handles[i] != DNNL_MEMORY_ALLOCATE) {
-                const auto *sycl_engine_impl
-                        = utils::downcast<const xpu::sycl::engine_impl_t *>(
-                                engine->impl());
-                auto &sycl_ctx = sycl_engine_impl->context();
-                ::sycl::usm::alloc ptr_type
-                        = get_pointer_type(handles[i], sycl_ctx);
-                if (ptr_type == ::sycl::usm::alloc::unknown
-                        && !engine->mayiuse_system_memory_allocators())
-                    return status::invalid_arguments;
-            }
             size_t sz = dnnl_memory_desc_get_size_v2(md, i);
             mem_storages[i].reset(new xpu::sycl::usm_memory_storage_t(engine));
             if (!mem_storages[i]) return status::out_of_memory;
@@ -116,17 +104,6 @@ status_t dnnl_sycl_interop_memory_create(memory_t **memory,
 
     std::unique_ptr<memory_storage_t> mem_storage;
     if (is_usm) {
-        if (handle != DNNL_MEMORY_NONE && handle != DNNL_MEMORY_ALLOCATE) {
-            const auto *sycl_engine_impl
-                    = utils::downcast<const xpu::sycl::engine_impl_t *>(
-                            engine->impl());
-            auto &sycl_ctx = sycl_engine_impl->context();
-            ::sycl::usm::alloc ptr_type = get_pointer_type(handle, sycl_ctx);
-            if (ptr_type == ::sycl::usm::alloc::unknown
-                    && !engine->mayiuse_system_memory_allocators())
-                return status::invalid_arguments;
-        }
-
         mem_storage.reset(new usm_memory_storage_t(engine));
     } else
         mem_storage.reset(new buffer_memory_storage_t(engine));


### PR DESCRIPTION
In before code, I get a pointer from virtual memory, but sycl::get_pointer_type will return unknown if check this pointer.
In oneDNN, I want to remove this memory type check to avoid throwing runtime error directly.

```
#include <sycl/sycl.hpp>

using namespace sycl::ext::oneapi::experimental;

int main(){

    sycl::queue q(sycl::default_selector_v, sycl::property::queue::enable_profiling{});
    auto device = q.get_device();
    std::cout << "Running on device: " << device.get_info<sycl::info::device::name>() << std::endl;

    auto mini = granularity_mode::minimum;
    auto reco = granularity_mode::recommended;

    auto syclContext = sycl::context(q.get_device());
    auto syclDevice = sycl::device(q.get_device());

    size_t mini_mem_granularity = get_mem_granularity(syclDevice, syclContext, mini);
    size_t reco_mem_granularity = get_mem_granularity(syclDevice, syclContext, reco);

    std::cout << "Minimum memory granularity: " << mini_mem_granularity << " bytes" << std::endl;
    std::cout << "Recommended memory granularity: " << reco_mem_granularity << " bytes" << std::endl;

    uintptr_t test_malloc1 = reserve_virtual_mem(mini_mem_granularity, syclContext);

    auto p_type = sycl::get_pointer_type(reinterpret_cast<void*>(test_malloc1), syclContext);
    std::cout << "is_unknown?:" << (p_type == sycl::usm::alloc::unknown) << std::endl;

    return 0;
}
```

Output:
```
Running on device: Intel(R) Graphics [0xe211]
Minimum memory granularity: 65536 bytes
Recommended memory granularity: 65536 bytes
is_unknown?:1
```