### PR TITLE
cpu: aarch64: bnorm: fix illegal instructions on some ISAs

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -33,8 +33,6 @@ if [[ "$OS" == "Linux" ]]; then
 fi
 
 # Nightly failures
-SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_all_blocked_cpu"
-SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_bnorm_regressions_cpu"
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
 
 # c7g failures. TODO: scope these to c7g only. Better yet, fix them.


### PR DESCRIPTION
# Description

Fixes an illegal instruction being thrown on unsupported platforms.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
