### PR TITLE
[GPU] Checks for double blocked format softmax/matmul

### DIFF
--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -211,7 +211,7 @@ bool xe_hp_systolic_t::pd_t::use_nocopy() {
 
     bool xehpc = (arch >= compute::gpu_arch_t::xe_hpc);
 
-    if (any_prepacked_ || (packed_a_ && packed_b_)) return false;
+    if (any_prepacked_) return false;
 
     // Use no-copy for gemv/ger cases.
     if (d->m() <= 1 || d->n() <= 1 || d->k() <= 1) return true;

--- a/src/gpu/intel/softmax/simple.hpp
+++ b/src/gpu/intel/softmax/simple.hpp
@@ -49,6 +49,10 @@ struct simple_fwd_t : public primitive_t {
 
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
+            const int num_blocks = 2;
+            auto is_not_double_blk
+                    = src_md()->format_desc.blocking.inner_nblks != num_blocks;
+
             VDISPATCH_SOFTMAX(is_fwd(), VERBOSE_BAD_PROPKIND);
             VDISPATCH_SOFTMAX(
                     utils::one_of(src_dt, f64, f32, f16, bf16, u8, s8),
@@ -73,6 +77,7 @@ struct simple_fwd_t : public primitive_t {
             VDISPATCH_SOFTMAX(attr()->has_default_values(skip_mask_t::scales
                                       | skip_mask_t::post_ops),
                     VERBOSE_UNSUPPORTED_ATTR);
+            VDISPATCH_SOFTMAX(is_not_double_blk, VERBOSE_UNSUPPORTED_TAG);
             VDISPATCH_SOFTMAX(attr_scales_ok(), VERBOSE_UNSUPPORTED_SCALES_CFG);
             VDISPATCH_SOFTMAX(post_ops_ok(), VERBOSE_UNSUPPORTED_POSTOP);
             VDISPATCH_SOFTMAX_SC(


### PR DESCRIPTION
This PR is adding checks to avoid failures for double blocked format for softmax/mamtul. Since Matmul gives input to softmax layers when used in larger context and we don't have any particular tests in benchdnn for this, we will just return unimplemented for such cases from init prim to avoid the false illusion. 
This is to avoid cases like: [MFDNN-13673](https://jira.devtools.intel.com/browse/MFDNN-13673)

