### PR TITLE
cpu: aarch64: jit_reorder: no fast_return if compensation needed

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -48,7 +48,6 @@ fi
 # Nightly failures
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_all_blocked_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_regressions_cpu"
-SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_conv_int8_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_matmul_sparse_gpu_cpu"
 

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -807,7 +807,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
             // transposition on the fly
             const bool fast_return = prb_.src_scale_type != scale_type_t::MANY
                     && prb_.dst_scale_type != scale_type_t::MANY
-                    && prb_.beta == 0.f && !prb_.req_src_zp && !prb_.req_dst_zp;
+                    && prb_.beta == 0.f && !prb_.req_src_zp && !prb_.req_dst_zp
+                    && !compensation_needed_;
             if (fast_return) {
                 if (prb_.src_scale_type == scale_type_t::COMMON)
                     for (int ur = 0; ur < reg_unroll; ur += load_step)

--- a/tests/benchdnn/inputs/reorder/harness_reorder_compensation
+++ b/tests/benchdnn/inputs/reorder/harness_reorder_compensation
@@ -52,6 +52,7 @@
 --oflag=,s8s8_comp:3,zp_comp:3,s8s8_comp:3+zp_comp:3
 --stag=abx,xcab
 --dtag=xcab        2x32x32x3 2x32x32x3x3 16x32x32x3x3x3
+--dtag=xab         79x79x2
 # Special case: no general 3D support for AMX and depthwise
 --dtag=aBCx4c16b4c 2x32x32x3 2x32x32x3x3
 --dtag=aBCx4b4c    2x36x36x3 2x36x36x3x3 2x35x35x3x3


### PR DESCRIPTION
# Description

The "fast return" path in `jit_uni_reorder` does not support compensation and needs to be skipped accordingly.

This should allow `test_benchdnn_modeC_conv_int8_cpu` to be removed from the CI skip-list.

Example failure:

**Before:**
```sh
$ ./build/tests/benchdnn/benchdnn --reorder --mode=C --sdt=f32 --stag=abc --ddt=s8 --dtag=cab --oflag=zp_comp:3 79x78x2
[   0][0:0] exp_f32:           1 exp:           1 got:           0 diff:       1 rdiff:       1
[   2][0:2] exp_f32:          -1 exp:          -1 got:           0 diff:       1 rdiff:       1
[   3][0:3] exp_f32:          -4 exp:          -4 got:           0 diff:       4 rdiff:       1
[   4][0:4] exp_f32:         -80 exp:         -80 got:           0 diff:      80 rdiff:       1
[   5][0:5] exp_f32:           1 exp:           1 got:           0 diff:       1 rdiff:       1
[   7][0:7] exp_f32:          -1 exp:          -1 got:           0 diff:       1 rdiff:       1
[   8][0:8] exp_f32:          -4 exp:          -4 got:           0 diff:       4 rdiff:       1
[   9][0:9] exp_f32:         -80 exp:         -80 got:           0 diff:      80 rdiff:       1
[  10][0:10] exp_f32:           1 exp:           1 got:           0 diff:       1 rdiff:       1
[  12][0:12] exp_f32:          -1 exp:          -1 got:           0 diff:       1 rdiff:       1
[COMPARE_STATS]: trh=0 err_max_diff:      80 err_max_rdiff:       1 all_max_diff:      80 all_max_rdiff:       1
Error: Function 'compare_compensation' at (oneDNN/tests/benchdnn/reorder/reorder.cpp:139) returned '1'
0:FAILED (errors:4551 total:18486) (11 ms) __REPRO: --reorder --sdt=f32 --ddt=s8 --stag=abc --dtag=cab --oflag=zp_comp:3 79x78x2
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED (errors:4551 total:18486) (11 ms) __REPRO: --reorder --sdt=f32 --ddt=s8 --stag=abc --dtag=cab --oflag=zp_comp:3 79x78x2
============================
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 0.01s; create_pd: 0.00s (2%); create_prim: 0.00s (1%); fill: 0.01s (58%); execute: 0.00s (2%); compute_ref: 0.00s (1%); compare: 0.00s (4%);
```

**After:**
```sh
$ ./build/tests/benchdnn/benchdnn --reorder --mode=C --sdt=f32 --stag=abc --ddt=s8 --dtag=cab --oflag=zp_comp:3 79x78x2
0:PASSED (8 ms) __REPRO: --reorder --sdt=f32 --ddt=s8 --stag=abc --dtag=cab --oflag=zp_comp:3 79x78x2
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (2%); create_prim: 0.00s (2%); fill: 0.00s (42%); execute: 0.00s (10%); compute_ref: 0.00s (2%); compare: 0.00s (5%);
```

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?
