### PR TITLE
graph: backend: dnnl: add matmul + select fusion support

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -408,6 +408,13 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
                                     binary_injector::is_data_supported(
                                             isa, src2_d.data_type),
                                     VERBOSE_ISA_DT_MISMATCH);
+                            auto bcast_strategy
+                                    = get_rhs_arg_broadcasting_strategy(
+                                            src2_d, *dst_d);
+                            VCHECK_PO_INJ_BOOL(bcast_strategy
+                                            == broadcasting_strategy_t::
+                                                    no_broadcast,
+                                    "Unsupported broadcast type");
                         }
                         return ok;
                     }

--- a/src/graph/backend/dnnl/fusion_info.cpp
+++ b/src/graph/backend/dnnl/fusion_info.cpp
@@ -298,6 +298,21 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                     sum_dt = dnnl::memory::data_type::s8;
                 }
                 dnnl_pops.append_sum(scale, zp, sum_dt);
+            } else if (alg == dnnl::algorithm::binary_select) {
+                // post-binary
+                VCHECK_FUSION_INFO(
+                        extra_inputs.size() == 2 && scale == 1.f && zp == 0,
+                        attr,
+                        "%s post-binary_select only has 2 extra inputs and "
+                        "doesn't support input scale and zp",
+                        op->get_name().c_str());
+                auto md1 = make_dnnl_memory_desc(psrc);
+                if (op->get_kind() == op_kind::dnnl_convolution)
+                    md1 = to_format_any(md1);
+                auto psrc_cond = op->get_input_value(extra_inputs[1])
+                                         ->get_logical_tensor();
+                auto md2 = make_dnnl_memory_desc(psrc_cond);
+                dnnl_pops.append_binary(alg, md1, md2);
             } else {
                 // post-binary
                 VCHECK_FUSION_INFO(

--- a/src/graph/backend/dnnl/op_executable.cpp
+++ b/src/graph/backend/dnnl/op_executable.cpp
@@ -1829,9 +1829,21 @@ static void get_arg_indices_for_post_ops(const op_t *op, fusion_info_mgr_t &mgr,
             indices.insert(
                     {DNNL_GRAPH_ARG_POST_SRC, indices_t {input, base_index++}});
         } else if (pops[i]->get_op()->get_kind() == op_kind::dnnl_binary) {
-            indices.insert(
-                    {DNNL_ARG_ATTR_MULTIPLE_POST_OP((int)i) | DNNL_ARG_SRC_1,
-                            indices_t {input, base_index++}});
+            if (static_cast<dnnl::algorithm>(
+                        pops[i]->get_op()->get_attr<int64_t>(op_attr::alg_kind))
+                    == algorithm::binary_select) {
+                indices.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP((int)i)
+                                | DNNL_ARG_SRC_1,
+                        indices_t {input, base_index++}});
+                // binary select condition input
+                indices.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP((int)i)
+                                | DNNL_ARG_SRC_2,
+                        indices_t {input, base_index++}});
+            } else {
+                indices.insert({DNNL_ARG_ATTR_MULTIPLE_POST_OP((int)i)
+                                | DNNL_ARG_SRC_1,
+                        indices_t {input, base_index++}});
+            }
         } else if (pops[i]->get_op()->get_kind() == op_kind::dnnl_convolution) {
             indices.insert({DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS,
                     indices_t {input, base_index++}});

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -972,6 +972,13 @@ status_t fuse_post_ops(std::shared_ptr<subgraph_t> &sg) {
             } else if (post_op->get_kind() == op_kind::dnnl_binary
                     && static_cast<dnnl::algorithm>(
                                post_op->get_attr<int64_t>(op_attr::alg_kind))
+                            == dnnl::algorithm::binary_select) {
+                fusion_info.append_post_binary(post_op->shared_from_this(),
+                        std::vector<size_t> {base_op->num_inputs(),
+                                base_op->num_inputs() + 1});
+            } else if (post_op->get_kind() == op_kind::dnnl_binary
+                    && static_cast<dnnl::algorithm>(
+                               post_op->get_attr<int64_t>(op_attr::alg_kind))
                             != dnnl::algorithm::binary_add) {
                 fusion_info.append_post_binary(post_op->shared_from_this(),
                         std::vector<size_t> {base_op->num_inputs()});

--- a/tests/benchdnn/inputs/graph/pattern/f32/matmul_select_v1_fusion.json
+++ b/tests/benchdnn/inputs/graph/pattern/f32/matmul_select_v1_fusion.json
@@ -1,0 +1,172 @@
+{
+    "version": "3.9.0",
+    "engine_kind": "cpu",
+    "fpmath_mode": "strict",
+    "fpmath_mode_apply_to_int": "false",
+    "input_ports": [
+      0,
+      1,
+      4,
+      3
+    ],
+    "output_ports": [
+      5
+    ],
+    "graph": [
+      {
+        "id": 0,
+        "name": "mm",
+        "kind": "MatMul",
+        "attrs": {
+          "transpose_a": {
+            "type": "bool",
+            "value": 0
+          },
+          "transpose_b": {
+            "type": "bool",
+            "value": 0
+          }
+        },
+        "inputs": [
+          {
+            "id": 0,
+            "dtype": "f32",
+            "shape": [
+              1,
+              16,
+              32,
+              256
+            ],
+            "stride": [
+              131072,
+              8192,
+              256,
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          },
+          {
+            "id": 1,
+            "dtype": "f32",
+            "shape": [
+              1,
+              16,
+              256,
+              32
+            ],
+            "stride": [
+              131072,
+              8192,
+              32,
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          }
+        ],
+        "outputs": [
+          {
+            "id": 2,
+            "dtype": "f32",
+            "shape": [
+              1,
+              16,
+              32,
+              32
+            ],
+            "stride": [
+              16384,
+              1024,
+              32,
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "name": "select",
+        "kind": "Select",
+        "attrs": {
+          "auto_broadcast": {
+            "type": "string",
+            "value": "numpy"
+          }
+        },
+        "inputs": [
+          {
+            "id": 4,
+            "dtype": "boolean",
+            "shape": [
+              1,
+              16,
+              32,
+              32
+            ],
+            "stride": [
+              16384,
+              1024,
+              32,
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          },
+          {
+            "id": 2,
+            "dtype": "f32",
+            "shape": [
+              1,
+              16,
+              32,
+              32
+            ],
+            "stride": [
+              16384,
+              1024,
+              32,
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          },
+          {
+            "id": 3,
+            "dtype": "f32",
+            "shape": [
+              1
+            ],
+            "stride": [
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          }
+        ],
+        "outputs": [
+          {
+            "id": 5,
+            "dtype": "f32",
+            "shape": [
+              1,
+              16,
+              32,
+              32
+            ],
+            "stride": [
+              16384,
+              1024,
+              32,
+              1
+            ],
+            "layout_type": "strided",
+            "property_type": "undef"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/tests/benchdnn/inputs/graph/pattern/f32/matmul_select_v2.json
+++ b/tests/benchdnn/inputs/graph/pattern/f32/matmul_select_v2.json
@@ -101,7 +101,7 @@
                     "dtype": "boolean",
                     "shape": [
                         1,
-                        1,
+                        16,
                         32,
                         32
                     ],
@@ -118,11 +118,17 @@
                     "id": 4,
                     "dtype": "f32",
                     "shape": [
-                        1
-                    ],
-                    "stride": [
-                        1
-                    ],
+              1,
+              16,
+              32,
+              32
+            ],
+            "stride": [
+              16384,
+              1024,
+              32,
+              1
+            ],
                     "layout_type": "strided",
                     "property_type": "undef"
                 },


### PR DESCRIPTION
Support matmul + select post op fusion pattern.

- Limitation
  - Only support this fusion on CPU, GPU not support yet.
  - Only support this optimized kernel fusion when select condition with full dims with dst shape. MFDNN-14003 is created to track this.
  - Only support fusion when previous op's output to be connected to select's src0.

- Performance:
  - See MFDNN-14003. Optimzied kernel has speedup.