### PR TITLE
xe: conv: jit: fix zp_plan count missing zp_src

### DIFF
--- a/src/gpu/intel/conv/jit/zp_plan.cpp
+++ b/src/gpu/intel/conv/jit/zp_plan.cpp
@@ -1473,6 +1473,7 @@ struct zp_plan_impl_t : public base_plan_t {
         if (is_src_precomp_compatible()) {
             ret += comp_init.estimate_fill_regs();
         } else if (has_zp_src()) {
+            ret += load.reg_buf_size() / grf_size();
             ret += comp_init.estimate_regs();
             ret += mask_init.estimate_regs();
         }


### PR DESCRIPTION
Fixes performance regression identified in [MFDNN-14105](https://jira.devtools.intel.com/browse/MFDNN-14105).

The root cause is that register usage misestimation triggers selection of a strategy with no register space which can be used for CSE, resulting in a poorly performing generated kernel.
