### PR TITLE
graph: backend: dnnl: binary chain + matmul + binary chain pattern

### DIFF
--- a/src/graph/backend/dnnl/dnnl_backend.cpp
+++ b/src/graph/backend/dnnl/dnnl_backend.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020-2024 Intel Corporation
+ * Copyright 2020-2025 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ pass::pass_registry_t dnnl_backend_t::register_passes() {
     DNNL_BACKEND_REGISTER_PATTERN_CALL(reduction_fusion, pass_registry);
     DNNL_BACKEND_REGISTER_PATTERN_CALL(groupnorm_fusion, pass_registry);
     DNNL_BACKEND_REGISTER_PATTERN_CALL(mlp, pass_registry);
+    DNNL_BACKEND_REGISTER_PATTERN_CALL(bmb, pass_registry);
 
     const std::vector<data_type_t> dtypes_to_check
             = {dnnl_bf16, dnnl_f16, dnnl_f8_e4m3, dnnl_f8_e5m2};

--- a/src/graph/backend/dnnl/patterns/binary_matmul_binary.cpp
+++ b/src/graph/backend/dnnl/patterns/binary_matmul_binary.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "graph/backend/dnnl/kernels/large_partition.hpp"
+
+#include "graph/backend/dnnl/patterns/fusions.hpp"
+#include "graph/backend/dnnl/patterns/pattern_matcher_pass.hpp"
+#include "graph/backend/dnnl/patterns/utils.hpp"
+
+#include "graph/utils/pm/pbuilder.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+namespace pattern {
+
+namespace pm = graph::utils::pm;
+using in_edges_t = pm::in_edges_t;
+using pb_graph_t = pm::pb_graph_t;
+using FCreatePattern = graph::pass::FCreatePattern;
+
+DNNL_BACKEND_REGISTER_PATTERN_DEF_BEGIN(bmb)
+
+// binary -> ... -> binary -> matmul -> binary -> ... -> binary ->
+DNNL_BACKEND_REGISTER_PATTERN_MATCHER_PASS(dnnl, float_bmb)
+        .set_priority(19.5f)
+        .set_kind(partition_kind_t::misc_post_ops)
+        .set_attr<FCreatePattern>("FCreatePattern",
+                [](const std::shared_ptr<pb_graph_t> &pgraph) -> void {
+                    // first binary
+                    auto first_bin
+                            = pgraph->append_alternation(get_binary_ops());
+                    first_bin->append_decision_function(
+                            check_output_dtype<impl::data_type::f32>);
+
+                    // repetition(alterative(add, div, mul, sub, ..), N).
+                    auto multi_bin = std::make_shared<pb_graph_t>();
+                    auto alter_bin
+                            = multi_bin->append_alternation(get_binary_ops());
+                    alter_bin->allow_internal_inputs();
+                    multi_bin->create_input_port(0, alter_bin, 0);
+                    multi_bin->create_output_port(0, alter_bin, 0);
+                    auto prep = pgraph->append_repetition(multi_bin, {0, 0}, 0,
+                            MAX_REPETITION, {in_edge(0, first_bin, 0)});
+
+                    // optional typecast
+                    auto tc_0 = std::make_shared<pb_graph_t>();
+                    pm::pb_op_t *ptypecast_0
+                            = tc_0->append_op(graph::op_kind::TypeCast);
+                    tc_0->create_input_port(0, ptypecast_0, 0);
+                    tc_0->create_output_port(0, ptypecast_0, 0);
+                    auto pre_tc_0 = pgraph->append_optional(
+                            tc_0, {in_edge(0, prep, 0)});
+
+                    // matmul
+                    pm::pb_op_t *mm = pgraph->append_op(
+                            graph::op_kind::MatMul, {in_edge(0, pre_tc_0, 0)});
+
+                    // repetition(alterative(add, div, mul, sub, ..), N).
+                    auto multi_bin_1 = std::make_shared<pb_graph_t>();
+                    auto alter_bin_1
+                            = multi_bin_1->append_alternation(get_binary_ops());
+                    alter_bin_1->allow_internal_inputs();
+                    multi_bin_1->create_input_port(0, alter_bin_1, 0);
+                    multi_bin_1->create_output_port(0, alter_bin_1, 0);
+                    auto prep_1 = pgraph->append_repetition(multi_bin_1, {0, 0},
+                            0, MAX_REPETITION, {in_edge(0, mm, 0)});
+
+                    // optional typecast
+                    auto tc_1 = std::make_shared<pb_graph_t>();
+                    pm::pb_op_t *ptypecast_1
+                            = tc_1->append_op(graph::op_kind::TypeCast);
+                    tc_1->create_input_port(0, ptypecast_1, 0);
+                    tc_1->create_output_port(0, ptypecast_1, 0);
+                    pgraph->append_optional(tc_1, {in_edge(0, prep_1, 0)});
+                })
+        .set_attr<FCreateKernel>("FCreateKernel", []() -> kernel_ptr {
+            return std::make_shared<larger_partition_kernel_t>();
+        });
+
+DNNL_BACKEND_REGISTER_PATTERN_DEF_END
+
+} // namespace pattern
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/patterns/fusions.hpp
+++ b/src/graph/backend/dnnl/patterns/fusions.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2024 Intel Corporation
+* Copyright 2022-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ DNNL_BACKEND_REGISTER_PATTERN_DECLARE(sum_fusion)
 DNNL_BACKEND_REGISTER_PATTERN_DECLARE(concat_fusion)
 DNNL_BACKEND_REGISTER_PATTERN_DECLARE(groupnorm_fusion)
 DNNL_BACKEND_REGISTER_PATTERN_DECLARE(mlp)
+DNNL_BACKEND_REGISTER_PATTERN_DECLARE(bmb)
 
 #undef DNNL_BACKEND_REGISTER_PATTERN_DECLARE
 

--- a/src/graph/backend/dnnl/patterns/pattern_matcher_pass.hpp
+++ b/src/graph/backend/dnnl/patterns/pattern_matcher_pass.hpp
@@ -157,7 +157,7 @@ public:
     void register_##pattern_class_(graph::pass::pass_registry_t &registry) {
 #define DNNL_BACKEND_REGISTER_PATTERN_DEF_END }
 
-#define MAX_REPETITION 5
+#define MAX_REPETITION 20
 } // namespace pattern
 } // namespace dnnl_impl
 } // namespace graph

--- a/tests/benchdnn/inputs/graph/complex_fusion/bmb/binary-matmul-binary-bf16.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/bmb/binary-matmul-binary-bf16.json
@@ -1,0 +1,1580 @@
+{
+  "version": "3.10.0",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21
+  ],
+  "output_ports": [
+    67
+  ],
+  "graph": [
+    {
+      "id": 23,
+      "name": "binary_0",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 1,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 22,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "name": "binary_1",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 22,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 2,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 24,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "name": "binary_2",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 24,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 3,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 26,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "name": "binary_3",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 26,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 4,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 28,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "name": "binary_4",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 28,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 5,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "name": "binary_5",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 6,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 32,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 35,
+      "name": "binary_6",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 32,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 7,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 34,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 37,
+      "name": "binary_7",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 34,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 8,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 36,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 39,
+      "name": "binary_8",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 36,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 9,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 38,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 41,
+      "name": "binary_9",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 38,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 10,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 40,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "name": "tc_0",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 40,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 43,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 45,
+      "name": "matmul",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        }
+      },
+      "inputs": [
+        {
+          "id": 43,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 11,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 44,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 47,
+      "name": "binary_10",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 44,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 12,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 46,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 49,
+      "name": "binary_11",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 46,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 13,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 48,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 51,
+      "name": "binary_12",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 48,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 14,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 50,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 53,
+      "name": "binary_13",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 50,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 15,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 52,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 55,
+      "name": "binary_14",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 52,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 16,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 54,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 57,
+      "name": "binary_15",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 54,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 17,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 56,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 59,
+      "name": "binary_16",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 56,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 18,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 58,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 61,
+      "name": "binary_17",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 58,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 19,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 60,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 63,
+      "name": "binary_18",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 60,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 20,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 62,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 65,
+      "name": "binary_19",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 62,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 21,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 64,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 66,
+      "name": "tc_1",
+      "kind": "TypeCast",
+      "attrs": {},
+      "inputs": [
+        {
+          "id": 64,
+          "dtype": "f32",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 67,
+          "dtype": "bf16",
+          "shape": [
+            8,
+            8,
+            8,
+            8
+          ],
+          "stride": [
+            512,
+            64,
+            8,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/benchdnn/inputs/graph/complex_fusion/bmb/binary-matmul-binary-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/bmb/binary-matmul-binary-f32.json
@@ -1,0 +1,1488 @@
+{
+  "version": "3.10.0",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21
+  ],
+  "output_ports": [
+    63
+  ],
+  "graph": [
+    {
+      "id": 23,
+      "name": "binary_0",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 1,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 22,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "name": "binary_1",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 22,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 2,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 24,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "name": "binary_2",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 24,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 3,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 26,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "name": "binary_3",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 26,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 4,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 28,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "name": "binary_4",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 28,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 5,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "name": "binary_5",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 30,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 6,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 32,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 35,
+      "name": "binary_6",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 32,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 34,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 37,
+      "name": "binary_7",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 34,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 8,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 36,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 39,
+      "name": "binary_8",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 36,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 9,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 38,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 41,
+      "name": "binary_9",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 38,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 10,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 40,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 44,
+      "name": "matmul",
+      "kind": "MatMul",
+      "attrs": {
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        }
+      },
+      "inputs": [
+        {
+          "id": 40,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 11,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 43,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 46,
+      "name": "binary_10",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 43,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 12,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 45,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 48,
+      "name": "binary_11",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 45,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 13,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 47,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 50,
+      "name": "binary_12",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 47,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 14,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 49,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 52,
+      "name": "binary_13",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 49,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 15,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 51,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 54,
+      "name": "binary_14",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 51,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 16,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 53,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 56,
+      "name": "binary_15",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 53,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 17,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 55,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 58,
+      "name": "binary_16",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 55,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 18,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 57,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 60,
+      "name": "binary_17",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 57,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 19,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 59,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 62,
+      "name": "binary_18",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 59,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 20,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 61,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 64,
+      "name": "binary_19",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 61,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 21,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 63,
+          "dtype": "f32",
+          "shape": [
+            1,
+            32,
+            32,
+            32
+          ],
+          "stride": [
+            32768,
+            1024,
+            32,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_bmb_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_bmb_all
@@ -1,0 +1,3 @@
+--reset --case=complex_fusion/bmb/binary-matmul-binary-f32.json
+--reset --case=complex_fusion/bmb/binary-matmul-binary-bf16.json
+--reset --dt=0:f16+1:f16+2:f16+3:f16+4:f16+5:f16+6:f16+7:f16+8:f16+9:f16+10:f16+11:f16+12:f16+13:f16+14:f16+15:f16+16:f16+17:f16+18:f16+19:f16+20:f16+21:f16+67:f16+43:f16 --case=complex_fusion/bmb/binary-matmul-binary-bf16.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_bmb_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_bmb_ci
@@ -1,0 +1,3 @@
+--reset --case=complex_fusion/bmb/binary-matmul-binary-f32.json
+--reset --case=complex_fusion/bmb/binary-matmul-binary-bf16.json
+--reset --dt=0:f16+1:f16+2:f16+3:f16+4:f16+5:f16+6:f16+7:f16+8:f16+9:f16+10:f16+11:f16+12:f16+13:f16+14:f16+15:f16+16:f16+17:f16+18:f16+19:f16+20:f16+21:f16+67:f16+43:f16 --case=complex_fusion/bmb/binary-matmul-binary-bf16.json

--- a/tests/benchdnn/inputs/graph/test_graph_ci
+++ b/tests/benchdnn/inputs/graph/test_graph_ci
@@ -8,3 +8,4 @@
 --batch=pattern/harness_f8_ci
 --batch=complex_fusion/harness_mha_ci
 --batch=complex_fusion/harness_mlp_ci
+--batch=complex_fusion/harness_bmb_ci

--- a/tests/benchdnn/inputs/graph/test_graph_fusions
+++ b/tests/benchdnn/inputs/graph/test_graph_fusions
@@ -1,2 +1,3 @@
 --batch=complex_fusion/harness_mha_all
 --batch=complex_fusion/harness_mlp_all
+--batch=complex_fusion/harness_bmb_all

--- a/tests/benchdnn/inputs/graph/test_graph_fusions_gpu
+++ b/tests/benchdnn/inputs/graph/test_graph_fusions_gpu
@@ -2,3 +2,4 @@
 --batch=complex_fusion/harness_mha_ci
 --batch=complex_fusion/harness_mlp_all
 --batch=complex_fusion/harness_mlp_ci
+--batch=complex_fusion/harness_bmb_all


### PR DESCRIPTION
Fix MFDNN-14020

- Extended the number of post-ops to 20.
- Added a new special pattern with binary ops chain + matmul + binary ops chain. Currently implemented through binary primitive and matmul primitive.
- Added corresponding test cases.