### PR TITLE
cpu: x64: brgemm: fix data type check

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -351,10 +351,15 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
             && (!one_of(dt_d, data_type::f32))
             && (!one_of(dt_bias, data_type::undef, data_type::f32, dt_d)))
         return status::unimplemented;
+    if (!IMPLICATION(brg->is_bf16,
+                one_of(dt_d, data_type::f32, data_type::bf16, data_type::f16)
+                        && one_of(dt_bias, data_type::undef, data_type::f32,
+                                data_type::bf16, data_type::f16)))
+        return status::unimplemented;
     if (!IMPLICATION(brg->is_f16,
                 one_of(dt_d, data_type::f32, data_type::f16)
                         && one_of(dt_bias, data_type::undef, data_type::f32,
-                                data_type::f16)))
+                                data_type::bf16, data_type::f16)))
         return status::unimplemented;
     const auto bias_f8_e5m2_compatible
             = one_of(dt_d, data_type::f32, data_type::f16, data_type::bf16,

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -57,12 +57,11 @@ status_t init_kernel_datatype(
     brg->is_int8 = utils::one_of(dt_a, data_type::u8, data_type::s8)
             && utils::one_of(dt_b, data_type::u8, data_type::s8);
     brg->is_bf16 = (dt_a == data_type::bf16) && (dt_b == data_type::bf16);
-    // Note: f32:bf16 is treated as f32 case while f32:f16 has already been
-    // treated as f16. Probably, need a common ground here.
     brg->is_f32 = (dt_a == data_type::f32)
             && utils::one_of(
                     dt_b, data_type::f32, data_type::bf16, data_type::f16);
-    brg->is_f16 = utils::one_of(data_type::f16, dt_a, dt_b) && !brg->is_f32;
+    brg->is_f16 = (dt_a == data_type::f16)
+            && utils::one_of(dt_b, data_type::f32, data_type::f16);
     brg->is_fp8 = one_of(dt_a, data_type::f8_e5m2, data_type::f8_e4m3)
             && one_of(dt_b, data_type::f8_e5m2, data_type::f8_e4m3);
     if (utils::everyone_is(false, brg->is_int8, brg->is_bf16, brg->is_f32,


### PR DESCRIPTION
[MFDNN-13836](https://jira.devtools.intel.com/browse/MFDNN-13836)

This addresses the issue that some data type combinations crash or produce incorrect results instead of returning unimplemented.

sde -gnr -- ./benchdnn --brgemm --dt=bf16:bf16:f8_e4m3 32x32:32x32
sde -gnr -- ./benchdnn --brgemm --dt=bf16:bf16:f8_e5m2 32x32:32x3

Crashed because the float8 output type is not supported.

brgemm.cpp already contained the logic to handle this case for the f16 data type.

The same logic for f16 was used for the bf16 input data type.

**Additionally** bf16 was add to the list of supported dest data types for the f16 case.

sde -gnr -- ./benchdnn --brgemm --dt=f16:bf16:f32 32x32:32x32

The brgemm_utils.cpp is updated to identify mixed f16, bf16 inputs and correctly not set the is_f16 flag.

Behavior of the init_kernel_datatype:

Before this PR:
a:b = is_dt
-------------------------------
f32:f16 = is_f32
f32:bf16 = is_f32
bf16:f16 = unsupported
bf16:f32 = unsupported
**f16:bf16 = is_f16 (incorrect results)**
f16:f32 = is_f16

After this PR:
a:b = is_dt
-------------------------------
f32:f16 = is_f32
f32:bf16 = is_f32
bf16:f16 = unsupported
bf16:f32 = unsupported
**f16:bf16 = unsupported**
f16:f32 = is_f16

Note: The comment on line 60 of brgemm_utils.cpp was removed because it did not match the behavior seen when testing.





