### PR TITLE
graph: backend: dnnl: fix ukernel check for int8 sdpa

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -51,6 +51,12 @@ status_t sdp_primitive_config_t::initial_check(
     // Dispatch f32 implicit causal mask cases into the f32 ukernel impl.
     for (auto &cur_op : sg->get_ops()) {
         const auto opk = cur_op->get_kind();
+        // SDPA with static quantization and dequantization is currently
+        // unsupported in the ukernel. Only compressed KV SDPA pattern with
+        // dynamic dequantization before K and V is supported.
+        VCHECK_SDP_PRIMITIVE(opk != graph::op_kind::Dequantize
+                        && opk != graph::op_kind::Quantize,
+                status::unimplemented, "Not support quantized SDPA");
         if (opk == graph::op_kind::GenIndex) { has_genindex = true; }
     }
     if (is_f32 && !has_genindex) {


### PR DESCRIPTION
As title, int8 sdpa is not support in ukernel, add check for it.
```
ONEDNN_VERBOSE=1,filter=graph ./tests/benchdnn/benchdnn --graph --engine=gpu --case=/home/gta/xiangguo/oneDNN/build/graph-100001.json
onednn_verbose,v1,graph,info,pattern,load,dnnl_graph_passes.json
onednn_verbose,v1,info,oneDNN v3.10.0 (commit 8393842cd4f3ae3b75c6e63a4e82fddad0ea4f40)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:224
onednn_verbose,v1,info,cpu,isa:Intel AVX-512 with float16, Intel DL Boost and bfloat16 support 
onednn_verbose,v1,info,gpu,runtime:DPC++
onednn_verbose,v1,info,gpu,engine,sycl gpu device count:8 
onednn_verbose,v1,info,gpu,engine,0,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,1,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,2,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,3,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,4,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,5,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,6,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,gpu,engine,7,backend:Level Zero,name:Intel(R) Data Center GPU Max 1550,driver_version:1.6.33276,binary_kernels:enabled
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,common,info,filter format is enabled, hit components: graph
onednn_verbose,v1,graph,exec,gpu,100002,quantized_sdp,q_deq;k_deq;bmm1;scale_div;mask_add;softmax;p_quant;p_deq;v_deq;bmm2;o_quant,,in0_u8:0:strided:undef:32x16x384x64:393216s24576s64s1 in1_u8:3:strided:undef:32x16x384x64:393216s24576s64s1 in2_f32:8:strided:undef:1:1 in3_f32:11:strided:undef:32x1x1x384:384s384s384s1 in4_u8:20:strided:undef:32x16x384x64:393216s24576s64s1 out0_u8:25:strided:undef:32x16x384x64:393216s24576s64s1,fpm:strict,larger_partition_kernel_t,dnnl_backend,10.717
0:PASSED (8661 ms) __REPRO: --graph --engine=gpu --case=/home/gta/xiangguo/oneDNN/build/graph-100001.json
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 8.66s; create_pd: 0.00s (0%); create_prim: 0.66s (8%); fill: 0.00s (0%); execute: 1.12s (13%); compute_ref: 0.00s (0%); compare: 0.00s (0%);
```
