### PR TITLE
xe: fix fp4 load/write handling in ocl_io.h

### DIFF
--- a/src/gpu/intel/conv/ref.cl
+++ b/src/gpu/intel/conv/ref.cl
@@ -125,15 +125,8 @@ __kernel void ref_convolution_fwd(
                     const off_t src_off = SRC_OFF(n, g * IC + ic, id, ih, iw);
                     const off_t wei_off = WEI_OFF(g, oc, ic, kd, kh, kw);
 
-                    ACC_DATA_T s;
-                    ACC_DATA_T w;
-#if SRC_DT_F4_E2M1 || SRC_DT_F4_E3M0
-                    load(&s, src, src_off);
-                    load(&w, wei, wei_off);
-#else
-                    load(&s, src + src_off);
-                    load(&w, wei + wei_off);
-#endif
+                    ACC_DATA_T s = load(s, src, src_off);
+                    ACC_DATA_T w = load(w, wei, wei_off);
                     d += s * w;
 
 #if WITH_SRC_ZPOINTS
@@ -293,15 +286,8 @@ __kernel void ref_convolution_bwd_data(__global SRC_DATA_T *diff_src,
         if (oh < OH && ow < OW && od < OD) {
             const off_t dst_off = DST_OFF(n, g * OC + oc, od, oh, ow);
             const off_t wei_off = WEI_OFF(g, oc, ic, kd, kh, kw);
-            ACC_DATA_T diff_d;
-            ACC_DATA_T w;
-#if DST_DT_F4_E2M1 || DST_DT_F4_E3M0
-            load(&diff_d, diff_dst, dst_off);
-            load(&w, wei, wei_off);
-#else
-            load(&diff_d, diff_dst + dst_off);
-            load(&w, wei + wei_off);
-#endif
+            ACC_DATA_T diff_d = load(diff_d, diff_dst, dst_off);
+            ACC_DATA_T w = load(w, wei, wei_off);
             d += diff_d * w;
 #if WITH_SRC_ZPOINTS
             const int src_zp
@@ -419,15 +405,8 @@ __kernel void ref_convolution_bwd_weights(const __global SRC_DATA_T *src,
                     off_t dst_off = DST_OFF(n, g * OC + oc, od, oh, ow);
                     off_t src_off = SRC_OFF(n, g * IC + ic, id, ih, iw);
 
-                    ACC_DATA_T diff_d;
-                    ACC_DATA_T s;
-#if DST_DT_F4_E2M1 || DST_DT_F4_E3M0
-                    load(&diff_d, diff_dst, dst_off);
-                    load(&s, src, src_off);
-#else
-                    load(&diff_d, diff_dst + dst_off);
-                    load(&s, src + src_off);
-#endif
+                    ACC_DATA_T diff_d = load(diff_d, diff_dst, dst_off);
+                    ACC_DATA_T s = load(s, src, src_off);
                     dw += diff_d * s;
                 }
     write(diff_wei + WEI_OFF(g, oc, ic, kd, kh, kw), dw);

--- a/src/gpu/intel/gemm/with_post_ops.cl
+++ b/src/gpu/intel/gemm/with_post_ops.cl
@@ -38,12 +38,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
 
     size_t data_idx = SRC_OFF(d0, d1, d2, d3, 0, 0);
 
-    ACC_DATA_T acc;
-#if SRC_DT_F4_E2M1 || SRC_DT_F4_E3M0
-    load(&acc, src, data_idx);
-#else
-    load(&acc, src + data_idx);
-#endif
+    ACC_DATA_T acc = load(acc, src, data_idx);
     POST_OP_DATA_T accumulator = 0;
     if (d0 < DST_D0 && d1 < DST_D1 && d2 < DST_D2 && d3 < DST_D3) {
         const float a_scale = A_SCALES ? a_scales[0] : 1;
@@ -58,12 +53,7 @@ __kernel void gemm_post_ops(__global SRC_DATA_T *src,
         }
 
         // Apply postops
-        POST_OP_DATA_T sum_src = 0.0f;
-#if DST_DT_F4_E2M1 || DST_DT_F4_E3M0
-        if (WITH_SUM) load(&sum_src, dst, data_idx);
-#else
-        if (WITH_SUM) load(&sum_src, dst + data_idx);
-#endif
+        POST_OP_DATA_T sum_src = WITH_SUM ? load(sum_src, dst, data_idx) : 0.0f;
 
         accumulator = AS_POST_OP_DATA_T(acc);
         APPLY_POST_OPS_SERIAL(accumulator, sum_src, d0, d1, d2, d3, 0, 0);


### PR DESCRIPTION
Fixes OCL build errors from [MFDNN-14125](https://jira.devtools.intel.com/projects/MFDNN/issues/MFDNN-14125).