### PR TITLE
cpu: aarch64: brgemm: Extend support for bf16 in BRGEMM Kernel

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -238,9 +238,9 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
             return status::unimplemented;
     }
     if ((brg->dt_a == data_type::bf16 && brg->dt_b == data_type::bf16)
-            && (!one_of(dt_d, data_type::bf16, data_type::f32))
-            && (!one_of(dt_bias, data_type::undef, data_type::bf16,
-                    data_type::f32)))
+            && ((!one_of(dt_d, data_type::bf16, data_type::f32))
+                    || (!one_of(dt_bias, data_type::undef, data_type::bf16,
+                            data_type::f32))))
         return status::unimplemented;
     if ((brg->dt_a == data_type::f32 && brg->dt_b == data_type::f32)
             && (!one_of(dt_d, data_type::f32))
@@ -250,8 +250,6 @@ status_t brgemm_desc_set_postops(brgemm_t *brg, const primitive_attr_t *attr,
 
     brg->dt_d = dt_d;
     brg->typesize_D = types::data_type_size(brg->dt_d);
-
-    if (brg->dt_d == bf16) return status::unimplemented;
 
     if (!brg->attr) return status::success;
 

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -100,9 +100,11 @@ status_t set_isa_impl(brgemm_t *brg) {
                 one_of(brg->isa_user, isa_undef, isa);
     };
 
-    if (brg->is_bf32 || brg->is_bf16 || brg->is_f16) {
+    if (brg->is_bf32 || brg->is_f16) {
         return status::unimplemented;
-    } else if (brg->is_f32 || brg->is_int8) {
+    } else if (brg->is_bf16 && !mayiuse_bf16()) {
+        return status::unimplemented;
+    } else if (brg->is_f32 || brg->is_bf16 || brg->is_int8) {
         brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(sve_512), sve_512,
                 is_isa_ok(sve_256), sve_256);
         return status::success;


### PR DESCRIPTION
# Description

This PR extends the BRGEMM (Batch-Reduce General Matrix Multiplication) kernel to support bf16 data type.

Major Code Changes:
• Support for data type bf16:bf16:f32 and bf16:bf16:bf16
• Support for bias data type bf16 and f32
Other minor changes added accordingly in some files.

Perf Timings (ms)  Compared with f32 for single core:
| Shapes | f32:f32:f32 | bf16:bf16:f32 | bf16:bf16:bf16 | 
|:----------:|:----------:|:----------:|:----------:|
|512x768:768x768 | 8.02 | 3.94 | 3.97 |
|197x3072:3072x768 | 30.93 | 7.07 | 7.08 |

## Checklist
General
[✓] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit? Yes
Test output is same with and without this commit.

### Gtest:
```./test_matmul```
[----------] Global test environment tear-down
[==========] 64 tests from 8 test suites ran. (22 ms total)
[  PASSED  ] 52 tests.
[  SKIPPED ] 12 tests, listed below:
[  SKIPPED ] TensorDims/attr_test_t.TestMatmulShouldCallSameImplementationWithAttributes/0
[  SKIPPED ] TensorDims/attr_test_t.TestMatmulShouldCallSameImplementationWithAttributes/1
[  SKIPPED ] TensorDims/attr_test_t.TestMatmulShouldCallSameImplementationWithAttributes/2
[  SKIPPED ] TensorDims/attr_test_t.TestMatmulShouldCallSameImplementationWithAttributes/3
[  SKIPPED ] TensorDims/attr_test_t.TestMatmulShouldCallSameImplementationWithAttributes/4
[  SKIPPED ] Generic_f16/iface.TestsMatMul/0
[  SKIPPED ] Generic_f16/iface.TestsMatMul/1
[  SKIPPED ] Generic_f16/iface.TestsMatMul/2
[  SKIPPED ] Generic_f16/iface.TestsMatMul/3
[  SKIPPED ] Generic_f16/iface.TestsMatMul/4
[  SKIPPED ] Generic_f16/iface.TestsMatMul/5
[  SKIPPED ] Generic_f16/iface.TestsMatMul/6

### ```make test```
98% tests passed, 4 tests failed out of 225

Total Test time (real) = 922.55 sec

The following tests FAILED:
        173 - test_graph_unit_dnnl_large_partition_cpu (Failed)
        196 - test_benchdnn_modeC_binary_ci_cpu (Failed)
        197 - test_benchdnn_modeC_binary_different_dt_ci_cpu (Failed)
        205 - test_benchdnn_modeC_graph_ci_cpu (Failed)
Errors while running CTest
Output from these tests are in: /home/vishwas/oss/oneDNN/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
make: *** [Makefile:71: test] Error 8

### Benchdnn tests:
```./benchdnn --brgemm --batch=inputs/brgemm/test_brgemm_bf16```
tests:50672 passed:34096 skipped:16576 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 87.88s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 36.69s (42%); execute: 0.00s (0%); compute_ref: 23.07s (26%); compare: 21.28s (24%);


```./benchdnn --brgemm --batch=inputs/brgemm/test_brgemm_all```
tests:660480 passed:215308 skipped:443056 mistrusted:2116 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 704.49s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 247.58s (35%); execute: 0.00s (0%); compute_ref: 177.49s (25%); compare: 141.39s (20%);


Clang formatting done [✓] 
 

