### PR TITLE
xe: enable runtime post-op arguments for OpenCL kernels

### DIFF
--- a/src/gpu/intel/gemm/gemm_with_post_ops.cpp
+++ b/src/gpu/intel/gemm/gemm_with_post_ops.cpp
@@ -256,8 +256,8 @@ status_t gemm_with_post_ops_t::execute(const gemm_exec_ctx_t &ctx) const {
     arg_list.set(1, GEMM_CTX_ARG_STORAGE(bias));
     arg_list.set(2, pd()->subbyte_pack_ ? *tmp : GEMM_CTX_ARG_STORAGE(c));
     const auto &args = ctx.args();
-    int idx = append_post_ops_to_arg_list_gemm(
-            args.exec_args, arg_list, 3, pd()->attr()->post_ops_);
+    int idx = append_post_ops_to_arg_list_gemm(args.exec_args, arg_list, 3,
+            pd()->attr()->post_ops_, *pd()->dst_md());
     //a/b tensors are swapped for gemm
     arg_list.set(idx++, GEMM_CTX_ARG_STORAGE(b_scales));
     arg_list.set(idx++, GEMM_CTX_ARG_STORAGE(a_scales));

--- a/src/gpu/intel/ocl_math_utils.h
+++ b/src/gpu/intel/ocl_math_utils.h
@@ -31,14 +31,35 @@ int __attribute__((overloadable)) div_up(int a, unsigned int b) {
     return (a / b) + (a % b != 0);
 }
 
+int __attribute__((overloadable)) div_up(unsigned int a, unsigned int b) {
+    return (a / b) + (a % b != 0);
+}
+
 long __attribute__((overloadable)) div_up(long a, unsigned int b) {
     return (a / b) + (a % b != 0);
 }
 
-int rnd_up(int a, unsigned int b) {
+int __attribute__((overloadable)) rnd_up(int a, unsigned int b) {
     return div_up(a, b) * b;
 }
-int rnd_down(int a, unsigned int b) {
+
+int __attribute__((overloadable)) rnd_up(unsigned int a, unsigned int b) {
+    return div_up(a, b) * b;
+}
+
+int __attribute__((overloadable)) rnd_up(long a, unsigned int b) {
+    return div_up(a, b) * b;
+}
+
+int __attribute__((overloadable)) rnd_down(int a, unsigned int b) {
+    return (a / b) * b;
+}
+
+int __attribute__((overloadable)) rnd_down(unsigned int a, unsigned int b) {
+    return (a / b) * b;
+}
+
+int __attribute__((overloadable)) rnd_down(long a, unsigned int b) {
     return (a / b) * b;
 }
 

--- a/src/gpu/intel/ocl_post_ops.h
+++ b/src/gpu/intel/ocl_post_ops.h
@@ -54,31 +54,23 @@ float fwd_binary(unsigned algorithm, POST_OP_DATA_T x, POST_OP_DATA_T y) {
 // unused arguments are maintained for interface compatibility
 #define APPLY_PO_BINARY(idx, acc, _sum_src, x0, x1, x2, x3, x4, x5) \
     { \
-        bool bcast0 = CONCAT3(PO_, idx, _BIN_ARG_D0) == 1; \
-        bool bcast1 = CONCAT3(PO_, idx, _BIN_ARG_D1) == 1; \
-        bool bcast2 = CONCAT3(PO_, idx, _BIN_ARG_D2) == 1; \
-        bool bcast3 = CONCAT3(PO_, idx, _BIN_ARG_D3) == 1; \
-        bool bcast4 = CONCAT3(PO_, idx, _BIN_ARG_D4) == 1; \
-        bool bcast5 = CONCAT3(PO_, idx, _BIN_ARG_D5) == 1; \
-        const auto po_off = OFF_MD(CONCAT3(PO_, idx, _BIN_ARG), \
-                bcast0 ? 0 : x0, bcast1 ? 0 : x1, bcast2 ? 0 : x2, \
-                bcast3 ? 0 : x3, bcast4 ? 0 : x4, bcast5 ? 0 : x5); \
+        const auto po_off \
+                = OFF_RMD(CONCAT2(PO_, idx), x0, x1, x2, x3, x4, x5); \
         POST_OP_DATA_T po_src \
-                = load(po_src, (CONCAT3(po_, idx, _binary_arg)) + po_off); \
+                = load(po_src, (CONCAT3(po, idx, _binary_arg)) + po_off); \
         acc = fwd_binary(CONCAT3(PO_, idx, _ALG), acc, po_src); \
     }
 
 // unused arguments are maintained for interface compatibility
 #define APPLY_PO_SUM(idx, acc, sum_src, _x0, _x1, _x2, _x3, _x4, _x5) \
-    acc += (load(acc, &sum_src) - (CONCAT3(PO_, idx, _SUM_ZP))) \
-            * CONCAT3(PO_, idx, _SUM_SCALE);
+    acc += (load(acc, &sum_src) - (CONCAT3(po, idx, _zp))) \
+            * CONCAT3(po, idx, _scale);
 
 // unused arguments are maintained for interface compatibility
 #define APPLY_PO_ELTWISE(idx, acc, _sum_src, _x0, _x1, _x2, _x3, _x4, _x5) \
     acc = fwd_eltwise_common(CONCAT3(PO_, idx, _ALG), acc, \
-            CONCAT3(PO_, idx, _ELTWISE_ALPHA), \
-            CONCAT3(PO_, idx, _ELTWISE_BETA), \
-            CONCAT3(PO_, idx, _ELTWISE_SCALE));
+            CONCAT3(po, idx, _alpha), CONCAT3(po, idx, _beta), \
+            CONCAT3(po, idx, _scale));
 
 // clang-format off
 #define APPLY_PO_STAGE_0(...)

--- a/src/gpu/intel/ocl_types.h
+++ b/src/gpu/intel/ocl_types.h
@@ -945,6 +945,9 @@
 #define OFF_MD(prefix, x0, x1, x2, x3, x4, x5) \
     CONCAT2(OFF_MD_, CONCAT2(prefix, _NLEVELS))(prefix, x0, x1, x2, x3, x4, x5)
 
+#define OFF_RMD(prefix, x0, x1, x2, x3, x4, x5) \
+    CONCAT2(prefix, _RMD_OFF)(x0, x1, x2, x3, x4, x5)
+
 #define ALIAS(prefix) CONCAT2(prefix, _DT_ALIAS)
 
 // BLOCK types

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -701,13 +701,13 @@ status_t def_post_ops_cfg(compute::kernel_ctx_t &kernel_ctx,
 
 int append_post_ops_to_arg_list_base(const exec_args_t &args,
         compute::kernel_arg_list_t &arg_list, int post_op_idx,
-        const post_ops_t &post_ops);
+        const post_ops_t &post_ops, memory_desc_wrapper dst_mdw);
 int append_post_ops_to_arg_list_gemm(const exec_args_t &args,
         compute::kernel_arg_list_t &arg_list, int post_op_idx,
-        const post_ops_t &post_ops);
+        const post_ops_t &post_ops, memory_desc_wrapper dst_mdw);
 int append_post_ops_to_arg_list(const exec_ctx_t &ctx,
         compute::kernel_arg_list_t &arg_list, int post_op_idx,
-        const post_ops_t &post_ops);
+        const post_ops_t &post_ops, memory_desc_wrapper dst_mdw);
 
 bool post_ops_preserves_zeroes(
         const exec_ctx_t &ctx, const post_ops_t &post_ops);

--- a/src/gpu/intel/reduction/combined_reduction.cpp
+++ b/src/gpu/intel/reduction/combined_reduction.cpp
@@ -492,7 +492,8 @@ status_t combined_reduction_t::execute_combined(const exec_ctx_t &ctx) const {
         auto empty_po = post_ops_t();
         const auto &actual_po = &pd()->attr()->post_ops_;
         const post_ops_t *po = phase.is_final ? actual_po : &empty_po;
-        append_post_ops_to_arg_list(ctx, reduction_arg_list, 2, *po);
+        append_post_ops_to_arg_list(
+                ctx, reduction_arg_list, 2, *po, *pd()->dst_md());
 
         status = parallel_for(ctx, nd_range, kernel, reduction_arg_list);
         CHECK(status);

--- a/src/gpu/intel/reduction/ref_reduction.cpp
+++ b/src/gpu/intel/reduction/ref_reduction.cpp
@@ -148,8 +148,8 @@ status_t ref_reduction_t::execute_ref(const exec_ctx_t &ctx) const {
 
     reduction_arg_list.set(0, src);
     reduction_arg_list.set(1, dst);
-    append_post_ops_to_arg_list(
-            ctx, reduction_arg_list, 2, pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(ctx, reduction_arg_list, 2,
+            pd()->attr()->post_ops_, *pd()->dst_md());
 
     auto nd_range = conf.dispatch.nd_range();
 

--- a/src/gpu/intel/ref_convolution.cpp
+++ b/src/gpu/intel/ref_convolution.cpp
@@ -209,7 +209,7 @@ status_t ref_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     arg_list.set(3, subbyte_pack ? *tmp : dst);
 
     unsigned arg_idx = append_post_ops_to_arg_list(
-            ctx, arg_list, 4, pd()->attr()->post_ops_);
+            ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
 
     arg_list.set(arg_idx++, src_scales);
     arg_list.set(arg_idx++, wei_scales);
@@ -293,7 +293,7 @@ status_t ref_convolution_bwd_data_t::execute_backward_data(
     arg_list.set(3, bias);
 
     unsigned arg_idx = append_post_ops_to_arg_list(
-            ctx, arg_list, 4, pd()->attr()->post_ops_);
+            ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
 
     arg_list.set(arg_idx++, src_scales);
     arg_list.set(arg_idx++, wei_scales);

--- a/src/gpu/intel/ref_eltwise.cpp
+++ b/src/gpu/intel/ref_eltwise.cpp
@@ -121,7 +121,8 @@ status_t ref_eltwise_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
     arg_list.set(2, alpha);
     arg_list.set(3, beta);
 
-    append_post_ops_to_arg_list(ctx, arg_list, 5, pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(
+            ctx, arg_list, 5, pd()->attr()->post_ops_, *pd()->dst_md());
 
     auto nd_range = conf.dispatch.nd_range();
     return large_parallel_for(ctx, nd_range, kernel_, arg_list, 4);

--- a/src/gpu/intel/ref_group_normalization.cpp
+++ b/src/gpu/intel/ref_group_normalization.cpp
@@ -149,8 +149,8 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
     arg_list.append(dst_scale);
     arg_list.append(pd()->desc()->group_norm_epsilon);
 
-    append_post_ops_to_arg_list(
-            ctx, arg_list, arg_list.nargs(), pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(ctx, arg_list, arg_list.nargs(),
+            pd()->attr()->post_ops_, *pd()->dst_md());
 
     const compute::nd_range_t &nd_range_kernel = pd()->dispatch.nd_range();
     status_t status = parallel_for(ctx, nd_range_kernel, kernel_, arg_list);

--- a/src/gpu/intel/ref_inner_product.cpp
+++ b/src/gpu/intel/ref_inner_product.cpp
@@ -195,7 +195,7 @@ status_t ref_inner_product_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     arg_list.set(3, dst);
 
     unsigned arg_idx = append_post_ops_to_arg_list(
-            ctx, arg_list, 4, pd()->attr()->post_ops_);
+            ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
 
     auto &src_scales = CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
     auto &wei_scales = CTX_IN_STORAGE(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS);

--- a/src/gpu/intel/ref_matmul.cpp
+++ b/src/gpu/intel/ref_matmul.cpp
@@ -290,7 +290,7 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
         arg_list.set(arg_idx++, CTX_IN_STORAGE(DNNL_ARG_ATTR_ROUNDING_SEED));
     }
     append_post_ops_to_arg_list(
-            ctx, arg_list, arg_idx, pd()->attr()->post_ops_);
+            ctx, arg_list, arg_idx, pd()->attr()->post_ops_, *pd()->dst_md());
 
     compute::range_t gws = {1, (size_t)N, (size_t)(D0 * D1 * D2 * D3)};
     auto nd_range = compute::nd_range_t(gws);

--- a/src/gpu/intel/ref_pooling.cpp
+++ b/src/gpu/intel/ref_pooling.cpp
@@ -125,7 +125,8 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     arg_list.set(0, src);
     arg_list.set(1, ws);
     arg_list.set(2, dst);
-    append_post_ops_to_arg_list(ctx, arg_list, 3, pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(
+            ctx, arg_list, 3, pd()->attr()->post_ops_, *pd()->dst_md());
 
     auto nd_range = pd()->conf.dispatch.nd_range();
 

--- a/src/gpu/intel/ref_resampling.cpp
+++ b/src/gpu/intel/ref_resampling.cpp
@@ -120,7 +120,8 @@ status_t ref_resampling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     compute::kernel_arg_list_t arg_list;
     arg_list.set(0, src);
     arg_list.set(1, dst);
-    append_post_ops_to_arg_list(ctx, arg_list, 2, pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(
+            ctx, arg_list, 2, pd()->attr()->post_ops_, *pd()->dst_md());
 
     auto nd_range = pd()->conf.dispatch.nd_range();
 

--- a/src/gpu/intel/simple_binary.cpp
+++ b/src/gpu/intel/simple_binary.cpp
@@ -202,7 +202,7 @@ status_t simple_binary_t::execute_simple(const exec_ctx_t &ctx) const {
     }
     arg_list.set(arg_idx++, dst);
     arg_idx = append_post_ops_to_arg_list(
-            ctx, arg_list, arg_idx, pd()->attr()->post_ops_);
+            ctx, arg_list, arg_idx, pd()->attr()->post_ops_, *pd()->dst_md());
 
     arg_list.set(arg_idx++, src0_scale);
     arg_list.set(arg_idx, src1_scale);

--- a/src/gpu/intel/simple_softmax.cpp
+++ b/src/gpu/intel/simple_softmax.cpp
@@ -34,7 +34,8 @@ status_t simple_softmax_fwd_t::execute_generic(const exec_ctx_t &ctx) const {
     arg_list.set(1, dst);
     arg_list.set(2, src_scale);
     arg_list.set(3, dst_scale);
-    append_post_ops_to_arg_list(ctx, arg_list, 4, pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(
+            ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
 
     if (pd()->group_size > 1) {
         auto nd_range = compute::nd_range_t(pd()->gws, pd()->lws);

--- a/src/gpu/intel/xe_binary.hpp
+++ b/src/gpu/intel/xe_binary.hpp
@@ -158,8 +158,8 @@ struct xe_binary_t : public gpu_primitive_t {
         }
 
         arg_list.set(arg_idx++, dst);
-        arg_idx = append_post_ops_to_arg_list(
-                ctx, arg_list, arg_idx, pd()->attr()->post_ops_);
+        arg_idx = append_post_ops_to_arg_list(ctx, arg_list, arg_idx,
+                pd()->attr()->post_ops_, *pd()->dst_md());
 
         arg_list.set(arg_idx++, src0_scale);
         arg_list.set(arg_idx, src1_scale);

--- a/src/gpu/intel/xe_pooling.cpp
+++ b/src/gpu/intel/xe_pooling.cpp
@@ -263,7 +263,8 @@ status_t xe_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     arg_list.set(0, src);
     arg_list.set(1, ws);
     arg_list.set(2, dst);
-    append_post_ops_to_arg_list(ctx, arg_list, 4, pd()->attr()->post_ops_);
+    append_post_ops_to_arg_list(
+            ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
 
     auto nd_range = pd()->conf.dispatch.nd_range();
 

--- a/src/gpu/intel/xe_wino_convolution.cpp
+++ b/src/gpu/intel/xe_wino_convolution.cpp
@@ -383,7 +383,8 @@ status_t xe_wino_convolution_fwd_t::execute_forward(
         arg_list.set(1, src);
         arg_list.set(2, *wei_trans);
         arg_list.set(3, bias);
-        append_post_ops_to_arg_list(ctx, arg_list, 4, pd()->attr()->post_ops_);
+        append_post_ops_to_arg_list(
+                ctx, arg_list, 4, pd()->attr()->post_ops_, *pd()->dst_md());
         auto nd_range = compute::nd_range_t(conf.gws_d, conf.lws_d);
         status = parallel_for(ctx, nd_range, kernel_, arg_list);
     } else {
@@ -410,8 +411,8 @@ status_t xe_wino_convolution_fwd_t::execute_forward(
         dst_transform_args.set(0, dst);
         dst_transform_args.set(1, *M_buf);
         dst_transform_args.set(2, bias);
-        append_post_ops_to_arg_list(
-                ctx, dst_transform_args, 3, pd()->attr()->post_ops_);
+        append_post_ops_to_arg_list(ctx, dst_transform_args, 3,
+                pd()->attr()->post_ops_, *pd()->dst_md());
         auto dst_trans_nd_range
                 = compute::nd_range_t(conf.M_gws_d, conf.M_lws_d);
         status = parallel_for(


### PR DESCRIPTION
Enables OpenCL kernels to take runtime arguments. In particular, the following are moved to runtime arguments:

```
// eltwise
alpha
beta
scale (when not 0 or 1)

// sum
zero point (when non-zero)
scale (when not 0 or 1)

// prelu,binary
non-broadcasted dimension strides
```
This is a byproduct of working to understand high level requirements for post-ops in the ir based gemm (with the ultimate goal of enabling bias support).