### PR TITLE
GPU DSL extensions

### DIFF
--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -2076,7 +2076,7 @@ private:
         if (slm_layout == layout_t()) return plan_status_t::invalid_slm_layout;
         auto thr_tile_coord = slm_layout.split(tg, &grid);
         auto abs_thr_tile_coord = tg_view.vtile_coord().sub(thr_tile_coord);
-        auto slm_thr_layout = slm_layout.map(thr_tile_coord);
+        auto slm_thr_layout = slm_layout.sub(thr_tile_coord);
         auto slm_thr_view = view_t(slm_thr_layout);
         auto thr_view = tg_view.create_sub_view(thr_tile_coord);
         auto load_params = get_send_params(cfg_.exec_cfg(), send_op_t::load,
@@ -2254,7 +2254,7 @@ private:
 
         if (plan_.hw < ngen::HW::XeHPG) {
             // Verifies that SLM loads after k-slicing are at GRF granularity.
-            auto l_sub = l.map(tile_t(rem_dims));
+            auto l_sub = l.sub(tile_t(rem_dims));
             int bytes = l_sub.type().size();
             stride_t stride = 1;
             for (auto &b : l_sub.blocks()) {

--- a/src/gpu/intel/conv/jit/plan_utils.hpp
+++ b/src/gpu/intel/conv/jit/plan_utils.hpp
@@ -53,7 +53,7 @@ inline std::string add_indent(const std::string &tag, const std::string &s) {
 inline layout_t split(const layout_t &layout, int factor) {
     auto tile_coord = layout.split_exact(factor);
     if (tile_coord.is_invalid()) return layout_t();
-    return layout.map(tile_coord.tile, tile_coord.coord);
+    return layout.sub(tile_coord.tile, tile_coord.coord);
 }
 
 } // namespace jit

--- a/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
+++ b/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
@@ -590,8 +590,8 @@ struct generator_dsl_t {
             assume(arg("ldc") % (problem.C.alignment / problem.Tc_ext) == 0);
         }
 
-        if_(kloop_it.is_inbounds(0), [&]() {
-            if_(
+        _if(kloop_it.is_inbounds(0), [&]() {
+            _if(
                     k >= k_loop_main.k_warmup(),
                     [&]() { build_k_loop(k_loop_main); },
                     [&]() { build_k_loop(k_loop_short); });
@@ -725,7 +725,7 @@ struct generator_dsl_t {
                     do_mma);
         }
 
-        while_(kloop_it.is_inbounds(warmup), [&]() {
+        _while(kloop_it.is_inbounds(warmup), [&]() {
             for (int k_unroll_idx = 0; k_unroll_idx < k_blk;
                     k_unroll_idx += k_unroll_blk) {
                 k_body(k_unroll_idx, cfg.A_prefetch_warmup,

--- a/src/gpu/intel/jit/codegen/reduce.hpp
+++ b/src/gpu/intel/jit/codegen/reduce.hpp
@@ -53,8 +53,8 @@ public:
 
         tile_t tile = find_1d_tile(src_layout_, dst_layout_);
         int tile_elems = (int)tile.elems();
-        auto src_tile_layout = src_layout_.map(tile);
-        auto dst_tile_layout = dst_layout_.map(tile);
+        auto src_tile_layout = src_layout_.sub(tile);
+        auto dst_tile_layout = dst_layout_.sub(tile);
         const auto &src_tile_blocks = src_tile_layout.blocks();
         const auto &dst_tile_blocks = dst_tile_layout.blocks();
         gpu_assert(src_tile_blocks.size() <= 1);

--- a/src/gpu/intel/jit/codegen/reorder.cpp
+++ b/src/gpu/intel/jit/codegen/reorder.cpp
@@ -156,8 +156,8 @@ void reorder_2d_impl_t::emit(
         auto *next_layout = &step.layout;
 
         // x -> y reorder.
-        auto x = prev_layout->map(tile).reinterpret(type);
-        auto y = next_layout->map(tile).reinterpret(type);
+        auto x = prev_layout->sub(tile).reinterpret(type);
+        auto y = next_layout->sub(tile).reinterpret(type);
 
         bool use_dst = ((path_len - i) % 2 == 1);
         copy_operand_t next_op = use_dst ? dst : tmp;
@@ -420,7 +420,7 @@ void reorder_2d_impl_t::vertex_t::set_edges(const std::vector<edge_t> &edges) {
 // - GRF region can't span more than 2 registers
 bool reorder_2d_impl_t::vertex_t::can_reorder(
         const tile_t &tile, const type_t &type) const {
-    auto ab_layout = layout.map(tile).reinterpret(type);
+    auto ab_layout = layout.sub(tile).reinterpret(type);
     int nblocks = int(ab_layout.blocks().size());
     if (nblocks == 0) return true;
     if (nblocks > 1) return false;
@@ -661,8 +661,8 @@ bool reorder_impl_t::try_emit_2d(copy_plan_t &plan,
     for (const auto &tile : tiles) {
         if (tile.size() < 2) continue;
         if (tile.elems() < 4) break;
-        auto src_tile_layout = src.layout.map(tile);
-        auto dst_tile_layout = dst.layout.map(tile);
+        auto src_tile_layout = src.layout.sub(tile);
+        auto dst_tile_layout = dst.layout.sub(tile);
         if (!dst_tile_layout.is_dense()) continue;
 
         // Set layout offset to 0 since the offset is handled by fixing up

--- a/src/gpu/intel/jit/dsl/decl.hpp
+++ b/src/gpu/intel/jit/dsl/decl.hpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_DSL_DECL_HPP
+#define GPU_INTEL_JIT_DSL_DECL_HPP
+
+#include "gpu/intel/jit/ir/core.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+namespace dsl {
+
+static type_t _bool = type_t::_bool();
+static type_t s8 = type_t::s8();
+static type_t u8 = type_t::u8();
+static type_t s16 = type_t::s16();
+static type_t u16 = type_t::u16();
+static type_t s32 = type_t::s32();
+static type_t u32 = type_t::u32();
+static type_t s64 = type_t::s64();
+static type_t u64 = type_t::u64();
+static type_t f32 = type_t::f32();
+static type_t f16 = type_t::f16();
+static type_t bf16 = type_t::bf16();
+
+using expr_t = jit::expr_t;
+
+} // namespace dsl
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -21,7 +21,6 @@
 #include "gpu/intel/jit/ir/kernel_info.hpp"
 #include "gpu/intel/jit/ir/message.hpp"
 #include "gpu/intel/jit/ir/message_patterns.hpp"
-#include "gpu/intel/jit/ir/v2/tensor.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -34,7 +33,9 @@ int grf_size();
 int min_align_2d();
 int min_pitch_2d();
 
-using layout_t = v2::layout_t;
+using tile_t = dnnl::impl::gpu::intel::jit::tile_t;
+using coord_t = dnnl::impl::gpu::intel::jit::coord_t;
+using layout_t = dnnl::impl::gpu::intel::jit::layout_t;
 using expr_t = dnnl::impl::gpu::intel::jit::expr_t;
 
 struct send_hint_t {
@@ -57,6 +58,7 @@ struct tensor_t {
     }
 
     IR_DEFINE_DUMP()
+
     expr_t buf;
     layout_t layout;
 };

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -230,7 +230,7 @@ void mma(const tensor_t &C, const tensor_t &A, const tensor_t &B,
         const tile_t &tile, const icoord_t &base, bool is_systolic);
 
 template <typename F>
-void if_(const expr_t &cond, F if_body) {
+void _if(const expr_t &cond, F if_body) {
     if (is_const(cond)) {
         if (to_cpp<bool>(cond)) {
             begin_scope();
@@ -245,7 +245,7 @@ void if_(const expr_t &cond, F if_body) {
 }
 
 template <typename F, typename G>
-void if_(const expr_t &cond, const F &if_body, const G &else_body) {
+void _if(const expr_t &cond, const F &if_body, const G &else_body) {
     if (is_const(cond)) {
         begin_scope();
         if (to_cpp<bool>(cond)) {
@@ -279,7 +279,7 @@ void _for(const expr_t &var, const expr_t &bound, const F &body) {
 }
 
 template <typename F>
-void while_(const expr_t &cond, F body) {
+void _while(const expr_t &cond, F body) {
     if (is_const(cond) && !to_cpp<bool>(cond)) return;
     begin_scope();
     body();

--- a/src/gpu/intel/jit/grf_usage.cpp
+++ b/src/gpu/intel/jit/grf_usage.cpp
@@ -223,7 +223,7 @@ private:
     bool is_header(const expr_t &buf) const {
         if (!is_buffer(buf)) return false;
         auto &name = buf.as<var_t>().name;
-        return name.find("h_") == 0;
+        return name == "h" || name.find("h_") == 0;
     }
 
     bool should_skip_if_set(const expr_t &buf, grf_usage_label_t label) const {

--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -461,6 +461,20 @@ void ir_visitor_t::_visit(const alloc_t &obj) {
     visit(obj.body);
 }
 
+object_t ir_mutator_t::_mutate(const assign_t &obj) {
+    auto var = mutate(obj.var);
+    auto value = mutate(obj.value);
+
+    if (var.is_same(obj.var) && value.is_same(obj.value)) return obj;
+
+    return assign_t::make(var, value);
+}
+
+void ir_visitor_t::_visit(const assign_t &obj) {
+    visit(obj.var);
+    visit(obj.value);
+}
+
 object_t ir_mutator_t::_mutate(const ref_t &obj) {
     auto var = mutate(obj.var);
     if (var.impl() == obj.var.impl()) return obj;

--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -108,6 +108,7 @@ std::string to_string(op_kind_t kind) {
 
         case op_kind_t::_and: return "&&";
         case op_kind_t::_or: return "||";
+        case op_kind_t::_xor: return "^";
 
         case op_kind_t::_add3: return "add3";
         case op_kind_t::_mad: return "mad";
@@ -143,6 +144,7 @@ bool is_commutative_op(op_kind_t op_kind) {
         case op_kind_t::_ne:
         case op_kind_t::_and:
         case op_kind_t::_or:
+        case op_kind_t::_xor:
         case op_kind_t::_add3: return true;
         default: return false;
     }
@@ -241,7 +243,8 @@ type_t binary_op_type(op_kind_t op_kind, const type_t &a, const type_t &b,
         return type_t::u32(a.elems(), attr);
     }
 
-    if (utils::one_of(op_kind, op_kind_t::_and, op_kind_t::_or)) {
+    if (utils::one_of(
+                op_kind, op_kind_t::_and, op_kind_t::_or, op_kind_t::_xor)) {
         if (a == b) return a;
         if (is_const(a_expr)) return b;
         if (is_const(b_expr)) return a;
@@ -405,6 +408,7 @@ DEFINE_BINARY_OPERATOR(<=, op_kind_t::_le)
 
 DEFINE_BINARY_OPERATOR(&, op_kind_t::_and)
 DEFINE_BINARY_OPERATOR(|, op_kind_t::_or)
+DEFINE_BINARY_OPERATOR(^, op_kind_t::_xor)
 
 #undef DEFINE_BINARY_OPERATOR
 

--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -183,11 +183,14 @@ type_attr_t common_attr(const type_t &a, const type_t &b) {
     return (a.attr() | b.attr()) & ~type_attr_t::mut;
 }
 
-type_t common_int_type(const type_t &_a, const type_t &_b) {
-    gpu_assert(_a.is_int() && _b.is_int()) << "Unexpected types.";
+type_t common_type(const type_t &base, const type_t &a, const type_t &b) {
+    auto attr = common_attr(a, b);
+    int elems = std::max(a.elems(), b.elems());
+    return type_t(base.kind(), elems, attr);
+}
 
-    type_attr_t attr = common_attr(_a, _b);
-    int elems = _a.elems();
+type_t common_int_type_impl(const type_t &_a, const type_t &_b) {
+    gpu_assert(_a.is_int() && _b.is_int()) << "Unexpected types.";
 
     // Promote to s32 first.
     type_t a = _a.size() < int(sizeof(int32_t)) ? type_t::s32() : _a;
@@ -198,31 +201,33 @@ type_t common_int_type(const type_t &_a, const type_t &_b) {
     // Integer promotion, follow C++ rules.
     int common_bits = 8 * std::max(a.size(), b.size());
     if (a.is_signed() == b.is_signed()) {
-        if (a.is_signed()) return type_t::s(common_bits, elems, attr);
-        return type_t::u(common_bits, elems, attr);
+        if (a.is_signed()) return type_t::s(common_bits);
+        return type_t::u(common_bits);
     }
 
-    if (a.size() >= b.size() && a.is_unsigned())
-        return type_t::u(common_bits, elems, attr);
-    if (b.size() >= a.size() && b.is_unsigned())
-        return type_t::u(common_bits, elems, attr);
-    if (a.size() > b.size() && a.is_signed())
-        return type_t::s(common_bits, elems, attr);
-    if (b.size() > a.size() && b.is_signed())
-        return type_t::s(common_bits, elems, attr);
+    if (a.size() >= b.size() && a.is_unsigned()) return type_t::u(common_bits);
+    if (b.size() >= a.size() && b.is_unsigned()) return type_t::u(common_bits);
+    if (a.size() > b.size() && a.is_signed()) return type_t::s(common_bits);
+    if (b.size() > a.size() && b.is_signed()) return type_t::s(common_bits);
 
-    return type_t::u(common_bits, elems, attr);
+    return type_t::u(common_bits);
 }
 
-type_t common_type(const type_t &a, const type_t &b) {
-    gpu_assert(a.elems() == b.elems())
-            << "Types must have the same number of components.";
+type_t common_int_type(const type_t &a, const type_t &b) {
+    return common_type(common_int_type_impl(a, b), a, b);
+}
+
+type_t common_type_impl(const type_t &a, const type_t &b) {
     if (a.is_undef() || b.is_undef()) return type_t::undef();
     if (a.is_fp() && !b.is_fp()) return a;
     if (!a.is_fp() && b.is_fp()) return b;
     if (a.is_fp() && b.is_fp()) return (a.size() > b.size() ? a : b);
     if (a.is_bool() && b.is_bool()) return a;
     return common_int_type(a, b);
+}
+
+type_t common_type(const type_t &a, const type_t &b) {
+    return common_type(common_type_impl(a, b), a, b);
 }
 
 type_t common_type(const expr_t &a, const expr_t &b) {
@@ -232,15 +237,12 @@ type_t common_type(const expr_t &a, const expr_t &b) {
 type_t binary_op_type(op_kind_t op_kind, const type_t &a, const type_t &b,
         const expr_t &a_expr = expr_t(), const expr_t &b_expr = expr_t()) {
     if (a.is_undef() || b.is_undef()) return type_t::undef();
-    gpu_assert(a.elems() == b.elems())
-            << "Types must have the same number of components.";
+    int elems = std::max(a.elems(), b.elems());
 
     type_attr_t attr = common_attr(a, b);
-    if (is_cmp_op(op_kind)) return type_t::_bool(a.elems(), attr);
+    if (is_cmp_op(op_kind)) return type_t::_bool(elems, attr);
     if (utils::one_of(op_kind, op_kind_t::_shl, op_kind_t::_shr)) {
-        gpu_assert(a.is_unsigned())
-                << "a must be unsigned for shift left/right.";
-        return type_t::u32(a.elems(), attr);
+        return a[elems].with_attr(attr);
     }
 
     if (utils::one_of(

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -2932,6 +2932,12 @@ public:
         return ((const func_impl_t *)impl())->call(args, attr);
     }
 
+    stmt_t operator()(const std::vector<expr_t> &args = {}) const {
+        return call(args);
+    }
+
+    stmt_t operator()(const expr_t &arg) const { return call({arg}); }
+
 private:
 #ifdef SANITY_CHECK
     void sanity_check() const override {

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -1120,6 +1120,7 @@ public:
     DECLARE_BINARY_ASSIGN_OPERATOR(/)
     DECLARE_BINARY_ASSIGN_OPERATOR(%)
     DECLARE_BINARY_ASSIGN_OPERATOR(&)
+    DECLARE_BINARY_ASSIGN_OPERATOR(^)
 
 #undef DECLARE_BINARY_ASSIGN_OPERATOR
 
@@ -1176,6 +1177,7 @@ enum class op_kind_t {
 
     _and,
     _or,
+    _xor,
 
     // Ternary operations.
     // Parametric ReLU.
@@ -2055,6 +2057,7 @@ DECLARE_BINARY_OPERATOR(<=, op_kind_t::_le)
 
 DECLARE_BINARY_OPERATOR(&, op_kind_t::_and)
 DECLARE_BINARY_OPERATOR(|, op_kind_t::_or)
+DECLARE_BINARY_OPERATOR(^, op_kind_t::_xor)
 
 #undef DECLARE_BINARY_OPERATOR
 

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -56,6 +56,7 @@
 // All IR statement objects.
 #define HANDLE_STMT_IR_OBJECTS() \
     HANDLE_IR_OBJECT(alloc_t) \
+    HANDLE_IR_OBJECT(assign_t) \
     HANDLE_IR_OBJECT(for_t) \
     HANDLE_IR_OBJECT(func_call_t) \
     HANDLE_IR_OBJECT(if_t) \
@@ -2322,6 +2323,42 @@ private:
         , body(body) {
         gpu_assert(!buf.type().is_ptr()) << buf;
     }
+};
+
+// Assignment of a value to a variable.
+// C++ equivalent:
+//    var = value;
+class assign_t : public stmt_impl_t {
+public:
+    IR_DECL_CORE_TYPE(assign_t)
+
+    static stmt_t make(const expr_t &var, const expr_t &value) {
+        return stmt_t(new assign_t(var, value));
+    }
+
+    bool is_equal(const object_impl_t &obj) const override {
+        if (!obj.is<self_type>()) return false;
+        auto &other = obj.as<self_type>();
+        return var.is_equal(other.var) && value.is_equal(other.value);
+    }
+
+    size_t get_hash() const override { return ir_utils::get_hash(var, value); }
+
+    std::string str() const override {
+        std::ostringstream oss;
+        oss << var.str() << "." << var.type().str();
+        oss << " = " << value.str();
+        return oss.str();
+    }
+
+    IR_DECLARE_TRAVERSERS()
+
+    expr_t var;
+    expr_t value;
+
+private:
+    assign_t(const expr_t &var, const expr_t &value)
+        : stmt_impl_t(_type_info()), var(var), value(value) {}
 };
 
 // Store to a GRF buffer.

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -498,6 +498,8 @@ public:
 
     bool is_slm() const { return any(attr() & type_attr_t::slm); }
 
+    type_t operator[](int elems) const { return with_elems(elems); }
+
     bool operator==(const type_t &other) const {
         return (kind() == other.kind()) && (elems() == other.elems())
                 && (is_ptr() == other.is_ptr());
@@ -630,6 +632,12 @@ public:
     type_t with_attr(type_attr_t attr) const {
         type_t copy = *this;
         copy.attr_ = attr;
+        return copy;
+    }
+
+    type_t with_kind(type_kind_t kind) const {
+        type_t copy = *this;
+        copy.kind_ = kind;
         return copy;
     }
 

--- a/src/gpu/intel/jit/ir/epilogue.cpp
+++ b/src/gpu/intel/jit/ir/epilogue.cpp
@@ -43,7 +43,7 @@ public:
     expr_t create_mask(const layout_t &reg_layout, const tile_t &tile,
             const coord_t &coord) const {
         gpu_assert(!is_empty());
-        auto layout = reg_layout.map(tile, coord);
+        auto layout = reg_layout.sub(tile, coord);
         auto view = mem_view_.create_sub_view(tile, coord);
         mask_tensor_t mask_tensor(layout);
         icoord_t args(layout.ndims());
@@ -159,9 +159,9 @@ public:
         if (!reg_layout_.is_empty()) {
             if (needs_reduction()) {
                 tile_coord_t reduce_tile(_tile_coord.tile, tile_coord.coord);
-                ret.reg_layout_ = ret.reg_layout_.map(reduce_tile);
+                ret.reg_layout_ = ret.reg_layout_.sub(reduce_tile);
             } else {
-                ret.reg_layout_ = ret.reg_layout_.map(tile_coord);
+                ret.reg_layout_ = ret.reg_layout_.sub(tile_coord);
             }
         }
         ret.allocs_.clear();
@@ -537,7 +537,7 @@ public:
         pvar_t inner_dim;
         auto base_inner_tile
                 = find_1d_tile(lhs_tensor.reg_layout().type(), args, inner_dim);
-        auto inner_layout = lhs_tensor.reg_layout().map(base_inner_tile);
+        auto inner_layout = lhs_tensor.reg_layout().sub(base_inner_tile);
         gpu_assert(!inner_dim.is_undef());
 
         // All post-ops arguments are f32 type except f64 bias and u64
@@ -839,7 +839,7 @@ private:
             base_tile = c_mem_view_.split_into_max_tile(
                     tmp_buf_elems, /*is_dense=*/false);
             try {
-                c_reg_layout.map(base_tile);
+                c_reg_layout.sub(base_tile);
                 break;
             } catch (std::runtime_error &) {
                 tmp_buf_elems /= 2;
@@ -890,7 +890,7 @@ private:
         // Iterate by tiles and apply post-ops.
         c_mem_view_.for_each_tile(base_tile, [&](const icoord_t &start) {
             tile_coord_t tile_coord(base_tile, start);
-            auto c_tile_layout = c_reg_layout.map(tile_coord);
+            auto c_tile_layout = c_reg_layout.sub(tile_coord);
             build_tile(tile_coord, c_tile_layout, c_reg_buf);
         });
 

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -121,9 +121,9 @@ bool dpas_t::matches(const multiply_desc_t &desc) const {
     if (desc.m() % m_blk != 0 || desc.k() % k_blk != 0) return false;
 
     auto a_blk_layout
-            = desc.a_layout().map(tile_t(std::vector<dim_t> {m_blk, k_blk}));
+            = desc.a_layout().sub(tile_t(std::vector<dim_t> {m_blk, k_blk}));
     auto b_blk_layout
-            = desc.b_layout().map(tile_t(std::vector<dim_t> {k_blk, n_blk}));
+            = desc.b_layout().sub(tile_t(std::vector<dim_t> {k_blk, n_blk}));
 
     if (a_blk_layout != a_layout()) return false;
     if (b_blk_layout != b_layout()) return false;

--- a/src/gpu/intel/jit/ir/ir.cpp
+++ b/src/gpu/intel/jit/ir/ir.cpp
@@ -39,6 +39,11 @@ class ir_printer_t : public ir_visitor_t {
 public:
     ir_printer_t(std::ostream &out) : out_(out) {}
 
+    void _visit(const assign_t &obj) override {
+        print_indent();
+        out_ << obj.str() << "\n";
+    }
+
     void _visit(const alloc_t &obj) override {
         auto grf_size = 1; // Assume all objects are grf aligned
         auto guard = mem_usage_guard(obj.register_alloc_size(grf_size));

--- a/src/gpu/intel/jit/ir/ir.hpp
+++ b/src/gpu/intel/jit/ir/ir.hpp
@@ -54,15 +54,22 @@ public:
     }
 
     std::string create_tmp_name(const std::string &prefix = "tmp") {
-        int &id = prefix_ids_[prefix];
-        auto name = prefix + "_" + std::to_string(id);
-        id++;
+        auto name = prefix;
+        if (all_names_.count(prefix) != 0) {
+            int &id = prefix_ids_[prefix];
+            do {
+                id++;
+                name = prefix + "_" + std::to_string(id);
+            } while (all_names_.count(name) != 0);
+        }
+        all_names_.insert(name);
         return name;
     }
 
 private:
     exec_config_t exec_cfg_;
     constraint_set_t &cset_;
+    std::unordered_set<std::string> all_names_;
     std::unordered_map<std::string, int> prefix_ids_;
 };
 

--- a/src/gpu/intel/jit/ir/kernel_info.hpp
+++ b/src/gpu/intel/jit/ir/kernel_info.hpp
@@ -111,6 +111,13 @@ public:
         return expr_t();
     }
 
+    int index(const std::string &name) const {
+        for (int i = 0; i < nargs(); i++) {
+            if (args_[i].name() == name) return i;
+        }
+        return -1;
+    }
+
     void register_arg(const expr_t &var) { args_.emplace_back(var); }
 
     void register_arg(const std::string &name, const type_t &type) {

--- a/src/gpu/intel/jit/ir/problem.hpp
+++ b/src/gpu/intel/jit/ir/problem.hpp
@@ -213,6 +213,13 @@ public:
         return map_[key];
     }
 
+    template <typename DerivedT>
+    DerivedT with_impl(const pvar_t &key, const ValueT &value) const {
+        DerivedT ret = static_cast<const DerivedT &>(*this);
+        ret[key] = value;
+        return ret;
+    }
+
     const ValueT &at(const pvar_t &key) const { return operator[](key); }
     const ValueT &at(size_t idx) const {
         return operator[](into<dim_idx_t>(idx));
@@ -434,6 +441,9 @@ public:
         coord_t ret;
         ret.set_valid(false);
         return ret;
+    }
+    coord_t with(const pvar_t &key, const expr_t &value) const {
+        return pvar_map_t<expr_t>::with_impl<coord_t>(key, value);
     }
 };
 

--- a/src/gpu/intel/jit/ir/reduce.cpp
+++ b/src/gpu/intel/jit/ir/reduce.cpp
@@ -68,7 +68,7 @@ stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
             continue;
         }
     }
-    dst_aligned = dst_aligned.map(sub_tile, sub_coord);
+    dst_aligned = dst_aligned.sub(sub_tile, sub_coord);
 
     auto func = reduce_t::make(src, dst_aligned);
     return func.call({dst_buf, src_buf});

--- a/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
+++ b/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
@@ -71,7 +71,7 @@ void slm_reduce_builder_t::build() {
         write_start[ndims + i] = tg_grid_.idx(i);
     }
     auto write = make_access_builder(*ir_ctx_,
-            view_t(slm_layout.map(write_tile, write_start)), slm_buf_, reg_buf_,
+            view_t(slm_layout.sub(write_tile, write_start)), slm_buf_, reg_buf_,
             send_op_t::store, send_address_t::slm);
     store_stmt_ = write.stmt();
 
@@ -83,7 +83,7 @@ void slm_reduce_builder_t::build() {
     grid_info_t full_grid = tg_grid_.sub_grid({dim_});
     grid_info_t split_grid;
     auto local_thr_tile_coord = reg_layout_.split(full_grid, &split_grid);
-    reg_layout_ = reg_layout_.map(local_thr_tile_coord.tile);
+    reg_layout_ = reg_layout_.sub(local_thr_tile_coord.tile);
 
     if (split_grid.elems() != full_grid.elems()) {
         for (dim_idx_t i = 0; i < full_grid.ndims(); i++) {
@@ -112,7 +112,7 @@ void slm_reduce_builder_t::build() {
         read_start[ndims + i] = (i == dim_) ? 0 : tg_grid_.idx(i);
     }
     auto read = make_access_builder(*ir_ctx_,
-            view_t(slm_layout.map(read_tile, read_start)), slm_buf_,
+            view_t(slm_layout.sub(read_tile, read_start)), slm_buf_,
             tmp_reg_buf_, send_op_t::load, send_address_t::slm);
 
     load_stmt_

--- a/src/gpu/intel/jit/ir/tensor.cpp
+++ b/src/gpu/intel/jit/ir/tensor.cpp
@@ -148,7 +148,7 @@ memory_desc_t layout_t::to_dnnl(const dim_t *dims_hint) const {
     return md;
 }
 
-layout_t layout_t::map(const tile_t &tile, const coord_t &start) const {
+layout_t layout_t::sub(const tile_t &tile, const coord_t &start) const {
     auto remaining_tile = tile;
     std::vector<layout_block_t> mapped_blocks;
 
@@ -174,7 +174,7 @@ layout_t layout_t::map(const tile_t &tile, const coord_t &start) const {
             // scratch.
             if (block % rem_dim == 0)
                 return split_block(eb, rem_dim, block / rem_dim)
-                        .map(tile, start);
+                        .sub(tile, start);
 
             // TODO: Remove exception usage.
             gpu_except_not_implemented("Can't map tensor layout.");

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -607,10 +607,10 @@ public:
     // Assumption: the original layout can be tiled by the passed sub-tensor.
     // For example: XaYb4a2b can be tiled into 2x2 sub-tensors but it's not
     // possible to tile it into 3x2 sub-tensors.
-    layout_t map(const tile_t &tile, const coord_t &start = {}) const;
+    layout_t sub(const tile_t &tile, const coord_t &start = {}) const;
 
-    layout_t map(const tile_coord_t &tile_coord) const {
-        return map(tile_coord.tile, tile_coord.coord);
+    layout_t sub(const tile_coord_t &tile_coord) const {
+        return sub(tile_coord.tile, tile_coord.coord);
     }
 
     layout_t reinterpret(
@@ -1184,9 +1184,9 @@ public:
         }
     }
 
-    mask_tensor_t map(const tile_t &tile, const coord_t &start) const {
+    mask_tensor_t sub(const tile_t &tile, const coord_t &start) const {
         icoord_t tile_start(start);
-        auto sub_layout = layout_.map(tile);
+        auto sub_layout = layout_.sub(tile);
         mask_tensor_t sub_mask(sub_layout);
         for_each(tile, [&](const icoord_t &sub_start) {
             dim_t sub_off = sub_layout.offset<dim_t>(sub_start);
@@ -1632,8 +1632,8 @@ public:
 
     layout_t create_vlayout(bool force_zero_offset = false) const {
         gpu_assert(can_convert_to_vlayout()) << "Can't convert view to layout.";
-        if (force_zero_offset) return tlayout_.map(vdims_);
-        return tlayout_.map(vdims_, vstart_);
+        if (force_zero_offset) return tlayout_.sub(vdims_);
+        return tlayout_.sub(vdims_, vstart_);
     }
 
     dim_t vlayout_size() const { return create_vlayout().size(); }

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -307,6 +307,10 @@ public:
         sanity_check();
     }
 
+    layout_t(const type_t &type, const expr_t &offset,
+            const std::vector<layout_block_t> &blocks, bool do_normalize = true)
+        : layout_t(type, dim_idx::invalid, offset, blocks, do_normalize) {}
+
     layout_t(const type_t &type, const expr_t &offset, const layout_t &other,
             bool do_normalize)
         : layout_t(type, other.ndims(), offset, other.blocks(), do_normalize) {}
@@ -396,15 +400,7 @@ public:
         return tile;
     }
 
-    dim_t dim(const pvar_t &dim) const {
-        dim_t ret = 1;
-        for (auto &b : blocks_) {
-            if (b.dim == dim) ret *= b.block;
-        }
-        return ret;
-    }
-
-    dim_t dim(dim_idx_t dim_idx) const { return dim(pvar_t(dim_idx)); }
+    dim_t dim(const pvar_t &dim) const { return elems(dim); }
 
     stride_t stride(const pvar_t &dim, int dim_block_idx = 0) const {
         int idx = 0;

--- a/src/gpu/intel/jit/pass/simplify.cpp
+++ b/src/gpu/intel/jit/pass/simplify.cpp
@@ -1906,7 +1906,7 @@ struct op_traits_t {};
                 typename = typename std::enable_if<dummy_op == op_kind_t::_and \
                         || dummy_op == op_kind_t::_or>::type> \
         static bool compute(bool a, bool b) { \
-            return a op b; \
+            return static_cast<bool>(a op b); \
         } \
     };
 
@@ -1923,6 +1923,9 @@ DECL_OP_TRAITS(op_kind_t::_le, <=)
 
 DECL_OP_TRAITS(op_kind_t::_and, &)
 DECL_OP_TRAITS(op_kind_t::_or, |)
+DECL_OP_TRAITS(op_kind_t::_xor, ^)
+DECL_OP_TRAITS(op_kind_t::_shl, <<)
+DECL_OP_TRAITS(op_kind_t::_shr, >>)
 
 template <>
 struct op_traits_t<op_kind_t::_min> {
@@ -2032,6 +2035,9 @@ public:
 
             CASE(op_kind_t::_and)
             CASE(op_kind_t::_or)
+            CASE(op_kind_t::_xor)
+            CASE(op_kind_t::_shl)
+            CASE(op_kind_t::_shr)
             CASE(op_kind_t::_min)
             CASE(op_kind_t::_max)
 

--- a/src/gpu/intel/jit/pass/slm.cpp
+++ b/src/gpu/intel/jit/pass/slm.cpp
@@ -124,8 +124,8 @@ private:
             auto src_tile = src_it.tile();
             auto dst_tile = dst_it.tile();
             if (src_tile == dst_tile) {
-                auto s = src.map(src_it.tile());
-                auto d = dst.map(dst_it.tile());
+                auto s = src.sub(src_it.tile());
+                auto d = dst.sub(dst_it.tile());
                 if (s.is_dense() && d.is_dense()
                         && src_it.outer_layout() == dst_it.outer_layout()) {
                     if (is_slm_reorder_ok(s, d)) {
@@ -153,7 +153,7 @@ private:
 
     stmt_t create_slm_reorder(const tile_t &tile, const layout_t &src,
             const layout_t &dst, const expr_t &src_buf, const expr_t &dst_buf) {
-        auto src_tile = src.map(tile);
+        auto src_tile = src.sub(tile);
         auto &src_tile_blocks = src_tile.blocks();
         int simd = into<int>(src_tile_blocks[0].block);
         int vect_size = into<int>(src_tile_blocks[1].block);


### PR DESCRIPTION
PR extends the IR/DSL functionality and includes other minor changes.

Full list of changes:

- IR changes:
    - Introduced `assign_t`
    - Extended `shuffle_t` to support SIMD types (used by `dsl::extract` to extract i-th component from a SIMD expression)
    - Added left/right shift and xor operations support
    - Adjusted type deduction to take into account SIMD types
    - Extended `type_t` to support `type[elems]` as a shortcut for `type.with_elems(elems)`
- DSL changes
    - Added `dsl::ctx_t::new_ir_api()` to enable new IR semantics with `assign_t` and without alloc/let
        - We should fully migrate to the new semantics in the future and drop this flag
    - Migrated DSL to rely on `jit::layout_t` instead of v2 (which is possible after #3604)
    - Introduced `dsl::def_slm()` to allocate SLM tensors
    - Introduced `dsl::_for` for for loops
    - Introduced `dsl/decl.hpp` for shorter aliases for types and `expr_t`.

There are conflicts with #3729 so this PR should be merged after #3729.
