### PR TITLE
doc: resolve a few warnings

### DIFF
--- a/include/oneapi/dnnl/dnnl_types.h
+++ b/include/oneapi/dnnl/dnnl_types.h
@@ -2725,35 +2725,35 @@ typedef struct {
 ///
 /// Query kind                      | Type of query result
 /// --------------------------------|-----------------------------
-/// dnnl_query_*_engine             | #dnnl_engine_t *
-/// #dnnl_query_primitive_kind      | #dnnl_primitive_kind_t *
-/// dnnl_query_*_s32                | int *
-/// dnnl_query_*_s64                | #dnnl_dim_t * (same as int64_t *)
-/// dnnl_query_*_f32                | float *
-/// dnnl_query_*_f64                | double *
-/// dnnl_query_*_str                | const char **
-/// dnnl_query_*_md                 | #const_dnnl_memory_desc_t *
-/// dnnl_query_*_pd                 | #const_dnnl_primitive_desc_t *
-/// dnnl_query_cache_blob_id        | const uint8_t **
-/// dnnl_query_strides              | const #dnnl_dims_t **
-/// dnnl_query_dilations            | const #dnnl_dims_t **
-/// dnnl_query_padding_l            | const #dnnl_dims_t **
-/// dnnl_query_padding_r            | const #dnnl_dims_t **
-/// dnnl_query_flags                | unsigned *
-/// dnnl_query_alg_kind             | #dnnl_alg_kind_t *
-/// dnnl_query_factors              | const float **
-/// dnnl_query_cell_kind            | #dnnl_alg_kind_t *
-/// dnnl_query_direction            | #dnnl_rnn_direction_t *
-/// dnnl_query_activation_kind      | #dnnl_alg_kind_t *
-/// dnnl_query_kernel               | const #dnnl_dims_t **
-/// dnnl_query_dims                 | const #dnnl_dims_t **
-/// dnnl_query_data_type            | #dnnl_data_type_t *
-/// dnnl_query_padded_dims          | const #dnnl_dims_t **
-/// dnnl_query_padded_offsets       | const #dnnl_dims_t **
-/// dnnl_query_format_kind          | #dnnl_format_kind_t *
-/// dnnl_query_inner_blks           | const #dnnl_dims_t **
-/// dnnl_query_inner_idxs           | const #dnnl_dims_t **
-/// dnnl_query_sparse_encoding      | #dnnl_sparse_encoding_t *
+/// dnnl_query_*_engine             | `#dnnl_engine_t *`
+/// #dnnl_query_primitive_kind      | `#dnnl_primitive_kind_t *`
+/// dnnl_query_*_s32                | `int *`
+/// dnnl_query_*_s64                | `#dnnl_dim_t *` (same as `int64_t *`)
+/// dnnl_query_*_f32                | `float *`
+/// dnnl_query_*_f64                | `double *`
+/// dnnl_query_*_str                | `const char **`
+/// dnnl_query_*_md                 | `#const_dnnl_memory_desc_t *`
+/// dnnl_query_*_pd                 | `#const_dnnl_primitive_desc_t *`
+/// dnnl_query_cache_blob_id        | `const uint8_t **`
+/// dnnl_query_strides              | `const #dnnl_dims_t **`
+/// dnnl_query_dilations            | `const #dnnl_dims_t **`
+/// dnnl_query_padding_l            | `const #dnnl_dims_t **`
+/// dnnl_query_padding_r            | `const #dnnl_dims_t **`
+/// dnnl_query_flags                | `unsigned *`
+/// dnnl_query_alg_kind             | `#dnnl_alg_kind_t *`
+/// dnnl_query_factors              | `const float **`
+/// dnnl_query_cell_kind            | `#dnnl_alg_kind_t *`
+/// dnnl_query_direction            | `#dnnl_rnn_direction_t *`
+/// dnnl_query_activation_kind      | `#dnnl_alg_kind_t *`
+/// dnnl_query_kernel               | `const #dnnl_dims_t **`
+/// dnnl_query_dims                 | `const #dnnl_dims_t **`
+/// dnnl_query_data_type            | `#dnnl_data_type_t *`
+/// dnnl_query_padded_dims          | `const #dnnl_dims_t **`
+/// dnnl_query_padded_offsets       | `const #dnnl_dims_t **`
+/// dnnl_query_format_kind          | `#dnnl_format_kind_t *`
+/// dnnl_query_inner_blks           | `const #dnnl_dims_t **`
+/// dnnl_query_inner_idxs           | `const #dnnl_dims_t **`
+/// dnnl_query_sparse_encoding      | `#dnnl_sparse_encoding_t *`
 ///
 /// @note
 ///     Rule of thumb: all opaque types and structures are returned by

--- a/include/oneapi/dnnl/dnnl_ukernel.h
+++ b/include/oneapi/dnnl/dnnl_ukernel.h
@@ -283,6 +283,11 @@ dnnl_status_t DNNL_API dnnl_brgemm_execute_postops(const_dnnl_brgemm_t brgemm,
 ///     otherwise.
 dnnl_status_t DNNL_API dnnl_brgemm_destroy(dnnl_brgemm_t brgemm);
 
+/// @} dnnl_api_ukernel_brgemm
+
+/// @addtogroup dnnl_api_ukernel_transform
+/// @{
+
 /// Creates a transform object.
 ///
 /// @param transform Output transform object.
@@ -325,7 +330,7 @@ dnnl_status_t DNNL_API dnnl_transform_execute(
 ///     otherwise.
 dnnl_status_t DNNL_API dnnl_transform_destroy(dnnl_transform_t transform);
 
-/// @} dnnl_api_ukernel_brgemm
+/// @} dnnl_api_ukernel_transform
 
 #endif
 

--- a/include/oneapi/dnnl/dnnl_ukernel_types.h
+++ b/include/oneapi/dnnl/dnnl_ukernel_types.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright 2024-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,6 +69,11 @@ typedef struct dnnl_brgemm *dnnl_brgemm_t;
 /// A constant brgemm ukernel handle.
 typedef const struct dnnl_brgemm *const_dnnl_brgemm_t;
 
+/// @} dnnl_api_ukernel_brgemm
+
+/// @addtogroup dnnl_api_ukernel_transform
+/// @{
+
 /// @struct dnnl_transform
 /// An opaque structure to describe a transform routine.
 struct dnnl_transform;
@@ -79,7 +84,7 @@ typedef struct dnnl_transform *dnnl_transform_t;
 /// A constant transform routine handle.
 typedef const struct dnnl_transform *const_dnnl_transform_t;
 
-/// @} dnnl_api_ukernel_brgemm
+/// @} dnnl_api_ukernel_transform
 #endif
 
 /// @} dnnl_api_ukernel


### PR DESCRIPTION
- transform-related functionality was incorrectly marked as brgemm group
- `*` is not handled very well, options are either using `\c` or simply `` (which results into nicer table displayed and all the reference to dnnl_ still work)