### PR TITLE
graph: backend: dnnl: fix utility functions

### DIFF
--- a/src/graph/backend/dnnl/common.cpp
+++ b/src/graph/backend/dnnl/common.cpp
@@ -625,7 +625,7 @@ std::string get_format_tag_str(const dnnl::memory::desc &md) {
     const auto &strs = md.get_strides();
     std::copy(strs.begin(), strs.end(), strides);
 
-    utils::simultaneous_sort(strides, ou_blocks, dim_chars, ndims,
+    impl::utils::simultaneous_sort(strides, ou_blocks, dim_chars, ndims,
             [](dim_t a, dim_t b) { return b - a; });
 
     std::string blk_tag = std::string(dim_chars);

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -2219,13 +2219,14 @@ status_t fuse_reciprocal_mul_to_div(std::shared_ptr<subgraph_t> &sg) {
             float alpha = 0.f;
             if (cur_op->has_attr(op_attr::alpha))
                 alpha = cur_op->get_attr<float>(op_attr::alpha);
-            if (!utils::compare_float(alpha, 1.f)) return false;
+            if (alpha != 1.f) return false;
 
             // check attribute beta
             float beta = 0.f;
             if (cur_op->has_attr(op_attr::beta))
                 beta = cur_op->get_attr<float>(op_attr::beta);
-            if (!utils::compare_float(beta, -1.f)) return false;
+            if (beta != -1.f) return false;
+
             return true;
         };
 

--- a/src/graph/backend/dnnl/passes/utils.cpp
+++ b/src/graph/backend/dnnl/passes/utils.cpp
@@ -684,9 +684,10 @@ bool inverse_mul_scales(std::shared_ptr<op_t> &scale_op) {
     VCHECK_UTILS(scale_op->num_inputs() <= 1
                     && !scale_op->has_attr(op_attr::with_runtime_scales),
             false, "scale_op should be static and have only one input value.");
-    auto scales = scale_op->get_attr<std::vector<float>>(op_attr::scales);
-    scales = dnnl_impl::utils::fmap(scales, [](float s) { return 1.f / s; });
-    scale_op->set_attr(op_attr::scales, scales);
+    const auto scales = scale_op->get_attr<std::vector<float>>(op_attr::scales);
+    const auto scales_inv
+            = dnnl_impl::utils::fmap(scales, [](float s) { return 1.f / s; });
+    scale_op->set_attr(op_attr::scales, scales_inv);
     return true;
 }
 

--- a/src/graph/backend/dnnl/subgraph.cpp
+++ b/src/graph/backend/dnnl/subgraph.cpp
@@ -126,7 +126,7 @@ std::string layout2str(const dnnl::memory::desc &md) {
         const auto &strs = md.get_strides();
         std::copy(strs.begin(), strs.end(), strides);
 
-        utils::simultaneous_sort(strides, ou_blocks, dim_chars, ndims,
+        impl::utils::simultaneous_sort(strides, ou_blocks, dim_chars, ndims,
                 [](dim_t a, dim_t b) { return b - a; });
 
         blk_tag = std::string(dim_chars);

--- a/src/graph/backend/dnnl/utils.hpp
+++ b/src/graph/backend/dnnl/utils.hpp
@@ -50,14 +50,6 @@ inline std::pair<bool, int64_t> try_reverse_axis(
     return std::make_pair(true, new_axis);
 }
 
-inline bool compare_float(
-        float ref, float given, float rtol = 1e-5f, float atol = 1e-6f) {
-    const float diff = std::abs(given - ref);
-    const float bigger
-            = std::abs(ref) > std::abs(given) ? std::abs(ref) : std::abs(given);
-    return diff <= rtol * bigger + atol;
-}
-
 inline std::vector<int32_t> cast_to_int32(const std::vector<int64_t> &vec) {
     return fmap(vec, [](int64_t e) { return static_cast<int32_t>(e); });
 }

--- a/src/graph/backend/dnnl/utils.hpp
+++ b/src/graph/backend/dnnl/utils.hpp
@@ -41,61 +41,6 @@ std::vector<U> fmap(const std::vector<T> &vec, const F &f) {
     return result;
 }
 
-/** sorts an array of values using @p comparator. While sorting the array
- * of value, the function permutes an array of @p keys accordingly.
- *
- * @note The arrays of @p keys can be omitted. In this case the function
- *       sorts the array of @vals only.
- */
-template <typename T, typename U, typename F>
-inline void simultaneous_sort(T *vals, U *keys, size_t size, F comparator) {
-    if (size == 0) return;
-
-    for (size_t i = 0; i < size - 1; ++i) {
-        bool swapped = false;
-        for (size_t j = 0; j < size - i - 1; j++) {
-            if (comparator(vals[j], vals[j + 1]) > 0) {
-                std::swap(vals[j], vals[j + 1]);
-                if (keys) std::swap(keys[j], keys[j + 1]);
-                swapped = true;
-            }
-        }
-
-        if (swapped == false) break;
-    }
-}
-
-/* Sorts an array of @p vals using @p comparator. Uses @p vals_2nd_level as a
- * second level comparing criteria in case comparator returns 0 (equal values)
- * for @p vals elements.
- * While sorting the array of @p vals, the function permutes an array of
- * @p vals_2nd_level and @p keys accordingly.
- */
-template <typename T, typename U, typename F>
-inline void simultaneous_sort(
-        T *vals, T *vals_2nd_level, U *keys, size_t size, F comparator) {
-    if (size == 0) return;
-
-    for (size_t i = 0; i < size - 1; ++i) {
-        bool swapped = false;
-
-        for (size_t j = 0; j < size - i - 1; j++) {
-            auto res = comparator(vals[j], vals[j + 1]);
-            if (res == 0)
-                res = comparator(vals_2nd_level[j], vals_2nd_level[j + 1]);
-
-            if (res > 0) {
-                std::swap(vals[j], vals[j + 1]);
-                std::swap(vals_2nd_level[j], vals_2nd_level[j + 1]);
-                std::swap(keys[j], keys[j + 1]);
-                swapped = true;
-            }
-        }
-
-        if (swapped == false) break;
-    }
-}
-
 inline std::pair<bool, int64_t> try_reverse_axis(
         const int64_t axis, const int32_t rank) {
     // oneDNN can not operate on the negative axis


### PR DESCRIPTION
- Use the utility functions from src/common and remove the duplicated ones.
- Change the return value of fmap to avoid a false warning with GCC 13.
- Compare 1.f and -1.f directly and remove compare_float() as it's not used elsewhere.