### PR TITLE
[WIP] common, xe: adjust e3m0 rounding

### DIFF
--- a/src/common/float4.cpp
+++ b/src/common/float4.cpp
@@ -14,12 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <array>
-
-#include "common/bit_cast.hpp"
-#include "common/dnnl_thread.hpp"
-#include "common/float16.hpp"
 #include "common/float4.hpp"
+#include "common/float16.hpp"
 #include "common/utils.hpp"
 
 namespace dnnl {
@@ -113,8 +109,10 @@ uint8_t float2e3m0(float f) {
             min_diff = diff;
             raw_bits = idx;
         }
-        // Special case for midpoint, we round to even (so even index)
-        if ((diff == min_diff) && !(idx & 1)) raw_bits = idx;
+        // Special case for midpoint:
+        //  - towards 0 for 0.125
+        //  - up for other ties
+        if ((diff == min_diff) && idx != 1) raw_bits = idx;
     }
     assert(raw_bits < 8);
     // reapply sign

--- a/src/gpu/intel/include/math_utils.h
+++ b/src/gpu/intel/include/math_utils.h
@@ -764,6 +764,9 @@ uchar __attribute__((overloadable)) cvt_f32_to_f4_e3m0(float a) {
     // and (nz)f0.0 null t0:ud 0x00ffffff:ud
     uint bits = as_uint(intermediate);
     bits -= 0x00400000;
+
+    // Special rounding
+    if (as_float(bits) > 0) bits |= 1;
     uint round_up = bits & 0x00ffffff;
 
     // shr t0:ud t0:ud 23


### PR DESCRIPTION
The current tiebreak for e3m0 RTNE is to choose the encoding with an unset last bit. Typically RTNE means choose an even mantissa, but as e3m0 has none, special rules apply:

 - zero is even, other values are odd
 - round towards the nearest representable value
 - in case of a tie, round to the nearest even, if one of the nearby representable values is even
 - if both nearby representable values are odd, round away from zero