### PR TITLE
[rls-v3.9] xe: sdpa: simplify batch calculation for non-blocked cases

### DIFF
--- a/src/gpu/intel/ocl/micro_sdpa.cpp
+++ b/src/gpu/intel/ocl/micro_sdpa.cpp
@@ -715,13 +715,8 @@ status_t micro_sdpa_t::execute(const exec_ctx_t &ctx) const {
                                const offset_t &offs) {
         int64x4_t dims4 = {offs[3][0], offs[3][1], offs[3][2], offs[3][3]};
         int64x4_t strides4 = {offs[1][0], offs[1][1], offs[1][2], offs[1][3]};
-        int64x4_t blocks4 = {offs[0][0], offs[0][1], offs[0][2], offs[0][3]};
-        int64x4_t block_strides4
-                = {offs[2][0], offs[2][1], offs[2][2], offs[2][3]};
         arg_list.append(dims4);
         arg_list.append(strides4);
-        arg_list.append(blocks4);
-        arg_list.append(block_strides4);
     };
 
     int mask_type = static_cast<int>(pd()->desc()->mask_type);

--- a/src/gpu/intel/ocl/micro_sdpa.hpp
+++ b/src/gpu/intel/ocl/micro_sdpa.hpp
@@ -117,6 +117,16 @@ struct micro_sdpa_t : public gpu_primitive_t {
                     utils::everyone_is(4, qry_md()->ndims, key_md()->ndims,
                             val_md()->ndims, dst_md()->ndims),
                     VERBOSE_UNSUPPORTED_TAG);
+
+            memory_desc_wrapper qry_mdw(qry_md());
+            memory_desc_wrapper key_mdw(key_md());
+            memory_desc_wrapper val_mdw(val_md());
+            memory_desc_wrapper dst_mdw(dst_md());
+            VCHECK_SDPA_COND(utils::everyone_is(true, qry_mdw.is_plain(),
+                                     key_mdw.is_plain(), val_mdw.is_plain(),
+                                     dst_mdw.is_plain()),
+                    VERBOSE_UNSUPPORTED_TAG);
+
             if (with_attn_mask()) {
                 VCHECK_SDPA_COND(
                         attn_mask_md()->ndims == 4, VERBOSE_UNSUPPORTED_TAG);

--- a/src/gpu/intel/ocl/sdpa_utils.h
+++ b/src/gpu/intel/ocl/sdpa_utils.h
@@ -28,11 +28,7 @@
 #define VAL_OFF(x0, x1, x2, x3) _4D_OFF(VAL, x0, x1, x2, x3)
 #define MSK_OFF(x0, x1, x2, x3) _4D_OFF(MSK, x0, x1, x2, x3)
 
-#define _BATCH_OFF(tag, x0, x1) \
-    (((x0) % tag##_B.array[0]) * tag##_SB.array[0] \
-            + ((x0) / tag##_B.array[0]) * tag##_S.array[0] \
-            + ((x1) % tag##_B.array[1]) * tag##_SB.array[1] \
-            + ((x1) / tag##_B.array[1]) * tag##_S.array[1])
+#define _BATCH_OFF(tag, x0, x1) ((x0)*tag##_S.array[0] + (x1)*tag##_S.array[1])
 
 #define QRY_BATCH(x0, x1) _BATCH_OFF(QRY, x0, x1)
 #define KEY_BATCH(x0, x1) _BATCH_OFF(KEY, x0, x1)
@@ -44,10 +40,7 @@
 
 #define RT_DIM4(varname) const int64x4_t varname
 #define RT_OFFSETS(basename) \
-    JOIN_COMMA(RT_DIM4(basename##_D), \
-            JOIN_COMMA(RT_DIM4(basename##_S), \
-                    JOIN_COMMA( \
-                            RT_DIM4(basename##_B), RT_DIM4(basename##_SB))))
+    JOIN_COMMA(RT_DIM4(basename##_D), RT_DIM4(basename##_S))
 
 #define KEY_OFFSETS RT_OFFSETS(KEY)
 #define QRY_OFFSETS RT_OFFSETS(QRY)


### PR DESCRIPTION
# Description

Backport of #3680. Addresses a Pytorch model validation performance regression for v3.9.