### PR TITLE
[GPU] Fixup post-ops k-parallel skip

### DIFF
--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -79,6 +79,7 @@ status_t pd_t::init_post_ops() {
                                 &e.binary.src1_desc);
                 binary_srcs_.push_back(
                         binary_src_t {binary_src_t::binary, int(i)});
+                non_scale_po_ = true;
                 break;
             case sum:
                 ok &= !with_sum_;
@@ -90,6 +91,7 @@ status_t pd_t::init_post_ops() {
             case eltwise:
                 ok &= eltwise_injector_f32_is_supported(e.eltwise.alg);
                 binary_srcs_.push_back(binary_src_t {binary_src_t::none, 0});
+                non_scale_po_ = true;
                 break;
             case prelu:
                 binary_srcs_.push_back(
@@ -99,10 +101,10 @@ status_t pd_t::init_post_ops() {
                         == status::success;
                 prelu_count++;
                 ok &= prelu_count <= 1;
+                non_scale_po_ = true;
                 break;
             default: return status::unimplemented;
         }
-        non_scale_po_ = true;
     }
 
     if (!ok) return status::unimplemented;


### PR DESCRIPTION
# Description

Sums shouldnt be detected as post-ops for the purpose of limiting k-parallel strategy application.

Fixes [MFDNN-14137](https://jira.devtools.intel.com/browse/MFDNN-14137) .

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
