### PR TITLE
softmax: add dst fp8 support

### DIFF
--- a/src/common/softmax.cpp
+++ b/src/common/softmax.cpp
@@ -96,6 +96,7 @@ status_t softmax_desc_init(softmax_desc_t *softmax_desc, prop_kind_t prop_kind,
 
 status_t softmax_attr_check(const softmax_desc_t &desc, const engine_t *engine,
         const primitive_attr_t *attr) {
+    using namespace data_type;
     using smask_t = primitive_attr_t::skip_mask_t;
 
     if (attr == nullptr) return status::success;
@@ -109,9 +110,10 @@ status_t softmax_attr_check(const softmax_desc_t &desc, const engine_t *engine,
 
         auto fwd_attr_mask = smask_t::post_ops;
 
-        const bool is_int8 = utils::one_of(src_dt, data_type::s8, data_type::u8)
-                || utils::one_of(dst_dt, data_type::s8, data_type::u8);
-        if (is_int8) fwd_attr_mask |= smask_t::scales;
+        const bool is_int8 = utils::one_of(src_dt, s8, u8)
+                || utils::one_of(dst_dt, s8, u8);
+        const bool is_f8 = utils::one_of(dst_dt, f8_e5m2, f8_e4m3);
+        if (is_int8 || is_f8) fwd_attr_mask |= smask_t::scales;
 
         VCHECK_SOFTMAX_UNIMPL(attr->has_default_values(fwd_attr_mask, dst_dt),
                 VERBOSE_UNSUPPORTED_ATTR);

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -51,11 +51,11 @@ struct ref_softmax_fwd_t : public primitive_t {
             VDISPATCH_SOFTMAX(
                     platform::has_data_type_support(dst_md()->data_type),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_SOFTMAX(
-                    utils::one_of(src_md()->data_type, f32, bf16, f16, s8, u8),
+            VDISPATCH_SOFTMAX(utils::one_of(src_md()->data_type, f32, bf16, f16,
+                                      f8_e5m2, f8_e4m3, s8, u8),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_SOFTMAX(
-                    utils::one_of(dst_md()->data_type, f32, bf16, f16, s8, u8),
+            VDISPATCH_SOFTMAX(utils::one_of(dst_md()->data_type, f32, bf16, f16,
+                                      f8_e5m2, f8_e4m3, s8, u8),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_SOFTMAX(attr()->has_default_values(skip_mask_t::scales
                                       | skip_mask_t::post_ops),

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -137,6 +137,13 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     const int bf16_emu_zmm_4_idx_ = 26;
     const int tail_opmask_idx_ = 2;
 
+    const int fp8_emu_zmm_1_idx_ = 23;
+    const int fp8_emu_zmm_2_idx_ = 24;
+    const int fp8_emu_zmm_3_idx_ = 25;
+    const int fp8_emu_zmm_4_idx_ = 26;
+    const int fp8_emu_zmm_5_idx_ = 27;
+    const int fp8_emu_kmask_idx_ = 3;
+
     Opmask tail_opmask = Opmask(tail_opmask_idx_);
 
     void operator()(const call_params_t *p) const override {
@@ -979,6 +986,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         if (log_injector_) log_injector_->prepare_table();
         if (with_eltwise_ && postops_injector_)
             postops_injector_->prepare_table(/* generate = */ true);
+        io_.prepare_table_fp8();
     }
 
     jit_softmax_dense_kernel_t(const softmax_pd_t *pd)
@@ -1022,10 +1030,14 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                 bf16_emu_zmm_4_idx_);
         io::io_saturation_conf_t io_saturation_conf(
                 vzero.getIdx(), vsaturation_ubound.getIdx(), reg_tmp);
+        io::io_emu_fp8_conf_t io_fp8_conf(fp8_emu_zmm_1_idx_,
+                fp8_emu_zmm_2_idx_, fp8_emu_zmm_3_idx_, fp8_emu_zmm_4_idx_,
+                fp8_emu_zmm_5_idx_, fp8_emu_kmask_idx_, reg_tmp);
         io_ = io::jit_io_multi_dt_helper_t<Vmm>(this, isa,
                 {src_d_.data_type(), dst_d_.data_type(), f32 /* stats */},
                 io_conf, io_tail_conf, io_bf16_conf,
-                {{dst_d_.data_type(), io_saturation_conf}});
+                {{dst_d_.data_type(), io_saturation_conf}}, utils::nullopt,
+                io_fp8_conf);
     }
 };
 
@@ -1107,6 +1119,13 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     const int bf16_emu_zmm_3_idx_ = 25;
     const int bf16_emu_zmm_4_idx_ = 26;
     const int tail_opmask_idx_ = 2;
+
+    const int fp8_emu_zmm_1_idx_ = 23;
+    const int fp8_emu_zmm_2_idx_ = 24;
+    const int fp8_emu_zmm_3_idx_ = 25;
+    const int fp8_emu_zmm_4_idx_ = 26;
+    const int fp8_emu_zmm_5_idx_ = 27;
+    const int fp8_emu_kmask_idx_ = 3;
 
     Opmask tail_opmask = Opmask(tail_opmask_idx_);
 
@@ -1553,6 +1572,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         if (log_injector_) log_injector_->prepare_table();
         if (with_eltwise_ && postops_injector_)
             postops_injector_->prepare_table(/* generate = */ true);
+        io_.prepare_table_fp8();
     }
 
     jit_softmax_strided_kernel_t(const softmax_pd_t *pd)
@@ -1601,10 +1621,14 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                 bf16_emu_zmm_4_idx_);
         io::io_saturation_conf_t io_saturation_conf(
                 vzero.getIdx(), vsaturation_ubound.getIdx(), reg_tmp);
+        io::io_emu_fp8_conf_t io_fp8_conf(fp8_emu_zmm_1_idx_,
+                fp8_emu_zmm_2_idx_, fp8_emu_zmm_3_idx_, fp8_emu_zmm_4_idx_,
+                fp8_emu_zmm_5_idx_, fp8_emu_kmask_idx_, reg_tmp);
         io_ = io::jit_io_multi_dt_helper_t<Vmm>(this, isa,
                 {src_d_.data_type(), dst_d_.data_type(), f32 /* stats */},
                 io_conf, io_tail_conf, io_bf16_conf,
-                {{dst_d_.data_type(), io_saturation_conf}});
+                {{dst_d_.data_type(), io_saturation_conf}}, utils::nullopt,
+                io_fp8_conf);
     }
 };
 

--- a/src/gpu/intel/softmax/simple.hpp
+++ b/src/gpu/intel/softmax/simple.hpp
@@ -53,8 +53,8 @@ struct simple_fwd_t : public primitive_t {
             VDISPATCH_SOFTMAX(
                     utils::one_of(src_dt, f64, f32, f16, bf16, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_SOFTMAX(
-                    utils::one_of(dst_dt, f32, f16, f64, bf16, u8, s8),
+            VDISPATCH_SOFTMAX(utils::one_of(dst_dt, f32, f16, f64, bf16,
+                                      f8_e5m2, f8_e4m3, u8, s8),
                     VERBOSE_UNSUPPORTED_DT);
             VDISPATCH_SOFTMAX(IMPLICATION(utils::one_of(f16, src_dt, dst_dt),
                                       intel_engine->mayiuse(

--- a/tests/benchdnn/inputs/softmax/test_softmax_ci
+++ b/tests/benchdnn/inputs/softmax/test_softmax_ci
@@ -27,3 +27,11 @@
 --attr-scales=src:common:64
 --attr-post-ops=,add:f32:per_oc,mul:f32:per_tensor,linear:0.5:2
 --batch=shapes_ci
+
+--dir=FWD_I
+--sdt=f32,bf16,f16
+--ddt=f8_e5m2,f8_e4m3
+--attr-acc-mode=strict
+--attr-scales=,dst:common:0.25
+--attr-post-ops=,add:f32:per_oc
+--batch=shapes_ci


### PR DESCRIPTION
This is a requirement for fp8 SDPA built under Graph API.