### PR TITLE
cpu: rv64: add support for rv64 binary feature with RISC-V Vector Extension

### DIFF
--- a/src/cpu/cpu_binary_list.cpp
+++ b/src/cpu/cpu_binary_list.cpp
@@ -29,6 +29,11 @@ using namespace dnnl::impl::cpu::x64;
 #include "cpu/aarch64/acl_binary.hpp"
 #endif
 using namespace dnnl::impl::cpu::aarch64;
+#elif DNNL_RV64
+#if DNNL_RISCV_USE_RVV_INTRINSICS
+#include "cpu/rv64/rvv_binary.hpp"
+using namespace dnnl::impl::cpu::rv64;
+#endif // DNNL_RISCV_USE_RVV_INTRINSICS
 #endif
 
 namespace dnnl {
@@ -43,6 +48,11 @@ constexpr impl_list_item_t impl_list[] = REG_BINARY_P({
         CPU_INSTANCE_X64(jit_uni_binary_t)
         CPU_INSTANCE_AARCH64(jit_uni_binary_t)
         CPU_INSTANCE_AARCH64_ACL(acl_binary_t)
+        CPU_INSTANCE_RV64GCV(rvv_binary_t<f32>)
+        CPU_INSTANCE_RV64GCV(rvv_binary_t<f16>)
+        CPU_INSTANCE_RV64GCV(rvv_binary_t<s32>)
+        CPU_INSTANCE_RV64GCV(rvv_binary_t<s8>)
+        CPU_INSTANCE_RV64GCV(rvv_binary_t<u8>)
         CPU_INSTANCE(ref_binary_t)
         /* eol */
         nullptr,

--- a/src/cpu/rv64/rvv_binary.cpp
+++ b/src/cpu/rv64/rvv_binary.cpp
@@ -1,0 +1,292 @@
+/******************************************************************************
+* Copyright 2025
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+#include <assert.h>
+#include <memory>
+#include <riscv_vector.h>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/math_utils.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/primitive_attr_postops.hpp"
+#include "cpu/rv64/rvv_binary_kernels.hpp"
+
+#include "cpu/rv64/rvv_binary.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+// Data type dispatch for RVV binary
+static inline void compute_binary_rvv(const alg_kind_t alg, const void *x,
+        const void *y, void *dst, const int8_t *c, const dim_t len,
+        const data_type_t dt) {
+    switch (dt) {
+        case data_type::f32:
+            rvv_binary_apply_f32(alg, static_cast<const float *>(x),
+                    static_cast<const float *>(y), static_cast<float *>(dst), c,
+                    len);
+            break;
+        case data_type::f16:
+            rvv_binary_apply_f16(alg, static_cast<const _Float16 *>(x),
+                    static_cast<const _Float16 *>(y),
+                    static_cast<_Float16 *>(dst), c, len);
+            break;
+        case data_type::s32:
+            rvv_binary_apply_s32(alg, static_cast<const int32_t *>(x),
+                    static_cast<const int32_t *>(y),
+                    static_cast<int32_t *>(dst), c, len);
+            break;
+        case data_type::s8:
+            rvv_binary_apply_s8(alg, static_cast<const int8_t *>(x),
+                    static_cast<const int8_t *>(y), static_cast<int8_t *>(dst),
+                    c, len);
+            break;
+        case data_type::u8:
+            rvv_binary_apply_u8(alg, static_cast<const uint8_t *>(x),
+                    static_cast<const uint8_t *>(y),
+                    static_cast<uint8_t *>(dst), c, len);
+            break;
+        default: assert(!"Unsupported data type for RVV binary");
+    }
+}
+
+template <data_type_t data_type>
+status_t rvv_binary_t<data_type>::execute_binary(const exec_ctx_t &ctx) const {
+    if (pd()->has_zero_dim_memory()) return status::success;
+
+    status_t status = status::success;
+    auto src0 = CTX_IN_MEM(
+            const typename prec_traits_t<data_type>::type *, DNNL_ARG_SRC_0);
+    auto src1 = CTX_IN_MEM(
+            const typename prec_traits_t<data_type>::type *, DNNL_ARG_SRC_1);
+    // src2 is optional (only for ternary ops like select); treat as s8 mask
+    const int8_t *src2_s8 = nullptr;
+    if (pd()->is_ternary_op()) {
+        src2_s8 = CTX_IN_MEM(const int8_t *, DNNL_ARG_SRC_2);
+    }
+    auto dst = CTX_OUT_CLEAN_MEM(
+            typename prec_traits_t<data_type>::type *, DNNL_ARG_DST, status);
+    CHECK(status);
+
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const memory_desc_wrapper src2_d(pd()->src_md(2));
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+
+    const auto nelems = dst_d.nelems(true);
+
+    const auto alg_kind = pd()->desc()->alg_kind;
+
+    if (pd()->use_dense_) {
+        const auto off0 = src0_d.offset0();
+        const auto off1 = src1_d.offset0();
+        const auto offd = dst_d.offset0();
+        const auto off2 = pd()->is_ternary_op() ? src2_d.offset0() : 0;
+
+        const auto *x_base = src0 + off0;
+        const auto *y_base = src1 + off1;
+        auto *d_base = dst + offd;
+        const int8_t *c_base
+                = pd()->is_ternary_op() ? (src2_s8 + off2) : nullptr;
+
+        parallel(0, [&](const int ithr, const int nthr) {
+            dim_t start = 0, end = 0;
+            balance211(nelems, nthr, ithr, start, end);
+            if (start == end) return;
+
+            const void *thr_x = static_cast<const void *>(x_base + start);
+            const void *thr_y = static_cast<const void *>(y_base + start);
+            void *thr_d = static_cast<void *>(d_base + start);
+            const int8_t *thr_c = c_base ? (c_base + start) : nullptr;
+            const dim_t len = end - start;
+
+            compute_binary_rvv(alg_kind, thr_x, thr_y, thr_d, thr_c, len,
+                    pd()->dst_md()->data_type);
+        });
+
+        return status::success;
+    }
+
+    if (pd()->use_nCspBc_padded_) {
+        const blocking_desc_t &blk = dst_d.blocking_desc();
+        const dim_t block = blk.inner_blks[0];
+
+        const dim_t MB = dst_d.dims()[0];
+        const dim_t C_PADDED = dst_d.padded_dims()[1] / block;
+        const dim_t C = dst_d.dims()[1] / block;
+        const dim_t tail = dst_d.dims()[1] % block;
+        const dim_t D = (dst_d.ndims() > 4 ? dst_d.dims()[2] : 1);
+        const dim_t H
+                = (dst_d.ndims() > 3 ? dst_d.dims()[dst_d.ndims() - 2] : 1);
+        const dim_t W
+                = (dst_d.ndims() > 2 ? dst_d.dims()[dst_d.ndims() - 1] : 1);
+        const dim_t SP = D * H * W;
+
+        parallel_nd(MB, C_PADDED, SP, [&](dim_t n, dim_t c, dim_t sp) {
+            // Decompose sp into D/H/W indices for proper broadcasting
+            dim_t dd = 0, hh = 0, ww = 0;
+            if (dst_d.ndims() > 4) {
+                const dim_t HW = H * W;
+                dd = sp / HW;
+                const dim_t hw_rem = sp % HW;
+                hh = hw_rem / W;
+                ww = hw_rem % W;
+            } else if (dst_d.ndims() > 3) { // 4D: NCHW
+                hh = sp / W;
+                ww = sp % W;
+            } else { // 3D or lower: treat as single spatial dim
+                ww = sp;
+            }
+
+            // Starting channel index of the current block
+            const dim_t c_start = c * block;
+
+            // Helper to fill logical positions per md with broadcasting
+            auto fill_pos = [&](const memory_desc_wrapper &md, dims_t &pos) {
+                for (int k = 0; k < md.ndims(); ++k)
+                    pos[k] = 0;
+                const int nd = md.ndims();
+                // N
+                pos[0] = (md.dims()[0] == 1) ? 0 : n;
+                // C (logical channel index)
+                pos[1] = (md.dims()[1] == 1) ? 0 : c_start;
+                if (nd > 4) {
+                    // D, H, W
+                    const dim_t Dm = md.dims()[2];
+                    const dim_t Hm = md.dims()[nd - 2];
+                    const dim_t Wm = md.dims()[nd - 1];
+                    pos[2] = (Dm == 1) ? 0 : dd;
+                    pos[nd - 2] = (Hm == 1) ? 0 : hh;
+                    pos[nd - 1] = (Wm == 1) ? 0 : ww;
+                } else if (nd > 3) {
+                    // H, W
+                    const dim_t Hm = md.dims()[nd - 2];
+                    const dim_t Wm = md.dims()[nd - 1];
+                    pos[nd - 2] = (Hm == 1) ? 0 : hh;
+                    pos[nd - 1] = (Wm == 1) ? 0 : ww;
+                } else if (nd > 2) {
+                    // Single spatial (W)
+                    const dim_t Wm = md.dims()[nd - 1];
+                    pos[nd - 1] = (Wm == 1) ? 0 : ww;
+                }
+            };
+
+            // Compute per-tensor offsets (include offset0())
+            dims_t pos;
+            fill_pos(dst_d, pos);
+            const dim_t d_off = dst_d.off_v(pos, false);
+            fill_pos(src0_d, pos);
+            const dim_t x_off = src0_d.off_v(pos, false);
+            fill_pos(src1_d, pos);
+            const dim_t y_off = src1_d.off_v(pos, false);
+            dim_t c_off = 0;
+            if (pd()->is_ternary_op()) {
+                fill_pos(src2_d, pos);
+                c_off = src2_d.off_v(pos, false);
+            }
+
+            const dim_t len = (c < C) ? block : ((c == C) ? tail : (dim_t)0);
+            if (len == 0) return;
+
+            using data_t = typename prec_traits_t<data_type>::type;
+            const data_t *x_ptr = src0 + x_off;
+            const data_t *y_ptr = src1 + y_off;
+            data_t *d_ptr = dst + d_off;
+            const int8_t *c_ptr
+                    = pd()->is_ternary_op() ? (src2_s8 + c_off) : nullptr;
+
+            // Replicate along C when the source has C==1 to avoid reading padded garbage
+            // in blocked layout.
+            const bool x_c_bcast = src0_d.dims()[1] == 1;
+            const bool y_c_bcast = src1_d.dims()[1] == 1;
+            const bool c_c_bcast
+                    = pd()->is_ternary_op() && src2_d.dims()[1] == 1;
+
+            // Small stack buffers for typical block sizes; fall back to heap if needed.
+            data_t x_tmp_stack[64];
+            data_t y_tmp_stack[64];
+            int8_t c_tmp_stack[64];
+
+            std::unique_ptr<data_t[]> x_tmp_heap;
+            std::unique_ptr<data_t[]> y_tmp_heap;
+            std::unique_ptr<int8_t[]> c_tmp_heap;
+
+            if (x_c_bcast) {
+                data_t *buf = (len <= (dim_t)64)
+                        ? x_tmp_stack
+                        : (x_tmp_heap.reset(new data_t[len]), x_tmp_heap.get());
+                const data_t val = *x_ptr;
+                for (dim_t i = 0; i < len; ++i)
+                    buf[i] = val;
+                x_ptr = buf;
+            }
+            if (y_c_bcast) {
+                data_t *buf = (len <= (dim_t)64)
+                        ? y_tmp_stack
+                        : (y_tmp_heap.reset(new data_t[len]), y_tmp_heap.get());
+                const data_t val = *y_ptr;
+                for (dim_t i = 0; i < len; ++i)
+                    buf[i] = val;
+                y_ptr = buf;
+            }
+            if (c_ptr && c_c_bcast) {
+                int8_t *buf = (len <= (dim_t)64)
+                        ? c_tmp_stack
+                        : (c_tmp_heap.reset(new int8_t[len]), c_tmp_heap.get());
+                const int8_t val = *c_ptr;
+                for (dim_t i = 0; i < len; ++i)
+                    buf[i] = val;
+                c_ptr = buf;
+            }
+
+            compute_binary_rvv(alg_kind, static_cast<const void *>(x_ptr),
+                    static_cast<const void *>(y_ptr),
+                    static_cast<void *>(d_ptr), c_ptr, len,
+                    pd()->dst_md()->data_type);
+        });
+
+        return status::success;
+    }
+
+    return status::unimplemented;
+}
+
+// Explicit template instantiations for forward RVV binary
+template status_t rvv_binary_t<data_type::f32>::execute_binary(
+        const exec_ctx_t &) const;
+template status_t rvv_binary_t<data_type::f16>::execute_binary(
+        const exec_ctx_t &) const;
+template status_t rvv_binary_t<data_type::s32>::execute_binary(
+        const exec_ctx_t &) const;
+template status_t rvv_binary_t<data_type::s8>::execute_binary(
+        const exec_ctx_t &) const;
+template status_t rvv_binary_t<data_type::u8>::execute_binary(
+        const exec_ctx_t &) const;
+
+template struct rvv_binary_t<data_type::f32>;
+template struct rvv_binary_t<data_type::f16>;
+template struct rvv_binary_t<data_type::s32>;
+template struct rvv_binary_t<data_type::s8>;
+template struct rvv_binary_t<data_type::u8>;
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/rvv_binary.hpp
+++ b/src/cpu/rv64/rvv_binary.hpp
@@ -1,0 +1,119 @@
+/******************************************************************************
+ * Copyright 2025
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#ifndef CPU_RV64_RVV_BINARY_HPP
+#define CPU_RV64_RVV_BINARY_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/cpu_binary_pd.hpp"
+#include "cpu/platform.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+template <impl::data_type_t date_type>
+struct rvv_binary_t : public primitive_t {
+    struct pd_t : public cpu_binary_pd_t {
+        using cpu_binary_pd_t::cpu_binary_pd_t;
+        DECLARE_COMMON_PD_T_("RISCV64GCV", rvv_binary_t);
+
+        status_t init(engine_t *engine) {
+            UNUSED(engine);
+            using namespace data_type;
+
+            VDISPATCH_BINARY(utils::everyone_is(date_type, src_md(0)->data_type,
+                                     src_md(1)->data_type, dst_md()->data_type)
+                            && platform::has_data_type_support(
+                                    src_md(0)->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_BINARY(IMPLICATION(is_ternary_op(),
+                                     platform::has_data_type_support(
+                                             src_md(2)->data_type)),
+                    VERBOSE_UNSUPPORTED_DT);
+
+            VDISPATCH_BINARY(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+
+            const memory_desc_wrapper src0_d(src_md(0));
+            const memory_desc_wrapper src1_d(src_md(1));
+            const memory_desc_wrapper dst_d(dst_md());
+
+            const bool layouts_identical
+                    = src0_d.similar_to(dst_d, /*with_padding=*/true,
+                              /*with_data_type=*/true)
+                    && src1_d.similar_to(dst_d, /*with_padding=*/true,
+                            /*with_data_type=*/true);
+
+            use_dense_ = src0_d.is_dense(/*with_padding=*/false)
+                    && src1_d.is_dense(/*with_padding=*/false)
+                    && dst_d.is_dense(/*with_padding=*/false)
+                    && layouts_identical;
+            use_nCspBc_padded_ = !use_dense_
+                    && src0_d.blocking_desc().inner_nblks == 1
+                    && src1_d.blocking_desc().inner_nblks == 1
+                    && dst_d.blocking_desc().inner_nblks == 1
+                    && utils::one_of(
+                            src0_d.blocking_desc().inner_blks[0], 8, 16)
+                    && src0_d.blocking_desc().inner_blks[0]
+                            == src1_d.blocking_desc().inner_blks[0]
+                    && src0_d.blocking_desc().inner_blks[0]
+                            == dst_d.blocking_desc().inner_blks[0]
+                    && src0_d.blocking_desc().inner_idxs[0] == 1
+                    && src1_d.blocking_desc().inner_idxs[0] == 1
+                    && dst_d.blocking_desc().inner_idxs[0] == 1
+                    && src0_d.only_padded_dim(1) && src1_d.only_padded_dim(1)
+                    && dst_d.only_padded_dim(1) && src0_d.is_dense(true)
+                    && src1_d.is_dense(true) && dst_d.is_dense(true);
+
+            VDISPATCH_BINARY(use_dense_ || use_nCspBc_padded_,
+                    VERBOSE_UNSUPPORTED_SPARSE_CFG);
+
+            return status::success;
+        }
+
+        bool use_dense_, use_nCspBc_padded_;
+
+    private:
+        bool check_scales_mask() const {
+            const std::vector<int> supported_args
+                    = {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1};
+            return attr_scales_ok(supported_args);
+        }
+    };
+
+    rvv_binary_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_binary(ctx);
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t execute_binary(const exec_ctx_t &ctx) const;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_RVV_BINARY_HPP

--- a/src/cpu/rv64/rvv_binary_kernels.hpp
+++ b/src/cpu/rv64/rvv_binary_kernels.hpp
@@ -1,0 +1,727 @@
+/******************************************************************************
+* Copyright 2025
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+#ifndef CPU_RV64_RVV_BINARY_KERNELS_HPP
+#define CPU_RV64_RVV_BINARY_KERNELS_HPP
+
+#include <math.h>
+#include <vector>
+#include <riscv_vector.h>
+
+#include "common/c_types_map.hpp"
+#include "common/float16.hpp"
+#include "common/type_helpers.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using eval_f32m1_t = vfloat32m1_t (*)(vfloat32m1_t, vfloat32m1_t, size_t);
+using eval_f32m2_t = vfloat32m2_t (*)(vfloat32m2_t, vfloat32m2_t, size_t);
+using eval_f32m4_t = vfloat32m4_t (*)(vfloat32m4_t, vfloat32m4_t, size_t);
+using eval_f16m1_t = vfloat16m1_t (*)(vfloat16m1_t, vfloat16m1_t, size_t);
+using eval_s32m1_t = vint32m1_t (*)(vint32m1_t, vint32m1_t, size_t);
+using eval_s8m1_t = vint8m1_t (*)(vint8m1_t, vint8m1_t, size_t);
+using eval_u8m1_t = vuint8m1_t (*)(vuint8m1_t, vuint8m1_t, size_t);
+
+/*** Kernel methods ***/
+static inline void rvv_binary_kernel_f32(const float *x, const float *y,
+        float *dst, const int8_t * /*c*/, dim_t len, eval_f32m1_t eval) {
+    for (dim_t i = 0; i < len;) {
+        size_t vl = __riscv_vsetvl_e32m1(static_cast<size_t>(len - i));
+        vfloat32m1_t vx = __riscv_vle32_v_f32m1(x + i, vl);
+        vfloat32m1_t vy = __riscv_vle32_v_f32m1(y + i, vl);
+        vfloat32m1_t vd = eval(vx, vy, vl);
+        __riscv_vse32_v_f32m1(dst + i, vd, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+static inline void rvv_binary_kernel_f16(const _Float16 *x, const _Float16 *y,
+        _Float16 *dst, const int8_t * /*c*/, dim_t len, eval_f16m1_t eval) {
+    for (dim_t i = 0; i < len;) {
+        size_t vl = __riscv_vsetvl_e16m1(static_cast<size_t>(len - i));
+        vfloat16m1_t vx = __riscv_vle16_v_f16m1(x + i, vl);
+        vfloat16m1_t vy = __riscv_vle16_v_f16m1(y + i, vl);
+        vfloat16m1_t vd = eval(vx, vy, vl);
+        __riscv_vse16_v_f16m1(dst + i, vd, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+static inline void rvv_binary_kernel_s32(const int32_t *x, const int32_t *y,
+        int32_t *dst, const int8_t * /*c*/, dim_t len, eval_s32m1_t eval) {
+    for (dim_t i = 0; i < len;) {
+        size_t vl = __riscv_vsetvl_e32m1(static_cast<size_t>(len - i));
+        vint32m1_t vx = __riscv_vle32_v_i32m1(x + i, vl);
+        vint32m1_t vy = __riscv_vle32_v_i32m1(y + i, vl);
+        vint32m1_t vd = eval(vx, vy, vl);
+        __riscv_vse32_v_i32m1(dst + i, vd, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+static inline void rvv_binary_kernel_s8(const int8_t *x, const int8_t *y,
+        int8_t *dst, const int8_t * /*c*/, dim_t len, eval_s8m1_t eval) {
+    for (dim_t i = 0; i < len;) {
+        size_t vl = __riscv_vsetvl_e8m1(static_cast<size_t>(len - i));
+        vint8m1_t vx = __riscv_vle8_v_i8m1(x + i, vl);
+        vint8m1_t vy = __riscv_vle8_v_i8m1(y + i, vl);
+        vint8m1_t vd = eval(vx, vy, vl);
+        __riscv_vse8_v_i8m1(dst + i, vd, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+static inline void rvv_binary_kernel_u8(const uint8_t *x, const uint8_t *y,
+        uint8_t *dst, const int8_t * /*c*/, dim_t len, eval_u8m1_t eval) {
+    for (dim_t i = 0; i < len;) {
+        size_t vl = __riscv_vsetvl_e8m1(static_cast<size_t>(len - i));
+        vuint8m1_t vx = __riscv_vle8_v_u8m1(x + i, vl);
+        vuint8m1_t vy = __riscv_vle8_v_u8m1(y + i, vl);
+        vuint8m1_t vd = eval(vx, vy, vl);
+        __riscv_vse8_v_u8m1(dst + i, vd, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+
+/*** Convert methods for f16/s32/s8/u8 and apply in f32 domain ***/
+inline vfloat16m1_t rvv_convert_and_apply_f32_to_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl, eval_f32m2_t eval) {
+    vfloat32m2_t vx = __riscv_vfwcvt_f_f_v_f32m2(x, vl);
+    vfloat32m2_t vy = __riscv_vfwcvt_f_f_v_f32m2(y, vl);
+    vfloat32m2_t vout_f32 = eval(vx, vy, vl);
+    return __riscv_vfncvt_f_f_w_f16m1(vout_f32, vl);
+}
+inline vint32m1_t rvv_convert_and_apply_f32_to_s32(
+        vint32m1_t x, vint32m1_t y, size_t vl, eval_f32m1_t eval) {
+    vfloat32m1_t vx = __riscv_vfcvt_f_x_v_f32m1(x, vl);
+    vfloat32m1_t vy = __riscv_vfcvt_f_x_v_f32m1(y, vl);
+    vfloat32m1_t vout_f32 = eval(vx, vy, vl);
+    vfloat32m1_t vmin = __riscv_vfmv_v_f_f32m1(-2147483648.0f, vl);
+    vfloat32m1_t vmax = __riscv_vfmv_v_f_f32m1(2147483647.0f, vl);
+    vout_f32 = __riscv_vfmax_vv_f32m1(vout_f32, vmin, vl);
+    vout_f32 = __riscv_vfmin_vv_f32m1(vout_f32, vmax, vl);
+    return __riscv_vfcvt_x_f_v_i32m1(vout_f32, vl);
+}
+inline vint8m1_t rvv_convert_and_apply_f32_to_s8(
+        vint8m1_t x, vint8m1_t y, size_t vl, eval_f32m4_t eval) {
+    vint32m4_t vx_s32 = __riscv_vsext_vf4_i32m4(x, vl);
+    vint32m4_t vy_s32 = __riscv_vsext_vf4_i32m4(y, vl);
+    vfloat32m4_t vx_f32 = __riscv_vfcvt_f_x_v_f32m4(vx_s32, vl);
+    vfloat32m4_t vy_f32 = __riscv_vfcvt_f_x_v_f32m4(vy_s32, vl);
+    vfloat32m4_t vout_f32 = eval(vx_f32, vy_f32, vl);
+    vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(-128.0f, vl);
+    vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(127.0f, vl);
+    vout_f32 = __riscv_vfmax_vv_f32m4(vout_f32, vmin, vl);
+    vout_f32 = __riscv_vfmin_vv_f32m4(vout_f32, vmax, vl);
+    vint32m4_t vout_s32 = __riscv_vfcvt_x_f_v_i32m4(vout_f32, vl);
+    vint16m2_t vout_s16 = __riscv_vncvt_x_x_w_i16m2(vout_s32, vl);
+    return __riscv_vncvt_x_x_w_i8m1(vout_s16, vl);
+}
+
+inline vuint8m1_t rvv_convert_and_apply_f32_to_u8(
+        vuint8m1_t x, vuint8m1_t y, size_t vl, eval_f32m4_t eval) {
+    vuint32m4_t vx_u32 = __riscv_vzext_vf4_u32m4(x, vl);
+    vuint32m4_t vy_u32 = __riscv_vzext_vf4_u32m4(y, vl);
+    vfloat32m4_t vx_f32 = __riscv_vfcvt_f_xu_v_f32m4(vx_u32, vl);
+    vfloat32m4_t vy_f32 = __riscv_vfcvt_f_xu_v_f32m4(vy_u32, vl);
+    vfloat32m4_t vout_f32 = eval(vx_f32, vy_f32, vl);
+    vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+    vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(255.0f, vl);
+    vout_f32 = __riscv_vfmax_vv_f32m4(vout_f32, vmin, vl);
+    vout_f32 = __riscv_vfmin_vv_f32m4(vout_f32, vmax, vl);
+    vuint32m4_t vout_u32 = __riscv_vfcvt_xu_f_v_u32m4(vout_f32, vl);
+    vuint16m2_t vout_u16 = __riscv_vncvt_x_x_w_u16m2(vout_u32, vl);
+    return __riscv_vncvt_x_x_w_u8m1(vout_u16, vl);
+}
+
+/*** Operations (evaluate in f32 domain) ***/
+// Add
+inline vfloat32m1_t rvv_binary_add_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    return __riscv_vfadd_vv_f32m1(x, y, vl);
+}
+inline vfloat16m1_t rvv_binary_add_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    return __riscv_vfadd_vv_f16m1(x, y, vl);
+}
+inline vint32m1_t rvv_binary_add_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    return __riscv_vadd_vv_i32m1(x, y, vl);
+}
+inline vint8m1_t rvv_binary_add_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    return __riscv_vadd_vv_i8m1(x, y, vl);
+}
+inline vuint8m1_t rvv_binary_add_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    return __riscv_vadd_vv_u8m1(x, y, vl);
+}
+// Div
+inline vfloat32m1_t rvv_binary_div_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    return __riscv_vfdiv_vv_f32m1(x, y, vl);
+}
+inline vfloat32m4_t rvv_binary_div_f32_m4(
+        vfloat32m4_t x, vfloat32m4_t y, size_t vl) {
+    return __riscv_vfdiv_vv_f32m4(x, y, vl);
+}
+inline vfloat16m1_t rvv_binary_div_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    return __riscv_vfdiv_vv_f16m1(x, y, vl);
+}
+inline vint32m1_t rvv_binary_div_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    return rvv_convert_and_apply_f32_to_s32(x, y, vl, rvv_binary_div_f32);
+}
+inline vint8m1_t rvv_binary_div_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    return rvv_convert_and_apply_f32_to_s8(x, y, vl, rvv_binary_div_f32_m4);
+}
+inline vuint8m1_t rvv_binary_div_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    return rvv_convert_and_apply_f32_to_u8(x, y, vl, rvv_binary_div_f32_m4);
+}
+// Max
+inline vfloat32m1_t rvv_binary_max_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    return __riscv_vfmax_vv_f32m1(x, y, vl);
+}
+inline vfloat16m1_t rvv_binary_max_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    return __riscv_vfmax_vv_f16m1(x, y, vl);
+}
+inline vint32m1_t rvv_binary_max_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    return __riscv_vmax_vv_i32m1(x, y, vl);
+}
+inline vint8m1_t rvv_binary_max_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    return __riscv_vmax_vv_i8m1(x, y, vl);
+}
+inline vuint8m1_t rvv_binary_max_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    return __riscv_vmaxu_vv_u8m1(x, y, vl);
+}
+// Min
+inline vfloat32m1_t rvv_binary_min_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    return __riscv_vfmin_vv_f32m1(x, y, vl);
+}
+inline vfloat16m1_t rvv_binary_min_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    return __riscv_vfmin_vv_f16m1(x, y, vl);
+}
+inline vint32m1_t rvv_binary_min_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    return __riscv_vmin_vv_i32m1(x, y, vl);
+}
+inline vint8m1_t rvv_binary_min_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    return __riscv_vmin_vv_i8m1(x, y, vl);
+}
+inline vuint8m1_t rvv_binary_min_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    return __riscv_vminu_vv_u8m1(x, y, vl);
+}
+// Mul
+inline vfloat32m1_t rvv_binary_mul_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    return __riscv_vfmul_vv_f32m1(x, y, vl);
+}
+inline vfloat32m4_t rvv_binary_mul_f32_m4(
+        vfloat32m4_t x, vfloat32m4_t y, size_t vl) {
+    return __riscv_vfmul_vv_f32m4(x, y, vl);
+}
+inline vfloat16m1_t rvv_binary_mul_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    return __riscv_vfmul_vv_f16m1(x, y, vl);
+}
+inline vint32m1_t rvv_binary_mul_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    return rvv_convert_and_apply_f32_to_s32(x, y, vl, rvv_binary_mul_f32);
+}
+inline vint8m1_t rvv_binary_mul_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    return rvv_convert_and_apply_f32_to_s8(x, y, vl, rvv_binary_mul_f32_m4);
+}
+inline vuint8m1_t rvv_binary_mul_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    return rvv_convert_and_apply_f32_to_u8(x, y, vl, rvv_binary_mul_f32_m4);
+}
+// Sub
+inline vfloat32m1_t rvv_binary_sub_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    return __riscv_vfsub_vv_f32m1(x, y, vl);
+}
+inline vfloat32m4_t rvv_binary_sub_f32_m4(
+        vfloat32m4_t x, vfloat32m4_t y, size_t vl) {
+    return __riscv_vfsub_vv_f32m4(x, y, vl);
+}
+inline vfloat16m1_t rvv_binary_sub_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    return __riscv_vfsub_vv_f16m1(x, y, vl);
+}
+inline vint32m1_t rvv_binary_sub_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    return __riscv_vsub_vv_i32m1(x, y, vl);
+}
+inline vint8m1_t rvv_binary_sub_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    return __riscv_vsub_vv_i8m1(x, y, vl);
+}
+inline vuint8m1_t rvv_binary_sub_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    // Compute in f32 domain and clamp to [0, 255] to avoid unsigned wrap-around
+    return rvv_convert_and_apply_f32_to_u8(x, y, vl, rvv_binary_sub_f32_m4);
+}
+// Ge
+inline vfloat32m1_t rvv_binary_ge_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmfge_vv_f32m1_b32(x, y, vl);
+    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
+}
+inline vfloat16m1_t rvv_binary_ge_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    vbool16_t mask = __riscv_vmfge_vv_f16m1_b16(x, y, vl);
+    vfloat16m1_t zero = __riscv_vfmv_v_f_f16m1(static_cast<_Float16>(0.f), vl);
+    return __riscv_vfmerge_vfm_f16m1(
+            zero, static_cast<_Float16>(1.f), mask, vl);
+}
+inline vint32m1_t rvv_binary_ge_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmsge_vv_i32m1_b32(x, y, vl);
+    vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
+    return __riscv_vmerge_vxm_i32m1(zero, static_cast<int32_t>(1), mask, vl);
+}
+inline vint8m1_t rvv_binary_ge_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsge_vv_i8m1_b8(x, y, vl);
+    vint8m1_t zero = __riscv_vmv_v_x_i8m1(static_cast<int8_t>(0), vl);
+    return __riscv_vmerge_vxm_i8m1(zero, static_cast<int8_t>(1), mask, vl);
+}
+inline vuint8m1_t rvv_binary_ge_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsgeu_vv_u8m1_b8(x, y, vl);
+    vuint8m1_t zero = __riscv_vmv_v_x_u8m1(static_cast<uint8_t>(0), vl);
+    return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
+}
+// Gt
+inline vfloat32m1_t rvv_binary_gt_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmfgt_vv_f32m1_b32(x, y, vl);
+    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
+}
+inline vfloat16m1_t rvv_binary_gt_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    vbool16_t mask = __riscv_vmfgt_vv_f16m1_b16(x, y, vl);
+    vfloat16m1_t zero = __riscv_vfmv_v_f_f16m1(static_cast<_Float16>(0.f), vl);
+    return __riscv_vfmerge_vfm_f16m1(
+            zero, static_cast<_Float16>(1.f), mask, vl);
+}
+inline vint32m1_t rvv_binary_gt_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmsgt_vv_i32m1_b32(x, y, vl);
+    vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
+    return __riscv_vmerge_vxm_i32m1(zero, static_cast<int32_t>(1), mask, vl);
+}
+inline vint8m1_t rvv_binary_gt_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsgt_vv_i8m1_b8(x, y, vl);
+    vint8m1_t zero = __riscv_vmv_v_x_i8m1(static_cast<int8_t>(0), vl);
+    return __riscv_vmerge_vxm_i8m1(zero, static_cast<int8_t>(1), mask, vl);
+}
+inline vuint8m1_t rvv_binary_gt_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsgtu_vv_u8m1_b8(x, y, vl);
+    vuint8m1_t zero = __riscv_vmv_v_x_u8m1(static_cast<uint8_t>(0), vl);
+    return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
+}
+// Le
+inline vfloat32m1_t rvv_binary_le_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmfle_vv_f32m1_b32(x, y, vl);
+    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
+}
+inline vfloat16m1_t rvv_binary_le_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    vbool16_t mask = __riscv_vmfle_vv_f16m1_b16(x, y, vl);
+    vfloat16m1_t zero = __riscv_vfmv_v_f_f16m1(static_cast<_Float16>(0.f), vl);
+    return __riscv_vfmerge_vfm_f16m1(
+            zero, static_cast<_Float16>(1.f), mask, vl);
+}
+inline vint32m1_t rvv_binary_le_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmsle_vv_i32m1_b32(x, y, vl);
+    vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
+    return __riscv_vmerge_vxm_i32m1(zero, static_cast<int32_t>(1), mask, vl);
+}
+inline vint8m1_t rvv_binary_le_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsle_vv_i8m1_b8(x, y, vl);
+    vint8m1_t zero = __riscv_vmv_v_x_i8m1(static_cast<int8_t>(0), vl);
+    return __riscv_vmerge_vxm_i8m1(zero, static_cast<int8_t>(1), mask, vl);
+}
+inline vuint8m1_t rvv_binary_le_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsleu_vv_u8m1_b8(x, y, vl);
+    vuint8m1_t zero = __riscv_vmv_v_x_u8m1(static_cast<uint8_t>(0), vl);
+    return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
+}
+// Lt
+inline vfloat32m1_t rvv_binary_lt_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmflt_vv_f32m1_b32(x, y, vl);
+    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
+}
+inline vfloat16m1_t rvv_binary_lt_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    vbool16_t mask = __riscv_vmflt_vv_f16m1_b16(x, y, vl);
+    vfloat16m1_t zero = __riscv_vfmv_v_f_f16m1(static_cast<_Float16>(0.f), vl);
+    return __riscv_vfmerge_vfm_f16m1(
+            zero, static_cast<_Float16>(1.f), mask, vl);
+}
+inline vint32m1_t rvv_binary_lt_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmslt_vv_i32m1_b32(x, y, vl);
+    vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
+    return __riscv_vmerge_vxm_i32m1(zero, static_cast<int32_t>(1), mask, vl);
+}
+inline vint8m1_t rvv_binary_lt_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmslt_vv_i8m1_b8(x, y, vl);
+    vint8m1_t zero = __riscv_vmv_v_x_i8m1(static_cast<int8_t>(0), vl);
+    return __riscv_vmerge_vxm_i8m1(zero, static_cast<int8_t>(1), mask, vl);
+}
+inline vuint8m1_t rvv_binary_lt_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsltu_vv_u8m1_b8(x, y, vl);
+    vuint8m1_t zero = __riscv_vmv_v_x_u8m1(static_cast<uint8_t>(0), vl);
+    return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
+}
+// Eq
+inline vfloat32m1_t rvv_binary_eq_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmfeq_vv_f32m1_b32(x, y, vl);
+    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
+}
+inline vfloat16m1_t rvv_binary_eq_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    vbool16_t mask = __riscv_vmfeq_vv_f16m1_b16(x, y, vl);
+    vfloat16m1_t zero = __riscv_vfmv_v_f_f16m1(static_cast<_Float16>(0.f), vl);
+    return __riscv_vfmerge_vfm_f16m1(
+            zero, static_cast<_Float16>(1.f), mask, vl);
+}
+inline vint32m1_t rvv_binary_eq_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmseq_vv_i32m1_b32(x, y, vl);
+    vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
+    return __riscv_vmerge_vxm_i32m1(zero, static_cast<int32_t>(1), mask, vl);
+}
+inline vint8m1_t rvv_binary_eq_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmseq_vv_i8m1_b8(x, y, vl);
+    vint8m1_t zero = __riscv_vmv_v_x_i8m1(static_cast<int8_t>(0), vl);
+    return __riscv_vmerge_vxm_i8m1(zero, static_cast<int8_t>(1), mask, vl);
+}
+inline vuint8m1_t rvv_binary_eq_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmseq_vv_u8m1_b8(x, y, vl);
+    vuint8m1_t zero = __riscv_vmv_v_x_u8m1(static_cast<uint8_t>(0), vl);
+    return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
+}
+// Ne
+inline vfloat32m1_t rvv_binary_ne_f32(
+        vfloat32m1_t x, vfloat32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmfne_vv_f32m1_b32(x, y, vl);
+    vfloat32m1_t zero = __riscv_vfmv_v_f_f32m1(0.f, vl);
+    return __riscv_vfmerge_vfm_f32m1(zero, 1.f, mask, vl);
+}
+inline vfloat16m1_t rvv_binary_ne_f16(
+        vfloat16m1_t x, vfloat16m1_t y, size_t vl) {
+    vbool16_t mask = __riscv_vmfne_vv_f16m1_b16(x, y, vl);
+    vfloat16m1_t zero = __riscv_vfmv_v_f_f16m1(static_cast<_Float16>(0.f), vl);
+    return __riscv_vfmerge_vfm_f16m1(
+            zero, static_cast<_Float16>(1.f), mask, vl);
+}
+inline vint32m1_t rvv_binary_ne_s32(vint32m1_t x, vint32m1_t y, size_t vl) {
+    vbool32_t mask = __riscv_vmsne_vv_i32m1_b32(x, y, vl);
+    vint32m1_t zero = __riscv_vmv_v_x_i32m1(static_cast<int32_t>(0), vl);
+    return __riscv_vmerge_vxm_i32m1(zero, static_cast<int32_t>(1), mask, vl);
+}
+inline vint8m1_t rvv_binary_ne_s8(vint8m1_t x, vint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsne_vv_i8m1_b8(x, y, vl);
+    vint8m1_t zero = __riscv_vmv_v_x_i8m1(static_cast<int8_t>(0), vl);
+    return __riscv_vmerge_vxm_i8m1(zero, static_cast<int8_t>(1), mask, vl);
+}
+inline vuint8m1_t rvv_binary_ne_u8(vuint8m1_t x, vuint8m1_t y, size_t vl) {
+    vbool8_t mask = __riscv_vmsne_vv_u8m1_b8(x, y, vl);
+    vuint8m1_t zero = __riscv_vmv_v_x_u8m1(static_cast<uint8_t>(0), vl);
+    return __riscv_vmerge_vxm_u8m1(zero, static_cast<uint8_t>(1), mask, vl);
+}
+
+/*** Select op needs three oprands: x, y, c mask. Do it specially without op dispatching ***/
+inline void rvv_binary_select_kernel_f32(const float *x, const float *y,
+        float *dst, const int8_t *c, dim_t len) {
+    for (dim_t i = 0; i < len;) {
+        // Set VL for f32m4 ops and compute vector length in elements
+        size_t vl = __riscv_vsetvl_e32m4(static_cast<size_t>(len - i));
+        vfloat32m4_t vx = __riscv_vle32_v_f32m4(x + i, vl);
+        vfloat32m4_t vy = __riscv_vle32_v_f32m4(y + i, vl);
+        // Mask
+        vint8m1_t vc8 = __riscv_vle8_v_i8m1(c + i, vl);
+        vbool8_t mask
+                = __riscv_vmsne_vx_i8m1_b8(vc8, static_cast<int8_t>(0), vl);
+        vfloat32m4_t vsel = __riscv_vmerge_vvm_f32m4(vy, vx, mask, vl);
+        __riscv_vse32_v_f32m4(dst + i, vsel, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+inline void rvv_binary_select_kernel_f16(const _Float16 *x, const _Float16 *y,
+        _Float16 *dst, const int8_t *c, dim_t len) {
+    for (dim_t i = 0; i < len;) {
+        // Load f16 with e16m2
+        size_t vl = __riscv_vsetvl_e16m2(static_cast<size_t>(len - i));
+        vfloat16m2_t vx16 = __riscv_vle16_v_f16m2(x + i, vl);
+        vfloat16m2_t vy16 = __riscv_vle16_v_f16m2(y + i, vl);
+        // Widen and compute in f32m4
+        vfloat32m4_t vx = __riscv_vfwcvt_f_f_v_f32m4(vx16, vl);
+        vfloat32m4_t vy = __riscv_vfwcvt_f_f_v_f32m4(vy16, vl);
+        // Mask
+        vint8m1_t vc8 = __riscv_vle8_v_i8m1(c + i, vl);
+        vbool8_t mask
+                = __riscv_vmsne_vx_i8m1_b8(vc8, static_cast<int8_t>(0), vl);
+        // Merge in f32 and narrow back to f16m2
+        vfloat32m4_t vsel = __riscv_vmerge_vvm_f32m4(vy, vx, mask, vl);
+        vfloat16m2_t vd16 = __riscv_vfncvt_f_f_w_f16m2(vsel, vl);
+        __riscv_vse16_v_f16m2(dst + i, vd16, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+inline void rvv_binary_select_kernel_s32(const int32_t *x, const int32_t *y,
+        int32_t *dst, const int8_t *c, dim_t len) {
+    for (dim_t i = 0; i < len;) {
+        size_t vl = __riscv_vsetvl_e32m4(static_cast<size_t>(len - i));
+        vint32m4_t vx32 = __riscv_vle32_v_i32m4(x + i, vl);
+        vint32m4_t vy32 = __riscv_vle32_v_i32m4(y + i, vl);
+        vfloat32m4_t vx = __riscv_vfcvt_f_x_v_f32m4(vx32, vl);
+        vfloat32m4_t vy = __riscv_vfcvt_f_x_v_f32m4(vy32, vl);
+        // Mask
+        vint8m1_t vc8 = __riscv_vle8_v_i8m1(c + i, vl);
+        vbool8_t mask
+                = __riscv_vmsne_vx_i8m1_b8(vc8, static_cast<int8_t>(0), vl);
+        // Merge and clamp in f32
+        vfloat32m4_t vsel = __riscv_vmerge_vvm_f32m4(vy, vx, mask, vl);
+        vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(-2147483648.0f, vl);
+        vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(2147483647.0f, vl);
+        vsel = __riscv_vfmax_vv_f32m4(vsel, vmin, vl);
+        vsel = __riscv_vfmin_vv_f32m4(vsel, vmax, vl);
+        vint32m4_t vds32 = __riscv_vfcvt_x_f_v_i32m4(vsel, vl);
+        __riscv_vse32_v_i32m4(dst + i, vds32, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+inline void rvv_binary_select_kernel_s8(const int8_t *x, const int8_t *y,
+        int8_t *dst, const int8_t *c, dim_t len) {
+    for (dim_t i = 0; i < len;) {
+        // Load e8m1
+        size_t vl = __riscv_vsetvl_e8m1(static_cast<size_t>(len - i));
+        vint8m1_t vxb = __riscv_vle8_v_i8m1(x + i, vl);
+        vint8m1_t vyb = __riscv_vle8_v_i8m1(y + i, vl);
+        // Widen to f32m4
+        vint32m4_t vxi = __riscv_vsext_vf4_i32m4(vxb, vl);
+        vint32m4_t vyi = __riscv_vsext_vf4_i32m4(vyb, vl);
+        vfloat32m4_t vx = __riscv_vfcvt_f_x_v_f32m4(vxi, vl);
+        vfloat32m4_t vy = __riscv_vfcvt_f_x_v_f32m4(vyi, vl);
+        // Mask
+        vint8m1_t vc8 = __riscv_vle8_v_i8m1(c + i, vl);
+        vbool8_t mask
+                = __riscv_vmsne_vx_i8m1_b8(vc8, static_cast<int8_t>(0), vl);
+        // Merge and clamp in f32
+        vfloat32m4_t vsel = __riscv_vmerge_vvm_f32m4(vy, vx, mask, vl);
+        vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(-128.0f, vl);
+        vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(127.0f, vl);
+        vsel = __riscv_vfmax_vv_f32m4(vsel, vmin, vl);
+        vsel = __riscv_vfmin_vv_f32m4(vsel, vmax, vl);
+        vint32m4_t vds32 = __riscv_vfcvt_x_f_v_i32m4(vsel, vl);
+        vint16m2_t vds16 = __riscv_vncvt_x_x_w_i16m2(vds32, vl);
+        vint8m1_t vds8 = __riscv_vncvt_x_x_w_i8m1(vds16, vl);
+        // Store e8m1
+        __riscv_vse8_v_i8m1(dst + i, vds8, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+inline void rvv_binary_select_kernel_u8(const uint8_t *x, const uint8_t *y,
+        uint8_t *dst, const int8_t *c, dim_t len) {
+    for (dim_t i = 0; i < len;) {
+        // Load e8m1
+        size_t vl = __riscv_vsetvl_e8m1(static_cast<size_t>(len - i));
+        vuint8m1_t vxb = __riscv_vle8_v_u8m1(x + i, vl);
+        vuint8m1_t vyb = __riscv_vle8_v_u8m1(y + i, vl);
+        // Widen to f32m4
+        vuint32m4_t vxu = __riscv_vzext_vf4_u32m4(vxb, vl);
+        vuint32m4_t vyu = __riscv_vzext_vf4_u32m4(vyb, vl);
+        vfloat32m4_t vx = __riscv_vfcvt_f_xu_v_f32m4(vxu, vl);
+        vfloat32m4_t vy = __riscv_vfcvt_f_xu_v_f32m4(vyu, vl);
+        // Mask
+        vint8m1_t vc8 = __riscv_vle8_v_i8m1(c + i, vl);
+        vbool8_t mask
+                = __riscv_vmsne_vx_i8m1_b8(vc8, static_cast<int8_t>(0), vl);
+        // Merge and clamp
+        vfloat32m4_t vsel = __riscv_vmerge_vvm_f32m4(vy, vx, mask, vl);
+        vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(0.0f, vl);
+        vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(255.0f, vl);
+        vsel = __riscv_vfmax_vv_f32m4(vsel, vmin, vl);
+        vsel = __riscv_vfmin_vv_f32m4(vsel, vmax, vl);
+        vuint32m4_t vdu32 = __riscv_vfcvt_xu_f_v_u32m4(vsel, vl);
+        vuint16m2_t vdu16 = __riscv_vncvt_x_x_w_u16m2(vdu32, vl);
+        vuint8m1_t vdu8 = __riscv_vncvt_x_x_w_u8m1(vdu16, vl);
+        // Store e8m1
+        __riscv_vse8_v_u8m1(dst + i, vdu8, vl);
+        i += static_cast<dim_t>(vl);
+    }
+}
+
+/*** Dispatch getters for different data types ***/
+inline eval_f32m1_t get_eval_f32(const alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::binary_add: return rvv_binary_add_f32;
+        case alg_kind::binary_div: return rvv_binary_div_f32;
+        case alg_kind::binary_max: return rvv_binary_max_f32;
+        case alg_kind::binary_min: return rvv_binary_min_f32;
+        case alg_kind::binary_mul: return rvv_binary_mul_f32;
+        case alg_kind::binary_sub: return rvv_binary_sub_f32;
+        case alg_kind::binary_ge: return rvv_binary_ge_f32;
+        case alg_kind::binary_gt: return rvv_binary_gt_f32;
+        case alg_kind::binary_le: return rvv_binary_le_f32;
+        case alg_kind::binary_lt: return rvv_binary_lt_f32;
+        case alg_kind::binary_eq: return rvv_binary_eq_f32;
+        case alg_kind::binary_ne: return rvv_binary_ne_f32;
+        default: return nullptr;
+    }
+}
+inline eval_f16m1_t get_eval_f16(const alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::binary_add: return rvv_binary_add_f16;
+        case alg_kind::binary_div: return rvv_binary_div_f16;
+        case alg_kind::binary_max: return rvv_binary_max_f16;
+        case alg_kind::binary_min: return rvv_binary_min_f16;
+        case alg_kind::binary_mul: return rvv_binary_mul_f16;
+        case alg_kind::binary_sub: return rvv_binary_sub_f16;
+        case alg_kind::binary_ge: return rvv_binary_ge_f16;
+        case alg_kind::binary_gt: return rvv_binary_gt_f16;
+        case alg_kind::binary_le: return rvv_binary_le_f16;
+        case alg_kind::binary_lt: return rvv_binary_lt_f16;
+        case alg_kind::binary_eq: return rvv_binary_eq_f16;
+        case alg_kind::binary_ne: return rvv_binary_ne_f16;
+        default: return nullptr;
+    }
+}
+inline eval_s32m1_t get_eval_s32(const alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::binary_add: return rvv_binary_add_s32;
+        case alg_kind::binary_div: return rvv_binary_div_s32;
+        case alg_kind::binary_max: return rvv_binary_max_s32;
+        case alg_kind::binary_min: return rvv_binary_min_s32;
+        case alg_kind::binary_mul: return rvv_binary_mul_s32;
+        case alg_kind::binary_sub: return rvv_binary_sub_s32;
+        case alg_kind::binary_ge: return rvv_binary_ge_s32;
+        case alg_kind::binary_gt: return rvv_binary_gt_s32;
+        case alg_kind::binary_le: return rvv_binary_le_s32;
+        case alg_kind::binary_lt: return rvv_binary_lt_s32;
+        case alg_kind::binary_eq: return rvv_binary_eq_s32;
+        case alg_kind::binary_ne: return rvv_binary_ne_s32;
+        default: return nullptr;
+    }
+}
+inline eval_s8m1_t get_eval_s8(const alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::binary_add: return rvv_binary_add_s8;
+        case alg_kind::binary_div: return rvv_binary_div_s8;
+        case alg_kind::binary_max: return rvv_binary_max_s8;
+        case alg_kind::binary_min: return rvv_binary_min_s8;
+        case alg_kind::binary_mul: return rvv_binary_mul_s8;
+        case alg_kind::binary_sub: return rvv_binary_sub_s8;
+        case alg_kind::binary_ge: return rvv_binary_ge_s8;
+        case alg_kind::binary_gt: return rvv_binary_gt_s8;
+        case alg_kind::binary_le: return rvv_binary_le_s8;
+        case alg_kind::binary_lt: return rvv_binary_lt_s8;
+        case alg_kind::binary_eq: return rvv_binary_eq_s8;
+        case alg_kind::binary_ne: return rvv_binary_ne_s8;
+        default: return nullptr;
+    }
+}
+inline eval_u8m1_t get_eval_u8(const alg_kind_t alg) {
+    switch (alg) {
+        case alg_kind::binary_add: return rvv_binary_add_u8;
+        case alg_kind::binary_div: return rvv_binary_div_u8;
+        case alg_kind::binary_max: return rvv_binary_max_u8;
+        case alg_kind::binary_min: return rvv_binary_min_u8;
+        case alg_kind::binary_mul: return rvv_binary_mul_u8;
+        case alg_kind::binary_sub: return rvv_binary_sub_u8;
+        case alg_kind::binary_ge: return rvv_binary_ge_u8;
+        case alg_kind::binary_gt: return rvv_binary_gt_u8;
+        case alg_kind::binary_le: return rvv_binary_le_u8;
+        case alg_kind::binary_lt: return rvv_binary_lt_u8;
+        case alg_kind::binary_eq: return rvv_binary_eq_u8;
+        case alg_kind::binary_ne: return rvv_binary_ne_u8;
+        default: return nullptr;
+    }
+}
+
+/*** Apply methods ***/
+static inline void rvv_binary_apply_f32(const alg_kind_t alg, const float *x,
+        const float *y, float *dst, const int8_t *c, const dim_t len) {
+    if (alg == alg_kind::binary_select) {
+        rvv_binary_select_kernel_f32(x, y, dst, c, len);
+        return;
+    }
+    auto eval = get_eval_f32(alg);
+    if (!eval) {
+        assert(!"[rvv_binary_apply_f32] unknown binary alg_kind");
+        return;
+    }
+    rvv_binary_kernel_f32(x, y, dst, c, len, eval);
+}
+static inline void rvv_binary_apply_f16(const alg_kind_t alg, const _Float16 *x,
+        const _Float16 *y, _Float16 *dst, const int8_t *c, const dim_t len) {
+    if (alg == alg_kind::binary_select) {
+        rvv_binary_select_kernel_f16(x, y, dst, c, len);
+        return;
+    }
+    auto eval = get_eval_f16(alg);
+    if (!eval) {
+        assert(!"[rvv_binary_apply_f16] unknown binary alg_kind");
+        return;
+    }
+    rvv_binary_kernel_f16(x, y, dst, c, len, eval);
+}
+static inline void rvv_binary_apply_s32(const alg_kind_t alg, const int32_t *x,
+        const int32_t *y, int32_t *dst, const int8_t *c, const dim_t len) {
+    if (alg == alg_kind::binary_select) {
+        rvv_binary_select_kernel_s32(x, y, dst, c, len);
+        return;
+    }
+    auto eval = get_eval_s32(alg);
+    if (!eval) {
+        assert(!"[rvv_binary_apply_s32] unknown binary alg_kind");
+        return;
+    }
+    rvv_binary_kernel_s32(x, y, dst, c, len, eval);
+}
+static inline void rvv_binary_apply_s8(const alg_kind_t alg, const int8_t *x,
+        const int8_t *y, int8_t *dst, const int8_t *c, const dim_t len) {
+    if (alg == alg_kind::binary_select) {
+        rvv_binary_select_kernel_s8(x, y, dst, c, len);
+        return;
+    }
+    auto eval = get_eval_s8(alg);
+    if (!eval) {
+        assert(!"[rvv_binary_apply_s8] unknown binary alg_kind");
+        return;
+    }
+    rvv_binary_kernel_s8(x, y, dst, c, len, eval);
+}
+static inline void rvv_binary_apply_u8(const alg_kind_t alg, const uint8_t *x,
+        const uint8_t *y, uint8_t *dst, const int8_t *c, const dim_t len) {
+    if (alg == alg_kind::binary_select) {
+        rvv_binary_select_kernel_u8(x, y, dst, c, len);
+        return;
+    }
+    auto eval = get_eval_u8(alg);
+    if (!eval) {
+        assert(!"[rvv_binary_apply_u8] unknown binary alg_kind");
+        return;
+    }
+    rvv_binary_kernel_u8(x, y, dst, c, len, eval);
+}
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_RVV_BINARY_KERNELS_HPP


### PR DESCRIPTION
# Description

This PR introduces optimized binary operation kernels for RISC-V architectures using RVV (RISC-V Vector) intrinsics. The `rvv_binary` implementation delivers significant performance improvements for common neural network operations including ReLU, square, abs, sqrt, and more.
This initial version provides:

1. Implementing binary operations utilizing RVV intrinsics, including all operations that supported by `ref_binary`.
2. Multiple data types including `f32`, `f16`, `s32`, `s8` and `u8`.
3. Supporting dense and channel-padded memory layouts.

## Key Features

- **RVV-Binary Kernels**: Added `rvv_binary_kernel_*dtype` kernels for unified design pattern across binary operations for better maintainability.
- **Data Types**: Source and destination tensors must be one of `f32`, `f16` (Zvfh extension required), `s32`, `s8` and `u8`. The third source required by select operation must be `s8` type.
- **Memory Layouts**: Source and destination tensors must be dense or nCspBc format.
- **Post-Ops**: Current implementation requires no post-ops.
- **Parallelization**: By adopting parallel methods provided by oneDNN API including `balance211`, `parallel_nd` and `parallel`, it leverages RVV-vectorize inner loops optimization and multi-core CPU performance.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

All experiments are performed on the LRW platform with VLEN=128. We draw comparisons among 1st baseline method of **scalar** implementation , 2nd baseline method of **auto vectoration** by compiler,and our method of **RVV intrinsic** implementation, using `benchdnn` with input batch of `test_binary_all` (filtered reduntant test cases that `rvv_binary` doesn't support).

Results are as follows:

| Data Types | Scalar Runtime (s) | RVV Intrinsics </br> Runtime (s) | Improvements |
|------------|--------------------|----------------------------|--------------|
| f32        | 1.59               | 1.46                       | 8.18%        |
| s32        | 2.36               | 2.2                       | 6.78%       |
| s8         | 2.32               | 2.19                       | 5.6%       |
| u8         | 2.33               |2.18                       | 6.44%         |

| Data Types | Auto Vectora-</br>tion Runtime (s) | RVV Intrinsics </br> Runtime (s) | Improvements |
|------------|--------------------|----------------------------|--------------|
| f32        | 1.8               | 1.46                       | 18.89%        |
| s32        | 2.66               | 2.2                       | 17.29%       |
| s8         | 2.61               | 2.19                       | 16.09%       |
| u8         | 2.61               | 2.18                       | 16.48%         |

*Note that the runtimes are the total time minus rerfence and comparison time for precise comparisons.*

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
