### PR TITLE
cpu: aarch64: skip unsupported ISAs in brgemm_matmul_matrix_B_reorder_t

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -51,7 +51,6 @@ SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_regressions_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_conv_int8_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_matmul_sparse_gpu_cpu"
-SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_reorder_all_cpu"
 
 # c7g failures. TODO: scope these to c7g only. Better yet, fix them.
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_binary_all_cpu"

--- a/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_reorders.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2022-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
@@ -15,6 +16,7 @@
 *******************************************************************************/
 
 #include "common/dnnl_thread.hpp"
+#include "cpu/aarch64/cpu_isa_traits.hpp"
 
 #include "cpu/aarch64/matmul/brgemm_matmul_reorders.hpp"
 
@@ -110,7 +112,15 @@ status_t brgemm_matmul_matrix_B_reorder_t::pd_t::init(
             : brgemm_broadcast_t::none;
     matmul_conf_for_reorder_.has_zero_point_a
             = matmul_conf_for_reorder_.src_zp_type != brgemm_broadcast_t::none;
-    matmul_conf_for_reorder_.isa = (!mayiuse(sve_512)) ? sve_256 : sve_512;
+
+    // jit_brgemm_matmul_copy_b_t assumes ISA == (sve_512 || sve_256)
+    if (mayiuse(sve_512)) {
+        matmul_conf_for_reorder_.isa = sve_512;
+    } else if (mayiuse(sve_256)) {
+        matmul_conf_for_reorder_.isa = sve_256;
+    } else {
+        return status::unimplemented;
+    }
 
     auto mask_ok = [&](bool check, int mask) {
         return IMPLICATION(


### PR DESCRIPTION
# Description
Fixes illegal instructions and/or correctness bugs on other platforms.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [X] Have you added relevant regression tests?