### PR TITLE
xe: gemm: fixup per_tensor zp for broadcast wei

### DIFF
--- a/src/gpu/intel/matmul/ref.cpp
+++ b/src/gpu/intel/matmul/ref.cpp
@@ -173,6 +173,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
                 = last_zp_stride == 0 ? 1 : last_zp_dim * last_zp_stride;
         last_zp_stride = wei_zp_strides[d];
         last_zp_dim = wei_zp_dims[d];
+        if (wei_zp_dims[d] == 1) wei_zp_strides[d] = 0;
     }
     const dim_t wei_zp_stride_n = wei_zp_strides[b_d.ndims() - 1];
     const dim_t wei_zp_stride_k = wei_zp_strides[b_d.ndims() - 2];
@@ -199,6 +200,7 @@ status_t ref_t::execute_ref(const exec_ctx_t &ctx) const {
                 = last_zp_stride == 0 ? 1 : last_zp_dim * last_zp_stride;
         last_zp_stride = src_zp_strides[d];
         last_zp_dim = src_zp_dims[d];
+        if (src_zp_dims[d] == 1) src_zp_strides[d] = 0;
     }
     const dim_t src_zp_stride_k = src_zp_strides[a_d.ndims() - 1];
     const dim_t src_zp_stride_m = src_zp_strides[a_d.ndims() - 2];


### PR DESCRIPTION
Addresses [MFDNN-14062](https://jira.devtools.intel.com/browse/MFDNN-14062). Fixes the following (minimized) correctness failure:
> ./benchdnn --matmul --engine=gpu --summary=no-failures --dt=f16:u4:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=wei:per_tensor:f16 --attr-zero-points=wei:per_tensor:u8 --attr-fpmath=f16:true --skip-impl=jit 2x1x2:1x2x1
[   1][DST][1:0:0] exp_f32:         -17 exp:         -17 got:        1252 diff:    1269 rdiff: 74.6471
[COMPARE_STATS][DST]: trh=0 err_max_diff:    1269 err_max_rdiff: 74.6471 all_max_diff:    1269 all_max_rdiff: 74.6471
0:FAILED (errors:1 total:2) (1064 ms) __REPRO: --matmul --engine=gpu --dt=f16:u4:f16 --stag=abc --wtag=cab --dtag=abc --attr-scales=wei:per_tensor:f16 --attr-zero-points=wei:per_tensor:u8 --attr-fpmath=f16:true --skip-impl=jit 2x1x2:1x2x1
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 1.09s; create_pd: 0.06s (5%); create_prim: 0.54s (49%); fill: 0.12s (11%); execute: 0.01s (1%); compute_ref: 0.00s (0%); compare: 0.01s (1%);