### PR TITLE
x64: cpu: matmul: Fuse copy of A in cases of unaligned K dimension

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -532,6 +532,17 @@ status_t brgemm_desc_set_attr(
         return status::unimplemented;
     }
 
+    // fused copy A already copies A for the BRGEMM. No need for partial copy.
+    if (brgattr.hint_fused_copy_a
+            && (brgattr.extendable_k || brgattr.wary_A_k_tail_read)) {
+        return status::unimplemented;
+    }
+
+    if (!IMPLICATION(brgattr.hint_fused_copy_a,
+                is_superset(brg->isa_impl, amx_tile))) {
+        return status::unimplemented;
+    }
+
     brg->prfA = brgattr.hint_prfA;
     brg->prfB = brgattr.hint_prfB;
     brg->prfC = brgattr.hint_prfC;
@@ -547,6 +558,8 @@ status_t brgemm_desc_set_attr(
     if (brgattr.hint_prefetching == brgemm_kernel_prefetching_t::brgemm_prf2
             && brg->prfC.dist2 < 0)
         brg->prfC.dist2 = 0;
+
+    if (brgattr.hint_fused_copy_a) brg->fused_copy_a = true;
 
     if (brg->is_fp8
             && !utils::one_of(true,

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -238,6 +238,8 @@ struct DNNL_API brgemm_attr_t {
     // static_offsets is a static array of fixed offsets used for
     // brgemm_static_offs batch kind
     const brgemm_batch_element_t *static_offsets;
+    // hint whether to use on the fly copy of A due to unaligned accesses
+    bool hint_fused_copy_a = false;
 };
 
 struct brgemm_desc_t {
@@ -254,6 +256,8 @@ struct brgemm_desc_t {
     int LDB = 0;
     int LDC = 0;
     int LDD = 0;
+
+    bool fused_copy_a = false;
     // we use two isa_ variables
     // isa_user to store the user provided isa value
     // isa_impl to store actual implementation. This can change until the kernel
@@ -444,12 +448,21 @@ struct brgemm_desc_t {
         return downcvt_tiles * tilesize;
     }
 
+    int get_fused_copy_a_wsp_buffer_size() const noexcept {
+        if (fused_copy_a)
+            return brgattr.max_bs * bcast_dim
+                    * dnnl::impl::utils::rnd_up(reduce_dim, max_rd_block())
+                    * typesize_A;
+        return 0;
+    }
+
     int get_wsp_buffer_size() const noexcept {
         int sz = 0;
         if (is_tmm) {
             sz = get_num_C_tiles() * tilesize; // postops buffer
             sz += get_convert_wsp_buffer_size();
             if (amx_wary_k_tail()) sz += tilesize;
+            sz += get_fused_copy_a_wsp_buffer_size();
         }
         return sz;
     }

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -663,6 +663,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     if (brg->amx_may_extend_k()) {
         brg->rd_block = nstl::min(
                 rnd_up(brg->reduce_dim, brg->rd_step), max_rd_block);
+    } else if (brg->fused_copy_a) {
+        brg->rd_block = max_rd_block;
     } else {
         brg->rd_block = rd_block_step;
         for (int i = max_rd_block; i > 0; i -= rd_block_step) {
@@ -681,7 +683,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     // TODO: these checks do not work for fp8-f16 and f16-fp8 cfgs
     if (!IMPLICATION(brg->rdb > 0 && brg->rdb_tail,
                 brg->is_tf32 || brg->is_input_convert()
-                        || brg->amx_wary_k_tail())) {
+                        || brg->amx_wary_k_tail() || brg->fused_copy_a)) {
         return status::unimplemented;
     }
 
@@ -689,7 +691,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                              % ((brg->is_bf16_tmm || brg->is_f16_tmm) ? 2 : 4))
                         != 0,
                 brg->is_tf32 || brg->is_input_convert()
-                        || brg->amx_wary_k_tail())) {
+                        || brg->amx_wary_k_tail() || brg->fused_copy_a)) {
         return status::unimplemented;
     }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -536,10 +536,16 @@ private:
 
     bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
             const Tmm &t1, reg64_t reg_base, size_t offset, reg64_t reg_stride,
-            matrix_kind_t mk);
+            matrix_kind_t mk, bool use_memadvice);
+
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
+            const Tmm &t1, reg64_t reg_base, size_t offset_src,
+            size_t offset_dst, bool mem_advice_A);
 
     void maybe_tileloadd_nt(
             brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, size_t offset);
+
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
 
     void maybe_sprinkle_prefetches();
 
@@ -580,6 +586,9 @@ private:
     size_t A_offset(
             const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
 
+    size_t A_offset_wsp(
+            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+
     size_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
             int bd_elem_idx = 0) const noexcept;
 
@@ -616,6 +625,10 @@ private:
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
     void fill_imap();
+    void copy_k_tail_to_wsp(const Tmm &t1,
+            jit_brgemm_amx_uker_base_t::reg64_t &reg_base, size_t src_offset,
+            jit_brgemm_amx_uker_base_t::reg64_t &reg_src_stride,
+            bool use_memadvice);
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
@@ -721,6 +734,26 @@ int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
         return inp_bd;
     else
         return skipped_bd_mask_buffer_[inp_bd];
+}
+
+size_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
+        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+    // Full WSP buffer layout:
+    //   1. partial C results.
+    //   2. data type conversion.
+    //   3. Wary K: No need to reserve space since it is mutually exclusive with fused copy A.
+    //   4. Fused copy A with layout: [bs][k / rd_block][m][k = rd_block]
+    auto transform_offset = brg.get_num_C_tiles() * brgemm_desc_t::tilesize
+            + brg.get_convert_wsp_buffer_size();
+
+    const auto bs_offs = bi.bsi->pos * brg.bcast_dim
+            * rnd_up(brg.reduce_dim, brg.max_rd_block()) * brg.typesize_A;
+
+    const auto bdb_offs = bi.bdi->pos(bdb) * brg.rd_block * brg.typesize_A;
+    const auto rdb_offs
+            = bi.rdi->pos(rdb) * brg.bcast_dim * brg.rd_block * brg.typesize_A;
+
+    return transform_offset + bs_offs + bdb_offs + rdb_offs;
 }
 
 size_t jit_brgemm_amx_uker_base_t::A_offset(
@@ -1813,7 +1846,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
         return;
     }
 
-    if (maybe_pre_process_k_tail(bi, xdb, t1, reg_base, offset, reg_stride, mk))
+    if (maybe_pre_process_k_tail(
+                bi, xdb, t1, reg_base, offset, reg_stride, mk, has_mem_advice))
         return;
 
     if (load_nt) {
@@ -1829,6 +1863,46 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
     }
 }
 
+void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
+        brgemm_iteration_t &bi, int bdb) {
+    auto t1 = Tmm(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb)));
+
+    auto load_a_tile_from_wsp = [&]() {
+        if (brg.load_nt_A) {
+            tileloaddt1(
+                    t1, ptr[reg_buf + A_offset_wsp(bi, bdb) + reg_stride_lda]);
+        } else {
+            tileloadd(
+                    t1, ptr[reg_buf + A_offset_wsp(bi, bdb) + reg_stride_lda]);
+        }
+    };
+
+    if (bi.ldi->pos(0) == 0) {
+        mov(reg_stride_lda, lda());
+        const bool has_mem_advice = utils::one_of(brg.brgattr.mem_advice,
+                brgemm_hint_mem_advice_A, brgemm_hint_mem_advice_A_B);
+
+        auto src_offset = A_offset(bi, bdb);
+        // fused copy A: load from A orig and store it aligned in the wsp buffer
+        if (bi.rdi->is_tail(0)) {
+            pre_process_k_tail_fused_copy_a(bi, bdb, t1, reg_A, src_offset,
+                    A_offset_wsp(bi, bdb), has_mem_advice);
+            mov(reg_stride_lda, 64);
+            load_a_tile_from_wsp();
+        } else {
+            if (has_mem_advice)
+                tileloaddrst1(t1, ptr[reg_A + src_offset + reg_stride_lda]);
+            else
+                tileloaddt1(t1, ptr[reg_A + src_offset + reg_stride_lda]);
+            mov(reg_stride_lda, 64);
+            tilestored(
+                    ptr[reg_buf + A_offset_wsp(bi, bdb) + reg_stride_lda], t1);
+        }
+
+    } else {
+        load_a_tile_from_wsp();
+    };
+}
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
         int bdb_idx, int ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
@@ -2177,9 +2251,18 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     if (buf_offt) sub(reg_buf, buf_offt);
 }
 
+void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
+        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        size_t offset_src, size_t offset_dst, bool mem_advice_A) {
+    if (offset_dst) add(reg_buf, offset_dst);
+    copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
+    if (offset_dst) sub(reg_buf, offset_dst);
+}
+
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
         brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
-        size_t offset, reg64_t reg_stride, matrix_kind_t mk) {
+        size_t offset, reg64_t reg_stride, matrix_kind_t mk,
+        bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
 
     const auto need_k_tail_processing = mk == matrix_A && brg.amx_wary_k_tail()
@@ -2197,43 +2280,7 @@ bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
 
     // reuse transformed data from matrix A for ldi > 0
     if (bi.ldi->idx == 0) {
-        const auto num_rows = palette_.rows[t1.getIdx()];
-        const auto num_col_bytes = palette_.cols[t1.getIdx()];
-
-        const auto max_num_cols
-                = nstl::min<int>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
-        const size_t col_tail
-                = max_num_cols % (zmm_width_in_bytes / brg.typesize_A);
-        if (col_tail) {
-            const auto tail_mask = (static_cast<size_t>(1) << col_tail) - 1;
-            mov(reg_tmp_gpr, tail_mask);
-            kmovq(rd_tail_mask, reg_tmp_gpr);
-        }
-        auto zmm_1 = zmm_tmp_1();
-        auto zmm_1_masked = col_tail ? zmm_1 | rd_tail_mask | T_z : zmm_1;
-
-        assert(max_num_cols > 0);
-
-        const auto reg_data_aux = reg_tmp_gpr;
-        lea(reg_data_aux, ptr[reg_base + offset]);
-
-        for (int r = 0; r < num_rows; ++r) {
-            switch (brg.dt_a) {
-                case data_type::bf16:
-                case data_type::f16:
-                    vmovdqu16(zmm_1_masked, ptr[reg_data_aux]);
-                    break;
-                case data_type::f8_e5m2:
-                case data_type::f8_e4m3:
-                case data_type::s8:
-                case data_type::u8:
-                    vmovdqu8(zmm_1_masked, ptr[reg_data_aux]);
-                    break;
-                default: assert(!"unsupported data type");
-            }
-            vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_1);
-            add(reg_data_aux, reg_stride);
-        }
+        copy_k_tail_to_wsp(t1, reg_base, offset, reg_stride, use_memadvice);
     }
     // load into tmm from the transformed data.
     tileloadd(t1, ptr[reg_buf + reg_converted_stride]);
@@ -2241,6 +2288,54 @@ bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
     // reset buf pointer
     if (transform_offset) sub(reg_buf, transform_offset);
     return true;
+}
+void jit_brgemm_amx_uker_base_t::copy_k_tail_to_wsp(const Tmm &t1,
+        jit_brgemm_amx_uker_base_t::reg64_t &reg_base, size_t src_offset,
+        jit_brgemm_amx_uker_base_t::reg64_t &reg_src_stride,
+        bool use_memadvice) {
+    const auto num_rows = palette_.rows[t1.getIdx()];
+    const auto num_col_bytes = palette_.cols[t1.getIdx()];
+
+    const auto max_num_cols
+            = nstl::min<int>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
+    const size_t col_tail
+            = max_num_cols % (zmm_width_in_bytes / brg.typesize_A);
+    if (col_tail) {
+        const auto tail_mask = (static_cast<size_t>(1) << col_tail) - 1;
+        mov(reg_tmp_gpr, tail_mask);
+        kmovq(rd_tail_mask, reg_tmp_gpr);
+    }
+    auto zmm_1 = zmm_tmp_1();
+    auto zmm_1_masked = col_tail ? zmm_1 | rd_tail_mask | T_z : zmm_1;
+
+    assert(max_num_cols > 0);
+
+    const auto reg_src = reg_tmp_gpr;
+    lea(reg_src, ptr[reg_base + src_offset]);
+
+    for (int r = 0; r < num_rows; ++r) {
+        switch (brg.dt_a) {
+            case data_type::bf16:
+            case data_type::f16:
+                if (use_memadvice)
+                    vmovrsw(zmm_1_masked, ptr[reg_src]);
+                else
+                    vmovdqu16(zmm_1_masked, ptr[reg_src]);
+                break;
+            case data_type::f8_e5m2:
+            case data_type::f8_e4m3:
+            case data_type::s8:
+            case data_type::u8:
+                if (use_memadvice)
+                    vmovrsb(zmm_1_masked, ptr[reg_src]);
+                else
+                    vmovdqu8(zmm_1_masked, ptr[reg_src]);
+                break;
+            default: assert(!"unsupported data type");
+        }
+        vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_1);
+        add(reg_src, reg_src_stride);
+    }
 }
 
 void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
@@ -2267,7 +2362,13 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
         mov(reg_stride_ld_block, LDC_size_);
 
     for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
-        maybe_tileloadd_nt(bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
+        if (brg.fused_copy_a) {
+            maybe_fused_copy_A_nt_load(bi, bdb);
+        } else {
+            maybe_tileloadd_nt(
+                    bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
+        }
+
         for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
@@ -2881,7 +2982,7 @@ void jit_brgemm_amx_uker_base_t::generate() {
     prepare_bd_mask();
 
     Label permute_index_table;
-    if (brg.is_input_convert() || brg.amx_wary_k_tail()) {
+    if (brg.is_input_convert() || brg.amx_wary_k_tail() || brg.fused_copy_a) {
         // save tiles description for later use
         brgemm_init_tiles(brg, (char *)(&palette_));
         // load permute indices

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -50,6 +50,7 @@ public:
         , set_nt_(set_nt)
         , need_prefetch_a_(need_prefetch_a)
         , need_prefetch_b_(need_prefetch_b)
+        , use_fused_copy_a_(use_fused_copy_a)
         , brgemm_batch_size_(brgemm_batch_size)
         , current_lda_(LDA)
         , need_buf_c_(use_buffer_c)
@@ -81,7 +82,7 @@ protected:
     bool is_a_nt_ {true}, is_b_nt_ {true};
     bool set_nt_ {false};
     bool need_prefetch_a_ {false}, need_prefetch_b_ {false};
-
+    bool use_fused_copy_a_ {false};
     dim_t brgemm_batch_size_ {0};
     dim_t current_lda_ {0};
     bool need_buf_c_ {false}, need_buf_a_ {false};

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -354,6 +354,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
 
             brgattr.hint_prfA.sprinkled = bgmmc_.need_prefetch_a && prefetching;
             brgattr.hint_prfB.sprinkled = bgmmc_.need_prefetch_b && prefetching;
+            brgattr.hint_fused_copy_a = bgmmc_.use_fused_copy_a;
 
             if (bgmmc_.set_nt) {
                 brgattr.hint_load_nt_A = bgmmc_.is_a_nt ? brgemm_hint_nt_true
@@ -2403,10 +2404,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     int get_current_K_pad(int current_K_iters) const {
         if (current_K_iters % bgmmc_.wei_k_blk == 0) return 0;
-        return bgmmc_.extendable_k ? bgmmc_.wei_k_blk
+        return (bgmmc_.extendable_k || bgmmc_.use_fused_copy_a)
+                ? bgmmc_.wei_k_blk
                         - rnd_up(
                                 current_K_iters % bgmmc_.wei_k_blk, vnni_factor)
-                                   : 0;
+                : 0;
     }
 
 private:

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1571,9 +1571,10 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.M_tail = bgmmc.is_runtime_M ? 0 : bgmmc.M % bgmmc.M_blk;
     bgmmc.N_tail = bgmmc.is_runtime_N ? 0 : bgmmc.N % bgmmc.N_blk;
     bgmmc.K_tail = bgmmc.K > bgmmc.K_blk
-            ? (bgmmc.extendable_k ? bgmmc.K % bgmmc.K_blk
-                                  : rnd_up(bgmmc.K % bgmmc.K_blk,
-                                          bgmmc.required_k_granularity))
+            ? ((bgmmc.extendable_k || bgmmc.use_fused_copy_a)
+                            ? bgmmc.K % bgmmc.K_blk
+                            : rnd_up(bgmmc.K % bgmmc.K_blk,
+                                    bgmmc.required_k_granularity))
             : 0;
 
     bgmmc.LDB = bm_conf_utils.get_actual_LDB();

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -90,6 +90,7 @@ struct brgemm_matmul_conf_t {
     int M_chunk_size, N_chunk_size, K_chunk_size;
     bool is_a_nt, is_b_nt, set_nt;
     bool need_prefetch_a, need_prefetch_b;
+    bool use_fused_copy_a;
     dim_t LDA, LDB, LDC, LDD;
     dim_t LDB2;
     int brgemm_batch_size, brgemm_batch_tail_size;


### PR DESCRIPTION
When the K dimension is not aligned to the cache line, loading matrix A can degrade the performance of highly optimized BRGEMMs by up to 2×. To prevent this, matrix A is copied to an aligned buffer on the fly, ensuring proper cache line alignment. This avoids misaligned memory accesses and reduces L1 bandwidth usage, resulting in improved overall performance.