### PR TITLE
fixup: cpu: x64: brgemm: handle src and wei scales inside the kernel

### DIFF
--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -855,13 +855,11 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
             const bool is_single_scale = !brg_.is_oc_scale;
 
             const auto vmm = vector(m, n);
-            const auto vmm_m = maybe_mask(vmm, is_tail, false, k_mask);
             const auto vmm_wei_scales = vmm_tmp(0);
-            const auto vmm_wei_scales_masked
-                    = maybe_mask(vmm_wei_scales, is_tail, false, k_mask);
             if (is_single_scale) {
                 if (has_ptr_b_support) {
                     // Same isa has masks support.
+                    const auto vmm_m = maybe_mask(vmm, is_tail, false, k_mask);
                     vmulps(vmm_m, vmm, ptr_b[aux_reg_wei_scales]);
                 } else {
                     vbroadcastss(vmm_wei_scales, addr);
@@ -869,6 +867,9 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
                 }
             } else {
                 if (IMPLICATION(is_tail, isa_has_masks(brg_.isa_impl))) {
+                    const auto vmm_m = maybe_mask(vmm, is_tail, false, k_mask);
+                    const auto vmm_wei_scales_masked = maybe_mask(
+                            vmm_wei_scales, is_tail, false, k_mask);
                     vmovups(vmm_wei_scales_masked, addr);
                     vmulps(vmm_m, vmm, vmm_wei_scales);
                 } else {


### PR DESCRIPTION
[MFDNN-14082](https://jira.devtools.intel.com/browse/MFDNN-14082)

Hiding AVX512-specific objects behind the if branch.