### PR TITLE
gtest: graph: unit: limit sdpa decompose kernel test runtime and times

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/CMakeLists.txt
+++ b/tests/gtests/graph/unit/backend/dnnl/CMakeLists.txt
@@ -1,5 +1,5 @@
 #===============================================================================
-# Copyright 2021-2024 Intel Corporation
+# Copyright 2021-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,6 +70,14 @@ FILE(GLOB DNNL_OP_EXECUTION_TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test_typecast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_pass.cpp
 )
+
+# SDPA/MQA decompose kernel only support OMP and THREADPOOL runtime.
+if(NOT (DNNL_CPU_RUNTIME STREQUAL "OMP" OR DNNL_CPU_RUNTIME STREQUAL "THREADPOOL"))
+    list(REMOVE_ITEM DNNL_OP_EXECUTION_TEST_SOURCES 
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_sdp_decomp.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_mqa_decomp.cpp"
+    )
+endif()
 
 if(_ONEDNN_GRAPH_LAYOUT_DEBUG)
     file(GLOB FILES_REQUIRED_LAYOUT_DEBUG

--- a/tests/gtests/graph/unit/backend/dnnl/test_sdp_decomp.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_sdp_decomp.cpp
@@ -524,7 +524,7 @@ TEST(test_sdp_decomp_execute, MultithreaSdpDecomp_CPU) {
             for (auto &lt : partition_outputs) {
                 outputs_ts.emplace_back(lt, eng);
             }
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < 5; i++)
                 ASSERT_EQ(cp.execute(strm,
                                   test_tensor_t::to_graph_tensor(inputs_ts),
                                   test_tensor_t::to_graph_tensor(outputs_ts)),


### PR DESCRIPTION
As the title. Found in MFDNN-14122.