### PR TITLE
fixup: gpu: add debug capabilities for kernels

### DIFF
--- a/src/gpu/intel/compute/kernel.hpp
+++ b/src/gpu/intel/compute/kernel.hpp
@@ -257,6 +257,7 @@ public:
     // kernel. In particular, it may come from the blob, or it could be
     // properly generated.
     void hash_dump(const char *tag = nullptr) const {
+        if (!*this) return;
         if (get_verbose_dev_mode(verbose_t::debuginfo) >= 6) {
             printf("kernel creation [%s] %s -> %zu\n", tag ? tag : "unlabeled",
                     name().c_str(), get_hash());


### PR DESCRIPTION
This fixes segfaults in batch normalization with `ONEDNN_VERBOSE=all` as some kernels may be empty.