### PR TITLE
ci: aarch64: upgrade baseline version to v3.9

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -3,6 +3,6 @@
         "acl": "v52.2.0",
         "gcc": "13",
         "clang": "17",
-        "onednn-base": "v3.8"
+        "onednn-base": "v3.9"
     }
 }


### PR DESCRIPTION
The current perf failures we see in nightly are due to a deliberate change where we changed f16:f16:f16 accumulation from f16 to f32. Updating the baseline should get rid of this false positive