### PR TITLE
WIP: xe: gemm: drop C type memory check

### DIFF
--- a/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
@@ -372,8 +372,6 @@ MatchParamsBase::MatchParamsBase(ngen::HW hw, bool systolicAvailable, bool isInt
     selector.layouts[1] = &temp[14];
     selector.layouts[2] = &temp[16];
 
-    precisionCExt = precisionChar(problem.Tc_ext);
-
     alignment[0] = problem.A.alignment;
     alignment[1] = problem.B.alignment;
     alignment[2] = problem.C.alignment;


### PR DESCRIPTION
As @petercad suggested - to relax kernel selector rules about accumulator type and C type in memory.

Related Jira: https://jira.devtools.intel.com/browse/MFDNN-14093