### PR TITLE
xe: rnn, zeropad: fixup renaming

### DIFF
--- a/src/gpu/intel/jit/generator_base.hpp
+++ b/src/gpu/intel/jit/generator_base.hpp
@@ -17,8 +17,6 @@
 #ifndef GPU_INTEL_JIT_GENERATOR_BASE_HPP
 #define GPU_INTEL_JIT_GENERATOR_BASE_HPP
 
-#include <CL/cl.h>
-
 #include "gpu/intel/compute/kernel.hpp"
 #include "gpu/intel/engine.hpp"
 

--- a/src/gpu/intel/rnn/utils.cpp
+++ b/src/gpu/intel/rnn/utils.cpp
@@ -16,6 +16,8 @@
 
 #include "gpu/intel/rnn/utils.hpp"
 
+#include <CL/cl.h>
+
 #include "common/c_types_map.hpp"
 #include "common/math_utils.hpp"
 

--- a/src/gpu/intel/rnn/utils.cpp
+++ b/src/gpu/intel/rnn/utils.cpp
@@ -16,8 +16,6 @@
 
 #include "gpu/intel/rnn/utils.hpp"
 
-#include <CL/cl.h>
-
 #include "common/c_types_map.hpp"
 #include "common/math_utils.hpp"
 
@@ -299,8 +297,7 @@ void set_conf(conf_t &conf, const desc_t &rd,
     // usage. Can be removed when further improvements are made to
     // copy_diff_src_layer
     conf.scratch_diff_states_ld = get_good_ld(conf.arch_ld,
-            nstl::max(conf.slc, nstl::max(conf.sic, conf.dhc)),
-            sizeof(cl_float),
+            nstl::max(conf.slc, nstl::max(conf.sic, conf.dhc)), sizeof(float),
             utils::everyone_is(conf.slc, conf.sic, conf.dhc)
                     && conf.n_layer * conf.n_dir * conf.n_iter * conf.mb
                             > 128 * 1024);

--- a/src/gpu/intel/zeropad/simple.cpp
+++ b/src/gpu/intel/zeropad/simple.cpp
@@ -16,8 +16,9 @@
 
 #include "gpu/intel/zeropad/simple.hpp"
 
+#include <CL/cl.h>
+
 #include "gpu/intel/compute/utils.hpp"
-#include "gpu/intel/zeropad/config.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/src/gpu/intel/zeropad/simple.hpp
+++ b/src/gpu/intel/zeropad/simple.hpp
@@ -17,8 +17,8 @@
 #ifndef GPU_INTEL_ZEROPAD_SIMPLE_HPP
 #define GPU_INTEL_ZEROPAD_SIMPLE_HPP
 
-#include "gpu/gpu_zero_pad_pd.hpp"
 #include "gpu/intel/primitive.hpp"
+#include "gpu/intel/zeropad/config.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -33,8 +33,8 @@ namespace zeropad {
 
 struct simple_t : public primitive_t {
     using primitive_t::primitive_t;
-    struct pd_t : public gpu_zero_pad_pd_t {
-        using gpu_zero_pad_pd_t::gpu_zero_pad_pd_t;
+    struct pd_t : public zeropad::pd_t {
+        using zeropad::pd_t::pd_t;
 
         DECLARE_COMMON_PD_T("ocl:simple:any", simple_t);
         status_t init(impl::engine_t *engine) {


### PR DESCRIPTION
Fixes errors in [coverity builds](https://intel-ci.intel.com/f076d8b9-a66a-f1a0-abfe-a4bf010d0e2d) ( [MFDNN-14050](https://jira.devtools.intel.com/browse/MFDNN-14050)) and adds missing rename of zero pad pd.