### PR TITLE
xe: introduce stable type_t interface

### DIFF
--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -115,11 +115,11 @@ bool is_small(const type_t &type, dim_t elems) {
 }
 
 bool is_small_ic(const problem_t &prb) {
-    return is_small(prb.src_data_type, prb.ic);
+    return is_small(to_ir(prb.src_data_type), prb.ic);
 }
 
 bool is_small_oc(const problem_t &prb) {
-    return is_small(prb.src_data_type, prb.oc);
+    return is_small(to_ir(prb.src_data_type), prb.oc);
 }
 
 status_t problem_t::init(
@@ -553,12 +553,12 @@ void init_data_tags(const config_t &cfg, const memory_desc_t &src_md,
     auto wei_compute_type = prb.is_bwd_w ? prb.c_data_type : prb.b_data_type;
 
     auto src_blk = nc_block_t::get_default_blocking(cfg.hw(), cfg.fma_kind(),
-            src_compute_type, prb.is_dw, prb.mb, prb.ic, prb.g,
+            to_ir(src_compute_type), prb.is_dw, prb.mb, prb.ic, prb.g,
             /*is_output=*/prb.is_bwd_d);
     auto dst_blk = nc_block_t::get_default_blocking(cfg.hw(), cfg.fma_kind(),
-            dst_compute_type, prb.is_dw, prb.mb, prb.oc, prb.g,
+            to_ir(dst_compute_type), prb.is_dw, prb.mb, prb.oc, prb.g,
             /*is_output=*/prb.is_fwd);
-    auto wei_blk = goi_block_t::get_default_blocking(wei_compute_type,
+    auto wei_blk = goi_block_t::get_default_blocking(to_ir(wei_compute_type),
             cfg.vec_size(), cfg.fma_kind(), prb.is_fwd, prb.is_bwd_d, prb.g,
             prb.oc, prb.ic, prb.ab_swap_transpose);
 
@@ -1058,8 +1058,8 @@ status_t init_simd(config_t &cfg) {
     if (cfg.exec_cfg_param().is_overridden("simd")) return status::success;
 
     const auto &prb = cfg.prb();
-    int simd = get_simd_size(cfg.hw(), cfg.fma_kind(), prb.a_data_type,
-            prb.b_data_type, prb.acc_data_type);
+    int simd = get_simd_size(cfg.hw(), cfg.fma_kind(), to_ir(prb.a_data_type),
+            to_ir(prb.b_data_type), to_ir(prb.acc_data_type));
     cfg.set_simd(simd);
     return status::success;
 }
@@ -1832,8 +1832,8 @@ void validate_config_and_plan(config_t &cfg) {
         b_load_pattern = validate_blocking(
                 cfg, stride_layout_t::input_tensor_t::dst, b_2d);
     }
-    auto dummy_mem(var_t::make(type_t::byte_ptr(), "mem"));
-    auto dummy_reg(var_t::make(type_t::byte_ptr(), "reg"));
+    auto dummy_mem(var_t::make(type_t::byte(type::attr_t::ptr), "mem"));
+    auto dummy_reg(var_t::make(type_t::byte(type::attr_t::ptr), "reg"));
     if (!a_load_pattern.matches(
                 plan.x2r.a_load.create_stmt(dummy_mem, dummy_reg))) {
         gpu_warning() << "Generated load for tensor A does not match "

--- a/src/gpu/intel/conv/jit/ir_builder.cpp
+++ b/src/gpu/intel/conv/jit/ir_builder.cpp
@@ -559,8 +559,8 @@ private:
                 || !plan_.slm.x_reduce_tile_coord.is_invalid());
         auto x_reduce_buf = buf_mgr_.find("x_reduce", /*allow_empty=*/true).buf;
         if (x_reduce_buf.is_empty()) return;
-        auto x_reduce_dummy_buf
-                = var_t::make(type_t::byte_ptr(), "x_reduce_dummy");
+        auto x_reduce_dummy_buf = var_t::make(
+                type_t::byte(type::attr_t::ptr), "x_reduce_dummy");
         auto x_reduce_view
                 = plan_.bia_view.create_sub_view(plan_.x_reduce_tile_coord());
         auto r2g = make_access_builder(ir_ctx_, x_reduce_view, x_reduce_buf_,

--- a/src/gpu/intel/conv/jit/normalization.cpp
+++ b/src/gpu/intel/conv/jit/normalization.cpp
@@ -275,7 +275,8 @@ view_t post_op_view_mapper_t::create_view(const memory_desc_t &md) const {
 
 view_t post_op_view_mapper_t::try_create_bias_view(uint32_t mask) const {
     if ((prb_.is_fwd || prb_.is_bwd_d) && prb_.with_bias)
-        return create_view(prb_.conv_pd->invariant_bia_md()->data_type, mask);
+        return create_view(
+                to_ir(prb_.conv_pd->invariant_bia_md()->data_type), mask);
     return {};
 }
 

--- a/src/gpu/intel/conv/jit/pipeline.cpp
+++ b/src/gpu/intel/conv/jit/pipeline.cpp
@@ -469,10 +469,12 @@ public:
         // outer loop iteration.
         if (count_object(s.as<for_t>().body, var) != 0) {
             has_var_refs_ = true;
-            mul_var_buf_ = ir_ctx.create_tmp_var(
-                    type_t::byte_ptr(), var.as<var_t>().name + "_mul_buf");
-            preload_var_buf_ = ir_ctx.create_tmp_var(
-                    type_t::byte_ptr(), var.as<var_t>().name + "_preload_buf");
+            mul_var_buf_
+                    = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr),
+                            var.as<var_t>().name + "_mul_buf");
+            preload_var_buf_
+                    = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr),
+                            var.as<var_t>().name + "_preload_buf");
 
             auto mul_alloc = alloc_t::make(
                     mul_var_buf_, var.type().size(), alloc_kind_t::grf);
@@ -1332,8 +1334,8 @@ public:
         // slm_idx[0] -> slm_buf_store
         // slm_idx[1] -> slm_buf_compute
         // slm_idx[2] -> slm_counter
-        auto slm_idx_buf
-                = ir_ctx_.create_tmp_var(type_t::byte_ptr(), "slm_idx");
+        auto slm_idx_buf = ir_ctx_.create_tmp_var(
+                type_t::byte(type::attr_t::ptr), "slm_idx");
         int slm_idx_size = type_t::s32().size();
 
         auto slm_idx_load = [&](int off, int elems) {

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -687,9 +687,11 @@ void init_bwd_w(const config_t &cfg_, gemm_schedule_t &gemm_schedule,
 reorder_plan_t create_reorder_plan(
         const hw_t &hw, const layout_t &src, const layout_t &dst) {
     if (src == dst) return reorder_plan_t();
-    if (src.type().is_bitwise_compatible(dst.type())
+    if ((src.type() == dst.type()
+                || (src.type().is_f32() && dst.type().is_tf32()))
             && src.retype(dst.type()) == dst)
         return reorder_plan_t();
+
     reorder_plan_t ret(hw);
     ret.src = src;
     ret.dst = dst;
@@ -1268,8 +1270,8 @@ struct fma_context_t {
         , simd(cfg.simd())
         , vec_size(cfg.vec_size())
         , fma(cfg.fma_kind())
-        , a_type(cfg.prb().a_data_type)
-        , b_type(cfg.prb().b_data_type)
+        , a_type(to_ir(cfg.prb().a_data_type))
+        , b_type(to_ir(cfg.prb().b_data_type))
         , acc_type(get_accumulation_type(cfg, a_type, b_type))
         , is_src1_broadcast(!cfg.prb().is_dw)
         , ab_swap_transpose_(cfg.prb().ab_swap_transpose) {}

--- a/src/gpu/intel/conv/jit/v2/bridge.hpp
+++ b/src/gpu/intel/conv/jit/v2/bridge.hpp
@@ -139,7 +139,7 @@ inline problem_t to_problem(const pd_t *pd, const impl::engine_t *engine) {
     prb.set_hw(hw_t(engine));
     prb.set_prop(prop);
     prb.set_with_groups(pd->with_groups());
-    prb.set_bias_type(type_t(pd->invariant_bia_md()->data_type));
+    prb.set_bias_type(to_ir(pd->invariant_bia_md()->data_type));
     prb.set_src_tag(src);
     prb.set_wei_tag(wei);
     prb.set_dst_tag(dst);

--- a/src/gpu/intel/conv/jit/v2/builder.cpp
+++ b/src/gpu/intel/conv/jit/v2/builder.cpp
@@ -658,7 +658,7 @@ private:
             alg_kind_t alg = (arg == DNNL_ARG_DST ? alg_kind::binary_div
                                                   : alg_kind::binary_mul);
             build_post_op(coord, tile, alg, nullptr, f32_layout, buf,
-                    buf_info_.mem_buf(rhs_buf_name), type_t(data_type),
+                    buf_info_.mem_buf(rhs_buf_name), to_ir(data_type),
                     into<uint16_t>(to_rhs_mask(arg, mask)));
         };
         // Apply non-dst scales.
@@ -679,7 +679,7 @@ private:
             } else if (po.is_sum()) {
                 auto &s = po.as_sum();
                 build_post_op(coord, tile, alg_kind::binary_add, &po,
-                        f32_layout, buf, buf_info_.mem_buf("c"), type_t(s.dt),
+                        f32_layout, buf, buf_info_.mem_buf("c"), to_ir(s.dt),
                         0xFFFF, s.scale, s.zero_point);
             } else if (po.is_binary()) {
                 auto &b = po.as_binary();
@@ -688,7 +688,7 @@ private:
                         b.src1_desc.broadcast_mask ^ 0xFFFF,
                         c_tag.raw_tag().ndims());
                 build_post_op(coord, tile, b.alg, &po, f32_layout, buf,
-                        buf_info_.mem_buf(rhs_buf_name), type_t(b.src1_desc.dt),
+                        buf_info_.mem_buf(rhs_buf_name), to_ir(b.src1_desc.dt),
                         mask);
             } else {
                 gpu_error_not_expected();

--- a/src/gpu/intel/conv/jit/v2/kernel_desc.cpp
+++ b/src/gpu/intel/conv/jit/v2/kernel_desc.cpp
@@ -758,7 +758,7 @@ compute::range_t kernel_desc_t::local_range() const {
 void kernel_desc_t::init_kernel_iface(kernel_iface_t &kernel_iface) const {
     auto tensor_config = get_tensor_config(*this);
     for (auto &t : tensor_config.tensors()) {
-        kernel_iface.register_arg(t.name, type_t::byte_ptr());
+        kernel_iface.register_arg(t.name, type_t::byte(type::attr_t::ptr));
     }
     auto _reqs = reqs();
     auto tg_grid = create_thread_group_grid(*this);
@@ -1030,7 +1030,7 @@ jit::layout_t get_kernel_layout(const std::string &name,
     } else if (name.find("binary") == 0) {
         auto out_kind = pick_c(desc.prop, tensor_kind_t::src,
                 tensor_kind_t::wei, tensor_kind_t::dst);
-        tag = make_layout_tag(out_kind, "axb:" + type_t(md.data_type).str());
+        tag = make_layout_tag(out_kind, "axb:" + to_ir(md.data_type).str());
     }
     gpu_assert(!tag.is_empty()) << "Unknown tensor: " << name;
     auto layout = to_layout(tag, md, name == "wei" && !pd->with_groups());

--- a/src/gpu/intel/conv/jit/v2/primitive_plan.cpp
+++ b/src/gpu/intel/conv/jit/v2/primitive_plan.cpp
@@ -125,7 +125,7 @@ status_t primitive_init_plan_t::add_reorder_kernel(
         impl::engine_t *engine) const {
     kernel_info_t kernel_info;
     for (auto *e : {&src, &dst}) {
-        auto buf_var = var_t::make(type_t::byte_ptr(), e->name);
+        auto buf_var = var_t::make(type_t::byte(type::attr_t::ptr), e->name);
         if (e->is_user()) {
             kernel_info.register_user_arg(
                     buf_var, e->arg_key, /*is_input=*/e == &src);

--- a/src/gpu/intel/conv/jit/v2/tensor_utils.cpp
+++ b/src/gpu/intel/conv/jit/v2/tensor_utils.cpp
@@ -97,7 +97,8 @@ layout_tag_t make_layout_tag(tensor_kind_t tensor_kind, const std::string &s) {
     bool is_wei = (tensor_kind == tensor_kind_t::wei);
     auto desc = make_layout_desc(tensor_kind);
     auto parts = gpu_utils::split(s, ":");
-    auto type = (parts.size() > 1 ? type_t(parts[1]) : type_t::f32());
+    auto type
+            = (parts.size() > 1 ? jit::parse<type_t>(parts[1]) : type_t::f32());
     auto str_tag = desc.to_abx_tag(parts[0]);
     auto raw_tag = layout_raw_tag_t(str_tag, is_wei ? 6 : 5);
     return layout_tag_t(desc, type, raw_tag);
@@ -264,7 +265,7 @@ layout_tag_t make_layout_tag(
     memory_desc_wrapper mdw(md);
     bool is_strided = (mdw.is_plain() && !mdw.is_dense());
     auto desc = make_layout_desc(tensor_kind);
-    type_t type(md.data_type);
+    type_t type(to_ir(md.data_type));
     if (is_any) return layout_tag_t(desc, type, layout_raw_tag_t::any());
     auto str_tag = blocked_to_str_tag(md);
     auto raw_tag = layout_raw_tag_t(str_tag);

--- a/src/gpu/intel/conv/jit/zero_out.cpp
+++ b/src/gpu/intel/conv/jit/zero_out.cpp
@@ -40,7 +40,7 @@ compute::range_t zero_out_kernel_desc_t::local_range() const {
 void zero_out_kernel_desc_t::init_kernel_iface(
         kernel_iface_t &kernel_iface) const {
     kernel_iface.register_arg("size", type_t::u32());
-    kernel_iface.register_arg("ptr", type_t::byte_ptr());
+    kernel_iface.register_arg("ptr", type_t::byte(type::attr_t::ptr));
 }
 
 void zero_out_kernel_desc_t::init_kernel_info(kernel_info_t &kernel_info,

--- a/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
+++ b/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
@@ -265,8 +265,9 @@ void apply_post_ops(const dnnl::impl::gpu::intel::gpu_post_ops_t &ops,
                             : expr_t(0); //TODO: Get actual size
                 }
 
-                return {arg("binary" + i_s), e.src1_desc.dt, src_g_offset,
-                        coord_t(), g_sizes, g_strides, {}};
+                return {arg("binary" + i_s),
+                        dnnl::impl::gpu::intel::jit::to_ir(e.src1_desc.dt),
+                        src_g_offset, coord_t(), g_sizes, g_strides, {}};
             }();
 
             layout_t src_layout = {src_g.type};

--- a/src/gpu/intel/jit/codegen/codegen.cpp
+++ b/src/gpu/intel/jit/codegen/codegen.cpp
@@ -660,8 +660,7 @@ private:
             ngen::InstructionModifier &mod, const ngen::RegData &mem_off_op,
             ngen::RegData &rd) const {
         int size = send_func.payload_size();
-        gpu_assert(utils::one_of(send_func.type.kind(), type_kind_t::dword,
-                           type_kind_t::qword)
+        gpu_assert((send_func.type.is_dword() || send_func.type.is_qword())
                 && (size == 32 || size == 64))
                 << "expected atomic message dwordx8 or qwordx8";
         auto load_func = send_t::make(send_func.hw, send_op_t::load,
@@ -674,7 +673,7 @@ private:
                 send_func.fill_buf, send_func.cache_hint);
         auto &cmpwr_send = cmpwr_func.as<send_t>();
         send_impl_t cmpwr(cmpwr_send);
-        bool is_df = send_func.type.kind() == type_kind_t::qword;
+        bool is_df = send_func.type.is_qword();
 
         int grf_size = ngen::GRF::bytes(hw());
         int regs = utils::div_up(size, grf_size);
@@ -752,8 +751,7 @@ private:
         }
         if ((hw() <= ngen::HW::XeLP && send_func.is_atomic())
                 || (hw() == ngen::HW::XeHPG && send_func.is_atomic()
-                        && send_func.type.kind() == type_kind_t::qword
-                        && !with_atomic_fp64_)) {
+                        && send_func.type.is_qword() && !with_atomic_fp64_)) {
             send_atomic_add_emu(
                     scope, send_func, mask_op, mod, mem_off_op.reg_data(), rd);
         } else {
@@ -1044,9 +1042,10 @@ public:
         auto dst_op = alloc_dst_op(obj);
 
         // Handle ptr -> u64 and u64 -> ptr casts.
-        if (utils::one_of(obj.type, type_t::u64(), type_t::byte_ptr())
-                && utils::one_of(
-                        obj.expr.type(), type_t::u64(), type_t::byte_ptr())) {
+        if (utils::one_of(
+                    obj.type, type_t::u64(), type_t::byte(type::attr_t::ptr))
+                && utils::one_of(obj.expr.type(), type_t::u64(),
+                        type_t::byte(type::attr_t::ptr))) {
             eval(obj.expr, dst_op);
             bind(obj, dst_op);
             return;

--- a/src/gpu/intel/jit/codegen/ngen_helpers.hpp
+++ b/src/gpu/intel/jit/codegen/ngen_helpers.hpp
@@ -61,12 +61,12 @@ inline ngen::DataType to_ngen(const type_t &type) {
     gpu_assert(type.is_scalar()) << "Expected scalar type.";
 
 #define CASE(_kind, ngen_enum) \
-    if (type.kind() == type_kind_t::_kind) return ngen::DataType::ngen_enum
+    if (type.scalar() == type_t::_kind()) return ngen::DataType::ngen_enum
 
     // Until f4_e3m0 lands in ngen
-    if (type.kind() == type_kind_t::f4_e3m0) return ngen_f4_e3m0();
+    if (type.scalar() == type_t::f4_e3m0()) return ngen_f4_e3m0();
     // Until f4_e2m1 lands in ngen
-    if (type.kind() == type_kind_t::f4_e2m1) return ngen_f4_e2m1();
+    if (type.scalar() == type_t::f4_e2m1()) return ngen_f4_e2m1();
 
     CASE(bf16, bf);
     CASE(f16, hf);
@@ -86,7 +86,7 @@ inline ngen::DataType to_ngen(const type_t &type) {
     CASE(u8, ub);
     CASE(u4, u4);
 
-    if (type == type_t::byte_ptr()) return ngen::DataType::uq;
+    if (type == type_t::byte(1, type::attr_t::ptr)) return ngen::DataType::uq;
 
 #undef CASE
     gpu_error_not_expected();
@@ -133,7 +133,7 @@ inline ngen::Immediate to_ngen(
             return ngen::Immediate(imm.value);
             // Do conversion.
 #define CASE(cpp_type) \
-    if (type.is_cpp<cpp_type>()) return ngen::Immediate(cpp_type(imm.value))
+    if (is_cpp<cpp_type>(type)) return ngen::Immediate(cpp_type(imm.value))
 
         CASE(int16_t);
         CASE(int32_t);

--- a/src/gpu/intel/jit/dsl/dsl.hpp
+++ b/src/gpu/intel/jit/dsl/dsl.hpp
@@ -80,10 +80,7 @@ struct global_tensor_t {
     global_tensor_t() = default;
     global_tensor_t(const expr_t &buf, const pvar_map_t<expr_t> &sizes,
             const pvar_map_t<expr_t> &strides)
-        : buf(buf)
-        , type(buf.type().remove_ptr())
-        , sizes(sizes)
-        , strides(strides) {}
+        : buf(buf), type(buf.type().scalar()), sizes(sizes), strides(strides) {}
     global_tensor_t(const expr_t &buf, const type_t &type,
             const expr_t &base_offset, const coord_t &coord,
             const pvar_map_t<expr_t> &sizes, const pvar_map_t<expr_t> &strides,

--- a/src/gpu/intel/jit/ir/epilogue.cpp
+++ b/src/gpu/intel/jit/ir/epilogue.cpp
@@ -425,7 +425,8 @@ private:
         if (!var && needs_compute()) var = op_var().as_ptr<var_t>();
         gpu_assert(var) << "Can't extract variable from buffer: " << mem_buf();
         auto &name = var->name;
-        return ir_ctx_->create_tmp_var(type_t::byte_ptr(), "tmp_" + name);
+        return ir_ctx_->create_tmp_var(
+                type_t::byte(type::attr_t::ptr), "tmp_" + name);
     }
 
     void register_buffer(const expr_t &buf, uint32_t size) {
@@ -767,7 +768,7 @@ public:
 
 private:
     expr_t make_c_tmp_buffer() const {
-        return ir_ctx_.create_tmp_var(type_t::byte_ptr(), "c_tmp");
+        return ir_ctx_.create_tmp_var(type_t::byte(type::attr_t::ptr), "c_tmp");
     }
 
     // Represents a GRF buffer and layout to store C tensor.

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -81,8 +81,7 @@ type_t multiply_desc_t::get_c_type(
 }
 
 bool dpas_t::is_src_type(type_t type) {
-    return utils::one_of(type.kind(), type_kind_t::u8, type_kind_t::s8,
-            type_kind_t::bf16, type_kind_t::f16, type_kind_t::tf32);
+    return type.is_x8() || type.is_bf16() || type.is_f16() || type.is_tf32();
 }
 
 layout_t dpas_t::a_layout() const {

--- a/src/gpu/intel/jit/ir/fma.hpp
+++ b/src/gpu/intel/jit/ir/fma.hpp
@@ -59,6 +59,11 @@ inline bool is_dp_fma(fma_kind_t kind) {
 fma_kind_t get_supported_fma_kind(
         const hw_t &hw, const type_t &a, const type_t &b, const type_t &c);
 
+inline fma_kind_t get_supported_fma_kind(
+        const hw_t &hw, data_type_t a, data_type_t b, data_type_t c) {
+    return get_supported_fma_kind(hw, to_ir(a), to_ir(b), to_ir(c));
+}
+
 int get_simd_size(const hw_t &hw, fma_kind_t kind, const type_t &a,
         const type_t &b, const type_t &c);
 

--- a/src/gpu/intel/jit/ir/include/ir.hpp
+++ b/src/gpu/intel/jit/ir/include/ir.hpp
@@ -1,0 +1,22 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_IR_INCLUDE_IR_HPP
+#define GPU_INTEL_JIT_IR_INCLUDE_IR_HPP
+
+#include "gpu/intel/jit/ir/include/type.hpp"
+
+#endif

--- a/src/gpu/intel/jit/ir/include/type.hpp
+++ b/src/gpu/intel/jit/ir/include/type.hpp
@@ -1,0 +1,425 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_JIT_IR_INCLUDE_TYPE_HPP
+#define GPU_INTEL_JIT_IR_INCLUDE_TYPE_HPP
+
+#include <cstdint>
+#include <string>
+
+#include "gpu/intel/jit/utils/utils.hpp"
+
+namespace ngen {
+enum class DataType : uint8_t;
+}
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+
+namespace type {
+enum class attr_t : uint32_t { undef = 0, ptr = 1, mut = 2, simd = 4, slm = 8 };
+
+constexpr attr_t operator&(attr_t a, attr_t b) {
+    return static_cast<attr_t>(
+            static_cast<uint32_t>(a) & static_cast<uint32_t>(b));
+}
+constexpr attr_t operator|(attr_t a, attr_t b) {
+    return static_cast<attr_t>(
+            static_cast<uint32_t>(a) | static_cast<uint32_t>(b));
+}
+constexpr attr_t operator~(attr_t a) {
+    return static_cast<attr_t>(~static_cast<uint32_t>(a));
+}
+constexpr bool any(attr_t a) {
+    return a != static_cast<attr_t>(0);
+}
+
+inline attr_t &operator|=(attr_t &a, attr_t b) {
+    return a = a | b;
+}
+inline attr_t &operator&=(attr_t &a, attr_t b) {
+    return a = a & b;
+}
+} // namespace type
+
+class type_t {
+public:
+    friend struct type_internal_accessor_t;
+    using attr_t = type::attr_t;
+
+    static type_t undef() { return type_t(kind_t::undef); }
+
+    static type_t _bool(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::_bool, elems, attr);
+    }
+
+    static type_t u4(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::u4, elems, attr);
+    }
+    static type_t s4(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::s4, elems, attr);
+    }
+    static type_t u8(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::u8, elems, attr);
+    }
+    static type_t s8(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::s8, elems, attr);
+    }
+    static type_t u16(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::u16, elems, attr);
+    }
+    static type_t s16(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::s16, elems, attr);
+    }
+    static type_t u32(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::u32, elems, attr);
+    }
+    static type_t s32(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::s32, elems, attr);
+    }
+    static type_t u64(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::u64, elems, attr);
+    }
+    static type_t s64(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::s64, elems, attr);
+    }
+
+    // Returns unsigned integer type.
+    static type_t u(int bits, int elems = 1, attr_t attr = attr_t::undef) {
+        switch (bits) {
+            case 4: return u4(elems, attr);
+            case 8: return u8(elems, attr);
+            case 16: return u16(elems, attr);
+            case 32: return u32(elems, attr);
+            case 64: return u64(elems, attr);
+            default: gpu_error_not_expected();
+        }
+        return type_t::undef();
+    }
+
+    // Returns signed integer type.
+    static type_t s(int bits, int elems = 1, attr_t attr = attr_t::undef) {
+        switch (bits) {
+            case 4: return s4(elems, attr);
+            case 8: return s8(elems, attr);
+            case 16: return s16(elems, attr);
+            case 32: return s32(elems, attr);
+            case 64: return s64(elems, attr);
+            default: gpu_error_not_expected();
+        }
+        return type_t::undef();
+    }
+
+    static type_t f4_e3m0(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f4_e3m0, elems, attr);
+    }
+    static type_t f4_e2m1(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f4_e2m1, elems, attr);
+    }
+    static type_t f8_e5m2(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f8_e5m2, elems, attr);
+    }
+    static type_t f8_e4m3(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f8_e4m3, elems, attr);
+    }
+    static type_t bf8(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::bf8, elems, attr);
+    }
+    static type_t hf8(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::hf8, elems, attr);
+    }
+    static type_t bf16(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::bf16, elems, attr);
+    }
+    static type_t f16(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f16, elems, attr);
+    }
+    static type_t tf32(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::tf32, elems, attr);
+    }
+    static type_t f32(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f32, elems, attr);
+    }
+    static type_t f64(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::f64, elems, attr);
+    }
+    static type_t byte(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::byte, elems, attr);
+    }
+    static type_t byte(attr_t attr) { return type_t(kind_t::byte, 1, attr); }
+    static type_t dword(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::dword, elems, attr);
+    }
+    static type_t qword(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::qword, elems, attr);
+    }
+    static type_t oword(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::oword, elems, attr);
+    }
+    static type_t hword(int elems = 1, attr_t attr = attr_t::undef) {
+        return type_t(kind_t::hword, elems, attr);
+    }
+
+    template <typename T>
+    T max() const {
+        switch (kind()) {
+            case kind_t::u4:
+            case kind_t::s4:
+            case kind_t::u8:
+            case kind_t::s8:
+            case kind_t::u16:
+            case kind_t::s16:
+            case kind_t::u32:
+            case kind_t::s32:
+            case kind_t::u64:
+            case kind_t::s64: {
+                int bits = scalar().bitsize();
+                if (is_signed()) bits--;
+                T ret = T(1) << (bits - 1);
+                return ret + (ret - 1);
+            }
+            default: gpu_error_not_expected();
+        }
+        return 0;
+    }
+
+    template <typename T>
+    T min() const {
+        switch (kind()) {
+            case kind_t::u4:
+            case kind_t::s4:
+            case kind_t::u8:
+            case kind_t::s8:
+            case kind_t::u16:
+            case kind_t::s16:
+            case kind_t::u32:
+            case kind_t::s32:
+            case kind_t::u64:
+            case kind_t::s64: {
+                if (is_unsigned()) return 0;
+                return -max<T>() - 1;
+            }
+            default: gpu_error_not_expected();
+        }
+        return 0;
+    }
+
+    type_t() : type_t(type_t::undef()) {}
+
+    type_t(ngen::DataType type, uint32_t elems = 1,
+            attr_t attr = attr_t::undef);
+
+    int elems() const { return elems_; }
+
+    attr_t attr() const { return attr_; }
+
+    type_t operator[](int elems) const { return with_elems(elems); }
+
+    bool operator==(const type_t &other) const {
+        return (kind() == other.kind()) && (elems() == other.elems())
+                && (attr() == other.attr());
+    }
+
+    bool operator!=(const type_t &other) const { return !operator==(other); }
+
+    size_t get_hash() const;
+
+    bool is_ptr() const { return any(attr() & attr_t::ptr); }
+
+    bool is_slm() const { return any(attr() & attr_t::slm); }
+
+    bool is_undef() const { return kind() == kind_t::undef; }
+
+    bool is_bool() const { return kind() == kind_t::_bool; }
+
+    bool is_fp() const {
+        return is_fp4() || is_fp8() || is_bf16() || is_f16() || is_tf32()
+                || is_f32() || is_f64();
+    }
+
+    bool is_f4_e3m0() const { return kind() == kind_t::f4_e3m0; }
+    bool is_f4_e2m1() const { return kind() == kind_t::f4_e2m1; }
+    bool is_bf8() const { return kind() == kind_t::bf8; }
+    bool is_hf8() const { return kind() == kind_t::hf8; }
+    bool is_bf16() const { return kind() == kind_t::bf16; }
+    bool is_f16() const { return kind() == kind_t::f16; }
+    bool is_tf32() const { return kind() == kind_t::tf32; }
+    bool is_f32() const { return kind() == kind_t::f32; }
+    bool is_f64() const { return kind() == kind_t::f64; }
+
+    bool is_fp4() const { return is_f4_e3m0() || is_f4_e2m1(); }
+    bool is_fp8() const { return is_bf8() || is_hf8(); }
+
+    bool is_int() const {
+        return is_x4() || is_x8() || is_x16() || is_x32() || is_x64();
+    }
+
+    bool is_s4() const { return kind() == kind_t::s4; }
+    bool is_u4() const { return kind() == kind_t::u4; }
+    bool is_x4() const { return is_s4() || is_u4(); }
+
+    bool is_s8() const { return kind() == kind_t::s8; }
+    bool is_u8() const { return kind() == kind_t::u8; }
+    bool is_x8() const { return is_s8() || is_u8(); }
+
+    bool is_s16() const { return kind() == kind_t::s16; }
+    bool is_u16() const { return kind() == kind_t::u16; }
+    bool is_x16() const { return is_s16() || is_u16(); }
+
+    bool is_s32() const { return kind() == kind_t::s32; }
+    bool is_u32() const { return kind() == kind_t::u32; }
+    bool is_x32() const { return is_s32() || is_u32(); }
+
+    bool is_s64() const { return kind() == kind_t::s64; }
+    bool is_u64() const { return kind() == kind_t::u64; }
+    bool is_x64() const { return is_s64() || is_u64(); }
+
+    bool is_byte() const { return kind() == kind_t::byte; }
+    bool is_dword() const { return kind() == kind_t::dword; }
+    bool is_qword() const { return kind() == kind_t::qword; }
+    bool is_oword() const { return kind() == kind_t::oword; }
+    bool is_hword() const { return kind() == kind_t::hword; }
+
+    bool is_signed(int elems = -1) const {
+        if (elems != -1 && elems_ != elems) return false;
+        return is_s4() || is_s8() || is_s16() || is_s32() || is_s64();
+    }
+
+    bool is_unsigned(int elems = -1) const {
+        if (elems != -1 && elems_ != elems) return false;
+        return is_u4() || is_u8() || is_u16() || is_u32() || is_u64();
+    }
+
+    bool is_scalar() const { return elems() == 1; }
+
+    bool is_mutable() const { return any(attr() & attr_t::mut); }
+
+    bool is_simd() const { return any(attr() & attr_t::simd); }
+
+    type_t with_elems(int new_elems) const {
+        type_t copy = *this;
+        copy.elems_ = new_elems;
+        return copy;
+    }
+
+    type_t with_ptr() const {
+        type_t copy = *this;
+        copy.attr_ |= attr_t::ptr;
+        return copy;
+    }
+
+    type_t with_attr(attr_t attr) const {
+        type_t copy = *this;
+        copy.attr_ = attr;
+        return copy;
+    }
+
+    type_t with_simd() const {
+        type_t copy = *this;
+        copy.attr_ |= attr_t::simd;
+        return copy;
+    }
+
+    type_t with_slm() const {
+        type_t copy = *this;
+        copy.attr_ |= attr_t::slm;
+        return copy;
+    }
+
+    type_t scalar() const { return type_t(kind()); }
+
+    // Returns size in bytes.
+    int size() const;
+
+    // Returns size in bits.
+    int bitsize() const {
+        // 8 elements occupy the same number of bytes that a single element
+        // occupies in bits.
+        constexpr int bits_per_byte = 8;
+        return with_elems(bits_per_byte * elems()).size();
+    }
+
+    // Returns number of elements that fit in `size()` bytes.
+    // The size in bytes of `n` packed elements is
+    //     `div_up(n * size(), packing())`.
+    int packing() const {
+        constexpr int bits_per_byte = 8;
+        return bits_per_byte * size() / bitsize();
+    }
+
+    std::string str() const;
+    static type_t parse(std::istream &in);
+
+protected:
+    enum class kind_t {
+        undef,
+        _bool,
+
+        // Integer types.
+        u4,
+        s4,
+        u8,
+        s8,
+        u16,
+        s16,
+        u32,
+        s32,
+        u64,
+        s64,
+
+        // Floating point types.
+        f4_e3m0,
+        f4_e2m1,
+        bf8,
+        f8_e5m2 = bf8,
+        hf8,
+        f8_e4m3 = hf8,
+        bf16,
+        f16,
+        tf32,
+        f32,
+        f64,
+
+        // Message data types.
+        byte,
+        dword,
+        qword,
+        oword,
+        hword
+    };
+
+    type_t(kind_t kind, uint32_t elems = 1, attr_t attr = attr_t::undef)
+        : kind_(kind), elems_(elems), attr_(attr) {}
+
+    kind_t kind() const { return kind_; }
+
+    int mantissa_bits() const;
+
+private:
+    kind_t kind_ = kind_t::undef;
+    int elems_ = 0;
+    attr_t attr_ = attr_t::undef;
+};
+
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+#endif

--- a/src/gpu/intel/jit/ir/ir.cpp
+++ b/src/gpu/intel/jit/ir/ir.cpp
@@ -788,7 +788,7 @@ bool is_const_broadcast(const expr_t &e, const expr_t &value) {
 }
 
 expr_t make_buffer(const std::string &name) {
-    return var_t::make(type_t::byte_ptr(), name);
+    return var_t::make(type_t::byte(type::attr_t::ptr), name);
 }
 
 // Returns number of occurrences of `obj` in `root` (based on identity equality).

--- a/src/gpu/intel/jit/ir/kernel_info.hpp
+++ b/src/gpu/intel/jit/ir/kernel_info.hpp
@@ -82,9 +82,10 @@ public:
             if (a.exttype == ngen::ExternalArgumentType::Scalar) {
                 register_arg(a.name, type_t(a.type));
             } else if (a.exttype == ngen::ExternalArgumentType::GlobalPtr) {
-                register_arg(a.name, type_t::byte_ptr(1, false));
+                register_arg(a.name, type_t::byte(type::attr_t::ptr));
             } else if (a.exttype == ngen::ExternalArgumentType::LocalPtr) {
-                register_arg(a.name, type_t::byte_ptr(1, true));
+                register_arg(a.name,
+                        type_t::byte(type::attr_t::ptr | type::attr_t::slm));
             } else {
                 gpu_assert(false) << "Unimplemented";
             }

--- a/src/gpu/intel/jit/ir/message.cpp
+++ b/src/gpu/intel/jit/ir/message.cpp
@@ -52,7 +52,7 @@ stmt_t send_t::create_offset_store(const expr_t &header_buf,
     expr_t off;
     if (is_a64()) {
         off = cast(mem_buf, address_type());
-        if (mem_off.type().is_vector()) {
+        if (mem_off.type().elems() > 1) {
             off = shuffle_t::make_broadcast(off, mem_off.type().elems());
         }
         off += mem_off;

--- a/src/gpu/intel/jit/ir/message.hpp
+++ b/src/gpu/intel/jit/ir/message.hpp
@@ -257,8 +257,7 @@ public:
     bool is_slm() const { return address == send_address_t::slm; }
 
     bool is_block() const {
-        return utils::one_of(
-                type.kind(), type_kind_t::oword, type_kind_t::hword);
+        return utils::one_of(type.scalar(), type_t::oword(), type_t::hword());
     }
 
     bool is_scattered() const { return !is_block() && !is_2d(); }

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -83,9 +83,9 @@ public:
         , common_dst_zero_point(0) {
         if (pd) {
             auto &zp = pd->attr()->zero_points_;
-            src_zp_type = zp.get_data_type(DNNL_ARG_SRC);
-            wei_zp_type = zp.get_data_type(DNNL_ARG_WEIGHTS);
-            dst_zp_type = zp.get_data_type(DNNL_ARG_DST);
+            src_zp_type = to_ir(zp.get_data_type(DNNL_ARG_SRC));
+            wei_zp_type = to_ir(zp.get_data_type(DNNL_ARG_WEIGHTS));
+            dst_zp_type = to_ir(zp.get_data_type(DNNL_ARG_DST));
         }
     }
 
@@ -252,7 +252,7 @@ public:
     }
 
     virtual view_t create_view(const memory_desc_t &md) const {
-        return cp_view().retype(md.data_type);
+        return cp_view().retype(to_ir(md.data_type));
     }
 
     virtual view_t create_src_zp_view(uint32_t mask) const {

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -2323,8 +2323,8 @@ public:
             send_params_t &send_params)
         : send_params_(send_params)
         , ir_ctx_(exec_cfg, cset_)
-        , dummy_mem_buf_(var_t::make(type_t::byte_ptr(), "mem"))
-        , dummy_reg_buf_(var_t::make(type_t::byte_ptr(), "reg"))
+        , dummy_mem_buf_(var_t::make(type_t::byte(type::attr_t::ptr), "mem"))
+        , dummy_reg_buf_(var_t::make(type_t::byte(type::attr_t::ptr), "reg"))
         , access_(make_access_builder(
                   ir_ctx_, view, dummy_mem_buf_, dummy_reg_buf_, send_params))
         , reg_layout_(access_.reg_layout()) {

--- a/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
+++ b/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
@@ -42,8 +42,9 @@ slm_reduce_builder_t::slm_reduce_builder_t(ir_context_t &ir_ctx,
     gpu_assert((dim_ != dim_idx::invalid) && (dim_ <= 2));
     gpu_assert(tg_grid_.dim(dim_) > 1);
 
-    tmp_reg_buf_ = ir_ctx.create_tmp_var(type_t::byte_ptr());
-    slm_buf_ = ir_ctx.create_tmp_var(type_t::byte_ptr(), "reduce_slm");
+    tmp_reg_buf_ = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr));
+    slm_buf_ = ir_ctx.create_tmp_var(
+            type_t::byte(type::attr_t::ptr), "reduce_slm");
     tg_ndims_ = (dim_ != dim_idx_t(2)) ? dim_ + 1 : tg_grid_.ndims();
 
     build();

--- a/src/gpu/intel/jit/ir/tensor.cpp
+++ b/src/gpu/intel/jit/ir/tensor.cpp
@@ -83,7 +83,7 @@ layout_t::layout_t(const type_t &type, const expr_t &offset, dim_idx_t ndims,
 }
 
 layout_t::layout_t(const memory_desc_wrapper &mdw, bool do_normalize)
-    : type_(mdw.data_type()), offset_(mdw.offset0()) {
+    : type_(to_ir(mdw.data_type())), offset_(mdw.offset0()) {
     gpu_assert(mdw.is_blocking_desc())
             << "Expected blocking memory descriptor.";
 

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -278,7 +278,7 @@ public:
 
     layout_t(const memory_desc_wrapper &mdw, const std::string &format,
             bool do_normalize = true)
-        : layout_t(mdw.data_type(), mdw.offset0(), format,
+        : layout_t(to_ir(mdw.data_type()), mdw.offset0(), format,
                 std::vector<dim_t>(mdw.dims(), mdw.dims() + mdw.ndims()),
                 do_normalize) {}
 
@@ -436,7 +436,7 @@ public:
 
     bool is_strictly_equal(const layout_t &other, bool compare_offset = true,
             bool compare_strides = true) const {
-        if (!type_.is_equal(other.type_)) return false;
+        if (type_ != other.type_) return false;
         if (compare_offset && !offset_.is_equal(other.offset_)) return false;
         if (blocks_.size() != other.blocks_.size()) return false;
         for (size_t i = 0; i < blocks_.size(); i++) {
@@ -453,7 +453,7 @@ public:
 
     bool operator!=(const layout_t &other) const { return !operator==(other); }
     bool operator<=(const layout_t &other) const {
-        if (!type_.is_equal(other.type_)) return false;
+        if (type_ != other.type_) return false;
         auto other_blocks = other.normalize().blocks();
         auto self_blocks = normalize().blocks();
         if (self_blocks.size() > other_blocks.size()) return false;

--- a/src/gpu/intel/jit/ir/type.cpp
+++ b/src/gpu/intel/jit/ir/type.cpp
@@ -1,0 +1,225 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/jit/ir/include/type.hpp"
+#include "gpu/intel/jit/ir/core.hpp"
+#include "gpu/intel/jit/utils/utils.hpp"
+#include "ngen.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace jit {
+
+struct type_internal_accessor_t {
+    using kind_t = type_t::kind_t;
+    static int mantissa_bits(const type_t &t) { return t.mantissa_bits(); }
+};
+
+namespace type {
+using kind_t = type_internal_accessor_t::kind_t;
+
+static auto kind_names = nstl::to_array({
+        make_enum_name(kind_t::undef, "undef"),
+        make_enum_name(kind_t::u4, "u4"),
+        make_enum_name(kind_t::s4, "s4"),
+        make_enum_name(kind_t::u8, "u8"),
+        make_enum_name(kind_t::s8, "s8"),
+        make_enum_name(kind_t::u16, "u16"),
+        make_enum_name(kind_t::s16, "s16"),
+        make_enum_name(kind_t::u32, "u32"),
+        make_enum_name(kind_t::s32, "s32"),
+        make_enum_name(kind_t::u64, "u64"),
+        make_enum_name(kind_t::s64, "s64"),
+        make_enum_name(kind_t::f4_e3m0, "f4_e3m0"),
+        make_enum_name(kind_t::f4_e2m1, "f4_e2m1"),
+        make_enum_name(kind_t::bf8, "bf8"),
+        make_enum_name(kind_t::hf8, "hf8"),
+        make_enum_name(kind_t::bf16, "bf16"),
+        make_enum_name(kind_t::f16, "f16"),
+        make_enum_name(kind_t::tf32, "tf32"),
+        make_enum_name(kind_t::f32, "f32"),
+        make_enum_name(kind_t::f64, "f64"),
+        make_enum_name(kind_t::byte, "byte"),
+        make_enum_name(kind_t::dword, "dword"),
+        make_enum_name(kind_t::qword, "qword"),
+        make_enum_name(kind_t::oword, "oword"),
+        make_enum_name(kind_t::hword, "hword"),
+        make_enum_name(kind_t::_bool, "bool"),
+});
+
+const std::string &to_string(kind_t kind) {
+    for (auto &entry : kind_names) {
+        if (entry.first == kind) return entry.second;
+    }
+    static const std::string invalid = "(invalid type::kind_t)";
+    return invalid;
+}
+
+kind_t get_kind(ngen::DataType t) {
+    switch (t) {
+        case ngen::DataType::uq: return kind_t::u64;
+        case ngen::DataType::q: return kind_t::s64;
+        case ngen::DataType::ud: return kind_t::u32;
+        case ngen::DataType::d: return kind_t::s32;
+        case ngen::DataType::uw: return kind_t::u16;
+        case ngen::DataType::w: return kind_t::s16;
+        case ngen::DataType::ub: return kind_t::u8;
+        case ngen::DataType::b: return kind_t::s8;
+        case ngen::DataType::u4: return kind_t::u4;
+        case ngen::DataType::s4: return kind_t::s4;
+
+        case ngen::DataType::df: return kind_t::f64;
+        case ngen::DataType::f: return kind_t::f32;
+        case ngen::DataType::tf32: return kind_t::tf32;
+        case ngen::DataType::hf: return kind_t::f16;
+        case ngen::DataType::bf: return kind_t::bf16;
+        case ngen::DataType::bf8: return kind_t::bf8;
+        case ngen::DataType::hf8: return kind_t::hf8;
+        default: return kind_t::undef;
+    }
+}
+
+} // namespace type
+
+type_t::type_t(ngen::DataType type, uint32_t elems, attr_t attr)
+    : type_t(type::get_kind(type), elems, attr) {}
+
+size_t type_t::get_hash() const {
+    return ir_utils::get_hash(kind(), elems(), is_ptr());
+}
+
+int type_t::size() const {
+    if (is_ptr()) return sizeof(uint64_t);
+
+    if (is_bool()) return utils::div_up(elems(), 8);
+    if (is_x4() || is_fp4()) return utils::div_up(elems(), 2);
+
+    if (elems() != 1) return elems() * scalar().size();
+
+    switch (kind()) {
+        case kind_t::u8:
+        case kind_t::s8:
+        case kind_t::bf8:
+        case kind_t::hf8:
+        case kind_t::byte: return 1;
+        case kind_t::u16:
+        case kind_t::s16:
+        case kind_t::bf16:
+        case kind_t::f16: return 2;
+        case kind_t::u32:
+        case kind_t::s32:
+        case kind_t::tf32:
+        case kind_t::f32:
+        case kind_t::dword: return 4;
+        case kind_t::f64:
+        case kind_t::u64:
+        case kind_t::s64:
+        case kind_t::qword: return 8;
+        case kind_t::oword: return 16;
+        case kind_t::hword: return 32;
+        default: gpu_error_not_expected();
+    }
+    return 0;
+}
+
+int type_t::mantissa_bits() const {
+    if (!is_fp()) return 0;
+
+    switch (kind()) {
+        case kind_t::f64: return 52;
+        case kind_t::f32: return 23;
+        case kind_t::tf32:
+        case kind_t::f16: return 10;
+        case kind_t::bf16: return 7;
+        case kind_t::hf8: return 3;
+        case kind_t::bf8: return 2;
+        case kind_t::f4_e2m1: return 1;
+        case kind_t::f4_e3m0: return 0;
+        default: gpu_error_not_expected();
+    }
+    return 0;
+}
+
+std::string type_t::str() const {
+    ostringstream_t oss;
+    oss << type::to_string(kind());
+    if (elems() > 1) oss << "x" << elems();
+    if (is_ptr()) oss << "*";
+    if (is_mutable()) oss << ".mut";
+    if (is_slm()) oss << ".slm";
+    return oss.str();
+}
+
+type_t type_t::parse(std::istream &in) {
+    bool found = false;
+    kind_t kind = {};
+    for (auto &entry : type::kind_names) {
+        if (stream_try_match(in, entry.second)) {
+            kind = entry.first;
+            found = true;
+        }
+    }
+    if (!found) return {};
+
+    int elems = 1;
+    if (stream_try_match(in, "x")) { in >> elems; }
+
+    attr_t attr {};
+    if (stream_try_match(in, "*")) { attr |= attr_t::ptr; }
+    if (stream_try_match(in, ".mut")) { attr |= attr_t::mut; }
+    if (stream_try_match(in, ".slm")) { attr |= attr_t::slm; }
+    return type_t(kind, elems, attr);
+}
+
+bool is_subset(const type_t &a, const type_t &b) {
+    auto is_untyped = [](const type_t &t) {
+        return t.is_byte() || t.is_dword() || t.is_qword() || t.is_oword()
+                || t.is_hword();
+    };
+
+    if (a.is_undef() || b.is_undef()) return false;
+    if (a.elems() != b.elems()) return false; // unordered
+    if (a.is_ptr() && b.is_ptr()) return true; // XXX: consider alignments?
+    if (a.is_ptr() || b.is_ptr()) return false; // unordered
+    if (a == b) return true;
+    if (a.is_tf32() && b.is_f32()) return true;
+    if (a.is_fp() && b.is_int()) return false;
+
+    const auto a_bits = a.scalar().bitsize();
+    const auto b_bits = b.scalar().bitsize();
+    if (is_untyped(a) && is_untyped(b)) return a_bits <= b_bits;
+    if (is_untyped(a) || is_untyped(b)) return false; // unordered
+    if (a.is_int() && b.is_fp())
+        return a_bits
+                <= type_internal_accessor_t::mantissa_bits(b) + a.is_signed();
+    if (a.is_int() && b.is_int())
+        // There are 4 cases:
+        // 1. sN is not a subset of uM
+        // 2. uN is a subset of sM if N <= M - 1
+        // 3. sN is a subset of sM if N - 1 <= M - 1
+        // 4. uN is a subset of uM if N <= M
+        return (!a.is_signed() || b.is_signed())
+                && a_bits + b.is_signed() <= b_bits + a.is_signed();
+    return a_bits < b_bits;
+}
+
+} // namespace jit
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl

--- a/src/gpu/intel/jit/pass/peephole.cpp
+++ b/src/gpu/intel/jit/pass/peephole.cpp
@@ -98,13 +98,9 @@ private:
     static bool add3_type_ok(const expr_t &e) {
         auto t = real_type(e);
         if (!t.is_scalar()) return false;
-        switch (t.kind()) {
-            case type_kind_t::s32:
-            case type_kind_t::u32: return !is_const(e);
-            case type_kind_t::s16:
-            case type_kind_t::u16: return true;
-            default: return false;
-        }
+        if (t.is_x32()) return !is_const(e);
+        if (t.is_x16()) return true;
+        return false;
     }
 };
 

--- a/src/gpu/intel/jit/pass/send.cpp
+++ b/src/gpu/intel/jit/pass/send.cpp
@@ -73,7 +73,8 @@ public:
 
         gpu_assert(is_var(mem_buf)) << mem_buf;
 
-        auto header_buf = ir_ctx_.create_tmp_var(type_t::byte_ptr(), "h");
+        auto header_buf
+                = ir_ctx_.create_tmp_var(type_t::byte(type::attr_t::ptr), "h");
         auto off_store = simplify_store(
                 send->create_offset_store(header_buf, mem_buf, mem_off));
 

--- a/src/gpu/intel/jit/utils/utils.hpp
+++ b/src/gpu/intel/jit/utils/utils.hpp
@@ -691,15 +691,15 @@ inline bool stream_try_match(std::istream &in, const std::string &s) {
 }
 
 template <typename T>
-using enum_name_t = std::pair<T, const char *>;
+using enum_name_t = std::pair<T, const std::string>;
 
 template <typename T>
-std::pair<T, const char *> make_enum_name(const T &value, const char *name) {
+enum_name_t<T> make_enum_name(const T &value, const char *name) {
     return std::make_pair(value, name);
 }
 
 template <typename E, size_t N>
-std::string to_string_impl(
+const std::string &to_string_impl(
         E e, const std::array<enum_name_t<E>, N> &enum_names);
 
 template <typename E, size_t N>
@@ -711,7 +711,7 @@ bool is_enum_name_templ_impl(
         const std::string &s, const std::array<enum_name_t<E>, N> &enum_names);
 
 #define GPU_DEFINE_PARSE_ENUM(enum_type, enum_names) \
-    inline std::string to_string(enum_type e) { \
+    inline const std::string &to_string(enum_type e) { \
         return to_string_impl(e, enum_names); \
     } \
     inline void to_enum_impl( \
@@ -1140,12 +1140,13 @@ private:
 };
 
 template <typename E, size_t N>
-std::string to_string_impl(
+const std::string &to_string_impl(
         E e, const std::array<enum_name_t<E>, N> &enum_names) {
     for (auto &p : enum_names)
         if (p.first == e) return p.second;
     gpu_error_not_expected();
-    return {};
+    static const std::string invalid = "(invalid enum)";
+    return invalid;
 }
 
 template <typename E, size_t N>

--- a/src/gpu/intel/pool/jit/config.hpp
+++ b/src/gpu/intel/pool/jit/config.hpp
@@ -206,12 +206,12 @@ public:
         switch (0x10 * read_type.is_int() + is_max()) {
             default:
             case 0x00: return type_t::f32(len); break;
-            case 0x01: return type_t(read_type.kind(), len); break;
+            case 0x01: return read_type.with_elems(len); break;
             case 0x10: return type_t::s32(len); break;
             case 0x11:
                 return ((read_type.is_signed()) ? type_t::s : type_t::u)(
                         8 * std::max(2, read_type.size()), len,
-                        type_attr_t::undef);
+                        type::attr_t::undef);
         }
     }
 

--- a/src/gpu/intel/pool/jit/ir_builder.cpp
+++ b/src/gpu/intel/pool/jit/ir_builder.cpp
@@ -374,11 +374,13 @@ stmt_t builder_t::try_build(builder_t &pb, const kernel_info_t &ki,
     ir_context_t ir_ctx(exec, init_cset);
 
     auto acc_type = cfg.acc_type(simd);
-    auto acc_buf = ir_ctx.create_tmp_var(type_t::byte_ptr(), "acc");
+    auto acc_buf
+            = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr), "acc");
     const auto acc_sc_size = acc_type.scalar().size();
     const auto acc_size = acc_sc_size * lg[4] * lg[3] * lg[2] * lg[1] * lg[0];
 
-    auto read_buf = ir_ctx.create_tmp_var(type_t::byte_ptr(), "read");
+    auto read_buf
+            = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr), "read");
     auto read_params = get_send_params(
             exec, send_op_t::load, send_address_t::a64, src_thr_view);
     read_params.try_legacy = false;
@@ -404,8 +406,7 @@ stmt_t builder_t::try_build(builder_t &pb, const kernel_info_t &ki,
 
     const bool is_identity(prb.kd * prb.kh * prb.kw <= 1);
 
-    const type_t read_type(read_layout.type().kind(), simd);
-    const type_t write_type(write_layout.type().kind(), simd);
+    const type_t read_type(read_layout.type()[simd]);
 
     stmt_t stmt;
 

--- a/src/gpu/intel/reorder/jit/ir_builder.cpp
+++ b/src/gpu/intel/reorder/jit/ir_builder.cpp
@@ -174,7 +174,8 @@ bool ir_builder_t::try_build(const tile_t &iter_tile, const tile_t &loop_tile) {
     auto dst_buf = kernel_info_.arg_var(1);
 
     ir_context_t ir_ctx(cfg_.exec_cfg(), init_cset);
-    auto reg_buf = ir_ctx.create_tmp_var(type_t::byte_ptr(), "reg");
+    auto reg_buf
+            = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr), "reg");
 
     std::vector<stmt_t> allocs;
     for (int i = 0; i < kernel_info_.nargs(); i++) {
@@ -216,7 +217,8 @@ bool ir_builder_t::try_build(const tile_t &iter_tile, const tile_t &loop_tile) {
                 /*force_c_reorder=*/true, post_op_ctx, thr_tile_coord,
                 read_layout, dst_buf, reg_buf, write_buf_size);
     } else if (read_layout != write_layout) {
-        auto tmp_buf = ir_ctx.create_tmp_var(type_t::byte_ptr(), "tmp");
+        auto tmp_buf
+                = ir_ctx.create_tmp_var(type_t::byte(type::attr_t::ptr), "tmp");
         allocs.push_back(
                 alloc_t::make(tmp_buf, write_buf_size, alloc_kind_t::grf));
         auto reorder_stmt = create_reorder_stmt(


### PR DESCRIPTION
This PR introduces the notion of a stable interface to IR constructs. The current PR is limited to `type_t`, although my eventual goal is to introduce a stable interface for all dependencies of `dsl.hpp` (`object_t`, `stmt_t`, `expr_t`, `layout_t`, `tile_t`, `coord_t`). Some of the key pieces of this change are to move `type_attr_t` and `type_kind_t` into a `type` namespace, remove `type_kind_t` from the stable interface, remove various interfaces with minimal usage or which duplicate other exposed functionality (such as `byte_ptr()`), and remove interfaces that depend on dnnl types (such as the constructor `type_t(dnnl_data_type_t)`).