### PR TITLE
cpu: x64: Added sprinkled prefetching

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -522,6 +522,12 @@ status_t brgemm_desc_set_attr(
             && (brg->is_tmm))
         return status::unimplemented;
 
+    // Sprinkled prefetch is supported for brgemm_batch_size is 1
+    if ((brgattr.max_bs != 1)
+            && (brgattr.hint_prfB.sprinkled || brgattr.hint_prfA.sprinkled)) {
+        return status::unimplemented;
+    }
+
     brg->prfA = brgattr.hint_prfA;
     brg->prfB = brgattr.hint_prfB;
     brg->prfC = brgattr.hint_prfC;

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -130,6 +130,7 @@ struct brgemm_prf_t {
     int dist1 {-1};
     int dist2 {-1};
     int distNTA {-1};
+    bool sprinkled {false};
 };
 
 struct brgemm_batch_element_t {

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -388,9 +388,21 @@ private:
         void reset() { vec = 0; }
     };
 
+    struct prf_sprinkled_t {
+        std::vector<size_t> prefetch_offsets;
+        size_t current_prefetch_idx;
+        void reset() {
+            prefetch_offsets.clear();
+            current_prefetch_idx = 0;
+        }
+    };
+
     // iteration map
     iteration_map_t imap_;
 
+    prf_sprinkled_t prf_sprinkled_a, prf_sprinkled_b;
+    size_t num_amx_ops;
+    size_t current_num_amx_ops;
     // interleave stores
     bool use_ils_ = false;
     bool was_prev_bi_ = false;
@@ -535,6 +547,8 @@ private:
     void maybe_tileloadd_nt(
             brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, size_t offset);
 
+    void maybe_sprinkle_prefetches();
+
     void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
@@ -569,10 +583,21 @@ private:
                 && !skip_accumulation);
     }
 
-    size_t A_offset(const brgemm_iteration_t &bi, int bdb) const noexcept;
-    size_t B_offset(const brgemm_iteration_t &bi, int ldb) const noexcept;
+    size_t A_offset(
+            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+
+    size_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
+            int bd_elem_idx = 0) const noexcept;
+
+    size_t B_offset(
+            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
+
+    size_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
+            int rd_elem_idx = 0) const noexcept;
+
     size_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             int ldb) const noexcept;
+
     size_t D_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             int ldb) const noexcept;
 
@@ -705,23 +730,28 @@ int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
 }
 
 size_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, int bdb) const noexcept {
+        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
     const auto bdb_offs
             = ununroll_bd_loop ? bi.bdi->rel_pos(bdb) : bi.bdi->pos(bdb);
     return bdb_offs * LDA2_size_ + bs_offs
-            + bi.rdi->pos(0) * brg.rd_block * brg.typesize_A;
+            + bi.rdi->pos(rdb) * brg.rd_block * brg.typesize_A;
+}
+
+size_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
+        int bdb, int rdb, int bd_elem_idx) const noexcept {
+    return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 size_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, int ldb) const noexcept {
+        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
 
-    const auto rdb_B_offset = bi.rdi->pos(0) * brg.rd_block * LDB_size_;
+    const auto rdb_B_offset = bi.rdi->pos(rdb) * brg.rd_block * LDB_size_;
 
     const auto ldb_offs = bi.ldi->pos(ldb) * brg.ld_block;
     const auto ldb_B_offset = brg.typesize_B
@@ -729,6 +759,11 @@ size_t jit_brgemm_amx_uker_base_t::B_offset(
                     + (ldb_offs % brg.LDB) * brg.rd_step);
 
     return rdb_B_offset + ldb_B_offset + bs_offs;
+}
+
+size_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
+        int ldb, int rdb, int rd_elem_idx) const noexcept {
+    return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
 size_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
@@ -1257,6 +1292,7 @@ void jit_brgemm_amx_uker_base_t::prefetching(
     maybe_prefetch_B(prf1B);
     maybe_prefetch_B(prf2B);
     maybe_prefetch_B(prfntaB);
+    if (!prefetch_all) maybe_sprinkle_prefetches();
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
@@ -1676,6 +1712,36 @@ void jit_brgemm_amx_uker_base_t::set_A_B_matrices() {
     }
 }
 
+void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
+    auto jit_prefetches = [&](prf_sprinkled_t &prf_sprinkled,
+                                  Xbyak::Reg64 base) {
+        // Calculate the number of cache lines to jit
+        float total_cache_lines_to_prefetch
+                = (float)prf_sprinkled.prefetch_offsets.size();
+        float cache_lines_per_amx_op
+                = total_cache_lines_to_prefetch / num_amx_ops;
+        int num_prefetches_to_jit
+                = (int)((current_num_amx_ops + 1) * cache_lines_per_amx_op)
+                - (int)(current_num_amx_ops * cache_lines_per_amx_op);
+
+        // Jit the prefetches
+        for (size_t i = prf_sprinkled.current_prefetch_idx;
+                i < num_prefetches_to_jit + prf_sprinkled.current_prefetch_idx;
+                i++) {
+            const auto ptr = EVEX_compress_addr(
+                    base, prf_sprinkled.prefetch_offsets[i]);
+            uni_prefetch(ptr, brgemm_prf1, false);
+        }
+
+        // Update idx of last prefetched line
+        prf_sprinkled.current_prefetch_idx += num_prefetches_to_jit;
+    };
+
+    if (brg.prfA.sprinkled) jit_prefetches(prf_sprinkled_a, reg_A);
+    if (brg.prfB.sprinkled) jit_prefetches(prf_sprinkled_b, reg_B);
+
+    current_num_amx_ops++;
+}
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
         brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, size_t offset) {
 
@@ -2429,19 +2495,33 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         tloop.ldis.reserve(brg.ldb2);
         tloop.rdis.reserve(brg.rdb);
         tloop.bsis.reserve(brg.brgattr.max_bs);
+        brgemm_iteration_t bi_prefetch;
 
         auto bdi_pos = skipped_bd_mask(0);
         bd_iteration_t bdi;
         bdi.blocks.reserve(brg.bd_block2);
+        int prefetch_distance_m = brg.bcast_dim;
+        bd_iteration_t bdi_prefetch;
+        bi_prefetch.bdi = &bdi_prefetch;
+
         for (int bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
             bdi.blocks.clear();
             for (int ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
                 auto abdb = bdb + ibdb;
                 if (abdb >= brg.bdb) break;
-                if (brg.bdb_tail && abdb == brg.bdb - 1)
+                if (brg.bdb_tail && abdb == brg.bdb - 1) {
                     bdi.blocks.emplace_back(bdi_pos, brg.bdb_tail, true);
-                else
+                    if (brg.prfA.sprinkled)
+                        bdi_prefetch.blocks.emplace_back(
+                                bdi_pos + prefetch_distance_m, brg.bdb_tail,
+                                true);
+                } else {
                     bdi.blocks.emplace_back(bdi_pos, brg.bd_block, false);
+                    if (brg.prfA.sprinkled)
+                        bdi_prefetch.blocks.emplace_back(
+                                bdi_pos + prefetch_distance_m, brg.bd_block,
+                                false);
+                }
                 bdi_pos += brg.bd_block;
                 if (bdi_pos >= brg.bcast_dim) break;
                 bdi_pos = skipped_bd_mask(bdi_pos);
@@ -2476,15 +2556,29 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         size_t ldi_pos = 0;
         dim_iteration_t ldi;
         ldi.blocks.reserve(brg.ld_block2);
+        size_t prefetch_distance_n = (size_t)brg.ldb;
+        bd_iteration_t ldi_prefetch;
+        bi_prefetch.ldi = &ldi_prefetch;
+
         for (int ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
             ldi.blocks.clear();
             for (int ildb = 0; ildb < brg.ld_block2; ildb++) {
                 auto aldb = ldb + ildb;
                 if (aldb >= brg.ldb) break;
-                if (brg.ldb_tail && aldb == brg.ldb - 1)
+                if (brg.ldb_tail && aldb == brg.ldb - 1) {
                     ldi.blocks.emplace_back(ldi_pos, brg.ldb_tail, true);
-                else
+                    if (brg.prfB.sprinkled)
+                        ldi_prefetch.blocks.emplace_back(
+                                ldi_pos + prefetch_distance_n, brg.ldb_tail,
+                                true);
+
+                } else {
                     ldi.blocks.emplace_back(ldi_pos, brg.ld_block, false);
+                    if (brg.prfB.sprinkled)
+                        ldi_prefetch.blocks.emplace_back(
+                                ldi_pos + prefetch_distance_n, brg.ld_block,
+                                false);
+                }
                 ldi_pos++;
             }
             ldi.idx = tloop.ldis.size();
@@ -2494,9 +2588,15 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         size_t rdi_pos = 0;
         dim_iteration_t rdi;
         rdi.blocks.reserve(1);
+        dim_iteration_t rdi_prefetch;
+        bi_prefetch.rdi = &rdi_prefetch;
+
         for (int rdb = 0; rdb < brg.rdb; rdb++) {
             rdi.blocks.clear();
             rdi.blocks.emplace_back(rdi_pos, brg.rd_block);
+            if (brg.prfA.sprinkled || brg.prfB.sprinkled) {
+                rdi_prefetch.blocks.emplace_back(rdi_pos, brg.rd_block);
+            }
             rdi.idx = tloop.rdis.size();
             tloop.rdis.push_back(rdi);
             rdi_pos++;
@@ -2504,10 +2604,16 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.rdb_tail > 0) {
             rdi.blocks.clear();
             rdi.blocks.emplace_back(rdi_pos, brg.rdb_tail, true);
+            if (brg.prfA.sprinkled || brg.prfB.sprinkled) {
+                rdi_prefetch.blocks.emplace_back(rdi_pos, brg.rdb_tail, true);
+            }
             rdi.idx = tloop.rdis.size();
             tloop.rdis.push_back(rdi);
         }
 
+        // The case where bs_max is > 1, and prefetches are enabled
+        // is not supported. In order to support prefetches in this case,
+        // current_num_amx_ops needs to be an array per bs in bs_max.
         bs_iteration_t bsi;
         for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
             bsi.pos = bs;
@@ -2522,6 +2628,40 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                 tloop.bdis[ibdi].similar
                         = find_similar(&(tloop.bdis[ibdi]), apply_postops);
             }
+        }
+
+        num_amx_ops = brg.bdb * brg.rdb * brg.ldb;
+        current_num_amx_ops = 0;
+        // Calculate the offsets of A's cache lines to prefetch
+        prf_sprinkled_a.reset();
+        if (brg.prfA.sprinkled) {
+            for (size_t bdb = 0; bdb < bdi_prefetch.blocks.size(); ++bdb) {
+                for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
+                    int bd_block_size = bdi_prefetch.blocks[bdb].block;
+                    for (int bd = 0; bd < bd_block_size; bd++) {
+                        prf_sprinkled_a.prefetch_offsets.push_back(
+                                A_offset_line(bi_prefetch, bdb, rdb, bd));
+                    }
+                }
+            }
+            std::sort(prf_sprinkled_a.prefetch_offsets.begin(),
+                    prf_sprinkled_a.prefetch_offsets.end());
+        }
+
+        // Calculate the offsets of B's cache lines to prefetch
+        prf_sprinkled_b.reset();
+        if (brg.prfB.sprinkled) {
+            for (size_t ldb = 0; ldb < ldi_prefetch.blocks.size(); ++ldb) {
+                for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
+                    int rd_block_size = rdi_prefetch.blocks[rdb].block;
+                    for (int rd = 0; rd < rd_block_size; rd += brg.rd_step) {
+                        prf_sprinkled_b.prefetch_offsets.push_back(
+                                B_offset_line(bi_prefetch, ldb, rdb, rd));
+                    }
+                }
+            }
+            std::sort(prf_sprinkled_b.prefetch_offsets.begin(),
+                    prf_sprinkled_b.prefetch_offsets.end());
         }
     }
 }

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -54,6 +54,8 @@ void matmul_amx_blocking_params_t::update_configuration(
     bgmmc.is_a_nt = is_a_nt_;
     bgmmc.is_b_nt = is_b_nt_;
     bgmmc.set_nt = set_nt_;
+    bgmmc.need_prefetch_a = need_prefetch_a_;
+    bgmmc.need_prefetch_b = need_prefetch_b_;
     bgmmc.is_macro_heuristics
             = dynamic_cast<const matmul_amx_blocking_params_macro_t *>(this)
             != nullptr;
@@ -764,13 +766,6 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
             k_blk_h = nstl::min(wei_k_blk * best_k_h, K);
             best_k_h = 1;
             is_a_nt_ = true;
-            // TODO: revive after precopy implementation
-            //            need_buf_a_ = false;
-            need_prefetch = false;
-        } else {
-            // TODO: revive after precopy implementation
-            //            need_buf_a_ = false;
-            need_prefetch = true;
         }
 
         k_blk_ = k_blk_h;
@@ -779,6 +774,8 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
         n_chunk_size_ = 1;
         m_blk_ = m_decomposition;
         m_chunk_size_ = div_up(m_per_thread, m_blk_);
+        need_prefetch_a_ = (m_per_thread / m_blk_) >= 2;
+        need_prefetch_b_ = false;
     } else {
         if (is_postops_bound(k_blk_v)) {
             // Give up on the L1 blocking
@@ -799,7 +796,8 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters() {
         m_chunk_size_ = 1;
         is_a_nt_ = true;
         is_b_nt_ = false;
-        need_prefetch = true;
+        need_prefetch_a_ = false;
+        need_prefetch_b_ = (n_per_thread / n_blk_) >= 2;
     }
 
     extendable_k_ = K % data_type_vnni_granularity(wei_dt) != 0;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -48,6 +48,8 @@ public:
         , is_a_nt_(is_a_nt)
         , is_b_nt_(is_b_nt)
         , set_nt_(set_nt)
+        , need_prefetch_a_(need_prefetch_a)
+        , need_prefetch_b_(need_prefetch_b)
         , brgemm_batch_size_(brgemm_batch_size)
         , current_lda_(LDA)
         , need_buf_c_(use_buffer_c)
@@ -78,6 +80,7 @@ protected:
 
     bool is_a_nt_ {true}, is_b_nt_ {true};
     bool set_nt_ {false};
+    bool need_prefetch_a_ {false}, need_prefetch_b_ {false};
 
     dim_t brgemm_batch_size_ {0};
     dim_t current_lda_ {0};
@@ -112,7 +115,6 @@ private:
     dim_t m_decomposition = 32;
     size_t gemm_dt_sz;
     dim_t m_per_thread, k_per_thread, n_per_thread, b_per_thread;
-    bool need_prefetch;
     bool is_horizontal;
     dim_t min_m_elem, min_k_elem, min_n_elem;
     dim_t k_threshold_write_bound_layer_elem, min_n_dim_write_bound_layer_elem;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -55,7 +55,7 @@ int get_brg_batchsize(
 
 int get_brg_kernel_index(const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail,
         bool do_initialization, int m_ker_idx, int n_ker_idx, bool is_K_tail,
-        int bs) {
+        int bs, bool is_prefetching) {
     const int max_m_ker_idx
             = bgmmc.is_runtime_M ? max_num_dynamic_m_tails + 1 : 2;
     if (m_ker_idx >= max_m_ker_idx) return -1;
@@ -79,10 +79,14 @@ int get_brg_kernel_index(const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail,
                     && !is_runtime_value(bgmmc.LDC)))
         return -1;
 
-    int idx = 2 * max_n_ker_idx
-                    * (4 * m_ker_idx + 2 * (int)is_bs_tail
-                            + (int)do_initialization)
-            + 2 * n_ker_idx + (int)is_K_tail;
+    if (is_prefetching && !bgmmc.need_prefetch_a && !bgmmc.need_prefetch_b) {
+        return -1;
+    }
+    int idx = 2 * 2 * 2 * max_n_ker_idx * max_m_ker_idx * (int)is_prefetching
+            + 2 * 2 * 2 * max_n_ker_idx * m_ker_idx
+            + 2 * 2 * max_n_ker_idx * (int)is_bs_tail
+            + 2 * max_n_ker_idx * (int)do_initialization + 2 * n_ker_idx
+            + (int)is_K_tail;
     assert(idx < max_num_brg_kernels_matmul);
     return idx;
 }
@@ -91,19 +95,11 @@ int get_brg_kernel_index(const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail,
 
 template <cpu_isa_t isa>
 int brgemm_matmul_t<isa>::pd_t::get_brg_kernel_idx(bool is_bs_tail,
-        bool do_initialization, int m_ker_idx, int n_ker_idx,
-        bool is_K_tail) const {
+        bool do_initialization, int m_ker_idx, int n_ker_idx, bool is_K_tail,
+        bool is_prefetching) const {
     int bs = get_brg_batchsize(bgmmc_, is_bs_tail, is_K_tail);
     return get_brg_kernel_index(bgmmc_, is_bs_tail, do_initialization,
-            m_ker_idx, n_ker_idx, is_K_tail, bs);
-}
-
-template <cpu_isa_t isa>
-void brgemm_matmul_t<isa>::pd_t::maybe_set_LDB2() {
-    if (bgmmc_.LDB < bgmmc_.N_blk
-            && (bgmmc_.N_blk % bgmmc_.LDB == 0 || bgmmc_.N_blk == bgmmc_.N)) {
-        bgmmc_.LDB2 = rnd_up(bgmmc_.K, bgmmc_.wei_k_blk) * bgmmc_.LDB;
-    }
+            m_ker_idx, n_ker_idx, is_K_tail, bs, is_prefetching);
 }
 
 template <cpu_isa_t isa>
@@ -295,8 +291,6 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                                                        : avx512_core)))
             : isa;
 
-    maybe_set_LDB2();
-
     const int i_bs_end = bgmmc_.brgemm_batch_tail_size ? 2 : 1;
     const int i_init_start = bgmmc_.K_blk != bgmmc_.K ? 0 : 1;
     const int i_K_end = bgmmc_.K_tail ? 2 : 1;
@@ -305,7 +299,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
     for_(int i_init = i_init_start; i_init < 2; i_init++)
     for_(int i_M = 0; i_M < max_m_ker_idx; i_M++)
     for_(int i_N = 0; i_N < max_n_ker_idx; i_N++)
-    for (int i_K = 0; i_K < i_K_end; i_K++) {
+    for_(int i_K = 0; i_K < i_K_end; i_K++)
+    for (int prefetching = 0; prefetching < 2; prefetching++) {
         auto vbeta = (i_init) ? beta_init : beta;
         auto vM = (i_M) == 0 ? bgmmc_.M_blk
                              : (bgmmc_.is_runtime_M ? dynamic_m_tails[i_M - 1]
@@ -316,7 +311,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         auto vK = (i_K) ? bgmmc_.K_tail : bgmmc_.K_blk;
 
         int bs = get_brg_batchsize(bgmmc_, i_bs, i_K);
-        int idx = get_brg_kernel_idx(i_bs, i_init, i_M, i_N, i_K);
+        int idx = get_brg_kernel_idx(i_bs, i_init, i_M, i_N, i_K, prefetching);
         if (idx < 0) continue;
 
         brgemm_desc_t &brg = brg_descs_[idx];
@@ -356,6 +351,10 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
             brgattr.hint_innermost_loop = brgemm_innermost_undef;
             brgattr.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
+
+            brgattr.hint_prfA.sprinkled = bgmmc_.need_prefetch_a && prefetching;
+            brgattr.hint_prfB.sprinkled = bgmmc_.need_prefetch_b && prefetching;
+
             if (bgmmc_.set_nt) {
                 brgattr.hint_load_nt_A = bgmmc_.is_a_nt ? brgemm_hint_nt_true
                                                         : brgemm_hint_nt_false;
@@ -398,8 +397,10 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
     for_(int i_M = 0; i_M < max_m_ker_idx; i_M++)
     for_(int i_N = 0; i_N < max_n_ker_idx; i_N++)
     for_(int i_K = 0; i_K < i_K_end; i_K++)
-    for (int i_init = i_init_start; i_init < 2; i_init++) {
-        int idx = pd()->get_brg_kernel_idx(i_bs, i_init, i_M, i_N, i_K);
+    for_(int i_init = i_init_start; i_init < 2; i_init++)
+    for (int prefetching = 0; prefetching < 2; prefetching++) {
+        int idx = pd()->get_brg_kernel_idx(
+                i_bs, i_init, i_M, i_N, i_K, prefetching);
         if (idx < 0) continue;
 
         brgemm_kernel_t *ker = nullptr;
@@ -469,6 +470,31 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
     }
 
     return status::success;
+}
+
+template <cpu_isa_t isa>
+bool brgemm_matmul_t<isa>::determine_prefetch(const int mb, const int m_end,
+        const int nb, const int n_end, const brgemm_matmul_conf_t &bgmmc,
+        brg_matmul_exec_ctx_t &brgmm_ctx) const {
+    // Prefetch if not the last BRGEMM in the chunk and
+    // if the next BRGEMM is identical to the current one.
+
+    assert(!(bgmmc.need_prefetch_a && bgmmc.need_prefetch_b));
+    bool do_prefetch = false;
+
+    if (bgmmc.need_prefetch_a) {
+        do_prefetch = mb != m_end - 1 && //not last
+                brgmm_ctx.get_M_kernel_idx(mb)
+                        == brgmm_ctx.get_M_kernel_idx(mb + 1);
+    }
+
+    if (bgmmc.need_prefetch_b) {
+        do_prefetch = nb != n_end - 1 && //not last
+                brgmm_ctx.get_N_kernel_idx(nb)
+                        == brgmm_ctx.get_N_kernel_idx(nb + 1);
+    }
+
+    return do_prefetch;
 }
 
 template <cpu_isa_t isa>
@@ -605,6 +631,8 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                                 && (b_prev == b
                                         || bgmmc.bcast_A_desc
                                                    .bcast_across_all_batch_dims);
+                        bool prefetch = determine_prefetch(
+                                mb, m_end, nb, n_end, bgmmc, brgmm_ctx);
                         for (int kb = kb_start; kb < kb_end; kb++) {
 
                             if (bgmmc.use_buffer_b && mb == m_start
@@ -619,7 +647,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                             compute_kernel(brgmm_ctx, a_batch_ptr, b_batch_ptr,
                                     ithr, b, mb, nb, kb,
                                     kc == kc_start && kb == kb_start,
-                                    prev_ker_idx);
+                                    prev_ker_idx, prefetch);
                         }
                     }
                     kc_prev = kc;
@@ -644,7 +672,8 @@ template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::compute_kernel(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
         const char *B_data_batch_ptr, int ithr, int b_idx, int m_blk_idx,
-        int n_blk_idx, int k_blk_idx, bool do_init, int &prev_ker_idx) const {
+        int n_blk_idx, int k_blk_idx, bool do_init, int &prev_ker_idx,
+        bool prefetch) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
     const auto addr_batch = brgmm_ctx.get_batch_elem_ptr(ithr);
 
@@ -668,7 +697,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
     auto is_bs_tail = (gemm_batch != bgmmc.brgemm_batch_size);
     const int brg_ker_idx = pd()->get_brg_kernel_idx(
-            is_bs_tail, do_init, m_ker_idx, n_ker_idx, false);
+            is_bs_tail, do_init, m_ker_idx, n_ker_idx, false, prefetch);
     const auto ptr_bias = brgmm_ctx.get_bias_ptr(n);
     auto ptr_D = brgmm_ctx.get_data_C_ptr(
             b_idx, brgmm_ctx.get_M_idx(m_blk_idx, true), n);
@@ -747,7 +776,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
         const bool use_init_ker = (do_init && gemm_batch == 0);
         const int brg_ker_idx = pd()->get_brg_kernel_idx(
-                false, use_init_ker, m_ker_idx, n_ker_idx, true);
+                false, use_init_ker, m_ker_idx, n_ker_idx, true, prefetch);
         if (brg_ker_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -1037,8 +1066,8 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                 if (bgmmc.post_ops_applicable) {
                     for (int nb = nb_start; nb < nb_end; nb++) {
                         const int n_ker_idx = brgmm_ctx.get_N_kernel_idx(nb);
-                        const int brg_ker_idx = pd()->get_brg_kernel_idx(
-                                false, false, m_ker_idx, n_ker_idx, false);
+                        const int brg_ker_idx = pd()->get_brg_kernel_idx(false,
+                                false, m_ker_idx, n_ker_idx, false, false);
                         if (brg_ker_idx == -1) {
                             assert(!"Requested brgemm kernel was not created.");
                             return;
@@ -1362,7 +1391,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         post_ops_binary_rhs_arg_vec_ = binary_injector::prepare_binary_args(
                 pd->attr()->post_ops_, ctx);
-        base_brg_ker_idx_ = pd->get_brg_kernel_idx(false, true, 0, 0, false);
+        base_brg_ker_idx_
+                = pd->get_brg_kernel_idx(false, true, 0, 0, false, false);
         vnni_factor = data_type_vnni_granularity(bgmmc.wei_dt);
 
         reorder_zp_a_comp_ptr_ = nullptr;

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -47,7 +47,8 @@ constexpr int max_num_dynamic_n_tails
         = sizeof(dynamic_n_tails) / sizeof(dynamic_n_tails[0]);
 constexpr int max_num_brg_kernels_matmul = 2 * 2 * 2
         * (max_num_dynamic_n_tails + 1 /* main kernel size */)
-        * (max_num_dynamic_m_tails + 1 /* main kernel size */);
+        * (max_num_dynamic_m_tails + 1 /* main kernel size */)
+        * 2; //prefetching on/off
 
 template <cpu_isa_t isa>
 struct brgemm_matmul_t : public primitive_t {
@@ -59,15 +60,14 @@ struct brgemm_matmul_t : public primitive_t {
 
         status_t init(engine_t *engine);
         int get_brg_kernel_idx(bool is_bs_tail, bool do_initialization,
-                int m_ker_idx, int n_ker_idx, bool is_K_tail) const;
+                int m_ker_idx, int n_ker_idx, bool is_K_tail,
+                bool is_prefetching) const;
         const brgemm_desc_t &get_brg_desc(int idx) const {
             return brg_descs_[idx];
         }
         const brgemm_matmul_conf_t &get_brgemm_matmul_conf() const {
             return bgmmc_;
         }
-
-        void maybe_set_LDB2();
 
     private:
         brgemm_desc_t brg_descs_[max_num_brg_kernels_matmul];
@@ -91,7 +91,12 @@ private:
     void compute_kernel(const brg_matmul_exec_ctx_t &brgmm_ctx,
             const char *A_data_batch_ptr, const char *B_data_batch_ptr,
             int ithr, int b_idx, int m_blk_idx, int n_blk_idx, int k_blk_idx,
-            bool do_init, int &prev_ker_idx) const;
+            bool do_init, int &prev_ker_idx, bool prefetch) const;
+
+    bool determine_prefetch(const int mc, const int m_end, const int nc,
+            const int n_end, const brgemm_matmul_conf_t &bgmmc,
+            brg_matmul_exec_ctx_t &brgmm_ctx) const;
+
     void copy_a_chunk_in_buffer(const brg_matmul_exec_ctx_t &brgmm_ctx,
             const char *A_data_batch_ptr, int ithr, int m_blk_idx,
             int k_blk_idx) const;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1665,6 +1665,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     is_small_shapes = is_small_shapes && !bgmmc.packed_sparse_weights;
     VCONDCHECK_BG(!is_small_shapes, VERBOSE_SMALL_SHAPES);
 
+    bgmmc.LDB2 = rnd_up(bgmmc.K, bgmmc.wei_k_blk) * bgmmc.LDB;
     return status::success;
 }
 

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -89,6 +89,7 @@ struct brgemm_matmul_conf_t {
     dim_t M_blk, N_blk, K_blk, M_tail, N_tail, K_tail;
     int M_chunk_size, N_chunk_size, K_chunk_size;
     bool is_a_nt, is_b_nt, set_nt;
+    bool need_prefetch_a, need_prefetch_b;
     dim_t LDA, LDB, LDC, LDD;
     dim_t LDB2;
     int brgemm_batch_size, brgemm_batch_tail_size;


### PR DESCRIPTION
This feature introduces prefetching for the A and B matrices. Each BRGEMM operation prefetches data for the subsequent BRGEMM, provided they share the same dimensions, otherwise no prefetching occurs. Cache lines are evenly distributed across AMX instructions and strategically sprinkled throughout the entire BRGEMM. The optimization results in a 4% geomean performance improvement on applicable layers.