### PR TITLE
cpu: conv: enable f32:f32:x8 and bf16:bf16:x8 in conv and deconv

### DIFF
--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -848,6 +848,11 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
             nullptr,
         })},
+        // BWD int8 (src:u8)
+        {{backward_data, u8, f32, f32}, REG_BWD_D_PK({
+            CPU_INSTANCE(ref_convolution_bwd_data_t)
+            nullptr,
+        })},
         // BWD int8 (diff_dst:s8)
         {{backward_data, f32, s8, s8}, REG_BWD_D_PK({
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
@@ -896,6 +901,11 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_convolution_bwd_strided_t<avx2_vnni>)
             CPU_INSTANCE(gemm_x8s8s32x_convolution_bwd_data_t)
             CPU_INSTANCE(ref_convolution_int8_bwd_data_t)
+            nullptr,
+        })},
+        // BWD int8 (src:s8)
+        {{backward_data, s8, f32, f32}, REG_BWD_D_PK({
+            CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
     });

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -853,6 +853,10 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},
+        {{backward_data, u8, bf16, bf16}, REG_BWD_D_PK({
+            CPU_INSTANCE(ref_convolution_bwd_data_t)
+            nullptr,
+        })},
         // BWD int8 (diff_dst:s8)
         {{backward_data, f32, s8, s8}, REG_BWD_D_PK({
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
@@ -905,6 +909,10 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         })},
         // BWD int8 (src:s8)
         {{backward_data, s8, f32, f32}, REG_BWD_D_PK({
+            CPU_INSTANCE(ref_convolution_bwd_data_t)
+            nullptr,
+        })},
+        {{backward_data, s8, bf16, bf16}, REG_BWD_D_PK({
             CPU_INSTANCE(ref_convolution_bwd_data_t)
             nullptr,
         })},

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -266,6 +266,14 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_convolution_fwd_t)
             nullptr,
         }},
+        {{forward, bf16, bf16, u8}, {
+            CPU_INSTANCE(ref_convolution_fwd_t)
+            nullptr,
+        }},
+        {{forward, bf16, bf16, s8}, {
+            CPU_INSTANCE(ref_convolution_fwd_t)
+            nullptr,
+        }},
         BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f16),
         BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f32),
         BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, bf16),

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -258,6 +258,14 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE(ref_fused_convolution_fwd_t)
             nullptr,
         }},
+        {{forward, f32, f32, u8}, {
+            CPU_INSTANCE(ref_convolution_fwd_t)
+            nullptr,
+        }},
+        {{forward, f32, f32, s8}, {
+            CPU_INSTANCE(ref_convolution_fwd_t)
+            nullptr,
+        }},
         BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f16),
         BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, f32),
         BRGEMM_FP8_FWD_CONVS(f8_e5m2, f8_e5m2, bf16),

--- a/src/cpu/ref_convolution.hpp
+++ b/src/cpu/ref_convolution.hpp
@@ -144,7 +144,8 @@ struct ref_convolution_bwd_data_t : public primitive_t {
                                    utils::one_of(wei_type, f16, bf16)
                                            && diff_dst_type == f32),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_CONV(utils::one_of(diff_src_type, f32, diff_dst_type),
+            VDISPATCH_CONV(
+                    utils::one_of(diff_src_type, f32, diff_dst_type, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_CONV(

--- a/src/cpu/ref_convolution.hpp
+++ b/src/cpu/ref_convolution.hpp
@@ -61,7 +61,7 @@ struct ref_convolution_fwd_t : public primitive_t {
                                    utils::one_of(wei_type, f16, bf16)
                                            && src_type == f32),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_CONV(utils::one_of(dst_type, src_type, f32),
+            VDISPATCH_CONV(utils::one_of(dst_type, src_type, f32, s8, u8),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_CONV(
                     utils::one_of(bia_type, data_type::undef, src_type, f32),


### PR DESCRIPTION
This PR adds support for f32:f32:u8, f32:f32:s8, bf16:bf16:u8 and bf16:bf16:s8 data types configurations in convolution and deconvolution.
Addresses [MFDNN-7683](https://jira.devtools.intel.com/browse/MFDNN-7683)
