### PR TITLE
[rls-v3.9] Backports of functional fixes

### DIFF
--- a/src/cpu/cpu_reduction_list.cpp
+++ b/src/cpu/cpu_reduction_list.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2022 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -33,18 +33,7 @@ using namespace dnnl::impl::data_type;
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_REDUCTION_P({
     CPU_INSTANCE_X64(jit_uni_reduction_t)
-
-    CPU_INSTANCE(ref_reduction_t<f32, f32, f32>)
-    CPU_INSTANCE(ref_reduction_t<bf16, bf16, f32>)
-    CPU_INSTANCE(ref_reduction_t<bf16, f32, f32>)
-    CPU_INSTANCE(ref_reduction_t<f16, f16, f32>)
-    CPU_INSTANCE(ref_reduction_t<f16, f32, f32>)
-    CPU_INSTANCE(ref_reduction_t<s8, s8, s32>)
-    CPU_INSTANCE(ref_reduction_t<s8, s32, s32>)
-    CPU_INSTANCE(ref_reduction_t<s8, f32, s32>)
-    CPU_INSTANCE(ref_reduction_t<u8, u8, s32>)
-    CPU_INSTANCE(ref_reduction_t<u8, s32, s32>)
-    CPU_INSTANCE(ref_reduction_t<u8, f32, s32>)
+    CPU_INSTANCE(ref_reduction_t)
     /* eol */
     nullptr,
 });

--- a/src/cpu/scale_utils.hpp
+++ b/src/cpu/scale_utils.hpp
@@ -27,10 +27,10 @@ namespace cpu {
 
 void book_precomputed_scales(memory_tracking::registrar_t &scratchpad,
         const scales_t &attr_scales, size_t wei_scales_count,
-        float scale_adjust_factor = 1.0f);
+        float scale_adjust_factor = 1.0f, bool req_transpose = false);
 
-bool req_copy_scales(
-        const scales_t &attr_scales, float scale_adjust_factor = 1.0f);
+bool req_copy_scales(const scales_t &attr_scales,
+        float scale_adjust_factor = 1.0f, bool req_transpose = false);
 
 // By default returns the original wei_scales buffer as a dequantization scale.
 // If both src_scales and wei_scales are set, returns a scratchpad memory that

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -376,7 +376,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     const auto wei_scale_count = bgmmc_.is_oscale_per_k
             ? (bgmmc_.is_oscale_per_n ? N() * K() : K())
             : N();
-    book_precomputed_scales(scratchpad, attr()->scales_, wei_scale_count);
+    book_precomputed_scales(scratchpad, attr()->scales_, wei_scale_count,
+            /* scale_adjust_factor = */ 1.f, bgmmc_.req_transpose_scales);
 
     return status::success;
 }

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1924,8 +1924,8 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
             bgmmc.with_scales && !bgmmc.apply_scales_in_buffer_b,
             bgmmc.with_eltwise, bgmmc.with_binary, bgmmc.acc_dt != bgmmc.dst_dt,
             bgmmc.s8s8_compensation_required, bgmmc.has_zero_point_a,
-            bgmmc.has_zero_point_b, bgmmc.has_zero_point_c,
-            bgmmc.with_dst_scales);
+            bgmmc.has_zero_point_b && !bgmmc.with_wei_decompression,
+            bgmmc.has_zero_point_c, bgmmc.with_dst_scales);
 
     bgmmc.zp_a_comp_shift_n = bgmmc.wei_n_blk;
     bgmmc.zp_a_comp_elems_per_thr

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -287,8 +287,11 @@ private:
         // only 1 GB so far to check if it proves working well.
         const bool is_total_size_big = total_size_ >= 1024 * 1024 * 1024;
         const bool is_total_size_unexpected = total_size_ > expected_max_;
-        if (!has_warned_ && is_max_set && is_total_size_big
-                && is_total_size_unexpected) {
+        // Perf mode might have cold-cache enabled which potentially allocates
+        // unaccounted memory. To avoid a dependency on a cold-cache in this
+        // file, just rely on perf mode.
+        if (!has_bench_mode_bit(mode_bit_t::perf) && !has_warned_ && is_max_set
+                && is_total_size_big && is_total_size_unexpected) {
             BENCHDNN_PRINT(0,
                     "[CHECK_MEM][ERROR]: Memory use is underestimated. Current "
                     "allocation size: %s; expected size: %s.\n",

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -92,17 +92,17 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
 
     const int64_t src_scale_group = !src_scale_groups.empty()
             ? src_scale_groups[1]
-            : (src_scale_mask << (src_m.ndims() - 1)) > 0 ? 1
-                                                          : K;
+            : ((src_scale_mask >> (src_m.ndims() - 1)) % 2) > 0 ? 1
+                                                                : K;
     const int64_t wei_scale_group = !wei_scale_groups.empty()
             ? wei_scale_groups[0]
-            : ((wei_scale_mask << (wei_m.ndims() - 2)) % 2) > 0 ? 1
+            : ((wei_scale_mask >> (wei_m.ndims() - 2)) % 2) > 0 ? 1
                                                                 : K;
-    const int64_t src_zp_group = !src_zp_groups.empty() ? src_zp_groups[1]
-            : (src_zp_mask << (src_m.ndims() - 1)) > 0  ? 1
-                                                        : K;
+    const int64_t src_zp_group = !src_zp_groups.empty()      ? src_zp_groups[1]
+            : ((src_zp_mask >> (src_m.ndims() - 1)) % 2) > 0 ? 1
+                                                             : K;
     const int64_t wei_zp_group = !wei_zp_groups.empty()      ? wei_zp_groups[0]
-            : ((wei_zp_mask << (wei_m.ndims() - 2)) % 2) > 0 ? 1
+            : ((wei_zp_mask >> (wei_m.ndims() - 2)) % 2) > 0 ? 1
                                                              : K;
 
     const auto smallest_k_group = std::min(


### PR DESCRIPTION
This PR is a backport of:
#3556 (cold-cache fixes)
#3625 (ref reduction change)
#3629 (the part fixing benchdnn matmul ref)
#3653 (cpu brgemm matmul fixes)