### PR TITLE
test: benchdnn: matmul: warn on legacy bia_dt option

### DIFF
--- a/.github/automation/performance/inputs/matmul_nightly
+++ b/.github/automation/performance/inputs/matmul_nightly
@@ -20,7 +20,7 @@
 # Plain cases
 --reset
 --dt=f32,s8:s8:f32
---bia_dt=f32,undef
+--bia-dt=f32,undef
 --bia_mask=2
 --batch=shapes_converted_ip_inf_lb_resnet
 --bia_mask=4
@@ -28,7 +28,7 @@
 
 --reset
 --dt=f32
---bia_dt=f32,undef
+--bia-dt=f32,undef
 --bia_mask=2
 --attr-fpmath=bf16
 --batch=shapes_converted_ip_inf_lb_resnet
@@ -38,7 +38,7 @@
 #f16
 --reset
 --dt=f16:f16:f16
---bia_dt=undef
+--bia-dt=undef
 --bia_mask=2
 --batch=shapes_converted_ip_inf_lb_resnet
 --bia_mask=4

--- a/tests/benchdnn/inputs/matmul/harness_matmul_smoke_ref
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_smoke_ref
@@ -8,7 +8,7 @@
 --dtag=any
 
 --dt=f32,bf16,f16
---bia_dt=undef,f32
+--bia-dt=undef,f32
 --bia_mask=2
 --attr-post-ops=,linear:2:1
 --batch=shapes_2d_ci
@@ -28,7 +28,7 @@
 --wtag=ab
 --dtag=ab
 --dt=f32,bf16,f16,u8:s8:s32
---bia_dt=undef,f32
+--bia-dt=undef,f32
 --bia_mask=2
 --attr-scales=
 --attr-zero-points=

--- a/tests/benchdnn/matmul/bench_matmul.cpp
+++ b/tests/benchdnn/matmul/bench_matmul.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -141,9 +142,9 @@ static const std::string help_runtime_dims_masks
 bool parse_legacy_dt(std::vector<dnnl_data_type_t> &dt,
         const std::vector<dnnl_data_type_t> &def_dt, const char *str,
         const std::string &option_name /* = "dt"*/) {
-    // TODO: uncomment in v3.8
-    // BENCHDNN_PRINT(0, "%s\n", "Warning: \'--bia_dt\' option is deprecated.
-    //         Please use the \'--bia-dt\' one.");
+    BENCHDNN_PRINT(0, "%s\n",
+            "Warning: \'--bia_dt\' option is deprecated. Please use the "
+            "\'--bia-dt\' one.");
     return parser::parse_dt(dt, def_dt, str, option_name);
 }
 


### PR DESCRIPTION
# Description

Uncomments a warning for when a user supplies the legacy `--bia_dt` option for `benchdnn --matmul`.