### PR TITLE
x64: fix brgconv k tail (backport)

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -610,7 +610,9 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
                 = exec_type == exec_trans && ic_block % simd_w == 0 && !is_xf32
                 ? simd_w
                 : vnni_block;
-        K_tail = kh_koef * rnd_up(ic % ic_block, ic_ceil);
+        K_tail = kh_koef
+                * (exec_type == exec_trans ? rnd_up(ic % ic_block, ic_ceil)
+                                           : (ic % ic_block));
     }
 
     const auto vK = K > 0 ? K : K_tail;

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -416,3 +416,7 @@ mb1_g50ic50oc50_ih28oh26_kh3sh1ph0_n"dw_post-op_ngroups-tail"
 # tests JIT bf16 depthwise convolution with bf16 bias
 --reset
 --dt=bf16 --bia-dt=bf16 --dir=FWD_I g4mb2_ic4oc4_ih6oh4kh3sh1dh0ph0_iw6ow4kw3sw1dw0pw0_n"aarch64_jit_dw_bia_dt_bf16"
+
+# test big oc tail processing in brgemm kernel
+--reset
+--dir=BWD_D --dt=f16:f16:f16 mb1ic1iw2oc1387ow2kw2pw0_n"brgemm_big_oc_tail"


### PR DESCRIPTION
backport of https://github.com/uxlfoundation/oneDNN/pull/3854