### PR TITLE
tests: benchdnn: fixup matmul bia_dt warning

### DIFF
--- a/tests/benchdnn/matmul/bench_matmul.cpp
+++ b/tests/benchdnn/matmul/bench_matmul.cpp
@@ -142,10 +142,13 @@ static const std::string help_runtime_dims_masks
 bool parse_legacy_dt(std::vector<dnnl_data_type_t> &dt,
         const std::vector<dnnl_data_type_t> &def_dt, const char *str,
         const std::string &option_name /* = "dt"*/) {
-    BENCHDNN_PRINT(0, "%s\n",
-            "Warning: \'--bia_dt\' option is deprecated. Please use the "
-            "\'--bia-dt\' one.");
-    return parser::parse_dt(dt, def_dt, str, option_name);
+    if (parser::parse_dt(dt, def_dt, str, option_name)) {
+        BENCHDNN_PRINT(0, "%s\n",
+                "Warning: \'--bia_dt\' option is deprecated. Please use the "
+                "\'--bia-dt\' one.");
+        return true;
+    }
+    return false;
 }
 
 int bench(int argc, char **argv) {


### PR DESCRIPTION
After, #3751 the warning about `--bia_dt` is emitted even when that option is no provided.

```
$ build/tests/benchdnn/benchdnn --matmul --engine=gpu --reset --stag=abc --wtag=cab --dtag=abc --strides=:: 1x1x3072:1x3072x256000
Warning: '--bia_dt' option is deprecated. Please use the '--bia-dt' one.
Warning: '--bia_dt' option is deprecated. Please use the '--bia-dt' one.
0:PASSED (4211 ms) __REPRO: --matmul --engine=gpu --stag=abc --wtag=cab --dtag=abc 1x1x3072:1x3072x256000
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 4.21s; create_pd: 0.00s (0%); create_prim: 0.01s (0%); fill: 2.15s (51%); execute: 0.69s (16%); compute_ref: 0.22s (5%); compare: 0.00s (0%);
```
