### PR TITLE
tests: benchdnn: add capability to import buffers from files

### DIFF
--- a/tests/benchdnn/bnorm/bnorm.cpp
+++ b/tests/benchdnn/bnorm/bnorm.cpp
@@ -38,6 +38,7 @@ namespace bnorm {
 
 int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt) {
+    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // Mean must be computed unless it is passed by user directly.
@@ -64,6 +65,7 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 
 int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_mean, res_t *res) {
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         return fill_random_real(mem_dt, mem_fp, res);
@@ -119,6 +121,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 int fill_variance(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
         const dnn_mem_t &ref_mean) {
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // Variance must be computed unless it is passed by user directly.
@@ -166,6 +169,7 @@ int fill_src_add(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         const dnn_mem_t &ref_mean) {
     const bool fill_src_add = prb->fuse_add_relu();
     if (!fill_src_add) return OK;
+    if (fill_from_file(DNNL_ARG_SRC_1, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -217,6 +221,7 @@ int fill_src_add(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const bool use_sc = prb->use_sc();
     if (!use_sc) return OK;
+    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -241,6 +246,7 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
 int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const bool use_sh = prb->use_sh();
     if (!use_sh) return OK;
+    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -307,6 +313,7 @@ int prepare_bwd(
 
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -214,11 +214,12 @@ namespace_impl::brgemm_batch_kind_t str2batch_kind(const std::string &str) {
 }
 #endif
 
-int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
+int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
 
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     assert(mem_dt.nelems() == mem_fp.nelems());
 
@@ -940,24 +941,29 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data(SRC, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(SRC, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_WEIGHTS:
-                SAFE(fill_data(WEI, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(WEI, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_BIAS:
-                SAFE(fill_data(BIA, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(BIA, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_DST: {
                 const auto &po = prb->attr.post_ops;
                 const int sum_idx = po.find(attr_t::post_ops_t::SUM);
                 if (sum_idx >= 0) {
-                    SAFE(fill_data(DST, prb, cfg, mem, ref_mem, res), WARN);
+                    SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                            WARN);
                 }
             } break;
             case DNNL_ARG_DST_1: {
                 if (need_fill_acc) {
-                    SAFE(fill_data(DST, prb, cfg, mem, ref_mem, res), WARN);
+                    SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                            WARN);
                 }
             } break;
             default:

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -30,6 +30,7 @@
 
 #include "common.hpp"
 
+#include "utils/fill.hpp"
 #include "utils/parallel.hpp"
 
 /* result structure */
@@ -145,6 +146,16 @@ void parse_result(res_t &res, const char *pstr) {
     if (is_failed) {
         bs.failed++;
         bs.failed_cases.emplace(bs.tests, full_repro);
+        // In theory, this can pop up for unimplemented and invalid args, too.
+        // Shouldn't be a problem though.
+        if (!buffer_prefix.empty()) {
+            BENCHDNN_PRINT(0, "%s\n",
+                    "Note: importing data from a file led to a correctness "
+                    "issue. It is impossible to tell if that was a real oneDNN "
+                    "bug or just benchdnn refusing to acknowledge a minuscule "
+                    "difference as a match. Take this 'FAILED' with a grain of "
+                    "salt, and proceed with extra caution.");
+        }
     }
     if (print_me) { BENCHDNN_PRINT(0, "%s\n", full_repro.c_str()); }
 

--- a/tests/benchdnn/concat/concat.cpp
+++ b/tests/benchdnn/concat/concat.cpp
@@ -64,10 +64,11 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     return dnnl_success;
 }
 
-int fill_src(int input_idx, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
+int fill_src(int exec_arg, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
         dnn_mem_t &mem_fp) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -99,7 +100,7 @@ int fill_src(int input_idx, dnnl_data_type_t dt, dnn_mem_t &mem_dt,
         int64_t idx_start = idx_chunk * chunk_size;
         int64_t idx_end = MIN2(idx_start + chunk_size, nelems);
         // See eltwise.cpp for implementation details.
-        std::minstd_rand msr(input_idx * n_chunks + idx_start + 1);
+        std::minstd_rand msr(exec_arg * n_chunks + idx_start + 1);
         msr.discard(1);
         std::uniform_int_distribution<> igen(min_val, max_val);
         // Most fp8 values can't be represented exactly with integers.

--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -143,10 +143,11 @@ int check_reorder_presence(
     return OK;
 }
 
-int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
+int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -535,18 +536,22 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data(SRC, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(SRC, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_WEIGHTS:
-                SAFE(fill_data(WEI, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(WEI, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_BIAS:
-                SAFE(fill_data(BIA, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(BIA, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_DST:
                 if (prb->attr.post_ops.find(attr_t::post_ops_t::kind_t::SUM)
                         >= 0) {
-                    SAFE(fill_data(DST, prb, cfg, mem, ref_mem, res), WARN);
+                    SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                            WARN);
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -555,7 +560,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_data(DST, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             default:
                 SAFE(init_ref_memory_args_default_case(

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -289,8 +289,8 @@ inline int64_t dst_off_f(const prb_t *prb, int64_t mb, int64_t g, int64_t oc,
             + ow;
 }
 
-int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res);
+int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res);
 
 dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args);
 void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -38,6 +38,7 @@
 #include "dnnl_memory.hpp"
 #include "utils/cold_cache.hpp"
 #include "utils/dims.hpp"
+#include "utils/fill.hpp"
 #include "utils/parser.hpp"
 #include "utils/stream_kind.hpp"
 
@@ -1074,6 +1075,8 @@ std::ostream &dump_global_params(std::ostream &s) {
 #endif
     if (canonical || cold_cache_input != default_cold_cache_input())
         s << "--cold-cache=" << cold_cache_input << " ";
+    if (canonical || !buffer_prefix.empty())
+        s << "--buffer-prefix=" << buffer_prefix << " ";
     if (canonical || execution_mode != execution_mode_t::direct)
         s << "--execution-mode=" << execution_mode2str(execution_mode) << " ";
 

--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1866,6 +1866,7 @@ int init_ref_memory_args_default_case(int exec_arg, dnn_mem_t &mem,
         dnn_mem_t &ref_mem, const attr_t &attr, res_t *res,
         const std::unordered_map<int, fill_cfg_t> &fill_cfg_map) {
     assert(exec_arg > 0); // Negative values will produce false-positive `true`.
+    if (fill_from_file(exec_arg, mem, ref_mem)) return OK;
 
     const int post_ops_range = DNNL_ARG_ATTR_MULTIPLE_POST_OP(31)
             - DNNL_ARG_ATTR_MULTIPLE_POST_OP(0);

--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -195,10 +195,11 @@ static float get_eltwise_zero_trust_percent(const prb_t *prb) {
     return ztp;
 }
 
-int fill_data(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp) {
+int fill_data(int exec_arg, const prb_t *prb, data_kind_t kind,
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -436,7 +437,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data(prb, SRC, mem, ref_mem), WARN);
+                SAFE(fill_data(exec_arg, prb, SRC, mem, ref_mem), WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
@@ -446,7 +447,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_data(prb, DST, mem, ref_mem), WARN);
+                SAFE(fill_data(exec_arg, prb, DST, mem, ref_mem), WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {

--- a/tests/benchdnn/gnorm/gnorm.cpp
+++ b/tests/benchdnn/gnorm/gnorm.cpp
@@ -34,6 +34,7 @@ namespace gnorm {
 
 int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt) {
+    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // Mean must be computed unless it is passed by user directly.
@@ -67,6 +68,7 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 
 int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_mean, res_t *res) {
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         return fill_random_real(mem_dt, mem_fp, res);
@@ -182,6 +184,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
         const dnn_mem_t &ref_mean) {
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // Variance must be computed unless it is passed by user directly.
@@ -230,6 +233,7 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const bool use_sc = prb->use_sc();
     if (!use_sc) return OK;
+    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -254,6 +258,7 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
 int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const bool use_sh = prb->use_sh();
     if (!use_sh) return OK;
+    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -312,6 +317,7 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 int fill_variance_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -341,6 +347,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         const dnn_mem_t &ref_mean, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -380,6 +387,7 @@ int fill_diff_dst_bwd(
         const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -172,10 +172,11 @@ int check_reorder_presence(
     return OK;
 }
 
-int fill_data(data_kind_t kind, const prb_t *prb, const cfg_t &cfg,
-        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
+int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -338,18 +339,22 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data(SRC, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(SRC, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_WEIGHTS:
-                SAFE(fill_data(WEI, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(WEI, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_BIAS:
-                SAFE(fill_data(BIA, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(BIA, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             case DNNL_ARG_DST:
                 if (prb->attr.post_ops.find(attr_t::post_ops_t::kind_t::SUM)
                         >= 0) {
-                    SAFE(fill_data(DST, prb, cfg, mem, ref_mem, res), WARN);
+                    SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                            WARN);
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
                     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -358,7 +363,8 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 }
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_data(DST, prb, cfg, mem, ref_mem, res), WARN);
+                SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                        WARN);
                 break;
             default:
                 SAFE(init_ref_memory_args_default_case(

--- a/tests/benchdnn/lnorm/lnorm.cpp
+++ b/tests/benchdnn/lnorm/lnorm.cpp
@@ -41,6 +41,7 @@ namespace lnorm {
 
 int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt) {
+    if (fill_from_file(DNNL_ARG_MEAN, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // Mean must be computed unless it is passed by user directly.
@@ -75,6 +76,7 @@ int fill_mean(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 
 int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_mean, res_t *res) {
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         return fill_random_real(mem_dt, mem_fp, res);
@@ -144,6 +146,7 @@ int fill_src(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
         dnn_mem_t &mem_dt, const dnn_mem_t &ref_src,
         const dnn_mem_t &ref_mean) {
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
         // Variance must be computed unless it is passed by user directly.
@@ -185,6 +188,7 @@ int fill_variance_fwd(const prb_t *prb, const cfg_t &cfg, dnn_mem_t &mem_fp,
 int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const bool use_sc = prb->use_sc();
     if (!use_sc) return OK;
+    if (fill_from_file(DNNL_ARG_SCALE, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -209,6 +213,7 @@ int fill_scale(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
 int fill_shift(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const bool use_sh = prb->use_sh();
     if (!use_sh) return OK;
+    if (fill_from_file(DNNL_ARG_SHIFT, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -267,6 +272,7 @@ int prepare_fwd(const prb_t *prb, dnn_mem_map_t &mem_map,
 int fill_variance_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_VARIANCE, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -295,6 +301,7 @@ int fill_src_bwd(const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt,
         const dnn_mem_t &ref_mean, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_SRC, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -330,6 +337,7 @@ int fill_diff_dst_bwd(
         const prb_t *prb, dnn_mem_t &mem_fp, dnn_mem_t &mem_dt, res_t *res) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(DNNL_ARG_DIFF_DST, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {

--- a/tests/benchdnn/lrn/lrn.cpp
+++ b/tests/benchdnn/lrn/lrn.cpp
@@ -33,10 +33,11 @@
 
 namespace lrn {
 
-int fill_dat(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp) {
+int fill_dat(int exec_arg, const prb_t *prb, data_kind_t kind,
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -61,12 +62,14 @@ int fill_dat(const prb_t *prb, data_kind_t kind, dnn_mem_t &mem_dt,
     return OK;
 }
 
-int fill_src(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    return fill_dat(prb, SRC, mem_dt, mem_fp);
+int fill_src(
+        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+    return fill_dat(exec_arg, prb, SRC, mem_dt, mem_fp);
 }
 
-int fill_dst(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
-    return fill_dat(prb, DST, mem_dt, mem_fp);
+int fill_dst(
+        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+    return fill_dat(exec_arg, prb, DST, mem_dt, mem_fp);
 }
 
 dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
@@ -174,9 +177,11 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
-            case DNNL_ARG_SRC: SAFE(fill_src(prb, mem, ref_mem), WARN); break;
+            case DNNL_ARG_SRC:
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_dst(prb, mem, ref_mem), WARN);
+                SAFE(fill_dst(exec_arg, prb, mem, ref_mem), WARN);
                 break;
             default: break;
         }

--- a/tests/benchdnn/prelu/prelu.cpp
+++ b/tests/benchdnn/prelu/prelu.cpp
@@ -32,9 +32,11 @@
 
 namespace prelu {
 
-int fill_data(data_kind_t kind, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_data(
+        data_kind_t kind, int exec_arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -202,12 +204,14 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
-            case DNNL_ARG_SRC: SAFE(fill_data(SRC, mem, ref_mem), WARN); break;
+            case DNNL_ARG_SRC:
+                SAFE(fill_data(SRC, exec_arg, mem, ref_mem), WARN);
+                break;
             case DNNL_ARG_WEIGHTS:
-                SAFE(fill_data(WEI, mem, ref_mem), WARN);
+                SAFE(fill_data(WEI, exec_arg, mem, ref_mem), WARN);
                 break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_data(DST, mem, ref_mem), WARN);
+                SAFE(fill_data(DST, exec_arg, mem, ref_mem), WARN);
                 break;
             default: break;
         }

--- a/tests/benchdnn/prelu/prelu.hpp
+++ b/tests/benchdnn/prelu/prelu.hpp
@@ -131,8 +131,6 @@ private:
     std::vector<std::string> stag_;
 };
 
-int fill_data(data_kind_t kind, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp);
-
 dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args);
 void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
         const args_t &ref_args);

--- a/tests/benchdnn/resampling/resampling.hpp
+++ b/tests/benchdnn/resampling/resampling.hpp
@@ -198,8 +198,6 @@ int compare_src(
         const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res);
 int compare_dst(
         const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res);
-int fill_dat(
-        const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res);
 
 int createit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
         const prb_t *prb, res_t *res);

--- a/tests/benchdnn/shuffle/shuffle.cpp
+++ b/tests/benchdnn/shuffle/shuffle.cpp
@@ -30,9 +30,11 @@
 
 namespace shuffle {
 
-int fill_src(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_src(
+        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -150,9 +152,11 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         auto &ref_mem = ref_mem_map[exec_arg];
 
         switch (exec_arg) {
-            case DNNL_ARG_SRC: SAFE(fill_src(prb, mem, ref_mem), WARN); break;
+            case DNNL_ARG_SRC:
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
+                break;
             case DNNL_ARG_DIFF_DST:
-                SAFE(fill_src(prb, mem, ref_mem), WARN);
+                SAFE(fill_src(exec_arg, prb, mem, ref_mem), WARN);
                 break;
             default: break;
         }

--- a/tests/benchdnn/softmax/softmax.cpp
+++ b/tests/benchdnn/softmax/softmax.cpp
@@ -98,9 +98,11 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     return dnnl_success;
 }
 
-int fill_data_fwd(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_data_fwd(
+        int exec_arg, const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -190,10 +192,11 @@ int fill_data_fwd(const prb_t *prb, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     return OK;
 }
 
-int fill_data_bwd(data_kind_t data_kind, const prb_t *prb, dnn_mem_t &mem_dt,
-        dnn_mem_t &mem_fp, int seed) {
+int fill_data_bwd(data_kind_t data_kind, int exec_arg, const prb_t *prb,
+        dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, int seed) {
     const auto nelems = mem_fp.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -391,7 +394,7 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data_fwd(prb, mem, ref_mem), WARN);
+                SAFE(fill_data_fwd(exec_arg, prb, mem, ref_mem), WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.
                 if (has_bench_mode_bit(mode_bit_t::bitwise) && prb->inplace) {
@@ -404,13 +407,16 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 if (!is_fwd_prim) {
                     const bool neg_sign = prb->alg == SOFTMAX
                             || prb->alg == SOFTMAX_INF_AS_ZERO;
-                    SAFE(fill_data_bwd(DST, prb, mem, ref_mem, neg_sign), WARN);
+                    SAFE(fill_data_bwd(
+                                 DST, exec_arg, prb, mem, ref_mem, neg_sign),
+                            WARN);
                 }
                 break;
             case DNNL_ARG_DIFF_DST: {
                 const bool neg_sign = prb->alg == SOFTMAX
                         || prb->alg == SOFTMAX_INF_AS_ZERO;
-                SAFE(fill_data_bwd(DIFF_DST, prb, mem, ref_mem, !neg_sign),
+                SAFE(fill_data_bwd(
+                             DIFF_DST, exec_arg, prb, mem, ref_mem, !neg_sign),
                         WARN);
                 // Need a copy of source data for inplace mode for bitwise
                 // testing.

--- a/tests/benchdnn/sum/sum.cpp
+++ b/tests/benchdnn/sum/sum.cpp
@@ -65,9 +65,10 @@ dnnl_status_t init_pd(init_pd_args_t<prb_t> &init_pd_args) {
     return dnnl_success;
 }
 
-int fill_src(int input_idx, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
+int fill_src(int exec_arg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
 
     // Refer to modes documentation for filling principles.
     if (has_bench_mode_bit(mode_bit_t::bitwise)) {
@@ -83,7 +84,7 @@ int fill_src(int input_idx, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp) {
     const int f_min = dt == dnnl_u8 ? 0 : -range / 2;
 
     benchdnn_parallel_nd(nelems, [&](int64_t i) {
-        const float gen = ((97 * i) - 17 * input_idx + 101) % range;
+        const float gen = ((97 * i) - 17 * exec_arg + 101) % range;
         const float value = (dt == dnnl_bf16 || dt == dnnl_f16)
                 ? (f_min + gen) / range
                 : (f_min + gen) * (1.0f + 4.0f / range);

--- a/tests/benchdnn/utils/fill.hpp
+++ b/tests/benchdnn/utils/fill.hpp
@@ -89,4 +89,8 @@ int fill_random_real(dnn_mem_t &mem_ref,
         const fill_cfg_t &fill_cfg = get_default_fill_cfg(),
         const_dnnl_memory_t dnnl_memory = nullptr);
 
+extern std::string buffer_prefix;
+
+bool fill_from_file(int exec_arg, dnn_mem_t &mem, dnn_mem_t &ref_mem);
+
 #endif

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 
 #include "utils/cold_cache.hpp"
+#include "utils/fill.hpp"
 #include "utils/parser.hpp"
 #include "utils/stream_kind.hpp"
 
@@ -1497,6 +1498,20 @@ static bool parse_start(
             test_start, 0, parser_utils::stoll_safe, str, option_name, help);
 }
 
+static bool parse_buffer_prefix(
+        const char *str, const std::string &option_name = "buffer-prefix") {
+    static const std::string help
+            = "PREFIX    (Default: not specified)\n    Instructs the driver to "
+              "fill specified buffers with the data from the files provided by "
+              "`PREFIX`.\n    The expected filename format is "
+              "\'PREFIX.ID.bin\'; the files must have binary data in them.\n   "
+              " More details at "
+            + doc_url + "knobs_common.md#--buffer-prefix\n";
+    const auto str2self = [](const std::string &str) { return str; };
+    return parse_single_value_option(
+            buffer_prefix, std::string(), str2self, str, option_name, help);
+}
+
 static bool parse_stream_kind(
         const char *str, const std::string &option_name = "stream-kind") {
     static const std::string help
@@ -1600,7 +1615,8 @@ bool parse_bench_settings(const char *str) {
             || parse_memory_kind(str) || parse_mode(str)
             || parse_mode_modifier(str) || parse_start(str)
             || parse_stream_kind(str) || parse_summary(str)
-            || parse_verbose(str) || parse_execution_mode(str);
+            || parse_verbose(str) || parse_execution_mode(str)
+            || parse_buffer_prefix(str);
 
     // Last condition makes this help message to be triggered once driver_name
     // is already known.


### PR DESCRIPTION
The direct predecessor to this patch was instrumental in resolving [MFDNN-14086](https://jira.devtools.intel.com/browse/MFDNN-14086).

Buffer import capability is a great feature to have when debugging real-world usecases in which the synthetic data generated by `benchdnn` is not always enough to reproduce the error.