### PR TITLE
xe: sdpa: revert remainder_q to compile time

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -217,7 +217,7 @@ static std::vector<config_record_t> sorted_configs = []() {
         {{compute::gpu_arch_t::xe_hpg, 64, second_token | quantized | fma | f32}, {16, 16,  8,  8, 32, 1, 16, 2 }},
 
 
-        {{compute::gpu_arch_t::xe_hpg, 80, fma}, {8, 16, 16, 16, 8, 4, 8, 4}},
+        {{compute::gpu_arch_t::xe_hpg, 80, fma}, {16, 16, 16, 16, 5, 4, 5, 4}},
 
         {{compute::gpu_arch_t::xe_hpg, 128},                    {16, 16, 32, 8, 8, 4, 4, 8}},
         {{compute::gpu_arch_t::xe_hpg, 128, 32},                {16, 16, 16, 8, 16, 2, 8, 4}},

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -82,7 +82,8 @@ struct micro_params_t : trivially_serializable_t<micro_params_t> {
     bool d_full, arch_gte_hpc;
     bool block_q, block_a, block_msk, block_2d_a;
     bool prefetch_mask, prefetch_k0, prefetch_k, prefetch_v, prefetch_remainder;
-    uint8_t padding2[5] = {0};
+    bool remainder_q;
+    uint8_t padding2[4] = {0};
     int prefetch_d_max;
 
     bool softmax_inf_as_zero;


### PR DESCRIPTION
# Description

This PR addresses a minor performance regression when handling remainder cases for the number of queries. The parameter has been restored to compile time. This shouldn't significantly increase recompilations since the transition from first to second token usually involves a config change anyways. Runtime branching logic causes a slowdown for both remainder/non-remainder cases.

Before:
```
Output template: perf,%engine%,%prb%,%-time%,%0time%
--mode=P --graph --engine=gpu --memory-kind=usm_device --cold-cache=all --dt=0:s8+1:f16+2:s8+3:f16+4:f16+6:s8+7:f16+8:s8+27:f16+50:f16 --in-shapes=0:2x10x64x77*abcd+1:2x10x1x77+2:2x10x1x77+3:2x10x1024x64*abcd+6:2x10x77x64*abcd+7:2x10x77x1+8:2x10x77x1 --op-attrs=100:group_shape:1x1x64x1+600:group_shape:1x1x1x64 --attr-fpmath=f16:true --case=complex_fusion/mha/sdpa-dqk-scl-dqv.json,0.0312,0.0420642
```
After:
```
perf,gpu,--mode=P --graph --engine=gpu --memory-kind=usm_device --cold-cache=all --dt=0:s8+1:f16+2:s8+3:f16+4:f16+6:s8+7:f16+8:s8+27:f16+50:f16 --in-shapes=0:2x10x64x77*abcd+1:2x10x1x77+2:2x10x1x77+3:2x10x1024x64*abcd+6:2x10x77x64*abcd+7:2x10x77x1+8:2x10x77x1 --op-attrs=100:group_shape:1x1x64x1+600:group_shape:1x1x1x64 --attr-fpmath=f16:true --case=complex_fusion/mha/sdpa-dqk-scl-dqv.json,0.028,0.0295995
```