### PR TITLE
host-side scalar scales and zps support for (de)conv ref ocl

### DIFF
--- a/src/common/convolution.cpp
+++ b/src/common/convolution.cpp
@@ -212,12 +212,6 @@ status_t conv_attr_check(const convolution_desc_t &desc, const engine_t *engine,
                     IMPLICATION(!sc.has_default_values(DNNL_ARG_DST),
                             utils::one_of(sc.get_mask(DNNL_ARG_DST), 0, 2)),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
-
-            // By default, host scalar scales are not supported for GPU
-            // as the value should be accessed differently in the kernel
-            VCHECK_CONV_UNIMPL(IMPLICATION(engine->kind() == engine_kind::gpu,
-                                       !sc.has_host_scalars()),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
 
         // Check zero points
@@ -235,12 +229,6 @@ status_t conv_attr_check(const convolution_desc_t &desc, const engine_t *engine,
             VCHECK_CONV_UNIMPL(IMPLICATION(!zp.has_default_values(DNNL_ARG_DST),
                                        utils::one_of(zp.get_mask(DNNL_ARG_DST),
                                                0, 1 << 1)),
-                    VERBOSE_UNSUPPORTED_ZP_CFG);
-
-            // By default, host scalar zero points are not supported for GPU
-            // as the value should be accessed differently in the kernel
-            VCHECK_CONV_UNIMPL(IMPLICATION(engine->kind() == engine_kind::gpu,
-                                       !zp.has_host_scalars()),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         }
 

--- a/src/common/deconvolution.cpp
+++ b/src/common/deconvolution.cpp
@@ -189,12 +189,6 @@ status_t deconv_attr_check(const deconvolution_desc_t &desc,
                     IMPLICATION(!sc.has_default_values(DNNL_ARG_DST),
                             sc.get_mask(DNNL_ARG_DST) == 0),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
-
-            // By default, host scalar scales are not supported for GPU
-            // as the value should be accessed differently in the kernel
-            VCHECK_DECONV_UNIMPL(IMPLICATION(engine->kind() == engine_kind::gpu,
-                                         !sc.has_host_scalars()),
-                    VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
 
         // Check zero points
@@ -212,12 +206,6 @@ status_t deconv_attr_check(const deconvolution_desc_t &desc,
                     IMPLICATION(!zp.has_default_values(DNNL_ARG_DST),
                             utils::one_of(
                                     zp.get_mask(DNNL_ARG_DST), 0, 1 << 1)),
-                    VERBOSE_UNSUPPORTED_ZP_CFG);
-
-            // By default, host scalar zero points are not supported for GPU
-            // as the value should be accessed differently in the kernel
-            VCHECK_DECONV_UNIMPL(IMPLICATION(engine->kind() == engine_kind::gpu,
-                                         !zp.has_host_scalars()),
                     VERBOSE_UNSUPPORTED_ZP_CFG);
         }
 

--- a/src/gpu/generic/sycl/ref_convolution.hpp
+++ b/src/gpu/generic/sycl/ref_convolution.hpp
@@ -118,6 +118,16 @@ struct ref_convolution_fwd_t : public gpu::generic::sycl::primitive_t {
             VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
                     VERBOSE_BAD_ALGORITHM);
 
+            // By default, host scalar scales and zero points are not supported for GPU
+            // as the value should be accessed differently in the kernel
+            VDISPATCH_CONV(IMPLICATION(!attr()->scales_.has_default_values(),
+                                   !attr()->scales_.has_host_scalars()),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_CONV(
+                    IMPLICATION(!attr()->zero_points_.has_default_values(),
+                            !attr()->zero_points_.has_host_scalars()),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+
             return init_conf();
         }
 
@@ -188,6 +198,16 @@ struct ref_convolution_bwd_data_t : public gpu::generic::sycl::primitive_t {
                     VERBOSE_BAD_ALGORITHM);
             VDISPATCH_CONV(sycl_post_ops_t::post_ops_ok(attr(), false),
                     VERBOSE_UNSUPPORTED_POSTOP);
+
+            // By default, host scalar scales and zero points are not supported for GPU
+            // as the value should be accessed differently in the kernel
+            VDISPATCH_CONV(IMPLICATION(!attr()->scales_.has_default_values(),
+                                   !attr()->scales_.has_host_scalars()),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+            VDISPATCH_CONV(
+                    IMPLICATION(!attr()->zero_points_.has_default_values(),
+                            !attr()->zero_points_.has_host_scalars()),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
 
             return init_conf();
         }

--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -935,6 +935,8 @@ bool zero_points_ok(const problem_t &prb) {
             !utils::one_of(input_type, s8, u8), zp.has_default_values());
     if (!ok) return false;
 
+    if (zp.has_host_scalars()) return false;
+
     if (!zp.has_default_values(DNNL_ARG_SRC)) {
         int mask_src = zp.get_mask(DNNL_ARG_SRC);
         ok = utils::one_of(mask_src, 0, (1 << 1));
@@ -982,6 +984,8 @@ bool post_ops_ok(const problem_t &prb, const hw_t &hw) {
     if (!attr->post_ops_.check_sum_consistency(
                 prb.c_data_type, utils::one_of(input_type, s8, u8), true))
         return false;
+
+    if (attr->scales_.has_host_scalars()) return false;
 
     if (!attr->scales_.has_default_values())
         if (!prb.is_s32_accumulator() && !prb.is_fp8_conv()) return false;

--- a/src/gpu/intel/conv/jit_v2.cpp
+++ b/src/gpu/intel/conv/jit_v2.cpp
@@ -121,6 +121,9 @@ public:
         auto skip_mask
                 = sm::post_ops | sm::sum_dt | sm::scales | sm::scales_data_type;
         if (!pd->attr()->has_default_values(skip_mask)) return false;
+        if (pd->attr()->scales_.has_host_scalars()
+                || pd->attr()->zero_points_.has_host_scalars())
+            return false;
         return true;
     }
 

--- a/src/gpu/intel/conv/ref.cl
+++ b/src/gpu/intel/conv/ref.cl
@@ -41,11 +41,36 @@ KERNEL_ATTR
 __kernel void ref_convolution_fwd(
         const __global SRC_DATA_T *src, const __global WEI_DATA_T *wei,
         const __global BIA_DATA_T *bias, __global DST_DATA_T *dst POST_OP_ARGS,
+#if WITH_HOST_SRC_SCALE
+        SRC_SCALES_DATA_T src_scale_value,
+#else
         const __global SRC_SCALES_DATA_T *src_scales,
+#endif
+#if WITH_HOST_WEI_SCALE
+        WEI_SCALES_DATA_T wei_scale_value,
+#else
         const __global WEI_SCALES_DATA_T *wei_scales,
+#endif
+#if WITH_HOST_DST_SCALE
+        DST_SCALES_DATA_T dst_scale_value,
+#else
         const __global DST_SCALES_DATA_T *dst_scales,
-        const __global int *src_zpoints, const __global WEI_ZP_T *wei_zpoints,
+#endif
+#if WITH_HOST_SRC_ZP
+        int src_zp_value,
+#else
+        const __global int *src_zpoints,
+#endif
+#if WITH_HOST_WEI_ZP
+        WEI_ZP_T wei_zp_value,
+#else
+        const __global WEI_ZP_T *wei_zpoints,
+#endif
+#if WITH_HOST_DST_ZP
+        int dst_zp_value
+#else
         const __global int *dst_zpoints
+#endif
 #if WITH_SROUND
         ,
         __global uint *sround_seed_buf
@@ -53,6 +78,25 @@ __kernel void ref_convolution_fwd(
 ) {
 #if WITH_SROUND
     uint sround_seed = sround_seed_buf[0];
+#endif
+
+#if WITH_HOST_SRC_SCALE
+    SRC_SCALES_DATA_T *src_scales = &src_scale_value;
+#endif
+#if WITH_HOST_WEI_SCALE
+    WEI_SCALES_DATA_T *wei_scales = &wei_scale_value;
+#endif
+#if WITH_HOST_DST_SCALE
+    DST_SCALES_DATA_T *dst_scales = &dst_scale_value;
+#endif
+#if WITH_HOST_SRC_ZP
+    int *src_zpoints = &src_zp_value;
+#endif
+#if WITH_HOST_DST_ZP
+    int *dst_zpoints = &dst_zp_value;
+#endif
+#if WITH_HOST_WEI_ZP
+    WEI_ZP_T *wei_zpoints = &wei_zp_value;
 #endif
 
     src += SRC_OFFSET0;

--- a/src/gpu/intel/conv/ref.cl
+++ b/src/gpu/intel/conv/ref.cl
@@ -218,9 +218,56 @@ KERNEL_ATTR
 __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
         const __global WEI_DATA_T *wei, const __global DST_DATA_T *diff_dst,
         const __global BIA_DATA_T *bias POST_OP_ARGS,
-        const __global float *src_scales, const __global float *wei_scales,
-        const __global float *dst_scales, const __global int *src_zpoints,
-        const __global WEI_ZP_T *wei_zpoints, const __global int *dst_zpoints) {
+#if WITH_HOST_SRC_SCALE
+        float src_scale_value,
+#else
+        const __global float *src_scales,
+#endif
+#if WITH_HOST_WEI_SCALE
+        float wei_scale_value,
+#else
+        const __global float *wei_scales,
+#endif
+#if WITH_HOST_DST_SCALE
+        float dst_scale_value,
+#else
+        const __global float *dst_scales,
+#endif
+#if WITH_HOST_SRC_ZP
+        int src_zp_value,
+#else
+        const __global int *src_zpoints,
+#endif
+#if WITH_HOST_WEI_ZP
+        WEI_ZP_T wei_zp_value,
+#else
+        const __global WEI_ZP_T *wei_zpoints,
+#endif
+#if WITH_HOST_DST_ZP
+        int dst_zp_value
+#else
+        const __global int *dst_zpoints
+#endif
+) {
+#if WITH_HOST_SRC_SCALE
+    SRC_SCALES_DATA_T *src_scales = &src_scale_value;
+#endif
+#if WITH_HOST_WEI_SCALE
+    WEI_SCALES_DATA_T *wei_scales = &wei_scale_value;
+#endif
+#if WITH_HOST_DST_SCALE
+    DST_SCALES_DATA_T *dst_scales = &dst_scale_value;
+#endif
+#if WITH_HOST_SRC_ZP
+    int *src_zpoints = &src_zp_value;
+#endif
+#if WITH_HOST_DST_ZP
+    int *dst_zpoints = &dst_zp_value;
+#endif
+#if WITH_HOST_WEI_ZP
+    WEI_ZP_T *wei_zpoints = &wei_zp_value;
+#endif
+
     const off_t n = GWS_GET_MB();
     const off_t ic = GWS_GET_IC();
     const off_t g = GWS_GET_G();

--- a/src/gpu/intel/matmul/ref.cl
+++ b/src/gpu/intel/matmul/ref.cl
@@ -37,25 +37,25 @@ uint get_dropout_threshold(float p) {
 
 __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
         __global DST_DATA_T *C, __global BIA_DATA_T *bia,
-#if HOST_SRC_ZP
+#if WITH_HOST_SRC_ZP
         SRC_ZP_DATA_T a0_value,
 #else
         __global SRC_ZP_DATA_T *a0,
 #endif
         long src_zp_stride_k, long src_zp_stride_m, long src_zp_group_k,
-#if HOST_WEI_ZP
+#if WITH_HOST_WEI_ZP
         WEI_ZP_DATA_T b0_value,
 #else
         __global WEI_ZP_DATA_T *b0,
 #endif
         long wei_zp_stride_n, long wei_zp_stride_k, long wei_zp_stride_d0,
         long wei_zp_stride_d1, long wei_zp_group_n, long wei_zp_group_k,
-#if HOST_DST_ZP
+#if WITH_HOST_DST_ZP
         int c0_value,
 #else
         __global int *c0,
 #endif
-#if HOST_SRC_SCALE
+#if WITH_HOST_SRC_SCALE
         SRC_SCALES_DATA_T src_scale_value,
 #else
         __global SRC_SCALES_DATA_T *src_scales,
@@ -63,7 +63,7 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
         long src_scale_stride_k, long src_scale_stride_m,
         long src_scale_stride_d0, long src_scale_stride_d1,
         long src_scale_group_k,
-#if HOST_WEI_SCALE
+#if WITH_HOST_WEI_SCALE
         WEI_SCALES_DATA_T wei_scale_value,
 #else
         __global WEI_SCALES_DATA_T *wei_scales,
@@ -71,7 +71,7 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
         long wei_scale_stride_n, long wei_scale_stride_k,
         long wei_scale_stride_d0, long wei_scale_stride_d1,
         long wei_scale_group_n, long wei_scale_group_k,
-#if HOST_DST_SCALE
+#if WITH_HOST_DST_SCALE
         DST_SCALES_DATA_T dst_scale_value,
 #else
         __global DST_SCALES_DATA_T *dst_scales,
@@ -97,22 +97,22 @@ __kernel void ref_matmul(__global SRC_DATA_T *A, __global WEI_DATA_T *B,
 #endif
                 POST_OP_ARGS) {
 
-#if HOST_SRC_ZP
+#if WITH_HOST_SRC_ZP
     SRC_ZP_DATA_T *a0 = &a0_value;
 #endif
-#if HOST_WEI_ZP
+#if WITH_HOST_WEI_ZP
     WEI_ZP_DATA_T *b0 = &b0_value;
 #endif
-#if HOST_DST_ZP
+#if WITH_HOST_DST_ZP
     int *c0 = &c0_value;
 #endif
-#if HOST_SRC_SCALE
+#if WITH_HOST_SRC_SCALE
     SRC_SCALES_DATA_T *src_scales = &src_scale_value;
 #endif
-#if HOST_WEI_SCALE
+#if WITH_HOST_WEI_SCALE
     WEI_SCALES_DATA_T *wei_scales = &wei_scale_value;
 #endif
-#if HOST_DST_SCALE
+#if WITH_HOST_DST_SCALE
     DST_SCALES_DATA_T *dst_scales = &dst_scale_value;
 #endif
 

--- a/src/gpu/intel/matmul/ref.hpp
+++ b/src/gpu/intel/matmul/ref.hpp
@@ -255,20 +255,6 @@ struct ref_t : public primitive_t {
             kernel_ctx.define_int("NDIMS", ndims);
         }
         kernel_ctx.define_int("RUNTIME_DIMS", runtime_dims);
-        kernel_ctx.define_int("HOST_SRC_SCALE",
-                pd()->attr()->scales_.get(DNNL_ARG_SRC).is_host_scalar());
-        kernel_ctx.define_int("HOST_WEI_SCALE",
-                pd()->attr()->scales_.get(DNNL_ARG_WEIGHTS).is_host_scalar());
-        kernel_ctx.define_int("HOST_DST_SCALE",
-                pd()->attr()->scales_.get(DNNL_ARG_DST).is_host_scalar());
-        kernel_ctx.define_int("HOST_SRC_ZP",
-                pd()->attr()->zero_points_.get(DNNL_ARG_SRC).is_host_scalar());
-        kernel_ctx.define_int("HOST_WEI_ZP",
-                pd()->attr()
-                        ->zero_points_.get(DNNL_ARG_WEIGHTS)
-                        .is_host_scalar());
-        kernel_ctx.define_int("HOST_DST_ZP",
-                pd()->attr()->zero_points_.get(DNNL_ARG_DST).is_host_scalar());
 
         def_data_type(kernel_ctx, pd()->src_dt_, "SRC");
         def_data_type(kernel_ctx, pd()->wei_dt_, "WEI");

--- a/src/gpu/intel/primitive_conf.cpp
+++ b/src/gpu/intel/primitive_conf.cpp
@@ -133,6 +133,14 @@ attr_info_t attr_info_t::create(const primitive_attr_t *attr) {
     attr_info.wei_zpoints_data_type = zp.get_data_type(DNNL_ARG_WEIGHTS);
     attr_info.dst_zpoints_data_type = zp.get_data_type(DNNL_ARG_DST);
 
+    // host-side scalars for scales or zero-points
+    attr_info.with_host_src_scale = src_scales.is_host_scalar();
+    attr_info.with_host_wei_scale = wei_scales.is_host_scalar();
+    attr_info.with_host_dst_scale = dst_scales.is_host_scalar();
+    attr_info.with_host_src_zp = zp.get(DNNL_ARG_SRC).is_host_scalar();
+    attr_info.with_host_wei_zp = zp.get(DNNL_ARG_WEIGHTS).is_host_scalar();
+    attr_info.with_host_dst_zp = zp.get(DNNL_ARG_DST).is_host_scalar();
+
     attr_info.with_per_ic_src_zpoints = attr_info.with_src_zpoints
             && !zp.has_default_values(DNNL_ARG_SRC)
             && zp.get_mask(DNNL_ARG_SRC) > 0;
@@ -753,6 +761,13 @@ status_t def_attr_info_impl(compute::kernel_ctx_t &kernel_ctx,
             attr_info.wei_zpoints_data_type == dnnl_s8);
     kernel_ctx.define_int("WITH_WEI_ZPOINTS_DT_U8",
             attr_info.wei_zpoints_data_type == dnnl_u8);
+
+    kernel_ctx.define_int("WITH_HOST_SRC_ZP", attr_info.with_host_src_zp);
+    kernel_ctx.define_int("WITH_HOST_WEI_ZP", attr_info.with_host_wei_zp);
+    kernel_ctx.define_int("WITH_HOST_DST_ZP", attr_info.with_host_dst_zp);
+    kernel_ctx.define_int("WITH_HOST_SRC_SCALE", attr_info.with_host_src_scale);
+    kernel_ctx.define_int("WITH_HOST_WEI_SCALE", attr_info.with_host_wei_scale);
+    kernel_ctx.define_int("WITH_HOST_DST_SCALE", attr_info.with_host_dst_scale);
 
     def_binary_alg_kinds(kernel_ctx);
     def_eltwise_alg_kinds(kernel_ctx);

--- a/src/gpu/intel/primitive_conf.hpp
+++ b/src/gpu/intel/primitive_conf.hpp
@@ -97,6 +97,13 @@ struct attr_info_t {
     data_type_t wei_zpoints_data_type;
     data_type_t dst_zpoints_data_type;
     bool with_dst_sround;
+
+    bool with_host_src_scale;
+    bool with_host_wei_scale;
+    bool with_host_dst_scale;
+    bool with_host_src_zp;
+    bool with_host_wei_zp;
+    bool with_host_dst_zp;
 };
 
 template <size_t ndims>

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -193,7 +193,8 @@ int attr_t::get_default_mask(policy_t policy, int ndims) {
             assert(ndims > 0 && ndims <= DNNL_MAX_NDIMS);
             return (1 << ndims) - 1;
         case COMMON: return 0;
-        case HOST_SCALAR: return INT_MIN >> 1; // shouldn't rely on mask
+        case HOST_SCALAR:
+            return 0; // mask=0 is required for compatibility with preprocessing logic
         default: SAFE(FAIL, CRIT); return 0;
     }
 }

--- a/tests/benchdnn/inputs/conv/option_gpu_ci
+++ b/tests/benchdnn/inputs/conv/option_gpu_ci
@@ -28,9 +28,11 @@
 ## Attributes
 --dir=FWD_I
 --dt=u8:s8:s32
---attr-scales=,src:common:0.5+wei:common:2+dst:common:4
+--attr-scales=,src:common:0.5+wei:common:2+dst:common:4, \
+               src:host_scalar:0.5+wei:host_scalar:2+dst:host_scalar:4
 --attr-post-ops=,sum:0.5:3+add:f32:per_dim_1+mul:f16:per_tensor
---attr-zero-points=,src:common:2+dst:common:1,src:per_dim_1+wei:common:2+dst:per_dim_1
+--attr-zero-points=,src:common:2+dst:common:1,src:per_dim_1+wei:common:2+dst:per_dim_1,\
+                  src:host_scalar:2+dst:host_scalar:1,src:per_dim_1+wei:host_scalar:2+dst:per_dim_1
 --batch=shapes_ci_gpu
 --attr-scales=
 --attr-post-ops=

--- a/tests/benchdnn/inputs/conv/test_conv_ci
+++ b/tests/benchdnn/inputs/conv/test_conv_ci
@@ -51,7 +51,8 @@
 
 # Inference
 --dir=FWD_I
---attr-scales=,src:common:0.25,wei:per_oc,dst:common:2,src:common:0.25+wei:per_oc
+--attr-scales=,src:common:0.25,wei:per_oc,dst:common:2,src:common:0.25+wei:per_oc, \
+              src:host_scalar:0.25,dst:host_scalar:2
 
 ## Direct
 --alg=direct
@@ -72,7 +73,8 @@
 --attr-zero-points=
 --batch=shapes_basic
 --attr-post-ops=
---attr-zero-points=,src:common:2+dst:common:1,src:per_dim_1+dst:per_dim_1,src:per_dim_1+dst:common:1
+--attr-zero-points=,src:common:2+dst:common:1,src:per_dim_1+dst:per_dim_1,src:per_dim_1+dst:common:1, \
+                    src:host_scalar:2+dst:host_scalar:1
 --batch=shapes_basic
 ### Signed input
 --dt=s8:s8:s8

--- a/tests/benchdnn/inputs/deconv/test_deconv_ci
+++ b/tests/benchdnn/inputs/deconv/test_deconv_ci
@@ -33,7 +33,7 @@
 --dt=s8:s8:f32,s8:s8:bf16,s8:s8:s32,s8:s8:s8,s8:s8:u8,u8:s8:f32,u8:s8:bf16,u8:s8:s32,u8:s8:s8,u8:s8:u8
 --batch=shapes_ci
 
---attr-scales=,src:common:0.25,wei:per_oc,dst:common:2,src:common:0.25+wei:per_oc
+--attr-scales=,src:common:0.25,wei:per_oc,dst:common:2,src:common:0.25+wei:per_oc,src:host_scalar:0.25+dst:host_scalar:2
 ## Direct
 --alg=direct
 --dt=s8:s8:s8,u8:s8:s32
@@ -48,7 +48,7 @@
 --batch=shapes_ci
 
 --attr-post-ops=
---attr-zero-points=,src:common:31+dst:common:15
+--attr-zero-points=,src:common:31+dst:common:15,src:host_scalar:31+dst:host_scalar:15
 --batch=shapes_ci
 # BF32 and TF32
 --reset


### PR DESCRIPTION
Continuation of [MFDNN-13410](https://jira.devtools.intel.com/browse/MFDNN-13410) effort.

**Summary:**

- Extended OCL (de)conv impl to support host-side scalars scales and zps
  - Moved "generic" check for unsupported combinations to other impls
  - Added new macros for HOST_SCALE and HOST_ZP
- In benchdnn, set mask to 0 with HOST_SCALAR policy as this is a default property for host-side scalar memory and conv pre-processing relies on mask value
- Rebased matmul to new macros