### PR TITLE
gpu: make shuffle-by-reorder generic

### DIFF
--- a/src/gpu/generic/shuffle_by_reorder.hpp
+++ b/src/gpu/generic/shuffle_by_reorder.hpp
@@ -14,30 +14,30 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef GPU_INTEL_SHUFFLE_BY_REORDER_HPP
-#define GPU_INTEL_SHUFFLE_BY_REORDER_HPP
+#ifndef GPU_GENERIC_SHUFFLE_BY_REORDER_HPP
+#define GPU_GENERIC_SHUFFLE_BY_REORDER_HPP
 
 #include "common/c_types_map.hpp"
 #include "common/primitive.hpp"
 #include "common/reorder.hpp"
+#include "gpu/gpu_primitive.hpp"
 #include "gpu/gpu_shuffle_pd.hpp"
-#include "gpu/intel/gpu_primitive.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace gpu {
-namespace intel {
+namespace generic {
 
 // Implements shuffle using reorder kernel.
 // Pretends that instead of the one dimension to be shuffled there are two
 // smaller dimensions, then reorders the tensor to swap those two.
 // Reorder kernel is used more often so is expected to be better optimized.
-struct shuffle_by_reorder_t : public gpu_primitive_t {
-    using gpu_primitive_t::gpu_primitive_t;
+struct shuffle_by_reorder_t : public gpu::primitive_t {
+    using gpu::primitive_t::primitive_t;
     struct pd_t : public gpu_shuffle_pd_t {
         using gpu_shuffle_pd_t::gpu_shuffle_pd_t;
 
-        DECLARE_COMMON_PD_T("ocl:reorder:any", shuffle_by_reorder_t);
+        DECLARE_COMMON_PD_T("reorder:any", shuffle_by_reorder_t);
 
         status_t init(impl::engine_t *engine) {
             const auto &md_src = is_fwd() ? src_md() : diff_src_md();
@@ -132,7 +132,7 @@ private:
     std::shared_ptr<impl::primitive_t> reorder_;
 };
 
-} // namespace intel
+} // namespace generic
 } // namespace gpu
 } // namespace impl
 } // namespace dnnl

--- a/src/gpu/gpu_shuffle_list.cpp
+++ b/src/gpu/gpu_shuffle_list.cpp
@@ -14,11 +14,11 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "gpu/generic/shuffle_by_reorder.hpp"
 #include "gpu/gpu_impl_list.hpp"
 
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
 #include "gpu/intel/ref_shuffle.hpp"
-#include "gpu/intel/shuffle_by_reorder.hpp"
 #endif
 
 #ifdef GENERIC_SYCL_KERNELS_ENABLED
@@ -33,7 +33,7 @@ namespace {
 
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_SHUFFLE_P({
-        GPU_INSTANCE_INTEL(intel::shuffle_by_reorder_t)
+        GPU_INSTANCE_GENERIC(generic::shuffle_by_reorder_t)
         GPU_INSTANCE_INTEL(intel::ref_shuffle_t)
         GPU_INSTANCE_GENERIC_SYCL(generic::sycl::ref_shuffle_t)
         nullptr,


### PR DESCRIPTION
Shuffle by reorder has no Intel-specific dependencies, so move it into the generic namespace.

By pure luck, partially addresses [MFDNN-13823](https://jira.devtools.intel.com/browse/MFDNN-13823).