### PR TITLE
cpu: aarch64: fix scratchpad memory initialization

### DIFF
--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_utils.hpp
@@ -281,8 +281,11 @@ template <cpu_isa_t isa, data_type_t kernel_dt>
 void jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_scratchpad(
         memory_tracking::registrar_t &scratchpad, const jit_conv_conf_t &jcp) {
     using namespace dnnl::impl::memory_tracking::names;
-    if (jcp.with_bias && jcp.oc_without_padding != jcp.oc)
+    if (jcp.with_bias && jcp.bia_dt == data_type::bf16) {
+        scratchpad.book<float>(key_conv_bias_bf16_convert_wsp, jcp.oc);
+    } else if (jcp.with_bias && jcp.oc_without_padding != jcp.oc) {
         scratchpad.book<float>(key_conv_padded_bias, jcp.oc);
+    }
 }
 
 template struct jit_uni_dw_conv_fwd_kernel_t<sve_512, data_type::f32>;

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -412,3 +412,7 @@ mb1_g50ic50oc50_ih28oh26_kh3sh1ph0_n"dw_post-op_ngroups-tail"
 # test peform_outwork for brgemm kernel
 --reset
 --dir=FWD_I --dt=f32:f32:f32 --stag=acdb --wtag=any --dtag=acdb ic48oc134_ih23oh12kh2sh2dh0ph1_iw12ow4kw1sw13dw0pw14_n"brgemm_perform_outwork"
+
+# tests JIT bf16 depthwise convolution with bf16 bias
+--reset
+--dt=bf16 --bia-dt=bf16 --dir=FWD_I g4mb2_ic4oc4_ih6oh4kh3sh1dh0ph0_iw6ow4kw3sw1dw0pw0_n"aarch64_jit_dw_bia_dt_bf16"


### PR DESCRIPTION
This  fixes Conv dw (BF16) with Bias-dt=BF16. Bug introduced as part of this PR: https://github.com/uxlfoundation/oneDNN/pull/3441

I've added a fix and added unit testcases.

The failure was reported by unit test fails in this PR: https://github.com/pytorch/pytorch/pull/157994 

Example test : 

```
./benchdnn --conv --dt=bf16 --dir=FWD_I --bia-dt=bf16  g4mb2_ic4oc4_ih6oh4kh3sh1dh0ph0_iw6ow4kw3sw1dw0pw0
```
