### PR TITLE
benchdnn: memory tracking: address potential OOM cases

### DIFF
--- a/tests/benchdnn/binary/binary.cpp
+++ b/tests/benchdnn/binary/binary.cpp
@@ -23,6 +23,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnn_types.hpp"

--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -26,6 +26,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -20,10 +20,8 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cerrno>
 #include <fstream>
 #include <functional>
-#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -33,21 +31,6 @@
 #include "common.hpp"
 
 #include "utils/parallel.hpp"
-
-// BENCHDNN_MEMORY_CHECK macro enables guarding mechanism for memory allocation:
-// memory block is allocated on a page boundary and the page after the block is
-// protected to catch possible invalid accesses.
-//
-// Note that the macro affects the correctness mode only.
-#ifdef __unix__
-#define BENCHDNN_MEMORY_CHECK
-#endif
-
-#ifdef BENCHDNN_MEMORY_CHECK
-#include <stdlib.h>
-#include <unistd.h>
-#include <sys/mman.h>
-#endif
 
 /* result structure */
 const char *state2str(res_state_t state) {
@@ -188,185 +171,6 @@ void parse_result(res_t &res, const char *pstr) {
 }
 
 /* misc */
-
-#ifdef BENCHDNN_MEMORY_CHECK
-static void *zmalloc_protect(size_t size) {
-    const size_t page_sz = getpagesize();
-
-    const size_t block_sz = size + 3 * sizeof(void *);
-    const size_t total_sz = rnd_up(block_sz, page_sz) + page_sz;
-
-    void *mem_ptr;
-    int rc = ::posix_memalign(&mem_ptr, page_sz, total_sz);
-    if (rc != 0) return nullptr;
-
-    uint8_t *ptr_start = (uint8_t *)mem_ptr;
-    uint8_t *ptr = ptr_start + total_sz - page_sz - size;
-
-    // Aligned on a page boundary
-    void *ptr_protect = ptr + size;
-
-    // Layout of the allocated region:
-    // ptr_start   <- start of the allocated region
-    // ptr[-16]    <- stores start address: ptr_start
-    // ptr[-8]     <- stores protected address: ptr_protect
-    // ptr         <- pointer to be returned from the function
-    // ptr_protect <- pointer to the block to protect
-
-    // Protect one page right after the block of size bytes
-    int err = mprotect(ptr_protect, page_sz, PROT_NONE);
-    if (err != 0) {
-        printf("Error: mprotect returned \'%s\'.\n", strerror(errno));
-        ::free(ptr_start);
-        return nullptr;
-    }
-
-    // Align down `ptr` on 8 bytes before storing addresses to make behavior
-    // defined.
-    ptrdiff_t to_align = reinterpret_cast<ptrdiff_t>(ptr) % sizeof(void *);
-    void *ptr_aligned_8 = ptr - to_align;
-    // Save pointers for zfree_protect
-    ((void **)ptr_aligned_8)[-2] = ptr_start;
-    ((void **)ptr_aligned_8)[-1] = ptr_protect;
-
-    return ptr;
-}
-
-static void zfree_protect(void *ptr) {
-    // Get aligned ptr before obtaining addresses
-    ptrdiff_t to_align = reinterpret_cast<ptrdiff_t>(ptr) % sizeof(void *);
-    void *ptr_aligned_8 = reinterpret_cast<uint8_t *>(ptr) - to_align;
-
-    // Restore read-write access for the protected region
-    void *ptr_protect = ((void **)ptr_aligned_8)[-1];
-    const size_t page_sz = getpagesize();
-    mprotect(ptr_protect, page_sz, PROT_READ | PROT_WRITE);
-
-    // Deallocate the whole region
-    void *ptr_start = ((void **)ptr_aligned_8)[-2];
-    ::free(ptr_start);
-}
-#endif
-struct memory_registry_t {
-    void add(void *ptr, size_t size) {
-        std::lock_guard<std::mutex> g(m_);
-        assert(allocations_.find(ptr) == allocations_.end());
-        allocations_.emplace(std::pair<void *, size_t>(ptr, size));
-        total_size_ += size;
-
-        BENCHDNN_PRINT(8,
-                "[CHECK_MEM]: zmalloc request with size %s, total "
-                "allocation size: %s\n",
-                smart_bytes(size).c_str(), smart_bytes(total_size_).c_str());
-        warn_size_check();
-    }
-    void remove(void *ptr) {
-        std::lock_guard<std::mutex> g(m_);
-        const size_t size = allocations_[ptr];
-        total_size_ -= size;
-
-        BENCHDNN_PRINT(8,
-                "[CHECK_MEM]: zfree request with size %s, total "
-                "allocation size: %s\n",
-                smart_bytes(size).c_str(), smart_bytes(total_size_).c_str());
-        allocations_.erase(ptr);
-    }
-
-    void set_expected_max(size_t size) {
-        constexpr float expected_trh = 1.1f; // Smooth out small allocations.
-        expected_max_ = static_cast<size_t>(expected_trh * size);
-        has_warned_ = false;
-        warn_size_check();
-    }
-
-private:
-    size_t size() const { return total_size_; }
-    void warn_size_check() {
-        const bool is_max_set = expected_max_ != unset_;
-        // Verify the total amount of allocated memory when it starts exceeding
-        // 1 GB threshold. Small amount of memory is highly unlikely cause OOM.
-        // There's an idea to add a portion of RAM into account as well, keep
-        // only 1 GB so far to check if it proves working well.
-        const bool is_total_size_big = total_size_ >= 1024 * 1024 * 1024;
-        const bool is_total_size_unexpected = total_size_ > expected_max_;
-        // Perf mode might have cold-cache enabled which potentially allocates
-        // unaccounted memory. To avoid a dependency on a cold-cache in this
-        // file, just rely on perf mode.
-        if (!has_bench_mode_bit(mode_bit_t::perf) && !has_warned_ && is_max_set
-                && is_total_size_big && is_total_size_unexpected) {
-            BENCHDNN_PRINT(0,
-                    "[CHECK_MEM][ERROR]: Memory use is underestimated. Current "
-                    "allocation size: %s; expected size: %s.\n",
-                    smart_bytes(total_size_).c_str(),
-                    smart_bytes(expected_max_).c_str());
-            // Prevent spamming logs with subsequent overflowing allocations;
-            has_warned_ = true;
-        }
-    }
-    static constexpr size_t unset_ = 0;
-    size_t expected_max_ = unset_;
-    size_t total_size_ = 0;
-    bool has_warned_ = false;
-    std::unordered_map<void *, size_t> allocations_;
-    std::mutex m_;
-};
-
-memory_registry_t &zmalloc_registry() {
-    static memory_registry_t reg {};
-    return reg;
-}
-
-void set_zmalloc_max_expected_size(size_t size) {
-    zmalloc_registry().set_expected_max(size);
-}
-
-void *zmalloc(size_t size, size_t align) {
-#ifdef BENCHDNN_MEMORY_CHECK
-    if (has_bench_mode_bit(mode_bit_t::exec)
-            && !has_bench_mode_bit(mode_bit_t::perf)) {
-        void *ptr = zmalloc_protect(size);
-        zmalloc_registry().add(ptr, size);
-        return ptr;
-    }
-#endif
-
-    void *ptr;
-#ifdef _WIN32
-    ptr = _aligned_malloc(size, align);
-    int rc = ((ptr) ? 0 : errno);
-#else
-    // posix_memalign requires alignment to be
-    // a power of 2 and a multiple of sizeof(void *)
-    if (align < sizeof(void *)) align = sizeof(void *);
-    assert(((align & (align - 1)) == 0) && "align must be a power of 2");
-
-    // TODO. Heuristics: Increasing the size to alignment increases
-    // the stability of performance results.
-    if (has_bench_mode_bit(mode_bit_t::perf) && (size < align)) size = align;
-    int rc = ::posix_memalign(&ptr, align, size);
-#endif /* _WIN32 */
-    zmalloc_registry().add(ptr, size);
-    return rc == 0 ? ptr : nullptr;
-}
-
-// zfree behavior is aligned with UNIX free().
-void zfree(void *ptr) {
-    if (!ptr) return;
-    zmalloc_registry().remove(ptr);
-#ifdef BENCHDNN_MEMORY_CHECK
-    if (has_bench_mode_bit(mode_bit_t::exec)
-            && !has_bench_mode_bit(mode_bit_t::perf)) {
-        zfree_protect(ptr);
-        return;
-    }
-#endif
-
-#ifdef _WIN32
-    _aligned_free(ptr);
-#else
-    return ::free(ptr);
-#endif /* _WIN32 */
-}
 
 bool str2bool(const char *str) {
     return !strcasecmp("true", str) || !strcasecmp("1", str);

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -164,10 +164,6 @@ void parse_result(res_t &res, const char *pstr);
 /* misc */
 void init_fp_mode();
 
-void *zmalloc(size_t size, size_t align);
-void zfree(void *ptr);
-void set_zmalloc_max_expected_size(size_t size);
-
 bool str2bool(const char *str);
 const char *bool2str(bool value);
 

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -21,6 +21,7 @@
 
 #include "oneapi/dnnl/dnnl.h"
 
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -24,6 +24,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/conv/ref_wino.cpp
+++ b/tests/benchdnn/conv/ref_wino.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "conv/ref_conv.hpp"

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/deconv/ref_wino.cpp
+++ b/tests/benchdnn/deconv/ref_wino.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "deconv/ref_deconv.hpp"

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1235,7 +1235,8 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
     }
 
     size_t total_size_cpu = total_size_ref + total_size_compare
-            + check_mem_size_args.total_size_mapped;
+            + check_mem_size_args.total_size_mapped
+            + check_mem_size_args.extra_size_driver;
 
     // If the problem runs on CPU, the combined memory represents requirements
     // for the library and for the reference paths.

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1129,12 +1129,15 @@ int check_total_size(res_t *res, dnnl_primitive_t prim_ref) {
     const size_t device_max_capacity
             = is_cpu() ? cpu_device_capacity : gpu_device_capacity;
 
-    // 0.75f is taken randomly and is subject to change in future.
-    const double capacity_factor = 0.75;
+    // `0.70` is taken mostly due to integrated graphics and the way service
+    // reorders are handled by benchdnn. See a comment at `execute_reorder`.
+    // It's always a subject to change in the future.
+    const double capacity_factor = 0.70;
     const double benchdnn_device_limit = capacity_factor * device_max_capacity;
     // Note: there used to be a separate limit for combined memory pool, however
-    // it didn't work even at 0.80 point due to, likely, system memory
-    // requirements. Use same limit for combined cpu and pure cpu cases.
+    // it didn't work even at 0.80 point due to mentioned reorder peculiarity,
+    // and the way RNN allocates memory for ref computations.
+    // Use same limit for combined cpu and pure cpu cases.
     const double benchdnn_cpu_limit = capacity_factor * cpu_device_capacity;
     assert(benchdnn_device_limit > 0 && benchdnn_cpu_limit > 0);
 

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -239,8 +239,8 @@ int dnn_mem_t::reorder(const dnn_mem_t &rhs, const_dnnl_primitive_attr_t attr,
     return status;
 }
 
-size_t dnn_mem_t::size() const {
-    return dnnl_memory_desc_get_size(md_);
+size_t dnn_mem_t::size(int index) const {
+    return dnnl_memory_desc_get_size_v2(md_, index);
 }
 
 bool dnn_mem_t::is_sparse_md() const {

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -478,7 +478,8 @@ void dnn_mem_t::map() const {
         // Register a mapped memory entry if a different pointer from `data_`
         // was returned.
         if (IMPLICATION(!data_.empty(), data_[i] != mapped_ptrs_[i]))
-            zmalloc_registry().add_mapped(mapped_ptrs_[i], size(i));
+            memory_registry_t::get_instance().add_mapped(
+                    mapped_ptrs_[i], size(i));
     }
 }
 
@@ -493,7 +494,8 @@ void dnn_mem_t::unmap() const {
         // Unregister a mapped memory entry if a different pointer from `data_`
         // was returned when mapped.
         if (IMPLICATION(!data_.empty(), data_[i] != mapped_ptrs_[i]))
-            zmalloc_registry().remove_mapped(mapped_ptrs_[i], size(i));
+            memory_registry_t::get_instance().remove_mapped(
+                    mapped_ptrs_[i], size(i));
 
         DNN_SAFE_V(dnnl_memory_unmap_data_v2(mem, mapped_ptrs_[i], i));
         mapped_ptrs_[i] = nullptr;

--- a/tests/benchdnn/dnnl_memory.cpp
+++ b/tests/benchdnn/dnnl_memory.cpp
@@ -39,6 +39,7 @@
 #include "dnnl_memory.hpp"
 #include "utils/cold_cache.hpp"
 #include "utils/dnnl_query.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 extern "C" dnnl_status_t dnnl_memory_desc_create_with_string_tag(

--- a/tests/benchdnn/dnnl_memory.hpp
+++ b/tests/benchdnn/dnnl_memory.hpp
@@ -95,7 +95,7 @@ struct dnn_mem_t {
         return reorder(rhs, nullptr, swap_dt);
     }
 
-    size_t size() const;
+    size_t size(int index = 0) const;
 
     int64_t nelems(bool with_padded_dims = false) const {
         const auto &_dims = with_padded_dims ? padded_dims() : dims();

--- a/tests/benchdnn/doc/knobs_verbose.md
+++ b/tests/benchdnn/doc/knobs_verbose.md
@@ -39,6 +39,9 @@ following information is printed for certain verbosity levels.
 ## Level 7
 * Graph: prints the essential part of the graph (after the rewriter pass).
 
+## Level 8
+* Memory allocations and mapping statistics.
+
 ## Level 50
 * Full path of batch file used.
 

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -21,6 +21,7 @@
 
 #include "oneapi/dnnl/dnnl.h"
 
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -19,6 +19,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -22,6 +22,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -26,6 +26,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -23,6 +23,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -24,6 +24,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/pool/pool.cpp
+++ b/tests/benchdnn/pool/pool.cpp
@@ -23,6 +23,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -22,6 +22,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -25,6 +25,7 @@
 #include "common/memory_desc.hpp"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnn_types.hpp"

--- a/tests/benchdnn/resampling/resampling.cpp
+++ b/tests/benchdnn/resampling/resampling.cpp
@@ -22,6 +22,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -28,6 +28,7 @@
 #include "dnn_types.hpp"
 #include "dnnl_common.hpp"
 #include "dnnl_debug.hpp"
+#include "utils/memory.hpp"
 #include "utils/perf_report.hpp"
 #include "utils/settings.hpp"
 

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -20,6 +20,7 @@
 
 #include "oneapi/dnnl/dnnl.h"
 
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -26,6 +26,7 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "utils/fill.hpp"
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -23,6 +23,7 @@
 
 #include "oneapi/dnnl/dnnl.h"
 
+#include "utils/memory.hpp"
 #include "utils/parallel.hpp"
 
 #include "dnnl_common.hpp"

--- a/tests/benchdnn/utils/memory.cpp
+++ b/tests/benchdnn/utils/memory.cpp
@@ -1,0 +1,217 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "utils/memory.hpp"
+#include "common.hpp"
+#include "utils/bench_mode.hpp"
+
+// BENCHDNN_MEMORY_CHECK macro enables guarding mechanism for memory allocation:
+// memory block is allocated on a page boundary and the page after the block is
+// protected to catch possible invalid accesses.
+//
+// Note that the macro affects the correctness mode only.
+#ifdef __unix__
+#define BENCHDNN_MEMORY_CHECK
+#endif
+
+#ifdef BENCHDNN_MEMORY_CHECK
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#endif
+
+#include <cassert>
+#include <cerrno>
+#include <cstring>
+
+void memory_registry_t::add(void *ptr, size_t size) {
+    std::lock_guard<std::mutex> g(m_);
+    if (!ptr) return;
+
+    assert(allocations_.find(ptr) == allocations_.end());
+    allocations_.emplace(std::pair<void *, size_t>(ptr, size));
+    total_size_ += size;
+
+    BENCHDNN_PRINT(8,
+            "[CHECK_MEM]: zmalloc request (%p) with size %s, total "
+            "allocation size: %s\n",
+            ptr, smart_bytes(size).c_str(), smart_bytes(total_size_).c_str());
+    warn_size_check();
+}
+
+void memory_registry_t::remove(void *ptr) {
+    std::lock_guard<std::mutex> g(m_);
+    if (!ptr) return;
+
+    // Use `at` to catch cases when unallocated pointers are removed.
+    const size_t size = allocations_.at(ptr);
+    total_size_ -= size;
+
+    BENCHDNN_PRINT(8,
+            "[CHECK_MEM]: zfree request (%p) with size %s, total "
+            "allocation size: %s\n",
+            ptr, smart_bytes(size).c_str(), smart_bytes(total_size_).c_str());
+    allocations_.erase(ptr);
+}
+
+void memory_registry_t::set_expected_max(size_t size) {
+    expected_max_ = static_cast<size_t>(expected_trh_ * size);
+    has_warned_ = false;
+    warn_size_check();
+}
+
+void memory_registry_t::warn_size_check() {
+    const bool is_max_set = expected_max_ != unset_;
+    // Verify the total amount of allocated memory when it starts exceeding
+    // 1 GB threshold. Small amount of memory is highly unlikely cause OOM.
+    // There's an idea to add a portion of RAM into account as well, keep
+    // only 1 GB so far to check if it proves working well.
+    const bool is_total_size_big = total_size_ >= 1024 * 1024 * 1024;
+    const bool is_total_size_unexpected = total_size_ > expected_max_;
+    // Perf mode might have cold-cache enabled which potentially allocates
+    // unaccounted memory. To avoid a dependency on a cold-cache in this
+    // file, just rely on perf mode.
+    if (!has_bench_mode_bit(mode_bit_t::perf) && !has_warned_ && is_max_set
+            && is_total_size_big && is_total_size_unexpected) {
+        BENCHDNN_PRINT(0,
+                "[CHECK_MEM][ERROR]: Memory use is underestimated. Current "
+                "allocation size: %s; expected size: %s.\n",
+                smart_bytes(total_size_).c_str(),
+                smart_bytes(expected_max_).c_str());
+        // Prevent spamming logs with subsequent overflowing allocations;
+        has_warned_ = true;
+    }
+}
+
+memory_registry_t &zmalloc_registry() {
+    static memory_registry_t reg {};
+    return reg;
+}
+
+void set_zmalloc_max_expected_size(size_t size) {
+    zmalloc_registry().set_expected_max(size);
+}
+
+namespace {
+
+#ifdef BENCHDNN_MEMORY_CHECK
+void *zmalloc_protect(size_t size) {
+    const size_t page_sz = getpagesize();
+
+    const size_t block_sz = size + 3 * sizeof(void *);
+    const size_t total_sz = rnd_up(block_sz, page_sz) + page_sz;
+
+    void *mem_ptr;
+    int rc = ::posix_memalign(&mem_ptr, page_sz, total_sz);
+    if (rc != 0) return nullptr;
+
+    uint8_t *ptr_start = (uint8_t *)mem_ptr;
+    uint8_t *ptr = ptr_start + total_sz - page_sz - size;
+
+    // Aligned on a page boundary
+    void *ptr_protect = ptr + size;
+
+    // Layout of the allocated region:
+    // ptr_start   <- start of the allocated region
+    // ptr[-16]    <- stores start address: ptr_start
+    // ptr[-8]     <- stores protected address: ptr_protect
+    // ptr         <- pointer to be returned from the function
+    // ptr_protect <- pointer to the block to protect
+
+    // Protect one page right after the block of size bytes
+    int err = mprotect(ptr_protect, page_sz, PROT_NONE);
+    if (err != 0) {
+        printf("Error: mprotect returned \'%s\'.\n", strerror(errno));
+        ::free(ptr_start);
+        return nullptr;
+    }
+
+    // Align down `ptr` on 8 bytes before storing addresses to make behavior
+    // defined.
+    ptrdiff_t to_align = reinterpret_cast<ptrdiff_t>(ptr) % sizeof(void *);
+    void *ptr_aligned_8 = ptr - to_align;
+    // Save pointers for zfree_protect
+    ((void **)ptr_aligned_8)[-2] = ptr_start;
+    ((void **)ptr_aligned_8)[-1] = ptr_protect;
+
+    return ptr;
+}
+
+void zfree_protect(void *ptr) {
+    // Get aligned ptr before obtaining addresses
+    ptrdiff_t to_align = reinterpret_cast<ptrdiff_t>(ptr) % sizeof(void *);
+    void *ptr_aligned_8 = reinterpret_cast<uint8_t *>(ptr) - to_align;
+
+    // Restore read-write access for the protected region
+    void *ptr_protect = ((void **)ptr_aligned_8)[-1];
+    const size_t page_sz = getpagesize();
+    mprotect(ptr_protect, page_sz, PROT_READ | PROT_WRITE);
+
+    // Deallocate the whole region
+    void *ptr_start = ((void **)ptr_aligned_8)[-2];
+    ::free(ptr_start);
+}
+#endif
+
+} // namespace
+
+void *zmalloc(size_t size, size_t align) {
+#ifdef BENCHDNN_MEMORY_CHECK
+    if (has_bench_mode_bit(mode_bit_t::exec)
+            && !has_bench_mode_bit(mode_bit_t::perf)) {
+        void *ptr = zmalloc_protect(size);
+        zmalloc_registry().add(ptr, size);
+        return ptr;
+    }
+#endif
+
+    void *ptr;
+#ifdef _WIN32
+    ptr = _aligned_malloc(size, align);
+    int rc = ((ptr) ? 0 : errno);
+#else
+    // posix_memalign requires alignment to be
+    // a power of 2 and a multiple of sizeof(void *)
+    if (align < sizeof(void *)) align = sizeof(void *);
+    assert(((align & (align - 1)) == 0) && "align must be a power of 2");
+
+    // TODO. Heuristics: Increasing the size to alignment increases
+    // the stability of performance results.
+    if (has_bench_mode_bit(mode_bit_t::perf) && (size < align)) size = align;
+    int rc = ::posix_memalign(&ptr, align, size);
+#endif /* _WIN32 */
+    zmalloc_registry().add(ptr, size);
+    return rc == 0 ? ptr : nullptr;
+}
+
+// zfree behavior is aligned with UNIX free().
+void zfree(void *ptr) {
+    if (!ptr) return;
+    zmalloc_registry().remove(ptr);
+#ifdef BENCHDNN_MEMORY_CHECK
+    if (has_bench_mode_bit(mode_bit_t::exec)
+            && !has_bench_mode_bit(mode_bit_t::perf)) {
+        zfree_protect(ptr);
+        return;
+    }
+#endif
+
+#ifdef _WIN32
+    _aligned_free(ptr);
+#else
+    return ::free(ptr);
+#endif /* _WIN32 */
+}

--- a/tests/benchdnn/utils/memory.hpp
+++ b/tests/benchdnn/utils/memory.hpp
@@ -21,14 +21,20 @@
 #include <unordered_map>
 
 struct memory_registry_t {
+    // Increases the registered physically allocated memory.
     void add(void *ptr, size_t size);
 
+    // Decreases the registered physically allocated memory.
     void remove(void *ptr);
 
+    // Uses `size` as an upper limit to check if allocations fit the
+    // expectation. The check takes into account `expected_trh_` which increases
+    // the `size`.
     void set_expected_max(size_t size);
 
 private:
-    // To smooth out small allocations.
+    // `expected_trh_` smoothes out small allocations for attributes memory
+    // objects.
     static constexpr float expected_trh_ = 1.1f;
     static constexpr size_t unset_ = 0;
     size_t expected_max_ = unset_;

--- a/tests/benchdnn/utils/memory.hpp
+++ b/tests/benchdnn/utils/memory.hpp
@@ -27,10 +27,19 @@ struct memory_registry_t {
     // Decreases the registered physically allocated memory.
     void remove(void *ptr);
 
+    // Increases the registered mapped memory.
+    void add_mapped(void *ptr, size_t size);
+
+    // Decreases the registered mapped memory. Use `size` to track repeated
+    // mapped regions.
+    void remove_mapped(void *ptr, size_t size);
+
     // Uses `size` as an upper limit to check if allocations fit the
     // expectation. The check takes into account `expected_trh_` which increases
     // the `size`.
     void set_expected_max(size_t size);
+
+    ~memory_registry_t();
 
 private:
     // `expected_trh_` smoothes out small allocations for attributes memory
@@ -40,7 +49,11 @@ private:
     size_t expected_max_ = unset_;
     size_t total_size_ = 0;
     bool has_warned_ = false;
+    // For physically allocated memory.
     std::unordered_map<void *, size_t> allocations_;
+    // For mapped memory. Mapped memory can overflow the upper limit as it
+    // happens in sporadic places.
+    std::unordered_map<void *, size_t> mapped_allocations_;
     std::mutex m_;
 
     size_t size() const { return total_size_; }

--- a/tests/benchdnn/utils/memory.hpp
+++ b/tests/benchdnn/utils/memory.hpp
@@ -26,10 +26,10 @@ struct memory_registry_t {
         return instance;
     }
 
-    // Increases the registered physically allocated memory.
+    // Increases the registered physically allocated memory on CPU.
     void add(void *ptr, size_t size);
 
-    // Decreases the registered physically allocated memory.
+    // Decreases the registered physically allocated memory on CPU.
     void remove(void *ptr);
 
     // Increases the registered mapped memory.
@@ -38,6 +38,12 @@ struct memory_registry_t {
     // Decreases the registered mapped memory. Use `size` to track repeated
     // mapped regions.
     void remove_mapped(void *ptr, size_t size);
+
+    // Increases the registered physically allocated memory on a device.
+    void add_device(void *ptr, size_t size);
+
+    // Decreases the registered physically allocated memory on a device.
+    void remove_device(void *ptr);
 
     // Uses `size` as an upper limit to check if allocations fit the
     // expectation. The check takes into account `expected_trh_` which increases
@@ -50,10 +56,13 @@ private:
     static constexpr float expected_trh_ = 1.1f;
     static constexpr size_t unset_ = 0;
     size_t expected_max_ = unset_;
-    size_t total_size_ = 0;
+    size_t total_size_cpu_ = 0;
+    size_t total_size_gpu_ = 0;
     bool has_warned_ = false;
-    // For physically allocated memory.
+    // For physically allocated memory on CPU.
     std::unordered_map<void *, size_t> allocations_;
+    // For physically allocated memory on a device.
+    std::unordered_map<void *, size_t> allocations_device_;
     // For mapped memory. Mapped memory can overflow the upper limit as it
     // happens in sporadic places.
     std::unordered_map<void *, size_t> mapped_allocations_;
@@ -62,8 +71,6 @@ private:
     memory_registry_t() = default;
 
     ~memory_registry_t();
-
-    size_t size() const { return total_size_; }
 
     void warn_size_check();
 };

--- a/tests/benchdnn/utils/memory.hpp
+++ b/tests/benchdnn/utils/memory.hpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef UTILS_MEMORY_HPP
+#define UTILS_MEMORY_HPP
+
+#include <mutex>
+#include <unordered_map>
+
+struct memory_registry_t {
+    void add(void *ptr, size_t size);
+
+    void remove(void *ptr);
+
+    void set_expected_max(size_t size);
+
+private:
+    // To smooth out small allocations.
+    static constexpr float expected_trh_ = 1.1f;
+    static constexpr size_t unset_ = 0;
+    size_t expected_max_ = unset_;
+    size_t total_size_ = 0;
+    bool has_warned_ = false;
+    std::unordered_map<void *, size_t> allocations_;
+    std::mutex m_;
+
+    size_t size() const { return total_size_; }
+
+    void warn_size_check();
+};
+
+memory_registry_t &zmalloc_registry();
+
+void set_zmalloc_max_expected_size(size_t size);
+
+void *zmalloc(size_t size, size_t align);
+
+void zfree(void *ptr);
+
+#endif

--- a/tests/benchdnn/utils/memory.hpp
+++ b/tests/benchdnn/utils/memory.hpp
@@ -21,6 +21,11 @@
 #include <unordered_map>
 
 struct memory_registry_t {
+    static memory_registry_t &get_instance() {
+        static memory_registry_t instance;
+        return instance;
+    }
+
     // Increases the registered physically allocated memory.
     void add(void *ptr, size_t size);
 
@@ -39,8 +44,6 @@ struct memory_registry_t {
     // the `size`.
     void set_expected_max(size_t size);
 
-    ~memory_registry_t();
-
 private:
     // `expected_trh_` smoothes out small allocations for attributes memory
     // objects.
@@ -56,12 +59,14 @@ private:
     std::unordered_map<void *, size_t> mapped_allocations_;
     std::mutex m_;
 
+    memory_registry_t() = default;
+
+    ~memory_registry_t();
+
     size_t size() const { return total_size_; }
 
     void warn_size_check();
 };
-
-memory_registry_t &zmalloc_registry();
 
 void set_zmalloc_max_expected_size(size_t size);
 

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -67,6 +67,12 @@ struct check_mem_size_args_t {
     bool want_input = false;
     dir_t dir = DIR_UNDEF; // See ANCHOR: MEM_CHECK_ARGS_DIR;
 
+    // Manually input args: must be set by the user to handle additional logic.
+    //
+    // `extra_size_driver` specifies memory allocated by the driver for its
+    // needs. Must be updated manually at `checkit` function.
+    size_t extra_size_driver = 0;
+
     // Output args: values obtained by the memory collection logic.
     //
     // `sizes` used to validate OpenCL memory requirements.

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -93,7 +93,7 @@ struct check_mem_size_args_t {
     size_t total_ref_md_size[2] = {0, 0};
     // `scratchpad_size` specifies a scratchpad size for specific checks.
     size_t scratchpad_size = 0;
-    // A setting for zmalloc_registry. It's stashed inside `check_total_size`
+    // A setting for memory_registry. It's stashed inside `check_total_size`
     // call and used later in `doit` due to parallel mode as, otherwise, all
     // test objects will be validated against the numbers from the last created
     // test object.

--- a/tests/benchdnn/utils/res.hpp
+++ b/tests/benchdnn/utils/res.hpp
@@ -62,12 +62,13 @@ struct check_mem_size_args_t {
             const_dnnl_primitive_desc_t pd, bool want_input, dir_t dir)
         : pd(pd), want_input(want_input), dir(dir) {}
 
-    // Input args.
+    // Input args: get their values only at construction.
     const_dnnl_primitive_desc_t pd = nullptr;
     bool want_input = false;
     dir_t dir = DIR_UNDEF; // See ANCHOR: MEM_CHECK_ARGS_DIR;
 
-    // Output args:
+    // Output args: values obtained by the memory collection logic.
+    //
     // `sizes` used to validate OpenCL memory requirements.
     std::vector<size_t> sizes;
     // `total_size_device` specifies memory allocated on device for a test obj.


### PR DESCRIPTION
[MFDNN-14017](https://jira.devtools.intel.com/browse/MFDNN-14017) - this gets addressed by decreasing the allowed portion of memory from 0.75 to 0.7. There are comments that explain the problem.

[MFDNN-13670](https://jira.devtools.intel.com/browse/MFDNN-13670)
[MFDNN-11194](https://jira.devtools.intel.com/browse/MFDNN-11194) - this gets addressed by adding extra variable holding driver memory need.

Besides that, the PR moves memory allocations and tracking functionality into a separate file and extends tracking to mapped memories for easier identifying which spot looks ill.

