### PR TITLE
doc: give doxygen a hint wrt nested groups

### DIFF
--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -53,6 +53,7 @@ using fpmath_mode = dnnl::fpmath_mode;
 
 /// @addtogroup dnnl_graph_api_utils Utilities
 /// Utility types and definitions
+/// \ingroup dnnl_graph_api
 /// @{
 
 /// @cond DO_NOT_DOCUMENT_THIS
@@ -125,6 +126,7 @@ using req = typename std::enable_if<B, bool>::type;
 
 /// @addtogroup dnnl_graph_api_status Status
 /// Definitions of status values returned by the library functions.
+/// \ingroup dnnl_graph_api
 /// @{
 
 /// Status values returned by the library functions.

--- a/include/oneapi/dnnl/dnnl_ukernel.hpp
+++ b/include/oneapi/dnnl/dnnl_ukernel.hpp
@@ -75,6 +75,7 @@ namespace ukernel {
 
 /// @addtogroup dnnl_api_ukernel_utils ukernel utils
 /// ukernel utility functions
+/// \ingroup dnnl_api_ukernel
 /// @{
 
 /// Packing specification


### PR DESCRIPTION
Doxygen seems to have an issue parsing through nested groups and namespaces, but giving it a small hint helps.
Also explored option to update Doxygen, but this currently produces enormous amount of warnings.
This should take care of the 3 remaining doc warnings.