### PR TITLE
cpu: aarch64: support arbitrary eltwise post-ops in acl_post_ops_t

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.cpp
+++ b/src/cpu/aarch64/acl_post_ops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Arm Ltd. and affiliates
+* Copyright 2022-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,40 +53,11 @@ status_t acl_post_ops_t::execute(
         } else if (post_op->kind() == primitive_kind::eltwise) {
             // The post op at the sum index must be binary
             if (post_op_index == sum_index) return status::runtime_error;
-
-            auto eltwise_post_op
-                    = dynamic_cast<acl_eltwise_fwd_t *>(post_op.get());
-            if (eltwise_post_op == nullptr) return status::runtime_error;
-
-            if (dst_data_type == data_type::f16) {
-                // in this case we want to cast the src tensor up to fp32
-                arm_compute::TensorInfo src_info
-                        = eltwise_post_op->pd()->aep.data_info;
-                // new src tensor with fp32 datatype
-                arm_compute::Tensor src_tensor;
-                src_tensor.allocator()->init(src_info);
-                src_tensor.allocator()->allocate();
-                float *src_f32 = (float *)src_tensor.buffer();
-                // total_size gives the size in bytes, we divide by 4 because the src_tensor is fp32
-                size_t num_elements = src_tensor.info()->total_size() / 4;
-                // cast src up to fp32 and store the result in src_f32
-                cvt_float16_to_float(
-                        src_f32, (dnnl::impl::float16_t *)src, num_elements);
-                // perform the operation in fp32
-                status_t eltwise_status = eltwise_post_op->execute_forward(
-                        ctx, src_f32, src_f32);
-                if (eltwise_status == status::success) {
-                    // cast src_f32 down and store final result in src
-                    cvt_float_to_float16((dnnl::impl::float16_t *)src, src_f32,
-                            num_elements);
-                }
-                src_tensor.allocator()->free();
-                CHECK(eltwise_status);
-
-            } else {
-                CHECK(eltwise_post_op->execute_forward(ctx, src, src));
-            }
-
+            exec_args_t eltwise_args;
+            eltwise_args[DNNL_ARG_DST] = ctx.args().at(DNNL_ARG_DST);
+            eltwise_args[DNNL_ARG_SRC] = ctx.args().at(DNNL_ARG_DST);
+            exec_ctx_t eltwise_ctx(ctx, std::move(eltwise_args));
+            CHECK(post_op->execute(eltwise_ctx));
         } else {
             return status::runtime_error;
         }

--- a/src/cpu/aarch64/acl_post_ops.hpp
+++ b/src/cpu/aarch64/acl_post_ops.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Arm Ltd. and affiliates
+* Copyright 2022-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #ifndef CPU_AARCH64_ACL_POST_OPS_HPP
 #define CPU_AARCH64_ACL_POST_OPS_HPP
 
+#include "common/primitive_desc_iterator.hpp"
 #include "cpu/aarch64/acl_binary.hpp"
 #include "cpu/aarch64/acl_eltwise.hpp"
 
@@ -97,31 +98,29 @@ struct acl_post_ops_t {
                 ACL_CHECK_SUPPORT(po.eltwise.scale != 1.0f,
                         "eltwise post op scale must be 1 (no scale)");
 
-                eltwise_desc_t eltwise_desc;
-                eltwise_desc.primitive_kind = primitive_kind::eltwise;
-                eltwise_desc.alg_kind = po.eltwise.alg;
-                eltwise_desc.alpha = po.eltwise.alpha;
-                eltwise_desc.beta = po.eltwise.beta;
-                memory_desc_t temp_dst = dst_md;
-                // pass eltwise a desc with f32 datatype to perform the operation in fp32 rather than fp16
-                // since oneDNN requires all post-ops to run in fp32.
-                // we don't need to do that to the other post-ops as executing them in fp16 yields the same result.
-                if (dst_data_type == data_type::f16) {
-                    temp_dst.data_type = data_type::f32;
-                }
-                eltwise_desc.src_desc = temp_dst;
-                eltwise_desc.dst_desc = temp_dst;
-                eltwise_desc.prop_kind = prop_kind_t::dnnl_forward;
+                // Use the helper function to validate the descriptor arguments and
+                // assign them to our eltwise_desc_t
+                eltwise_desc_t ed;
+                CHECK(eltwise_desc_init(&ed, prop_kind_t::dnnl_forward,
+                        po.eltwise.alg, &dst_md, &dst_md, nullptr, nullptr,
+                        po.eltwise.alpha, po.eltwise.beta));
+
+                // Use an iterator to locate an implementation for this engine
                 auto empty_attr = dnnl_primitive_attr();
-                typename acl_eltwise_fwd_t::pd_t acl_eltwise_pd(
-                        &eltwise_desc, &empty_attr, nullptr);
-                CHECK(acl_eltwise_pd.init(engine));
+                primitive_desc_iterator_t it(engine,
+                        reinterpret_cast<const op_desc_t *>(&ed), &empty_attr,
+                        nullptr);
 
-                auto acl_eltwise
-                        = std::make_shared<acl_eltwise_fwd_t>(&acl_eltwise_pd);
-                CHECK(acl_eltwise->init(engine));
-                post_op_primitives.push_back(acl_eltwise);
+                // No implementations available
+                if (++it == it.end()) { return status::unimplemented; }
 
+                // We found an implementation; grab the first implementation descriptor
+                std::shared_ptr<primitive_desc_t> eltwise_pd = *it;
+
+                // Construct the primitive
+                std::shared_ptr<primitive_t> eltwise_prim;
+                CHECK(eltwise_pd->create_primitive(eltwise_prim, engine));
+                post_op_primitives.push_back(eltwise_prim);
             } else {
                 // Unsupported catchall
                 return status::unimplemented;
@@ -139,21 +138,23 @@ struct acl_post_ops_t {
             const memory_desc_t &dst_md,
             arm_compute::ActivationLayerInfo &act_info_to_fuse,
             int post_op_start_index = 0) {
-
         CHECK(base_post_ops.set_default_formats(&dst_md));
         dst_data_type = dst_md.data_type;
         // If the first entry is eltwise, we fuse it, except when the datatype
         // is fp16 because in this case we want to execute the eltwise in fp32.
         if (base_post_ops.len() >= 1 && base_post_ops.entry_[0].is_eltwise()
                 && dst_data_type != data_type::f16) {
-
             const auto &first_po = base_post_ops.entry_[0].eltwise;
             ACL_CHECK_SUPPORT(first_po.scale != 1.0f,
                     "eltwise post op scale must be 1 (no scale)");
-            CHECK(acl_utils::convert_to_acl_act(first_po, act_info_to_fuse));
+
+            auto offset
+                    = (acl_utils::convert_to_acl_act(first_po, act_info_to_fuse)
+                            == status::success);
 
             // post_op_start_index + 1 to skip the fused eltwise
-            return init(engine, base_post_ops, dst_md, post_op_start_index + 1);
+            return init(engine, base_post_ops, dst_md,
+                    post_op_start_index + offset);
         } else {
             // Nothing to fuse, just copy all post ops
             return init(engine, base_post_ops, dst_md, post_op_start_index);


### PR DESCRIPTION
## Description
The class `acl_post_ops_t`, commonly used by ACL operations, supports element-wise operations that have an ACL implementation only (e.g. ACL `inner_product` + ACL `gelu_erf`). This PR extends the class to handling arbitrary element-wise post-ops, e.g. an ACL `inner_product` followed by a JIT activation. 

### Example (`inner_product` + `eltwise_swish`)

**Command:**

```bash
>>> ONEDNN_VERBOSE=all ./tests/benchdnn/benchdnn --mode=R --ip --attr-post-ops=eltwise_swish --dt=f32 mb1ic256oc256
```

**Output before change:**

`inner_product` falls back to `gemm:ref` to support JIT `eltwise_swish`.

```bash
onednn_verbose,v1,info,oneDNN v3.10.0 (commit ffa3f03e1a5ecc648741ca37de69f4ad9aafc3ad)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:48
onednn_verbose,v1,info,cpu,isa:AArch64 SVE (256 bits)
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,primitive,create:cache_miss,cpu,inner_product,gemm:ref,forward_training,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:ab::f0 bia:f32:a:blocked:a::f0 dst:f32:a:blocked:ab::f0,attr-post-ops:eltwise_swish,,mb1ic256oc256,0.0219727
onednn_verbose,v1,primitive,create:cache_hit,cpu,inner_product,gemm:ref,forward_training,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:ab::f0 bia:f32:a:blocked:a::f0 dst:f32:a:blocked:ab::f0,attr-post-ops:eltwise_swish,,mb1ic256oc256,0.000976562
onednn_verbose,v1,primitive,exec,cpu,inner_product,gemm:ref,forward_training,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:ab::f0 bia:f32:a:blocked:a::f0 dst:f32:a:blocked:ab::f0,attr-post-ops:eltwise_swish,,mb1ic256oc256,1.28418
0:EXECUTED (5 ms) __REPRO: --mode=R --mode-modifier=M --ip --attr-post-ops=swish mb1ic256oc256
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (2%); create_prim: 0.00s (7%); fill: 0.00s (0%); execute: 0.00s (25%);
```

**Output after change:**

`inner_product` can use the `acl` implementation with the JIT `eltwise_swish`.

```bash
onednn_verbose,v1,info,oneDNN v3.9.0 (commit 0abfca1947b53c03ee74207e4710941ab6456f3b)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:48
onednn_verbose,v1,info,cpu,isa:AArch64 SVE (128 bits)
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,create_nested:cache_miss,cpu,eltwise,jit:sve_128,forward_training,data:f32::blocked:ab::f0,,alg:eltwise_swish alpha:0 beta:0,1x256,12.2339
onednn_verbose,v1,primitive,create:cache_miss,cpu,inner_product,acl,forward_training,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:Ab4a::f0 bia:f32:a:blocked:a::f0 dst:f32:a:blocked:ab::f0,attr-post-ops:eltwise_swish,,mb1ic256oc256,3.05908
onednn_verbose,v1,primitive,create:cache_hit,cpu,inner_product,acl,forward_training,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:Ab4a::f0 bia:f32:a:blocked:a::f0 dst:f32:a:blocked:ab::f0,attr-post-ops:eltwise_swish,,mb1ic256oc256,0.0170898
onednn_verbose,v1,primitive,exec:external,CpuGemmAssemblyWrapperKernel/sve_ffhybrid_fp32_mla_6x4VL,2.42407
onednn_verbose,v1,primitive,exec,cpu,inner_product,acl,forward_training,src:f32:a:blocked:ab::f0 wei:f32:a:blocked:Ab4a::f0 bia:f32:a:blocked:a::f0 dst:f32:a:blocked:ab::f0,attr-post-ops:eltwise_swish,,mb1ic256oc256,4.19385
0:EXECUTED (51 ms) __REPRO: --mode=R --mode-modifier=M --ip --attr-post-ops=swish mb1ic256oc256
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.05s; create_pd: 0.03s (65%); create_prim: 0.00s (6%); fill: 0.00s (0%); execute: 0.01s (12%);
```

_N.B. The outputs before and after have been collected on two different AArch64 machines so don't rely heavily on the timings._