### PR TITLE
[GPU] Relax IR message slot size restrictions - Part 1

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -1299,9 +1299,9 @@ void CopyPlan::planInt4Upconversion(CopyInstruction &i)
             i0.dst.stride *= 2;
             i0.src0.stride *= 2;
             i0.simd /= 2;
-            auto &i1 = split(i, false);
-            i1.dst.offset += i1.dst.stride / 2;
-            i1.src0.offset += i1.src0.stride / 2;
+            split(i, true);
+            i0.dst.offset += i0.dst.stride / 2;
+            i0.src0.offset += i0.src0.stride / 2;
         }
     } else {
         bool even = (i.src0.offset % 2 == 0);

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -3089,6 +3089,8 @@ void CopyPlan::materializeTemps(const GRFAllocator &grfAllocator, const FlagAllo
     while (order != end) {
         for (; order != end; ++order) {
             auto &temp = temps[order->second];
+            // Don't allocate unused temporaries.
+            if (temp.cnumMin > temp.cnumMax) continue;
             if (!manager.allocate(temp)) {
                 cnum1 = temp.cnumMin; break;
             }

--- a/src/gpu/intel/jit/codegen/ngen_helpers.hpp
+++ b/src/gpu/intel/jit/codegen/ngen_helpers.hpp
@@ -98,6 +98,9 @@ inline type_t to_ir(ngen::DataType type) {
 #define CASE(_kind, ngen_enum) \
     if (type == ngen::DataType::ngen_enum) return type_t::_kind();
 
+    if (type == ngen_f4_e3m0()) return type_t::f4_e3m0();
+    if (type == ngen_f4_e2m1()) return type_t::f4_e2m1();
+
     CASE(bf16, bf);
     CASE(f16, hf);
     CASE(bf8, bf8);

--- a/src/gpu/intel/jit/codegen/reorder.cpp
+++ b/src/gpu/intel/jit/codegen/reorder.cpp
@@ -543,7 +543,7 @@ void reorder_impl_t::emit(copy_plan_t &plan, const reg_buf_data_t &src,
         emit(plan, tmp_op, src_op);
         emit(plan, dst_op, tmp_op);
     } else if (do_post_conv) {
-        const auto &tmp_op = in_place
+        auto tmp_op = in_place
                 ? init_operand(std::move(down_layout), from_op(dst_op))
                 : init_operand(std::move(down_layout), from_temp);
         emit(plan, tmp_op, src_op);

--- a/src/gpu/intel/jit/codegen/reorder.hpp
+++ b/src/gpu/intel/jit/codegen/reorder.hpp
@@ -387,9 +387,7 @@ private:
 
         if (s == d) return d; // Swizzle only
         if (s.is_fp8() || d.is_fp8()) return type_t::f16();
-        if (s.size() > 4) return d;
-        if (d.size() > 4) return s;
-        return s.bitsize() >= d.bitsize() ? s : d;
+        return s.bitsize() > d.bitsize() ? d : s;
     }
 
     bool needs_saturate(const type_t &ddt, const type_t &sdt) const {

--- a/src/gpu/intel/jit/grf_usage.cpp
+++ b/src/gpu/intel/jit/grf_usage.cpp
@@ -273,6 +273,7 @@ private:
         if (is_invalid_) return;
         gpu_assert(is_buffer(src));
         gpu_assert(is_buffer(dst));
+        if (src.is_same(dst)) return;
         set_label(dst, grf_usage_label_t::reorder);
     }
 

--- a/src/gpu/intel/jit/ir/core.hpp
+++ b/src/gpu/intel/jit/ir/core.hpp
@@ -18,16 +18,13 @@
 #define GPU_INTEL_JIT_IR_CORE_HPP
 
 #include <algorithm>
-#include <atomic>
 #include <cstdio>
 #include <memory>
-#include <numeric>
 #include <string>
 
 #include "common/bfloat16.hpp"
 #include "common/c_types_map.hpp"
 #include "common/float16.hpp"
-#include "common/math_utils.hpp"
 #include "gpu/intel/jit/codegen/register_allocator.hpp"
 #include "gpu/intel/jit/utils/utils.hpp"
 
@@ -675,6 +672,9 @@ public:
         return bits_per_byte * size() / bitsize();
     }
 
+    // For floating point types, returns the number of mantissa bits
+    int mantissa_bits() const;
+
     std::string str() const {
         ostringstream_t oss;
         oss << to_string(kind());
@@ -692,6 +692,9 @@ private:
     int elems_ = 0;
     type_attr_t attr_ = type_attr_t::undef;
 };
+
+// Can type b represent all values of type a?
+bool is_subset(const type_t &a, const type_t &b);
 
 // type_t to dnnl_data_type_t convertor.
 data_type_t to_dnnl(const type_t &type);

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -2588,7 +2587,8 @@ send_group_t init_scattered(const view_info_t &info,
     int slot_stride = std::max(4, slot_size);
     int inner_slots = ir_utils::safe_divide(it.inner_bytes(), slot_size);
 
-    gpu_assert((slot_size % type_size == 0) || (slot_stride == slot_size));
+    gpu_assert((slot_size * type_packing % type_size == 0)
+            || (slot_stride == slot_size));
 
     send_group_t ret;
     ret.hw = info.hw();
@@ -2611,7 +2611,7 @@ send_group_t init_scattered(const view_info_t &info,
                     blocks.begin(), blocks.begin() + info.outer_idx()));
     reg_layout = reg_layout.make_dense();
     if (slot_stride != slot_size) {
-        if (slot_size == type_size) {
+        if (slot_size * type_packing == type_size) {
             reg_layout = reg_layout.make_strided(slot_stride / slot_size);
         } else {
             gpu_assert(reg_layout.nblocks() > 0);

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -1341,19 +1341,6 @@ public:
         else
             slot_size = ir_utils::max_divisor(inner_bytes, {1, 2, 4, 8});
 
-        // XXX: Prohibit type promotion with sub-dword slots as the resulting
-        // GRF layout will be strided in the middle and may trigger unsupported
-        // reorders. Once reorder is robust enough, this check is to be removed
-        const int type_size = send_params.mem_type.size();
-        const int type_packing = send_params.mem_type.packing();
-        if (type_size < slot_size * type_packing && slot_size < 4)
-            slot_size = type_size;
-
-        // Require sub-byte types to fill a dword to avoid striding. This
-        // restriction can be reduced to byte-alignment when the restriction
-        // above is lifted.
-        if (slot_size < 4 && type_packing > 1) gpu_error_not_expected();
-
         // GPUs <= XeLP requires qword alignment for qword scattered messages,
         // downgrade to byte scattered (x1, x2 or x4) when alignment is
         // sub-qword.


### PR DESCRIPTION
This will be the first of 2 (or 3) PRs to address [MFDNN-13450](https://jira.devtools.intel.com/browse/MFDNN-13450). This PR introduces an extra reorder to re/un-packed message payloads and adds additional int4 handling in the copy planner to support this. With these changes, the restrictions on 4-bit types is that the innermost block has stride 1 and that either: (1) the number of inner contiguous elements is divisible by 8 so loads are dense, or (2) the innermost block is divisible by 2 so the block is coterminous with a scattered message slot.

A side-effect of this PR is that it also addresses [MFDNN-13975](https://jira.devtools.intel.com/browse/MFDNN-13975).
