### PR TITLE
governance: Add Siddhartha Menon to onednn-devops

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -247,6 +247,7 @@ Team: @uxlfoundation/onednn-devops
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
 | Hamza Butt         | @theComputeKid        | Arm Ltd           | Code Owner |
 | Ryo Suzuki         | @Ryo-not-rio          | Arm Ltd           | Code Owner |
+| Siddhartha Menon   | @Sqvid                | Arm Ltd           | Code Owner |
 
 ### Release management
 


### PR DESCRIPTION
Siddhartha has been a contributor and maintainer for onednn-cpu-aarch64 for over a year: https://github.com/uxlfoundation/oneDNN/commits?author=Sqvid