### PR TITLE
xe: jit: dsl: add forward declaration concept to DSL

### DIFF
--- a/src/gpu/intel/jit/dsl/decl.hpp
+++ b/src/gpu/intel/jit/dsl/decl.hpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_DSL_DECL_HPP
+#define GPU_INTEL_JIT_DSL_DECL_HPP
+
+#include "gpu/intel/jit/ir/core.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+namespace dsl {
+
+static type_t _bool = type_t::_bool();
+static type_t s8 = type_t::s8();
+static type_t u8 = type_t::u8();
+static type_t s16 = type_t::s16();
+static type_t u16 = type_t::u16();
+static type_t s32 = type_t::s32();
+static type_t u32 = type_t::u32();
+static type_t s64 = type_t::s64();
+static type_t u64 = type_t::u64();
+static type_t f32 = type_t::f32();
+static type_t f16 = type_t::f16();
+static type_t bf16 = type_t::bf16();
+
+using expr_t = jit::expr_t;
+
+} // namespace dsl
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/intel/jit/dsl/dsl.cpp
+++ b/src/gpu/intel/jit/dsl/dsl.cpp
@@ -107,12 +107,12 @@ struct ctx_t {
         return def(value.type(), name, value);
     }
 
-    tensor_t def(const v2::layout_t &layout, const std::string &name,
+    tensor_t def(const layout_t &layout, const std::string &name,
             const expr_t &value = {}) {
         // Tensors need to be grf-aligned for loading/storing
         // TODO: IR should be modified to enable loading small tensors (such as
         // scalar values) without GRF alignment.
-        auto elems = std::max(layout.type().elems() * layout.elems(),
+        auto elems = std::max(into<int>(layout.type().elems() * layout.elems()),
                 grf_size() / layout.type().scalar().size());
         auto t = type_t(layout.type().kind(), elems);
         return {def(t, name, value, true), layout};
@@ -318,14 +318,14 @@ void scatter_send(const tensor_t &t, const global_tensor_t &g,
 void block_send(const tensor_t &t, const global_tensor_t &g,
         send_kind_t &op_kind, const icoord_t &base, const send_hint_t &hint) {
     bool is_prefetch = t.buf.is_empty();
-    auto &operation_tile = is_prefetch ? g.tile : t.layout.int_dim_sizes();
+    auto &operation_tile = is_prefetch ? g.tile : t.layout.tile();
 
     pvar_t w_dim;
     tile_t tile;
     for (auto &var : operation_tile) {
         if (is_const(g.strides[var]) && to_cpp<dim_t>(g.strides[var]) == 1
-                && !t.layout.is_scalar()) {
-            tile[var] = t.layout.blocks()[0].int_size();
+                && t.layout.elems() != 1) {
+            tile[var] = t.layout.blocks()[0].block;
             gpu_assert(t.layout.blocks()[0].dim == var);
             w_dim = var;
         } else {
@@ -397,7 +397,7 @@ void block_2d_send(const conf_2d_t &conf, const tensor_t &t,
         const send_hint_t &hint) {
 
     bool is_prefetch = t.buf.is_empty();
-    auto &operation_tile = is_prefetch ? g.tile : t.layout.int_dim_sizes();
+    auto &operation_tile = is_prefetch ? g.tile : t.layout.tile();
 
     pvar_t w_dim = conf.w_dim;
     pvar_t h_dim;
@@ -449,7 +449,7 @@ void block_2d_send(const conf_2d_t &conf, const tensor_t &t,
 void send(const tensor_t &t, const global_tensor_t &g, send_kind_t op_kind,
         const icoord_t &base, const send_hint_t &hint) {
     bool is_prefetch = t.buf.is_empty();
-    auto &operation_tile = is_prefetch ? g.tile : t.layout.int_dim_sizes();
+    auto &operation_tile = is_prefetch ? g.tile : t.layout.tile();
     pvar_t w_dim;
     for (auto &var : operation_tile) {
         if (is_const(g.strides[var]) && to_cpp<dim_t>(g.strides[var]) == 1) {
@@ -466,8 +466,8 @@ void send(const tensor_t &t, const global_tensor_t &g, send_kind_t op_kind,
         auto conf = [&]() -> conf_2d_t {
             if (is_prefetch) { return {g.type, w_dim, 0, false, false, false}; }
             auto &l = t.layout;
-            int pack_dim = l.blocks()[0].int_size() * l.type().size() == 4;
-            int pack_size = l.blocks()[pack_dim].int_size();
+            int pack_dim = l.blocks()[0].block * l.type().size() == 4;
+            int pack_size = into<int>(l.blocks()[pack_dim].block);
             bool is_transpose_vnni = l.blocks()[pack_dim].dim != w_dim;
             bool is_vnni = pack_dim == 1 && !is_transpose_vnni;
             bool is_store = op_kind == send_kind_t::store;
@@ -481,7 +481,7 @@ void send(const tensor_t &t, const global_tensor_t &g, send_kind_t op_kind,
         }
     }
 
-    if (is_prefetch || t.layout.is_scalar()
+    if (is_prefetch || t.layout.elems() == 1
             || t.layout.blocks()[0].dim == w_dim) {
         block_send(t, g, op_kind, base, hint);
     } else {
@@ -523,7 +523,7 @@ void mma(const tensor_t &C, const tensor_t &A, const tensor_t &B,
 
         gpu_assert(tile[dim_simd] % simd == 0);
         gpu_assert(tile[dim_sdepth] % (sdepth_pack * sdepth) == 0);
-        gpu_assert(C.layout.blocks()[0].size == simd);
+        gpu_assert(C.layout.blocks()[0].block == simd);
         std::vector<stmt_t> dpas_stmts;
 
         v2::for_each(tile, inst_tile, [&](const icoord_t &coord) {
@@ -564,8 +564,8 @@ void mma(const tensor_t &C, const tensor_t &A, const tensor_t &B,
         int K = (int)inst_tile.get(k_dim, 1);
         bool is_a_bcast = (M * K == 1);
         bool is_b_bcast = (K * N == 1);
-        int a_stride = is_a_bcast ? 0 : to_cpp<int>(A.layout.stride(m_dim));
-        int b_stride = is_b_bcast ? 0 : to_cpp<int>(B.layout.stride(n_dim));
+        int a_stride = is_a_bcast ? 0 : into<int>(A.layout.stride(m_dim));
+        int b_stride = is_b_bcast ? 0 : into<int>(B.layout.stride(n_dim));
 
         gpu_assert(tile[dim_simd] * C.layout.type().size() % grf_size() == 0);
         v2::for_each(tile, inst_tile, [&](const icoord_t &coord) {
@@ -590,7 +590,7 @@ void mma(const tensor_t &C, const tensor_t &A, const tensor_t &B,
 
 void binary(op_kind_t op, const tensor_t &dst, const tensor_t &src0,
         const tensor_t &src1) {
-    tile_t tile = dst.layout.int_dim_sizes();
+    tile_t tile = dst.layout.tile();
     tile_t matching_subtile = [&] {
         tile_t ret;
         for (auto &var : tile) {
@@ -603,9 +603,8 @@ void binary(op_kind_t op, const tensor_t &dst, const tensor_t &src0,
         for (size_t i = 0; i < bd.size(); i++) {
             if (b0.size() <= i) break;
             if (b1.size() <= i) break;
-            if (bd[i] == b0[i] && bd[i] == b1[i] && bd[i].has_const_size()
-                    && bd[i].has_const_stride())
-                ret[bd[i].dim] *= bd[i].int_size();
+            if (bd[i] == b0[i] && bd[i] == b1[i])
+                ret[bd[i].dim] *= bd[i].block;
             else
                 break;
         }

--- a/src/gpu/intel/jit/dsl/dsl.cpp
+++ b/src/gpu/intel/jit/dsl/dsl.cpp
@@ -30,8 +30,12 @@ namespace jit {
 namespace dsl {
 
 struct ctx_t {
+    bool new_ir_api() const { return new_ir_api_; }
 
-    void declare_kernel(const kernel_iface_t &interface, ir_context_t &ctx) {
+    void declare_kernel(const kernel_iface_t &interface, ir_context_t &ctx,
+            bool new_ir_api = false) {
+        slm_byte_offset_ = 0;
+        new_ir_api_ = new_ir_api;
         gpu_assert(stmts_stack_.empty())
                 << "Invalid generation of a kernel within a kernel";
         interface_ = interface;
@@ -39,25 +43,39 @@ struct ctx_t {
 
         begin_scope();
 
-        for (int i = 0; i < interface.nargs(); i++) {
-            const auto &var = interface.arg_var(i);
-            if (var.type().is_ptr()) {
-                if (var.type().is_slm()) {
-                    append(alloc_t::make(var, 0, alloc_kind_t::slm, stmt_t {}));
-                } else {
-                    append(alloc_t::make(
-                            var, 0, alloc_kind_t::global, stmt_t {}));
-                }
-            } else {
-                append(let_t::make(var, {}, {}));
+        if (new_ir_api_) {
+            for (int i = 0; i < 3; i++) {
+                local_sizes_[i] = var_t::make(local_size_type(),
+                        std::string("local_size_") + "012"[i]);
+                local_ids_[i] = var_t::make(
+                        local_id_type(), std::string("local_id_") + "012"[i]);
+                group_ids_[i] = var_t::make(
+                        group_id_type(), std::string("group_id_") + "012"[i]);
             }
-        }
+        } else {
+            for (int i = 0; i < interface.nargs(); i++) {
+                const auto &var = interface.arg_var(i);
+                if (var.type().is_ptr()) {
+                    if (var.type().is_slm()) {
+                        append(alloc_t::make(
+                                var, 0, alloc_kind_t::slm, stmt_t {}));
+                    } else {
+                        append(alloc_t::make(
+                                var, 0, alloc_kind_t::global, stmt_t {}));
+                    }
+                } else {
+                    if (!new_ir_api_) append(let_t::make(var, {}, {}));
+                }
+            }
 
-        for (int i = 0; i < 3; i++) {
-            group_ids_[i] = let(type_t::u32(), ir_builder_t::tg_idx(i), {});
-            local_ids_[i] = let(type_t::u16(), ir_builder_t::local_id(i), {});
-            local_sizes_[i]
-                    = let(type_t::u16(), ir_builder_t::local_size(i), {});
+            for (int i = 0; i < 3; i++) {
+                group_ids_[i]
+                        = let(group_id_type(), ir_builder_t::tg_idx(i), {});
+                local_ids_[i]
+                        = let(local_id_type(), ir_builder_t::local_id(i), {});
+                local_sizes_[i] = let(
+                        local_size_type(), ir_builder_t::local_size(i), {});
+            }
         }
     }
 
@@ -89,7 +107,7 @@ struct ctx_t {
             bool force_alloc = false) {
         auto type = type_t(
                 _type.kind(), _type.elems(), _type.attr() | type_attr_t::mut);
-        auto alloc_var = var(type, name);
+        auto alloc_var = var(type, ctx_->create_tmp_name(name));
         if (force_alloc || type.is_ptr()) {
             append(alloc_t::make(alloc_var, {}));
 
@@ -98,7 +116,11 @@ struct ctx_t {
                 append(funcs::zero_out(alloc_var, type.size()));
             }
         } else {
-            append(let_t::make(alloc_var, value, {}));
+            if (new_ir_api_) {
+                if (!value.is_empty()) append(assign_t::make(alloc_var, value));
+            } else {
+                append(let_t::make(alloc_var, value, {}));
+            }
         }
         return lval_t(alloc_var.as<var_t>());
     }
@@ -127,6 +149,10 @@ struct ctx_t {
         return let(value.type(), name, value);
     }
 
+    int slm_byte_offset() const { return slm_byte_offset_; }
+
+    void reserve_slm(int bytes) { slm_byte_offset_ += bytes; }
+
     void assume(const expr_t &e) { ctx_->add_constraint(e); }
 
     void begin_scope() { stmts_stack_.emplace(); }
@@ -152,6 +178,10 @@ struct ctx_t {
     const ir_context_t *ir_ctx() const { return ctx_; }
 
 private:
+    type_t local_id_type() const { return u16; }
+    type_t group_id_type() const { return u32; }
+    type_t local_size_type() const { return u16; }
+
     expr_t var(type_t type, const std::string &name) {
         return var_t::make(type, name);
     }
@@ -204,6 +234,8 @@ private:
     std::array<expr_t, 3> group_ids_;
     std::array<expr_t, 3> local_ids_;
     std::array<expr_t, 3> local_sizes_;
+    bool new_ir_api_ = false;
+    int slm_byte_offset_ = 0;
 };
 
 ctx_t &default_ctx() {
@@ -221,8 +253,9 @@ int min_pitch_2d() {
     return block_2d_pitch_alignment(default_ctx().ir_ctx()->hw().to_ngen());
 }
 
-void declare_kernel(const kernel_iface_t &interface, ir_context_t &ctx) {
-    default_ctx().declare_kernel(interface, ctx);
+void declare_kernel(
+        const kernel_iface_t &interface, ir_context_t &ctx, bool new_ir_api) {
+    default_ctx().declare_kernel(interface, ctx, new_ir_api);
 }
 
 stmt_t end_kernel() {
@@ -273,6 +306,11 @@ const expr_t &local_size(int idx) {
     return default_ctx().local_size(idx);
 }
 
+expr_t subgroup_id(int idx) {
+    int simd = default_ctx().ir_ctx()->exec_cfg().simd();
+    return extract((local_id(idx) / simd), 0);
+}
+
 expr_t arg(const std::string &name, bool allow_empty) {
     return default_ctx().arg(name, allow_empty);
 }
@@ -282,13 +320,38 @@ lval_t def(type_t type, const std::string &name, const expr_t &value,
     return default_ctx().def(type, name, value, force_alloc);
 }
 
+lval_t def(const std::string &name, const type_t &type, const expr_t &value) {
+    return def(type, name, value);
+}
+
 lval_t def(const std::string &name, const expr_t &value) {
     return def(value.type(), name, value);
 }
 
-tensor_t def(const v2::layout_t &layout, const std::string &name,
-        const expr_t &value) {
+tensor_t def(
+        const layout_t &layout, const std::string &name, const expr_t &value) {
     return default_ctx().def(layout, name, value);
+}
+
+tensor_t def_slm(layout_t layout, const std::string &name) {
+    auto alloc_elems = into<int>(layout.size() / layout.type().size());
+    auto buf = def(name, layout.type().slm()[alloc_elems]);
+    int bytes = (to_cpp<int>(layout.offset()) + alloc_elems)
+            * layout.type().size();
+    auto off = utils::div_up(
+            default_ctx().slm_byte_offset(), layout.type().size());
+    layout.set_offset(off);
+    default_ctx().reserve_slm(bytes);
+    return tensor_t(buf, layout);
+}
+
+expr_t iif(
+        const expr_t &cond, const expr_t &true_expr, const expr_t &false_expr) {
+    return iif_t::make(cond, true_expr, false_expr);
+}
+
+expr_t extract(const expr_t &expr, int lane) {
+    return shuffle_t::make(expr, {lane});
 }
 
 lval_t &lval_t::operator=(const expr_t &obj) {
@@ -305,7 +368,11 @@ expr_t let(const std::string &name, const expr_t &value) {
 }
 
 void assign(const expr_t &var, const expr_t &value) {
-    append(store_t::make(var, 0, value));
+    if (default_ctx().new_ir_api()) {
+        append(assign_t::make(var, value));
+    } else {
+        append(store_t::make(var, 0, value));
+    }
 }
 
 enum class send_kind_t { load, prefetch, store };
@@ -424,9 +491,9 @@ void block_2d_send(const conf_2d_t &conf, const tensor_t &t,
                 std::min(tile[h_dim], operation_tile[h_dim] - coord[h_dim]));
         int count = std::max(1, into<int>(tile[w_dim] / width));
         auto width_idx
-                = g.idxs[w_dim] + static_cast<uint32_t>((base + coord)[w_dim]);
+                = g.coord[w_dim] + static_cast<uint32_t>((base + coord)[w_dim]);
         auto height_idx
-                = g.idxs[h_dim] + static_cast<uint32_t>((base + coord)[h_dim]);
+                = g.coord[h_dim] + static_cast<uint32_t>((base + coord)[h_dim]);
         auto send_kind = [&]() {
             switch (op_kind) {
                 case send_kind_t::prefetch: return send_op_t::prefetch_2d;

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -46,8 +46,9 @@ struct tensor_t {
         return oss.str();
     }
     IR_DEFINE_DUMP()
+
     expr_t buf;
-    v2::layout_t layout;
+    layout_t layout;
 };
 
 struct global_tensor_t {
@@ -141,7 +142,7 @@ lval_t def(type_t type, const std::string &name, const expr_t &value = {},
         bool force_alloc = false);
 lval_t def(const std::string &name, const expr_t &value);
 
-tensor_t def(const v2::layout_t &layout, const std::string &name,
+tensor_t def(const layout_t &layout, const std::string &name,
         const expr_t &value = {});
 expr_t let(type_t type, const std::string &name, const expr_t &value);
 expr_t let(const std::string &name, const expr_t &value);

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -17,6 +17,7 @@
 #ifndef GPU_INTEL_JIT_DSL_DSL_HPP
 #define GPU_INTEL_JIT_DSL_DSL_HPP
 
+#include "gpu/intel/jit/dsl/decl.hpp"
 #include "gpu/intel/jit/ir/ir.hpp"
 #include "gpu/intel/jit/ir/kernel_info.hpp"
 #include "gpu/intel/jit/ir/message.hpp"
@@ -39,6 +40,17 @@ struct send_hint_t {
 };
 
 struct tensor_t {
+    tensor_t() = default;
+    tensor_t(const expr_t &buf, const layout_t &layout)
+        : buf(buf), layout(layout) {}
+    const type_t &type() const { return layout.type(); }
+
+    tensor_t map(const tile_t &tile, const coord_t &coord) const {
+        auto ret = *this;
+        ret.layout = layout.map(tile, coord);
+        return ret;
+    }
+
     std::string str() const {
         std::ostringstream oss;
         oss << "buffer:    " << buf.str();
@@ -55,24 +67,57 @@ struct global_tensor_t {
     expr_t buf;
     type_t type;
     expr_t base_offset;
-    pvar_map_t<expr_t> idxs;
+    coord_t coord;
     pvar_map_t<expr_t> strides;
     pvar_map_t<expr_t> sizes;
     tile_t tile;
 
-    expr_t offset(const icoord_t &coord) const {
+    global_tensor_t() = default;
+    global_tensor_t(const expr_t &buf, const pvar_map_t<expr_t> &sizes,
+            const pvar_map_t<expr_t> &strides)
+        : buf(buf)
+        , type(buf.type().remove_ptr())
+        , strides(strides)
+        , sizes(sizes) {}
+
+    expr_t offset(const icoord_t &sub_coord) const {
         expr_t ret = base_offset;
-        for (auto &c : coord) {
-            ret += (idxs[c] + coord[c]) * strides[c];
+        for (auto &c : sub_coord) {
+            ret += (coord[c] + sub_coord[c]) * strides[c];
         }
         return simplify(ret * type.size());
+    }
+
+    global_tensor_t map(const tile_t &tile, const coord_t &coord) const {
+        global_tensor_t ret = *this;
+        ret.coord = coord;
+        ret.tile = tile;
+        return ret;
+    }
+
+    pvar_t major_stride_dim() const {
+        gpu_assert(strides.size() == 2);
+        for (auto &d : strides) {
+            if (is_one(strides.at(d))) return d;
+        }
+        gpu_error_not_expected();
+        return pvar_t();
+    }
+
+    pvar_t minor_stride_dim() const {
+        auto major = major_stride_dim();
+        for (auto &d : strides) {
+            if (d != major) return d;
+        }
+        gpu_error_not_expected();
+        return pvar_t();
     }
 
     std::string str() const {
         std::ostringstream oss;
         oss << "(" << buf << "+" << base_offset << ")." << type << " : ";
-        for (auto &k : idxs) {
-            oss << " " << k << " - (idx: " << idxs[k]
+        for (auto &k : coord) {
+            oss << " " << k << " - (coord: " << coord[k]
                 << ", stride: " << strides[k] << ", size: " << sizes[k];
             if (!tile.is_empty()) oss << ", tile: " << tile[k];
             oss << ")";
@@ -81,7 +126,8 @@ struct global_tensor_t {
     }
 };
 
-void declare_kernel(const kernel_iface_t &interface, ir_context_t &ctx);
+void declare_kernel(const kernel_iface_t &interface, ir_context_t &ctx,
+        bool new_ir_api = false);
 stmt_t end_kernel();
 
 void begin_scope();
@@ -99,10 +145,11 @@ const std::array<expr_t, 3> &local_sizes();
 const expr_t &local_size(int idx);
 
 class lval_t {
-
 public:
+    lval_t() = default;
+    lval_t(const type_t &type, const std::string &name)
+        : var(var_t::make(type, name)) {}
     lval_t(const expr_t &v) : var(v) {}
-
     lval_t &operator=(const expr_t &obj);
 
     lval_t sub(int off, int elems) const {
@@ -123,7 +170,9 @@ public:
     DEFINE_BINARY_ASSIGN_OPERATOR(*)
     DEFINE_BINARY_ASSIGN_OPERATOR(/)
     DEFINE_BINARY_ASSIGN_OPERATOR(%)
+    DEFINE_BINARY_ASSIGN_OPERATOR(|)
     DEFINE_BINARY_ASSIGN_OPERATOR(&)
+    DEFINE_BINARY_ASSIGN_OPERATOR(^)
 
 #undef DEFINE_BINARY_ASSIGN_OPERATOR
 
@@ -137,15 +186,29 @@ public:
     expr_t var;
 };
 
+expr_t subgroup_id(int idx = 0);
 expr_t arg(const std::string &name, bool allow_empty = false);
+// TODO: Unify def() API, keep three versions:
+// 1. def(name, type, value)
+// 2. def(name, type)
+// 3. def(name, value)
+// name goes first in all three for consistency.
 lval_t def(type_t type, const std::string &name, const expr_t &value = {},
         bool force_alloc = false);
+lval_t def(
+        const std::string &name, const type_t &type, const expr_t &value = {});
 lval_t def(const std::string &name, const expr_t &value);
-
 tensor_t def(const layout_t &layout, const std::string &name,
         const expr_t &value = {});
 expr_t let(type_t type, const std::string &name, const expr_t &value);
 expr_t let(const std::string &name, const expr_t &value);
+tensor_t def_slm(layout_t layout, const std::string &name);
+
+expr_t iif(
+        const expr_t &cond, const expr_t &true_expr, const expr_t &false_expr);
+expr_t extract(const expr_t &expr, int lane);
+
+void assign(const expr_t &var, const expr_t &value);
 
 void prefetch(const global_tensor_t &g, const icoord_t &base = {},
         const send_hint_t &hint = {});
@@ -156,8 +219,6 @@ void store(const global_tensor_t &g, const tensor_t &t,
 
 void mma(const tensor_t &C, const tensor_t &A, const tensor_t &B,
         const tile_t &tile, const icoord_t &base, bool is_systolic);
-
-void assign(const expr_t &var, const expr_t &value);
 
 template <typename F>
 void if_(const expr_t &cond, F if_body) {
@@ -196,6 +257,19 @@ void if_(const expr_t &cond, const F &if_body, const G &else_body) {
 }
 
 template <typename F>
+void _for(const expr_t &var, const expr_t &bound, const expr_t &step,
+        const F &body) {
+    begin_scope();
+    body();
+    append(for_t::make(var, 0, bound, pop_scope(), step));
+}
+
+template <typename F>
+void _for(const expr_t &var, const expr_t &bound, const F &body) {
+    _for(var, bound, 1, body);
+}
+
+template <typename F>
 void while_(const expr_t &cond, F body) {
     if (is_const(cond) && !to_cpp<bool>(cond)) return;
     begin_scope();
@@ -205,6 +279,10 @@ void while_(const expr_t &cond, F body) {
 
 void binary(op_kind_t op, const tensor_t &dst, const tensor_t &src0,
         const tensor_t &src1);
+
+void barrier() {
+    append(builtin_t::make("barrier")());
+}
 
 } // namespace dsl
 } // namespace jit

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -144,6 +144,21 @@ const expr_t &local_id(int idx);
 const std::array<expr_t, 3> &local_sizes();
 const expr_t &local_size(int idx);
 
+class declaration_t {
+public:
+    declaration_t(const std::string &name, type_t type)
+        : var_(var_t::make(type, name)) {};
+    explicit declaration_t(expr_t var) : var_(std::move(var)) {}
+    const expr_t &expr() const { return var_; }
+
+private:
+    expr_t var_;
+};
+
+declaration_t declare(const std::string &name, type_t type);
+declaration_t declare(const std::string &name, const layout_t &layout,
+        bool is_mutable = false);
+
 class lval_t {
 public:
     lval_t() = default;
@@ -193,6 +208,8 @@ expr_t arg(const std::string &name, bool allow_empty = false);
 // 2. def(name, type)
 // 3. def(name, value)
 // name goes first in all three for consistency.
+lval_t def(const declaration_t &d, const expr_t &value = {},
+        bool force_alloc = false);
 lval_t def(type_t type, const std::string &name, const expr_t &value = {},
         bool force_alloc = false);
 lval_t def(
@@ -200,6 +217,7 @@ lval_t def(
 lval_t def(const std::string &name, const expr_t &value);
 tensor_t def(const layout_t &layout, const std::string &name,
         const expr_t &value = {});
+expr_t let(const declaration_t &d, const expr_t &value);
 expr_t let(type_t type, const std::string &name, const expr_t &value);
 expr_t let(const std::string &name, const expr_t &value);
 tensor_t def_slm(layout_t layout, const std::string &name);

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -221,7 +221,7 @@ void mma(const tensor_t &C, const tensor_t &A, const tensor_t &B,
         const tile_t &tile, const icoord_t &base, bool is_systolic);
 
 template <typename F>
-void if_(const expr_t &cond, F if_body) {
+void _if(const expr_t &cond, F if_body) {
     if (is_const(cond)) {
         if (to_cpp<bool>(cond)) {
             begin_scope();
@@ -236,7 +236,7 @@ void if_(const expr_t &cond, F if_body) {
 }
 
 template <typename F, typename G>
-void if_(const expr_t &cond, const F &if_body, const G &else_body) {
+void _if(const expr_t &cond, const F &if_body, const G &else_body) {
     if (is_const(cond)) {
         begin_scope();
         if (to_cpp<bool>(cond)) {
@@ -270,7 +270,7 @@ void _for(const expr_t &var, const expr_t &bound, const F &body) {
 }
 
 template <typename F>
-void while_(const expr_t &cond, F body) {
+void _while(const expr_t &cond, F body) {
     if (is_const(cond) && !to_cpp<bool>(cond)) return;
     begin_scope();
     body();

--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -461,6 +461,20 @@ void ir_visitor_t::_visit(const alloc_t &obj) {
     visit(obj.body);
 }
 
+object_t ir_mutator_t::_mutate(const assign_t &obj) {
+    auto var = mutate(obj.var);
+    auto value = mutate(obj.value);
+
+    if (var.is_same(obj.var) && value.is_same(obj.value)) return obj;
+
+    return assign_t::make(var, value);
+}
+
+void ir_visitor_t::_visit(const assign_t &obj) {
+    visit(obj.var);
+    visit(obj.value);
+}
+
 object_t ir_mutator_t::_mutate(const ref_t &obj) {
     auto var = mutate(obj.var);
     if (var.impl() == obj.var.impl()) return obj;

--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -108,6 +108,7 @@ std::string to_string(op_kind_t kind) {
 
         case op_kind_t::_and: return "&&";
         case op_kind_t::_or: return "||";
+        case op_kind_t::_xor: return "^";
 
         case op_kind_t::_add3: return "add3";
         case op_kind_t::_mad: return "mad";
@@ -143,6 +144,7 @@ bool is_commutative_op(op_kind_t op_kind) {
         case op_kind_t::_ne:
         case op_kind_t::_and:
         case op_kind_t::_or:
+        case op_kind_t::_xor:
         case op_kind_t::_add3: return true;
         default: return false;
     }
@@ -241,7 +243,8 @@ type_t binary_op_type(op_kind_t op_kind, const type_t &a, const type_t &b,
         return type_t::u32(a.elems(), attr);
     }
 
-    if (utils::one_of(op_kind, op_kind_t::_and, op_kind_t::_or)) {
+    if (utils::one_of(
+                op_kind, op_kind_t::_and, op_kind_t::_or, op_kind_t::_xor)) {
         if (a == b) return a;
         if (is_const(a_expr)) return b;
         if (is_const(b_expr)) return a;
@@ -405,6 +408,7 @@ DEFINE_BINARY_OPERATOR(<=, op_kind_t::_le)
 
 DEFINE_BINARY_OPERATOR(&, op_kind_t::_and)
 DEFINE_BINARY_OPERATOR(|, op_kind_t::_or)
+DEFINE_BINARY_OPERATOR(^, op_kind_t::_xor)
 
 #undef DEFINE_BINARY_OPERATOR
 

--- a/src/gpu/intel/jit/ir/core.cpp
+++ b/src/gpu/intel/jit/ir/core.cpp
@@ -183,11 +183,14 @@ type_attr_t common_attr(const type_t &a, const type_t &b) {
     return (a.attr() | b.attr()) & ~type_attr_t::mut;
 }
 
-type_t common_int_type(const type_t &_a, const type_t &_b) {
-    gpu_assert(_a.is_int() && _b.is_int()) << "Unexpected types.";
+type_t common_type(const type_t &base, const type_t &a, const type_t &b) {
+    auto attr = common_attr(a, b);
+    int elems = std::max(a.elems(), b.elems());
+    return type_t(base.kind(), elems, attr);
+}
 
-    type_attr_t attr = common_attr(_a, _b);
-    int elems = _a.elems();
+type_t common_int_type_impl(const type_t &_a, const type_t &_b) {
+    gpu_assert(_a.is_int() && _b.is_int()) << "Unexpected types.";
 
     // Promote to s32 first.
     type_t a = _a.size() < int(sizeof(int32_t)) ? type_t::s32() : _a;
@@ -198,31 +201,33 @@ type_t common_int_type(const type_t &_a, const type_t &_b) {
     // Integer promotion, follow C++ rules.
     int common_bits = 8 * std::max(a.size(), b.size());
     if (a.is_signed() == b.is_signed()) {
-        if (a.is_signed()) return type_t::s(common_bits, elems, attr);
-        return type_t::u(common_bits, elems, attr);
+        if (a.is_signed()) return type_t::s(common_bits);
+        return type_t::u(common_bits);
     }
 
-    if (a.size() >= b.size() && a.is_unsigned())
-        return type_t::u(common_bits, elems, attr);
-    if (b.size() >= a.size() && b.is_unsigned())
-        return type_t::u(common_bits, elems, attr);
-    if (a.size() > b.size() && a.is_signed())
-        return type_t::s(common_bits, elems, attr);
-    if (b.size() > a.size() && b.is_signed())
-        return type_t::s(common_bits, elems, attr);
+    if (a.size() >= b.size() && a.is_unsigned()) return type_t::u(common_bits);
+    if (b.size() >= a.size() && b.is_unsigned()) return type_t::u(common_bits);
+    if (a.size() > b.size() && a.is_signed()) return type_t::s(common_bits);
+    if (b.size() > a.size() && b.is_signed()) return type_t::s(common_bits);
 
-    return type_t::u(common_bits, elems, attr);
+    return type_t::u(common_bits);
 }
 
-type_t common_type(const type_t &a, const type_t &b) {
-    gpu_assert(a.elems() == b.elems())
-            << "Types must have the same number of components.";
+type_t common_int_type(const type_t &a, const type_t &b) {
+    return common_type(common_int_type_impl(a, b), a, b);
+}
+
+type_t common_type_impl(const type_t &a, const type_t &b) {
     if (a.is_undef() || b.is_undef()) return type_t::undef();
     if (a.is_fp() && !b.is_fp()) return a;
     if (!a.is_fp() && b.is_fp()) return b;
     if (a.is_fp() && b.is_fp()) return (a.size() > b.size() ? a : b);
     if (a.is_bool() && b.is_bool()) return a;
     return common_int_type(a, b);
+}
+
+type_t common_type(const type_t &a, const type_t &b) {
+    return common_type(common_type_impl(a, b), a, b);
 }
 
 type_t common_type(const expr_t &a, const expr_t &b) {
@@ -232,15 +237,12 @@ type_t common_type(const expr_t &a, const expr_t &b) {
 type_t binary_op_type(op_kind_t op_kind, const type_t &a, const type_t &b,
         const expr_t &a_expr = expr_t(), const expr_t &b_expr = expr_t()) {
     if (a.is_undef() || b.is_undef()) return type_t::undef();
-    gpu_assert(a.elems() == b.elems())
-            << "Types must have the same number of components.";
+    int elems = std::max(a.elems(), b.elems());
 
     type_attr_t attr = common_attr(a, b);
-    if (is_cmp_op(op_kind)) return type_t::_bool(a.elems(), attr);
+    if (is_cmp_op(op_kind)) return type_t::_bool(elems, attr);
     if (utils::one_of(op_kind, op_kind_t::_shl, op_kind_t::_shr)) {
-        gpu_assert(a.is_unsigned())
-                << "a must be unsigned for shift left/right.";
-        return type_t::u32(a.elems(), attr);
+        return a[elems].with_attr(attr);
     }
 
     if (utils::one_of(

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -1120,6 +1120,7 @@ public:
     DECLARE_BINARY_ASSIGN_OPERATOR(/)
     DECLARE_BINARY_ASSIGN_OPERATOR(%)
     DECLARE_BINARY_ASSIGN_OPERATOR(&)
+    DECLARE_BINARY_ASSIGN_OPERATOR(^)
 
 #undef DECLARE_BINARY_ASSIGN_OPERATOR
 
@@ -1176,6 +1177,7 @@ enum class op_kind_t {
 
     _and,
     _or,
+    _xor,
 
     // Ternary operations.
     // Parametric ReLU.
@@ -2055,6 +2057,7 @@ DECLARE_BINARY_OPERATOR(<=, op_kind_t::_le)
 
 DECLARE_BINARY_OPERATOR(&, op_kind_t::_and)
 DECLARE_BINARY_OPERATOR(|, op_kind_t::_or)
+DECLARE_BINARY_OPERATOR(^, op_kind_t::_xor)
 
 #undef DECLARE_BINARY_OPERATOR
 

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -1676,8 +1676,15 @@ class shuffle_t : public expr_impl_t {
 public:
     IR_DECL_CORE_TYPE(shuffle_t)
 
+    static expr_t make(const expr_t &vec_expr, const std::vector<int> &idx) {
+        check_indices(idx, vec_expr.type().elems());
+        std::vector<expr_t> vec {vec_expr};
+        return expr_t(new shuffle_t(vec, idx));
+    }
+
     static expr_t make(
             const std::vector<expr_t> &vec, const std::vector<int> &idx) {
+        check_indices(idx, (int)vec.size());
         if (idx.size() == 1) return vec[idx[0]];
         return expr_t(new shuffle_t(vec, idx));
     }
@@ -1762,8 +1769,12 @@ private:
     shuffle_t(const std::vector<expr_t> &vec, const std::vector<int> &idx)
         : expr_impl_t(_type_info(), shuffle_type(vec, idx))
         , vec(vec)
-        , idx(idx) {
-        gpu_assert(idx.size() > 1) << "Unexpected empty or scalar shuffle.";
+        , idx(idx) {}
+
+    static void check_indices(const std::vector<int> &idx, int elems) {
+        for (int i : idx) {
+            gpu_assert(i >= 0 && i < elems);
+        }
     }
 
     static type_t shuffle_type(
@@ -1771,6 +1782,12 @@ private:
         gpu_assert(!vec.empty() && !idx.empty());
 
         auto elem_type = vec[0].type();
+        if (vec.size() == 1) {
+            gpu_assert(idx.size() == 1);
+            gpu_assert(elem_type.is_simd());
+            return type_t(elem_type.kind());
+        }
+
         for (auto &v : vec)
             elem_type = common_type(elem_type, v.type());
 

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -56,6 +56,7 @@
 // All IR statement objects.
 #define HANDLE_STMT_IR_OBJECTS() \
     HANDLE_IR_OBJECT(alloc_t) \
+    HANDLE_IR_OBJECT(assign_t) \
     HANDLE_IR_OBJECT(for_t) \
     HANDLE_IR_OBJECT(func_call_t) \
     HANDLE_IR_OBJECT(if_t) \
@@ -2323,6 +2324,42 @@ private:
         , body(body) {
         gpu_assert(!buf.type().is_ptr()) << buf;
     }
+};
+
+// Assignment of a value to a variable.
+// C++ equivalent:
+//    var = value;
+class assign_t : public stmt_impl_t {
+public:
+    IR_DECL_CORE_TYPE(assign_t)
+
+    static stmt_t make(const expr_t &var, const expr_t &value) {
+        return stmt_t(new assign_t(var, value));
+    }
+
+    bool is_equal(const object_impl_t &obj) const override {
+        if (!obj.is<self_type>()) return false;
+        auto &other = obj.as<self_type>();
+        return var.is_equal(other.var) && value.is_equal(other.value);
+    }
+
+    size_t get_hash() const override { return ir_utils::get_hash(var, value); }
+
+    std::string str() const override {
+        std::ostringstream oss;
+        oss << var.str() << "." << var.type().str();
+        oss << " = " << value.str();
+        return oss.str();
+    }
+
+    IR_DECLARE_TRAVERSERS()
+
+    expr_t var;
+    expr_t value;
+
+private:
+    assign_t(const expr_t &var, const expr_t &value)
+        : stmt_impl_t(_type_info()), var(var), value(value) {}
 };
 
 // Store to a GRF buffer.

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -2933,6 +2933,12 @@ public:
         return ((const func_impl_t *)impl())->call(args, attr);
     }
 
+    stmt_t operator()(const std::vector<expr_t> &args = {}) const {
+        return call(args);
+    }
+
+    stmt_t operator()(const expr_t &arg) const { return call({arg}); }
+
 private:
 #ifdef SANITY_CHECK
     void sanity_check() const override {

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -498,6 +498,8 @@ public:
 
     bool is_slm() const { return any(attr() & type_attr_t::slm); }
 
+    type_t operator[](int elems) const { return with_elems(elems); }
+
     bool operator==(const type_t &other) const {
         return (kind() == other.kind()) && (elems() == other.elems())
                 && (is_ptr() == other.is_ptr());
@@ -630,6 +632,12 @@ public:
     type_t with_attr(type_attr_t attr) const {
         type_t copy = *this;
         copy.attr_ = attr;
+        return copy;
+    }
+
+    type_t with_kind(type_kind_t kind) const {
+        type_t copy = *this;
+        copy.kind_ = kind;
         return copy;
     }
 

--- a/src/gpu/intel/jit/ir/ir.cpp
+++ b/src/gpu/intel/jit/ir/ir.cpp
@@ -39,6 +39,11 @@ class ir_printer_t : public ir_visitor_t {
 public:
     ir_printer_t(std::ostream &out) : out_(out) {}
 
+    void _visit(const assign_t &obj) override {
+        print_indent();
+        out_ << obj.str() << "\n";
+    }
+
     void _visit(const alloc_t &obj) override {
         auto grf_size = 1; // Assume all objects are grf aligned
         auto guard = mem_usage_guard(obj.register_alloc_size(grf_size));

--- a/src/gpu/intel/jit/ir/kernel_info.hpp
+++ b/src/gpu/intel/jit/ir/kernel_info.hpp
@@ -111,6 +111,13 @@ public:
         return expr_t();
     }
 
+    int index(const std::string &name) const {
+        for (int i = 0; i < nargs(); i++) {
+            if (args_[i].name() == name) return i;
+        }
+        return -1;
+    }
+
     void register_arg(const expr_t &var) { args_.emplace_back(var); }
 
     void register_arg(const std::string &name, const type_t &type) {

--- a/src/gpu/intel/jit/ir/problem.hpp
+++ b/src/gpu/intel/jit/ir/problem.hpp
@@ -213,6 +213,13 @@ public:
         return map_[key];
     }
 
+    template <typename DerivedT>
+    DerivedT with_impl(const pvar_t &key, const ValueT &value) const {
+        DerivedT ret = static_cast<const DerivedT &>(*this);
+        ret[key] = value;
+        return ret;
+    }
+
     const ValueT &at(const pvar_t &key) const { return operator[](key); }
     const ValueT &at(size_t idx) const {
         return operator[](into<dim_idx_t>(idx));
@@ -434,6 +441,9 @@ public:
         coord_t ret;
         ret.set_valid(false);
         return ret;
+    }
+    coord_t with(const pvar_t &key, const expr_t &value) const {
+        return pvar_map_t<expr_t>::with_impl<coord_t>(key, value);
     }
 };
 

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -396,15 +396,7 @@ public:
         return tile;
     }
 
-    dim_t dim(const pvar_t &dim) const {
-        dim_t ret = 1;
-        for (auto &b : blocks_) {
-            if (b.dim == dim) ret *= b.block;
-        }
-        return ret;
-    }
-
-    dim_t dim(dim_idx_t dim_idx) const { return dim(pvar_t(dim_idx)); }
+    dim_t dim(const pvar_t &dim) const { return elems(dim); }
 
     stride_t stride(const pvar_t &dim, int dim_block_idx = 0) const {
         int idx = 0;

--- a/src/gpu/intel/jit/pass/simplify.cpp
+++ b/src/gpu/intel/jit/pass/simplify.cpp
@@ -1923,6 +1923,9 @@ DECL_OP_TRAITS(op_kind_t::_le, <=)
 
 DECL_OP_TRAITS(op_kind_t::_and, &)
 DECL_OP_TRAITS(op_kind_t::_or, |)
+DECL_OP_TRAITS(op_kind_t::_xor, ^)
+DECL_OP_TRAITS(op_kind_t::_shl, <<)
+DECL_OP_TRAITS(op_kind_t::_shr, >>)
 
 template <>
 struct op_traits_t<op_kind_t::_min> {
@@ -2032,6 +2035,8 @@ public:
 
             CASE(op_kind_t::_and)
             CASE(op_kind_t::_or)
+            CASE(op_kind_t::_shl)
+            CASE(op_kind_t::_shr)
             CASE(op_kind_t::_min)
             CASE(op_kind_t::_max)
 


### PR DESCRIPTION
While seeing if I can simplify tensor management in #3729, it seems like it would be beneficial to replace `tensor_config_t` with a structure like:
```
tensor_state_t {
    global_tensor_t global_tensor;
    tensor_t tensor;
    icoord_t tensor_coord;
    send_hint_t hint;
}
```
This structure needs setup before the k-loop is generated where `tensor` allocated. As such we can use a method to forward declare variables before they are allocated or initialized. 

@echeresh I feel like the abstraction provided by `global_tensor_t` and `tensor_t` isn't quite meshing with GEMM IR's needs. I don't feel like I should need to be creating this `tensor_state_t` structure within the GEMM IR, and should instead be relying on a DSL native construct. Do you have any suggestions for how we should modify the DSL? The core issue is that `tensor` maps to multiple `global_tensor` tiles and that the layout of `tensor` is fixed by the strategy, resulting in having to manually manage the correspondence.