### PR TITLE
xe: conv: switch ref_conv to use ocl_io.h

### DIFF
--- a/src/gpu/intel/conv/ref.cl
+++ b/src/gpu/intel/conv/ref.cl
@@ -15,6 +15,7 @@
 *******************************************************************************/
 
 #include "gpu/intel/include/dispatch.h"
+#include "gpu/intel/include/io.h"
 #include "gpu/intel/include/philox.h"
 #include "gpu/intel/include/post_ops.h"
 #include "gpu/intel/include/types.h"
@@ -80,17 +81,14 @@ __kernel void ref_convolution_fwd(
                     const off_t src_off = SRC_OFF(n, g * IC + ic, id, ih, iw);
                     const off_t wei_off = WEI_OFF(g, oc, ic, kd, kh, kw);
 
+                    ACC_DATA_T s;
+                    ACC_DATA_T w;
 #if SRC_DT_F4_E2M1 || SRC_DT_F4_E3M0
-                    ACC_DATA_T s
-                            = TO_ACC(SRC_TO_REF(GET_HALF_BYTE(src, src_off)));
+                    load(&s, src, src_off);
+                    load(&w, wei, wei_off);
 #else
-                    ACC_DATA_T s = TO_ACC(SRC_TO_REF(src[src_off]));
-#endif
-#if WEI_DT_F4_E2M1 || WEI_DT_F4_E3M0
-                    ACC_DATA_T w
-                            = TO_ACC(WEI_TO_REF(GET_HALF_BYTE(wei, wei_off)));
-#else
-                    ACC_DATA_T w = TO_ACC(WEI_TO_REF(wei[wei_off]));
+                    load(&s, src + src_off);
+                    load(&w, wei + wei_off);
 #endif
                     d += s * w;
 
@@ -113,24 +111,23 @@ __kernel void ref_convolution_fwd(
     POST_OP_DATA_T tmp = d;
 
 #if WITH_SRC_SCALES
-    tmp *= SRC_SCALES_TO_REF(src_scales[0]);
+    tmp *= load(tmp, src_scales);
 #endif
 #if WITH_WEI_SCALES
 #if WEI_SCALES_MASK == 0
-    tmp *= WEI_SCALES_TO_REF(wei_scales[0]);
+    tmp *= load(tmp, wei_scales);
 #else
-    tmp *= WEI_SCALES_TO_REF(wei_scales[g * OC + oc]);
+    tmp *= load(tmp, wei_scales + g * OC + oc);
 #endif
 #endif
 
 #if WITH_BIAS
-    tmp += (POST_OP_DATA_T)BIA_TO_REF(bias[g * OC + oc]);
+    tmp += load(tmp, bias + g * OC + oc);
 #endif
 
     POST_OP_DATA_T sum_src;
 #if WITH_SUM
-    sum_src = (POST_OP_DATA_T)SUM_TO_REF(
-            AS_SUM_DATA_T(dst[DST_OFF(n, g * OC + oc, od, oh, ow)]));
+    sum_src = load(tmp, dst + DST_OFF(n, g * OC + oc, od, oh, ow));
 #endif
 
 #if NDIMS == 3
@@ -158,9 +155,9 @@ __kernel void ref_convolution_fwd(
 
 #if WITH_DST_SCALES
 #if DST_SCALES_MASK == 0
-    tmp /= DST_SCALES_TO_REF(dst_scales[0]);
+    tmp /= load(tmp, dst_scales);
 #else
-    tmp /= DST_SCALES_TO_REF(dst_scales[g * OC + oc]);
+    tmp /= load(tmp, dst_scales + g * OC + oc);
 #endif
 #endif
 
@@ -168,7 +165,7 @@ __kernel void ref_convolution_fwd(
     const int dst_zp = dst_zpoints[WITH_DST_ZPOINTS_PER_OC ? g * OC + oc : 0];
     tmp += dst_zp;
 #endif // WITH_DST_ZPOINTS
-    dst[DST_OFF(n, g * OC + oc, od, oh, ow)] = TO_DST(tmp);
+    write(dst + DST_OFF(n, g * OC + oc, od, oh, ow), tmp);
 }
 #endif
 
@@ -205,15 +202,14 @@ __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
         if (oh < OH && ow < OW && od < OD) {
             const off_t dst_off = DST_OFF(n, g * OC + oc, od, oh, ow);
             const off_t wei_off = WEI_OFF(g, oc, ic, kd, kh, kw);
+            ACC_DATA_T diff_d;
+            ACC_DATA_T w;
 #if DST_DT_F4_E2M1 || DST_DT_F4_E3M0
-            ACC_DATA_T diff_d = DST_TO_REF(GET_HALF_BYTE(diff_dst, dst_off));
+            load(&diff_d, diff_dst, dst_off);
+            load(&w, wei, wei_off);
 #else
-            ACC_DATA_T diff_d = DST_TO_REF(diff_dst[dst_off]);
-#endif
-#if WEI_DT_F4_E2M1 || WEI_DT_F4_E3M0
-            ACC_DATA_T w = WEI_TO_REF(GET_HALF_BYTE(wei, wei_off));
-#else
-            ACC_DATA_T w = WEI_TO_REF(wei[wei_off]);
+            load(&diff_d, diff_dst + dst_off);
+            load(&w, wei + wei_off);
 #endif
             d += diff_d * w;
 #if WITH_SRC_ZPOINTS
@@ -247,13 +243,12 @@ __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
 #endif
 
 #if WITH_BIAS
-    tmp += (POST_OP_DATA_T)BIA_TO_REF(bias[g * IC + ic]);
+    tmp += load(tmp, bias + g * IC + ic);
 #endif
 
     POST_OP_DATA_T sum_src;
 #if WITH_SUM
-    sum_src = (POST_OP_DATA_T)SUM_TO_REF(
-            AS_SUM_DATA_T(diff_src[SRC_OFF(n, g * IC + ic, id, ih, iw)]));
+    load(&sum_src, diff_src + SRC_OFF(n, g * IC + ic, id, ih, iw));
 #endif
 
 #if NDIMS == 3
@@ -284,7 +279,7 @@ __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
     tmp += dst_zp;
 #endif // WITH_DST_ZPOINTS
 
-    diff_src[SRC_OFF(n, g * IC + ic, id, ih, iw)] = TO_SRC(tmp);
+    write(diff_src + SRC_OFF(n, g * IC + ic, id, ih, iw), tmp);
 }
 #endif
 
@@ -307,10 +302,10 @@ __kernel void ref_convolution_bwd_weights(const __global SRC_DATA_T *src,
             for (off_t od = 0; od < OD; ++od)
                 for (off_t oh = 0; oh < OH; ++oh)
                     for (off_t ow = 0; ow < OW; ++ow) {
-                        d += DST_TO_REF(
-                                diff_dst[DST_OFF(n, g * OC + oc, od, oh, ow)]);
+                        d += load(d,
+                                diff_dst + DST_OFF(n, g * OC + oc, od, oh, ow));
                     }
-        diff_bias[g * OC + oc] = TO_BIA(d);
+        write(diff_bias + g * OC + oc, d);
     }
 #endif
 
@@ -333,19 +328,17 @@ __kernel void ref_convolution_bwd_weights(const __global SRC_DATA_T *src,
                     off_t dst_off = DST_OFF(n, g * OC + oc, od, oh, ow);
                     off_t src_off = SRC_OFF(n, g * IC + ic, id, ih, iw);
 
+                    ACC_DATA_T diff_d;
+                    ACC_DATA_T s;
 #if DST_DT_F4_E2M1 || DST_DT_F4_E3M0
-                    ACC_DATA_T diff_d
-                            = SRC_TO_REF(GET_HALF_BYTE(diff_dst, dst_off));
+                    load(&diff_d, diff_dst, dst_off);
+                    load(&s, src, src_off);
 #else
-                    ACC_DATA_T diff_d = DST_TO_REF(diff_dst[dst_off]);
-#endif
-#if SRC_DT_F4_E2M1 || SRC_DT_F4_E3M0
-                    ACC_DATA_T s = SRC_TO_REF(GET_HALF_BYTE(src, src_off));
-#else
-                    ACC_DATA_T s = SRC_TO_REF(src[src_off]);
+                    load(&diff_d, diff_dst + dst_off);
+                    load(&s, src + src_off);
 #endif
                     dw += diff_d * s;
                 }
-    diff_wei[WEI_OFF(g, oc, ic, kd, kh, kw)] = TO_WEI(dw);
+    write(diff_wei + WEI_OFF(g, oc, ic, kd, kh, kw), dw);
 }
 #endif

--- a/src/gpu/intel/conv/ref.cpp
+++ b/src/gpu/intel/conv/ref.cpp
@@ -127,22 +127,22 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int(
             "IS_BWD_W", conf.prop_kind == prop_kind::backward_weights);
 
-    def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC");
-    def_memory_desc_info(kernel_ctx, conf.wei_md_info, "WEI");
-    def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST");
+    def_memory_desc_info(kernel_ctx, conf.src_md_info, "SRC", false);
+    def_memory_desc_info(kernel_ctx, conf.wei_md_info, "WEI", false);
+    def_memory_desc_info(kernel_ctx, conf.dst_md_info, "DST", false);
 
     def_dispatch(kernel_ctx, conf.dispatch);
 
     switch (conf.prop_kind) {
         case prop_kind::forward_training:
         case prop_kind::forward_inference:
-            kernel_ctx.set_data_type(conf.dst_data_type);
+            kernel_ctx.set_data_type(conf.dst_data_type, false);
             break;
         case prop_kind::backward_data:
-            kernel_ctx.set_data_type(conf.src_data_type);
+            kernel_ctx.set_data_type(conf.src_data_type, false);
             break;
         case prop_kind::backward_weights:
-            kernel_ctx.set_data_type(conf.weights_data_type);
+            kernel_ctx.set_data_type(conf.weights_data_type, false);
             break;
         default: break;
     }
@@ -151,16 +151,16 @@ static status_t init_kernel_ctx_common(compute::kernel_ctx_t &kernel_ctx,
     kernel_ctx.define_int("DST_DT_DIGITS",
             dnnl::impl::types::digits<uint32_t>(conf.dst_data_type));
 
-    def_data_type(kernel_ctx, conf.src_data_type, "SRC");
-    def_data_type(kernel_ctx, conf.weights_data_type, "WEI");
-    def_data_type(kernel_ctx, conf.bias_data_type, "BIA");
-    def_data_type(kernel_ctx, conf.dst_data_type, "DST");
-    def_data_type(kernel_ctx, conf.acc_data_type, "ACC");
+    def_data_type(kernel_ctx, conf.src_data_type, "SRC", false);
+    def_data_type(kernel_ctx, conf.weights_data_type, "WEI", false);
+    def_data_type(kernel_ctx, conf.bias_data_type, "BIA", false);
+    def_data_type(kernel_ctx, conf.dst_data_type, "DST", false);
+    def_data_type(kernel_ctx, conf.acc_data_type, "ACC", false);
     def_data_type(kernel_ctx,
             conf.attr_info.sum_data_type == dnnl_data_type_undef
                     ? conf.dst_data_type
                     : conf.attr_info.sum_data_type,
-            "SUM");
+            "SUM", false);
 
     CHECK(def_attr_info(kernel_ctx, conf.attr_info, post_ops, *dst_md));
     return status::success;


### PR DESCRIPTION
Fixes [MFDNN-14100](https://jira.devtools.intel.com/projects/MFDNN/issues/MFDNN-14100), which is a compilation error due to an incorrect AS_SUM_DATA_T definition.