### PR TITLE
cpu: riscv: gemm: add f32 gemm SIMD optimization with RISC-V V Extension

### DIFF
--- a/src/cpu/gemm/gemm.cpp
+++ b/src/cpu/gemm/gemm.cpp
@@ -48,7 +48,7 @@ using namespace dnnl::impl::cpu::ppc64;
 #elif DNNL_S390X
 #include "cpu/s390x/gemm.h"
 #elif DNNL_RV64
-#if DNNL_RISCV_USE_RVV_INTRINSICS
+#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
 using namespace dnnl::impl::cpu::rv64;
 #endif
@@ -150,7 +150,7 @@ dnnl_status_t extended_sgemm(const char *transa, const char *transb,
     }
 #endif
 
-#if DNNL_RV64 && DNNL_RISCV_USE_RVV_INTRINSICS
+#if DNNL_RV64 && defined(DNNL_RISCV_USE_RVV_INTRINSICS)
     return rvv_gemm_f32(
             transa, transb, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, bias);
 #endif

--- a/src/cpu/gemm/gemm.cpp
+++ b/src/cpu/gemm/gemm.cpp
@@ -47,6 +47,11 @@ using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::cpu::ppc64;
 #elif DNNL_S390X
 #include "cpu/s390x/gemm.h"
+#elif DNNL_RV64
+#if DNNL_RISCV_USE_RVV_INTRINSICS
+#include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
+using namespace dnnl::impl::cpu::rv64;
+#endif
 #endif
 
 namespace dnnl {
@@ -143,6 +148,11 @@ dnnl_status_t extended_sgemm(const char *transa, const char *transb,
                 force_jit_nocopy_gemm);
         if (status != status::unimplemented) return status;
     }
+#endif
+
+#if DNNL_RV64 && DNNL_RISCV_USE_RVV_INTRINSICS
+    return rvv_gemm_f32(
+            transa, transb, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc, bias);
 #endif
 
     return ref_gemm<float>(

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -1,0 +1,381 @@
+/*******************************************************************************
+* Copyright 2018-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dnnl/dnnl_types.h"
+
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/platform.hpp"
+
+#include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
+#include <riscv_vector.h>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace dnnl::impl::utils;
+using namespace gemm_utils;
+
+namespace {
+void copy_A(
+        bool isTransA, dim_t K, const float *A, const dim_t lda, float *ws) {
+    constexpr dim_t m = unroll_factor<float>::m;
+
+    for (dim_t k = 0; k < K; k++) {
+        dim_t i = 0;
+        if (isTransA) {
+            ptrdiff_t stride = lda * sizeof(float);
+            while (i < m) {
+                size_t vl = __riscv_vsetvl_e32m1(m - i);
+                const float *a_ptr = A + i * lda + k;
+                vfloat32m1_t v_a = __riscv_vlse32_v_f32m1(a_ptr, stride, vl);
+                __riscv_vse32_v_f32m1(ws + i, v_a, vl);
+                i += vl;
+            }
+        } else {
+            const float *a_ptr = A + k * lda;
+            while (i < m) {
+                size_t vl = __riscv_vsetvl_e32m1(m - i);
+                vfloat32m1_t v_a = __riscv_vle32_v_f32m1(a_ptr + i, vl);
+                __riscv_vse32_v_f32m1(ws + i, v_a, vl);
+                i += vl;
+            }
+        }
+        ws += m;
+    }
+}
+
+template <bool isTransA, bool isTransB>
+void kernel_mxn(dim_t K, const float *A, const dim_t lda, const float *B,
+        const dim_t ldb, float *C, const dim_t ldc, const float alpha,
+        const float beta, int ithr = -1) {
+    constexpr dim_t m = unroll_factor<float>::m;
+    constexpr dim_t n = unroll_factor<float>::n;
+
+    float c[m * n] = {0.0f};
+
+    for (dim_t k = 0; k < K; k++) {
+        dim_t i = 0;
+        while (i < m) {
+            size_t vl = __riscv_vsetvl_e32m1(m - i);
+            vfloat32m1_t v_a;
+            if (isTransA) {
+                ptrdiff_t stride_a = lda * sizeof(float);
+                v_a = __riscv_vlse32_v_f32m1(A + i * lda + k, stride_a, vl);
+            } else {
+                v_a = __riscv_vle32_v_f32m1(A + i + k * lda, vl);
+            }
+            for (dim_t j = 0; j < n; j++) {
+                float b = isTransB ? B[j + k * ldb] : B[k + j * ldb];
+                float *c_col_ptr = c + m * j + i;
+                vfloat32m1_t v_c = __riscv_vle32_v_f32m1(c_col_ptr, vl);
+                v_c = __riscv_vfmacc_vf_f32m1(v_c, b, v_a, vl);
+                __riscv_vse32_v_f32m1(c_col_ptr, v_c, vl);
+            }
+            i += vl;
+        }
+    }
+    for (dim_t j = 0; j < n; j++) {
+        dim_t i = 0;
+        while (i < m) {
+            size_t vl = __riscv_vsetvl_e32m1(m - i);
+
+            float *c_final_ptr = C + j * ldc + i;
+            float *c_acc_ptr = c + j * m + i;
+
+            vfloat32m1_t v_acc = __riscv_vle32_v_f32m1(c_acc_ptr, vl);
+            vfloat32m1_t v_res;
+
+            if (beta == 0.0f) {
+                v_res = __riscv_vfmul_vf_f32m1(v_acc, alpha, vl);
+            } else {
+                vfloat32m1_t v_c_old = __riscv_vle32_v_f32m1(c_final_ptr, vl);
+                v_res = __riscv_vfmul_vf_f32m1(v_c_old, beta, vl);
+                v_res = __riscv_vfmacc_vf_f32m1(v_res, alpha, v_acc, vl);
+            }
+
+            __riscv_vse32_v_f32m1(c_final_ptr, v_res, vl);
+            i += vl;
+        }
+    }
+}
+
+template <bool isTransA, bool isTransB>
+void block_ker(const dim_t M, const dim_t N, const dim_t K, const float *A,
+        const dim_t lda, const float *B, const dim_t ldb, float *C,
+        const dim_t ldc, const float alpha, const float beta, float *ws,
+        bool do_copy, int ithr = -1) {
+
+    dim_t Nu = rnd_dn(N, unroll_factor<float>::n);
+    dim_t Mu = rnd_dn(M, unroll_factor<float>::m);
+    for (dim_t i = 0; i < Mu; i += unroll_factor<float>::m) {
+        for (dim_t j = 0; j < Nu; j += unroll_factor<float>::n) {
+            const float *b = isTransB ? &B[j] : &B[j * ldb];
+            const float *a = isTransA ? &A[i * lda] : &A[i];
+            if (do_copy) {
+                if (j == 0) { copy_A(isTransA, K, a, lda, ws); }
+                kernel_mxn<false, isTransB>(K, ws, unroll_factor<float>::m, b,
+                        ldb, &C[i + j * ldc], ldc, alpha, beta, ithr);
+            } else {
+                kernel_mxn<isTransA, isTransB>(K, a, lda, b, ldb,
+                        &C[i + j * ldc], ldc, alpha, beta, ithr);
+            }
+        }
+    }
+
+    // tail processing
+    for (dim_t i = 0; i < M; i++) {
+        for (dim_t j = Nu; j < N; j++) {
+            float c = beta == 0.f ? 0.f : beta * C[i + j * ldc];
+            for (dim_t p = 0; p < K; p++) {
+                float b = isTransB ? B[j + p * ldb] : B[p + j * ldb];
+                float a = isTransA ? A[p + i * lda] : A[i + p * lda];
+                c += alpha * a * b;
+            }
+            C[i + j * ldc] = c;
+        }
+    }
+    for (dim_t i = Mu; i < M; i++) {
+        for (dim_t j = 0; j < Nu; j++) {
+            float c = beta == 0.f ? 0.f : beta * C[i + j * ldc];
+            for (dim_t p = 0; p < K; p++) {
+                float b = isTransB ? B[j + p * ldb] : B[p + j * ldb];
+                float a = isTransA ? A[p + i * lda] : A[i + p * lda];
+                c += alpha * a * b;
+            }
+            C[i + j * ldc] = c;
+        }
+    }
+}
+
+template <bool isTransA, bool isTransB>
+void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
+        const float *A, const dim_t lda, const float *B, const dim_t ldb,
+        const float beta, float *C, const dim_t ldc, bool do_copy, float *ws,
+        int ithr = -1) {
+
+    constexpr dim_t BM = gemm_traits_t<float, isTransA, isTransB>::BM;
+    constexpr dim_t BN = gemm_traits_t<float, isTransA, isTransB>::BN;
+    constexpr dim_t BK = gemm_traits_t<float, isTransA, isTransB>::BK;
+
+    const float *curA;
+    const float *curB;
+    float *curC;
+
+    if ((M <= 0) || (N <= 0)) return;
+
+    if ((K <= 0) || (alpha == 0.f)) {
+        dim_t MN = N * M;
+        if (beta == 0.f) {
+            for (dim_t j = 0; j < MN; j++)
+                C[j] = 0.f;
+        } else if (beta != 1.f) {
+            for (dim_t j = 0; j < MN; j++)
+                C[j] *= beta;
+        }
+        return;
+    }
+
+    for (dim_t Bk = 0; Bk < K; Bk += BK) {
+        dim_t kb = nstl::min(K - Bk, BK);
+        for (dim_t Bm = 0; Bm < M; Bm += BM) {
+            dim_t mb = nstl::min(M - Bm, BM);
+            for (dim_t Bn = 0; Bn < N; Bn += BN) {
+                dim_t nb = nstl::min(N - Bn, BN);
+                curA = isTransA ? A + Bk + Bm * lda : A + Bm + Bk * lda;
+                curB = isTransB ? B + Bn + Bk * ldb : B + Bk + Bn * ldb;
+                curC = C + Bm + Bn * ldc;
+
+                if (Bk == 0) {
+                    block_ker<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
+                            ldb, curC, ldc, alpha, beta, ws, do_copy, ithr);
+                } else {
+                    block_ker<isTransA, isTransB>(mb, nb, kb, curA, lda, curB,
+                            ldb, curC, ldc, alpha, 1.0f, ws, do_copy, ithr);
+                }
+            }
+        }
+    }
+}
+} // namespace
+
+dnnl_status_t rvv_gemm_f32(const char *transa_, const char *transb_,
+        const dim_t *M_, const dim_t *N_, const dim_t *K_, const float *alpha_,
+        const float *A, const dim_t *lda_, const float *B, const dim_t *ldb_,
+        const float *beta_, float *C, const dim_t *ldc_, const float *bias) {
+
+    if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
+                && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
+        return dnnl_unimplemented;
+
+    bool isTransA = (*transa_ == 'T' || *transa_ == 't');
+    bool isTransB = (*transb_ == 'T' || *transb_ == 't');
+    const dim_t M = *M_, N = *N_, K = *K_;
+    const dim_t lda = *lda_, ldb = *ldb_, ldc = *ldc_;
+    const float alpha = *alpha_, beta = *beta_;
+
+    // early out and avoid division by zero in partitioning
+    if (utils::one_of(0, M, N)) return dnnl_success;
+
+    int max_nthr = dnnl_get_current_num_threads();
+    int nthr_m, nthr_n, nthr_k;
+    dim_t MB, NB, KB;
+
+    calc_nthr_nocopy_rvv(
+            M, N, K, max_nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    assert(IMPLICATION(!dnnl_thr_syncable(), nthr_k == 1));
+
+    float *c_buffers = nullptr;
+    float *ws_buffers = nullptr;
+    if (nthr_k > 1) {
+        c_buffers = (float *)malloc(
+                sizeof(*c_buffers) * nthr_m * nthr_n * (nthr_k - 1) * MB * NB,
+                PAGE_4K);
+        if (!c_buffers) {
+            nthr_k = 1;
+            KB = K;
+        }
+    }
+
+    bool do_copy = (NB / unroll_factor<float>::n > 3);
+    const int nthr_mn = nthr_m * nthr_n;
+    const int nthr_to_use = nthr_mn * nthr_k;
+    const size_t ws_elems_per_thr = K * unroll_factor<float>::m;
+    const size_t ws_size_per_thr
+            = rnd_up(ws_elems_per_thr * sizeof(float), PAGE_4K);
+    if (do_copy) {
+        ws_buffers = (float *)malloc(nthr_to_use * ws_size_per_thr, PAGE_4K);
+        if (!ws_buffers) do_copy = false;
+    }
+
+    auto get_thr_block = [&](dim_t &from, dim_t &to, dim_t &myN, dim_t NB,
+                                 dim_t N, int ithr) {
+        from = NB * (ithr);
+        to = NB * (ithr + 1);
+        if (to > N) to = N;
+        myN = to - from;
+    };
+
+    parallel(nthr_to_use, [&](int ithr, int nthr) {
+        assert(nthr_to_use == nthr);
+        MAYBE_UNUSED(nthr);
+
+        int ithr_mn = ithr % nthr_mn;
+        int ithr_m = ithr_mn % nthr_m;
+        int ithr_n = ithr_mn / nthr_m;
+        int ithr_k = ithr / nthr_mn;
+
+        int cbase = (ithr_m + nthr_m * ithr_n) * (nthr_k - 1);
+
+        float *ws = do_copy
+                ? ws_buffers + ithr * ws_size_per_thr / sizeof(float)
+                : nullptr;
+
+        dim_t m_from = 0, m_to = 0, myM = 0, n_from = 0, n_to = 0, myN = 0,
+              k_from = 0, k_to = 0, myK = 0;
+
+        get_thr_block(m_from, m_to, myM, MB, M, ithr_m);
+        get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
+        get_thr_block(k_from, k_to, myK, KB, K, ithr_k);
+
+        if (myM > 0 && myN > 0) {
+            float myBeta, *myC;
+            dim_t ld;
+            if (ithr_k == 0) {
+                myC = &(C[m_from + n_from * ldc]);
+                myBeta = beta;
+                ld = ldc;
+            } else {
+                myC = c_buffers + MB * NB * (cbase + ithr_k - 1);
+                myBeta = 0.0f;
+                ld = MB;
+            }
+            const float *myA = isTransA ? &(A[k_from + m_from * lda])
+                                        : &(A[m_from + k_from * lda]);
+            const float *myB = isTransB ? &(B[n_from + k_from * ldb])
+                                        : &(B[k_from + n_from * ldb]);
+
+            if (!isTransA) {
+                if (!isTransB) {
+                    gemm_ithr<false, false>(myM, myN, myK, alpha, myA, lda, myB,
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                } else {
+                    gemm_ithr<false, true>(myM, myN, myK, alpha, myA, lda, myB,
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                }
+            } else {
+                if (!isTransB) {
+                    gemm_ithr<true, false>(myM, myN, myK, alpha, myA, lda, myB,
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                } else {
+                    gemm_ithr<true, true>(myM, myN, myK, alpha, myA, lda, myB,
+                            ldb, myBeta, myC, ld, do_copy, ws, ithr);
+                }
+            }
+        }
+    });
+
+    if (nthr_k > 1) {
+        parallel(nthr_to_use, [&](int ithr, int nthr) {
+            assert(nthr_to_use == nthr);
+            MAYBE_UNUSED(nthr);
+
+            int ithr_mn = ithr % nthr_mn;
+            int ithr_m = ithr_mn % nthr_m;
+            int ithr_k = ithr / nthr_mn;
+            int ithr_n = ithr_mn / nthr_m;
+
+            dim_t n_from = 0, n_to = 0, myN = 0;
+            dim_t m_from = 0, m_to = 0, myM = 0;
+
+            int cbase = (ithr_m + nthr_m * ithr_n) * (nthr_k - 1);
+
+            get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
+            get_thr_block(m_from, m_to, myM, MB, M, ithr_m);
+
+            dim_t offset = 0, block = 0;
+            gemm_utils::partition_unit_diff(
+                    ithr_k, nthr_k, myN, &offset, &block);
+            for (int ik = 1; ik < nthr_k; ++ik) {
+                float *myC = c_buffers
+                        + MB * ((dim_t)NB * (cbase + ik - 1) + offset);
+
+                gemm_utils::sum_two_matrices(myM, block, myC, MB,
+                        &C[m_from + (n_from + offset) * ldc], ldc);
+            }
+        });
+    }
+
+    if (bias) {
+        parallel_nd(N, M, [&](dim_t i, dim_t j) { C[i * ldc + j] += bias[j]; });
+    }
+
+    free(ws_buffers);
+    free(c_buffers);
+
+    return dnnl_success;
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.cpp
@@ -14,8 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "oneapi/dnnl/dnnl_types.h"
-
 #include "common/dnnl_thread.hpp"
 #include "common/nstl.hpp"
 #include "common/utils.hpp"
@@ -227,14 +225,14 @@ void gemm_ithr(const dim_t M, const dim_t N, const dim_t K, const float alpha,
 }
 } // namespace
 
-dnnl_status_t rvv_gemm_f32(const char *transa_, const char *transb_,
-        const dim_t *M_, const dim_t *N_, const dim_t *K_, const float *alpha_,
-        const float *A, const dim_t *lda_, const float *B, const dim_t *ldb_,
+status_t rvv_gemm_f32(const char *transa_, const char *transb_, const dim_t *M_,
+        const dim_t *N_, const dim_t *K_, const float *alpha_, const float *A,
+        const dim_t *lda_, const float *B, const dim_t *ldb_,
         const float *beta_, float *C, const dim_t *ldc_, const float *bias) {
 
     if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
                 && utils::one_of(*transb_, 'n', 'N', 't', 'T')))
-        return dnnl_unimplemented;
+        return status::unimplemented;
 
     bool isTransA = (*transa_ == 'T' || *transa_ == 't');
     bool isTransB = (*transb_ == 'T' || *transb_ == 't');
@@ -249,7 +247,7 @@ dnnl_status_t rvv_gemm_f32(const char *transa_, const char *transb_,
     const float alpha = *alpha_, beta = *beta_;
 
     // early out and avoid division by zero in partitioning
-    if (utils::one_of(0, M, N)) return dnnl_success;
+    if (utils::one_of(0, M, N)) return status::success;
 
     int max_nthr = dnnl_get_current_num_threads();
     int nthr_m, nthr_n, nthr_k;
@@ -387,7 +385,7 @@ dnnl_status_t rvv_gemm_f32(const char *transa_, const char *transb_,
     free(ws_buffers);
     free(c_buffers);
 
-    return dnnl_success;
+    return status::success;
 }
 
 } // namespace rv64

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
@@ -17,8 +17,6 @@
 #ifndef CPU_RV64_GEMM_RVV_GEMM_F32_HPP
 #define CPU_RV64_GEMM_RVV_GEMM_F32_HPP
 
-#include "oneapi/dnnl/dnnl_types.h"
-
 #include "common/c_types_map.hpp"
 
 namespace dnnl {
@@ -26,10 +24,10 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-dnnl_status_t rvv_gemm_f32(const char *transa, const char *transb,
-        const dim_t *M, const dim_t *N, const dim_t *K, const float *alpha,
-        const float *A, const dim_t *lda, const float *B, const dim_t *ldb,
-        const float *beta, float *C, const dim_t *ldc, const float *bias);
+status_t rvv_gemm_f32(const char *transa, const char *transb, const dim_t *M,
+        const dim_t *N, const dim_t *K, const float *alpha, const float *A,
+        const dim_t *lda, const float *B, const dim_t *ldb, const float *beta,
+        float *C, const dim_t *ldc, const float *bias);
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f32.hpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright 2018-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_GEMM_RVV_GEMM_F32_HPP
+#define CPU_RV64_GEMM_RVV_GEMM_F32_HPP
+
+#include "oneapi/dnnl/dnnl_types.h"
+
+#include "common/c_types_map.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+dnnl_status_t rvv_gemm_f32(const char *transa, const char *transb,
+        const dim_t *M, const dim_t *N, const dim_t *K, const float *alpha,
+        const float *A, const dim_t *lda, const float *B, const dim_t *ldb,
+        const float *beta, float *C, const dim_t *ldc, const float *bias);
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_GEMM_RVV_GEMM_F32_HPP

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
@@ -172,25 +172,6 @@ void partition_unit_diff(
     if (*t_offset + *t_block > n) { *t_block = n - *t_offset; }
 }
 
-// Sum the m*n values from p_src into p_dst, assuming the two-dimensional
-// arrays have leading dimensions ld_src and ld_dst, respectively
-template <typename data_t>
-void sum_two_matrices(dim_t m, dim_t n, data_t *__restrict p_src, dim_t ld_src,
-        data_t *__restrict p_dst, dim_t ld_dst) {
-
-    for (dim_t j = 0; j < n; j++) {
-        for (dim_t i = 0; i < m; i++) {
-            p_dst[i + j * ld_dst] += p_src[i + j * ld_src];
-        }
-    }
-}
-
-template void sum_two_matrices<float>(dim_t m, dim_t n, float *__restrict p_src,
-        dim_t ld_src, float *__restrict p_dst, dim_t ld_dst);
-
-template void sum_two_matrices<double>(dim_t m, dim_t n,
-        double *__restrict p_src, dim_t ld_src, double *__restrict p_dst,
-        dim_t ld_dst);
 } // namespace gemm_utils
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.cpp
@@ -1,0 +1,198 @@
+/*******************************************************************************
+* Copyright 2018-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+#include <cmath>
+
+#include "common/dnnl_thread.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace gemm_utils {
+#define BM_NOCOPY_RVV 64
+#define BN_NOCOPY_RVV 48
+#define BK_NOCOPY_RVV 384
+#define BN_LARGE_NOCOPY_RVV 192
+#define BM_SMALL_NOCOPY_RVV 16
+#define BN_SMALL_NOCOPY_RVV 1
+#define BK_SMALL_NOCOPY_RVV 4
+// Determine number of threads for each dimension of a 3-D partitioning
+// algorithm based on input parameters
+// m/n/k - First/second/third parameter for GEMM
+// nthrs - total available number of threads
+// nthrs_m/nthrs_n/nthrs_k - number of threads to use in each dimension
+// BM/BN/BK - blocking values
+void calc_nthr_nocopy_rvv(dim_t m, dim_t n, dim_t k, int nthrs, int *nthrs_m,
+        int *nthrs_n, int *nthrs_k, dim_t *BM, dim_t *BN, dim_t *BK) {
+
+    // Quick exit for single thread.
+    if (nthrs == 1) {
+        *nthrs_m = 1;
+        *nthrs_n = 1;
+        *nthrs_k = 1;
+
+        *BM = m;
+        *BN = n;
+        *BK = k;
+        return;
+    }
+
+    int nthr, nthr_m, nthr_n, nthr_k;
+    dim_t MB, NB, KB;
+
+    nthr = nthrs;
+    nthr_m = static_cast<int>((m + BM_NOCOPY_RVV - 1) / BM_NOCOPY_RVV);
+    nthr_n = static_cast<int>((n + BN_NOCOPY_RVV - 1) / BN_NOCOPY_RVV);
+    nthr_k = 1;
+
+    // Partition along K dimension
+    //  - if threading allows having barriers (e.g. OMP)
+    //  - if there is not enough parallelism along M or N
+    if (dnnl_thr_syncable()) {
+        int nthr_other = nthr_k = 1;
+        while ((nthr_m * nthr_n * nthr_other < nthr)
+                && (k / (nthr_other + 1) > BK_NOCOPY_RVV)) {
+            nthr_other++;
+            if ((nthr / nthr_other) * nthr_other > 0.9 * nthr)
+                nthr_k = nthr_other;
+        }
+    }
+    nthr /= nthr_k;
+
+    if (nthr_m == 1) nthr_n = nthr;
+    if (nthr_n == 1) nthr_m = nthr;
+
+    // Simple partition reduction
+    while (nthr_m * nthr_n > nthr)
+        if (nthr_m > nthr_n)
+            nthr_m--;
+        else
+            nthr_n--;
+    while (nthr_m * nthr_n < nthr)
+        if (nthr_m < nthr_n)
+            nthr_m++;
+        else
+            nthr_n++;
+
+    if ((nthr_m * nthr_n > nthr) && (nthr_m > 1) && (nthr_n > 1)) {
+
+        if (nthr_m <= nthr_n) {
+            nthr_m = (int)sqrt((double)nthr);
+            if (nthr_m > (m + BM_SMALL_NOCOPY_RVV - 1) / BM_SMALL_NOCOPY_RVV)
+                nthr_m = static_cast<int>(
+                        (m + BM_SMALL_NOCOPY_RVV - 1) / BM_SMALL_NOCOPY_RVV);
+            nthr_n = nthr / nthr_m;
+
+            while ((nthr_m > 1) && (nthr_m * nthr_n != nthr)) {
+                nthr_m--;
+                nthr_n = nthr / nthr_m;
+            }
+        } else {
+            nthr_n = (int)sqrt((double)nthr);
+            if (nthr_n > (n + BN_SMALL_NOCOPY_RVV - 1) / BN_SMALL_NOCOPY_RVV)
+                nthr_n = static_cast<int>(
+                        (n + BN_SMALL_NOCOPY_RVV - 1) / BN_SMALL_NOCOPY_RVV);
+            nthr_m = nthr / nthr_n;
+
+            while ((nthr_n > 1) && (nthr_m * nthr_n != nthr)) {
+                nthr_n--;
+                nthr_m = nthr / nthr_n;
+            }
+        }
+    }
+
+    MB = (m + nthr_m - 1) / nthr_m + BM_SMALL_NOCOPY_RVV - 1;
+    MB -= MB % BM_SMALL_NOCOPY_RVV;
+    NB = (n + nthr_n - 1) / nthr_n + BN_SMALL_NOCOPY_RVV - 1;
+    NB -= NB % BN_SMALL_NOCOPY_RVV;
+    KB = (k + nthr_k - 1) / nthr_k + BK_SMALL_NOCOPY_RVV - 1;
+    KB -= KB % BK_SMALL_NOCOPY_RVV;
+
+    if (MB * nthr_m > m) nthr_m = static_cast<int>((m + MB - 1) / MB);
+    if (NB * nthr_n > n) nthr_n = static_cast<int>((n + NB - 1) / NB);
+    if (KB * nthr_k > k) nthr_k = static_cast<int>((k + KB - 1) / KB);
+
+    *nthrs_m = nthr_m;
+    *nthrs_n = nthr_n;
+    *nthrs_k = nthr_k;
+
+    *BM = MB;
+    *BN = NB;
+    *BK = KB;
+}
+#undef BM_NOCOPY_RVV
+#undef BN_NOCOPY_RVV
+#undef BK_NOCOPY_RVV
+#undef BN_LARGE_NOCOPY_RVV
+#undef BM_SMALL_NOCOPY_RVV
+#undef BN_SMALL_NOCOPY_RVV
+#undef BK_SMALL_NOCOPY_RVV
+
+// Partition n values as equally as possible among nthr threads
+// and set the offset (t_offset) and number of values (t_block) for ithr
+// Assumption: 0 <= ithr < nthr
+void partition_unit_diff(
+        int ithr, int nthr, dim_t n, dim_t *t_offset, dim_t *t_block) {
+
+    dim_t band = n / nthr;
+    if (band == 0) band = 1;
+    dim_t tail = n - band * nthr;
+    if (tail < 0) tail = 0;
+
+    if (ithr < tail) {
+        band++;
+        *t_offset = band * ithr;
+        *t_block = band;
+    } else {
+        *t_offset = band * ithr + tail;
+        *t_block = band;
+    }
+
+    if (*t_offset >= n) {
+        *t_offset = 0;
+        *t_block = 0;
+    }
+
+    if (*t_offset + *t_block > n) { *t_block = n - *t_offset; }
+}
+
+// Sum the m*n values from p_src into p_dst, assuming the two-dimensional
+// arrays have leading dimensions ld_src and ld_dst, respectively
+template <typename data_t>
+void sum_two_matrices(dim_t m, dim_t n, data_t *__restrict p_src, dim_t ld_src,
+        data_t *__restrict p_dst, dim_t ld_dst) {
+
+    for (dim_t j = 0; j < n; j++) {
+        for (dim_t i = 0; i < m; i++) {
+            p_dst[i + j * ld_dst] += p_src[i + j * ld_src];
+        }
+    }
+}
+
+template void sum_two_matrices<float>(dim_t m, dim_t n, float *__restrict p_src,
+        dim_t ld_src, float *__restrict p_dst, dim_t ld_dst);
+
+template void sum_two_matrices<double>(dim_t m, dim_t n,
+        double *__restrict p_src, dim_t ld_src, double *__restrict p_dst,
+        dim_t ld_dst);
+} // namespace gemm_utils
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright 2018-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_GEMM_RVV_GEMM_UTILS_F32_HPP
+#define CPU_RV64_GEMM_RVV_GEMM_UTILS_F32_HPP
+
+#include <cstddef>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace gemm_utils {
+template <typename T, bool isTransA, bool isTransB>
+struct gemm_traits_t {};
+
+template <bool isTransA, bool isTransB>
+struct gemm_traits_t<float, isTransA, isTransB> {
+    static constexpr dim_t m = 16;
+    static constexpr dim_t n = 4;
+    static constexpr dim_t BM = 4032;
+    static constexpr dim_t BN = isTransA ? 96 : 48;
+    static constexpr dim_t BK = isTransB ? 96 : 256;
+};
+
+template <typename T>
+using unroll_factor = gemm_traits_t<T, false, false>;
+
+template <typename data_t>
+void sum_two_matrices(dim_t m, dim_t n, data_t *__restrict p_src, dim_t ld_src,
+        data_t *__restrict p_dst, dim_t ld_dst);
+
+void calc_nthr_nocopy_rvv(dim_t m, dim_t n, dim_t k, int nthrs, int *nthrs_m,
+        int *nthrs_n, int *nthrs_k, dim_t *BM, dim_t *BN, dim_t *BK);
+
+void partition_unit_diff(
+        int ithr, int nthr, dim_t n, dim_t *t_offset, dim_t *t_block);
+}; // namespace gemm_utils
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+#endif // CPU_RV64_GEMM_RVV_GEMM_UTILS_F32_HPP

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -17,6 +17,8 @@
 #ifndef CPU_RV64_GEMM_RVV_GEMM_UTILS_F32_HPP
 #define CPU_RV64_GEMM_RVV_GEMM_UTILS_F32_HPP
 
+#include "common/c_types_map.hpp"
+
 #include <cstddef>
 
 namespace dnnl {

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -29,7 +29,7 @@ struct gemm_traits_t {};
 
 template <bool isTransA, bool isTransB>
 struct gemm_traits_t<float, isTransA, isTransB> {
-    static constexpr dim_t m = 16;
+    static constexpr dim_t m = 8;
     static constexpr dim_t n = 4;
     static constexpr dim_t BM = 4032;
     static constexpr dim_t BN = isTransA ? 96 : 48;

--- a/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_utils_f32.hpp
@@ -37,18 +37,33 @@ struct gemm_traits_t<float, isTransA, isTransB> {
 };
 
 template <typename T>
-using unroll_factor = gemm_traits_t<T, false, false>;
+struct unroll_factor {};
 
+template <>
+struct unroll_factor<float> {
+    static constexpr dim_t m = gemm_traits_t<float, false, false>::m;
+    static constexpr dim_t n = gemm_traits_t<float, false, false>::n;
+};
+
+// Sum the m*n values from p_src into p_dst, assuming the two-dimensional
+// arrays have leading dimensions ld_src and ld_dst, respectively
 template <typename data_t>
 void sum_two_matrices(dim_t m, dim_t n, data_t *__restrict p_src, dim_t ld_src,
-        data_t *__restrict p_dst, dim_t ld_dst);
+        data_t *__restrict p_dst, dim_t ld_dst) {
+
+    for (dim_t j = 0; j < n; j++) {
+        for (dim_t i = 0; i < m; i++) {
+            p_dst[i + j * ld_dst] += p_src[i + j * ld_src];
+        }
+    }
+}
 
 void calc_nthr_nocopy_rvv(dim_t m, dim_t n, dim_t k, int nthrs, int *nthrs_m,
         int *nthrs_n, int *nthrs_k, dim_t *BM, dim_t *BN, dim_t *BK);
 
 void partition_unit_diff(
         int ithr, int nthr, dim_t n, dim_t *t_offset, dim_t *t_block);
-}; // namespace gemm_utils
+} // namespace gemm_utils
 } // namespace rv64
 } // namespace cpu
 } // namespace impl


### PR DESCRIPTION
# Description

This PR introduces a SIMD-optimized f32 GEMM kernel for the RISC-V 64-bit architecture, leveraging the RISC-V Vector (V) Extension.

The existing generic GEMM implementation in oneDNN (`ref_gemm`) relies on `PRAGMA_OMP_SIMD` for auto-vectorization. However, current RISC-V toolchains do not effectively vectorize this code, leading to suboptimal performance on RV64 platforms. This commit addresses this critical performance gap by providing a manually optimized SIMD implementation, `rvv_gemm_f32`, which is dispatched from `extended_sgemm`.

This optimization is integrated directly into the low-level `extended_sgemm` function. This provides two major benefits:
1.  It accelerates direct `sgemm` calls across the library.
2.  It boosts the performance of high-level primitives that rely on this function. The example is `gemm_convolution_fwd_t`, one of the most efficient forward convolution implementations in oneDNN.

By targeting the foundational GEMM routine, this PR delivers performance gains for models like Convolutional Neural Networks (CNNs).

The current implementation only focuses on the `f32` data type.

# Checklist

## General

- [√] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [√] Have you formatted the code using clang-format?

## Performance improvements

- [√] Have you submitted performance data that demonstrates performance improvements?  

All performance data was measured on a Spacemit X60 development board (VLEN=256). The performance baseline is the default `ref_gemm` implementation in the oneDNN main branch. Below are some example performance benchmarks for different problem sizes.

### Matmul Primitives Performance

| Benchmark Case                                                | Baseline (`ref_gemm`) | This PR (`rvv_gemm`) | Speedup |
| :------------------------------------------------------------ | :-------------------- | :------------------- | :------ |
| `--matmul --stag=acb --wtag=cab 2x457x3888:2x3888x2888`        | 11.44s                | 3.28s                | 3.49x |
| `--matmul --bia-dt=f32 1024x1024:1024x1024`                    | 3.34s                 | 2.53s                | 1.32x |
| `--matmul --stag=acb --wtag=abc 2x551x1276:2x1276x58`          | 0.09s                 | 0.04s                | ~2.25x |

### Convolution Primitives Performance (via GEMM)

This demonstrates the advantage of optimizing the `extended_sgemm`.

| Benchmark Case                                                                                            | Baseline (`gemm_conv`) | This PR (`gemm_conv` with `rvv_gemm`) | Speedup |
| :-------------------------------------------------------------------------------------------------------- | :-------------------- | :------------------ | :------ |
| `--conv mb1ic3id116ih132iw132oc32od114oh130ow130kd3kh3kw3pd0ph0pw0n"3d_unet:conv_1"` | 2.09s                 | 1.55s               | 1.35x |

### New features

- [  ] Have you published an RFC for the new feature?
- [  ] Was the RFC approved?
- [  ] Have you added relevant tests?

### Bug fixes

- [  ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [  ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [  ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [  ] Have you added a link to the rendered document?
