### PR TITLE
[GPU] Add host side scalars support in SDPA primitive

### DIFF
--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -745,8 +745,8 @@ size_t get_desc_hash(const sdpa_desc_t &desc) {
     seed = hash_combine(seed, desc.vs_zero_points.get_hash());
     seed = hash_combine(seed, get_md_hash(desc.dst_desc));
     seed = hash_combine(seed, get_md_hash(desc.attn_mask_desc));
+    seed = hash_combine(seed, get_md_hash(desc.scale_desc));
     // Scale type
-    seed = hash_combine(seed, static_cast<size_t>(desc.scale_dt));
     seed = hash_combine(seed, static_cast<size_t>(desc.kq_acc_dt));
     seed = hash_combine(seed, static_cast<size_t>(desc.vs_acc_dt));
     seed = hash_combine(seed, desc.invert_scale);

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -589,7 +589,7 @@ void serialize(serialization_stream_t &sstream, const sdpa_desc_t &desc) {
     desc.vs_zero_points.serialize(sstream);
     serialize(sstream, desc.dst_desc);
     serialize(sstream, desc.attn_mask_desc);
-    sstream.append(desc.scale_dt);
+    sstream.append(desc.scale_desc);
     sstream.append(desc.kq_acc_dt);
     sstream.append(desc.vs_acc_dt);
     sstream.append(desc.invert_scale);

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -589,7 +589,7 @@ void serialize(serialization_stream_t &sstream, const sdpa_desc_t &desc) {
     desc.vs_zero_points.serialize(sstream);
     serialize(sstream, desc.dst_desc);
     serialize(sstream, desc.attn_mask_desc);
-    sstream.append(desc.scale_desc);
+    serialize(sstream, desc.scale_desc);
     sstream.append(desc.kq_acc_dt);
     sstream.append(desc.vs_acc_dt);
     sstream.append(desc.invert_scale);

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -104,7 +104,7 @@ struct sdpa_pd_t : public primitive_desc_t {
     int n_outputs() const override { return 1; }
 
     bool with_attn_scale() const {
-        return (desc_.scale_dt != data_type::undef);
+        return (scale_md()->data_type != data_type::undef);
     }
 
     bool with_host_scale() const {

--- a/src/common/sdpa_pd.hpp
+++ b/src/common/sdpa_pd.hpp
@@ -96,6 +96,7 @@ struct sdpa_pd_t : public primitive_desc_t {
     const memory_desc_t *key_md() const { return &desc_.k_desc; }
     const memory_desc_t *val_md() const { return &desc_.v_desc; }
     const memory_desc_t *attn_mask_md() const { return &desc_.attn_mask_desc; }
+    const memory_desc_t *scale_md() const { return &desc_.scale_desc; }
 
     int n_inputs() const override {
         return 3 + int(with_attn_mask()) + int(with_attn_scale());
@@ -104,6 +105,10 @@ struct sdpa_pd_t : public primitive_desc_t {
 
     bool with_attn_scale() const {
         return (desc_.scale_dt != data_type::undef);
+    }
+
+    bool with_host_scale() const {
+        return (scale_md()->format_kind == format_kind::host_scalar);
     }
 
     bool with_attn_mask() const {

--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -39,10 +39,9 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
             query_desc, key_desc, value_desc, engine, attr, kq_attr, vs_attr));
 
     dnnl::impl::sdpa_desc_t sdpa_desc = dnnl::impl::create_sdpa_desc(query_desc,
-            key_desc, value_desc, dst_desc, mask_desc,
-            scale_desc, invert_scale, kv_head_number,
-            static_cast<attn_mask_type_t>(attn_mask_type), softmax_alg, kq_attr,
-            vs_attr);
+            key_desc, value_desc, dst_desc, mask_desc, scale_desc, invert_scale,
+            kv_head_number, static_cast<attn_mask_type_t>(attn_mask_type),
+            softmax_alg, kq_attr, vs_attr);
     return dnnl::impl::primitive_desc_create(primitive_desc_iface, engine,
             (const dnnl::impl::op_desc_t *)&sdpa_desc, nullptr, attr);
 }

--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -28,7 +28,7 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         dnnl_primitive_desc_t *primitive_desc_iface, dnnl_engine_t engine,
         const_dnnl_memory_desc_t query_desc, const_dnnl_memory_desc_t key_desc,
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
-        const_dnnl_memory_desc_t mask_desc, dnnl_data_type_t scale_dt,
+        const_dnnl_memory_desc_t mask_desc, const_dnnl_memory_desc_t scale_desc,
         bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
         dnnl_alg_kind_t softmax_alg, const_dnnl_primitive_attr_t attr,
         const_dnnl_primitive_attr_t kq_attr,
@@ -40,7 +40,7 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
 
     dnnl::impl::sdpa_desc_t sdpa_desc = dnnl::impl::create_sdpa_desc(query_desc,
             key_desc, value_desc, dst_desc, mask_desc,
-            (dnnl::impl::data_type_t)scale_dt, invert_scale, kv_head_number,
+            scale_desc, invert_scale, kv_head_number,
             static_cast<attn_mask_type_t>(attn_mask_type), softmax_alg, kq_attr,
             vs_attr);
     return dnnl::impl::primitive_desc_create(primitive_desc_iface, engine,

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -79,6 +79,7 @@ struct sdpa_desc_t : public op_desc_t {
 
     memory_desc_t dst_desc;
     memory_desc_t attn_mask_desc;
+    memory_desc_t scale_desc;
     data_type_t scale_dt {};
     data_type_t kq_acc_dt {};
     data_type_t vs_acc_dt {};

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -80,7 +80,6 @@ struct sdpa_desc_t : public op_desc_t {
     memory_desc_t dst_desc;
     memory_desc_t attn_mask_desc;
     memory_desc_t scale_desc;
-    data_type_t scale_dt {};
     data_type_t kq_acc_dt {};
     data_type_t vs_acc_dt {};
     // invert_scale = false: multiply by scale

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -151,7 +151,7 @@ static inline status_t sdpa_attr_check(const memory_desc_t *q_desc,
 static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
         const memory_desc_t *k_md, const memory_desc_t *v_md,
         const memory_desc_t *dst_md, const memory_desc_t *attn_mask_md,
-        data_type_t scale_dt, bool invert_scale, dim_t kv_head_number,
+        const memory_desc_t *scale_md, bool invert_scale, dim_t kv_head_number,
         attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
         const primitive_attr_t *kq_attr, const primitive_attr_t *vs_attr) {
     auto sdpa_desc = sdpa_desc_t();
@@ -177,7 +177,8 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     sdpa_desc.v_desc = *v_md;
     sdpa_desc.dst_desc = *dst_md;
     if (attn_mask_md) sdpa_desc.attn_mask_desc = *attn_mask_md;
-    sdpa_desc.scale_dt = scale_dt;
+    sdpa_desc.scale_dt = scale_md->data_type;
+    sdpa_desc.scale_desc = *scale_md;
     sdpa_desc.invert_scale = invert_scale;
     sdpa_desc.kv_head_number = kv_head_number;
     sdpa_desc.mask_type = attn_mask_type;
@@ -189,7 +190,7 @@ static inline status_t create_sdpa_pd(
         std::shared_ptr<primitive_desc_t> &sdpa_pd_, engine_t *engine,
         const memory_desc_t *q_md, const memory_desc_t *k_md,
         const memory_desc_t *v_md, const memory_desc_t *dst_md,
-        const memory_desc_t *attn_mask_md, data_type_t scale_dt,
+        const memory_desc_t *attn_mask_md, const memory_desc_t *scale_md,
         bool invert_scale, dim_t kv_head_number,
         attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
         const primitive_attr_t *attr, const primitive_attr_t *kq_attr = nullptr,
@@ -199,7 +200,7 @@ static inline status_t create_sdpa_pd(
             kq_attr, vs_attr));
 
     auto sdpa_desc = create_sdpa_desc(q_md, k_md, v_md, dst_md, attn_mask_md,
-            scale_dt, invert_scale, kv_head_number, attn_mask_type, softmax_alg,
+            scale_md, invert_scale, kv_head_number, attn_mask_type, softmax_alg,
             kq_attr, vs_attr);
 
     primitive_attr_t sdpa_attr = attr ? *attr : default_attr();

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -177,7 +177,6 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     sdpa_desc.v_desc = *v_md;
     sdpa_desc.dst_desc = *dst_md;
     if (attn_mask_md) sdpa_desc.attn_mask_desc = *attn_mask_md;
-    sdpa_desc.scale_dt = scale_md->data_type;
     sdpa_desc.scale_desc = *scale_md;
     sdpa_desc.invert_scale = invert_scale;
     sdpa_desc.kv_head_number = kv_head_number;

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -985,7 +985,7 @@ inline bool operator==(const sdpa_desc_t &lhs, const sdpa_desc_t &rhs) {
             && COMPARE_DESC_MEMBERS(vs_zero_points)
             && COMPARE_DESC_MEMBERS(dst_desc)
             && COMPARE_DESC_MEMBERS(attn_mask_desc)
-            && COMPARE_DESC_MEMBERS(scale_dt)
+            && COMPARE_DESC_MEMBERS(scale_desc)
             && COMPARE_DESC_MEMBERS(kq_acc_dt)
             && COMPARE_DESC_MEMBERS(vs_acc_dt)
             && COMPARE_DESC_MEMBERS(invert_scale)

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1632,7 +1632,7 @@ std::string init_info_sdpa(const engine_t *e, const pd_t *pd) {
             ss << "div:";
         else
             ss << "mul:";
-        ss << dnnl_dt2str(desc->scale_dt);
+        ss << dnnl_dt2str(pd->scale_md()->data_type);
     }
 
     ss << "," << md2dim_str(pd->qry_md()) << ":" << md2dim_str(pd->key_md())

--- a/src/gpu/intel/include/math_utils.h
+++ b/src/gpu/intel/include/math_utils.h
@@ -396,6 +396,8 @@ float4  __attribute__((overloadable)) cvt_bf16_to_f32(ushort4  a) { return __bui
 float8  __attribute__((overloadable)) cvt_bf16_to_f32(ushort8  a) { return __builtin_IB_bftof_8 (as_short8 (a)); }
 float16 __attribute__((overloadable)) cvt_bf16_to_f32(ushort16 a) { return __builtin_IB_bftof_16(as_short16(a)); }
 
+float   __attribute__((overloadable)) cvt_bf16_to_f32(bf16     a) { return __builtin_IB_bftof_1 (a.data); }
+
 #ifdef cl_khr_fp64
 double   __attribute__((overloadable)) cvt_bf16_to_f64(ushort   a) { return convert_double(__builtin_IB_bftof_1 (as_short  (a))); }
 double2  __attribute__((overloadable)) cvt_bf16_to_f64(ushort2  a) { return convert_double2(__builtin_IB_bftof_2 (as_short2 (a))); }

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -456,7 +456,7 @@ status_t micro_t::pd_t::init_conf(impl::engine_t *engine) {
     if (pd->with_value_scales() || pd->with_value_zp())
         conf.val_group_size = pd->value_group_size();
 
-    conf.scale_data_t = d->scale_dt;
+    conf.scale_data_t = pd->scale_md()->data_type;
 
     conf.attn_mask_undef = attn_mask_type::undef;
     conf.attn_mask_buffer = attn_mask_type::buffer;

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -76,7 +76,7 @@ struct micro_params_t : trivially_serializable_t<micro_params_t> {
             attn_mask_bottom_right;
     bool invert_scale, with_attn_scale, with_host_scale, with_attn_mask,
             broadcast_mask_q, with_causal_mask;
-    uint8_t padding1[3] = {0};
+    uint8_t padding1[2] = {0};
     int subgroup_size, d_max;
 
     bool d_full, arch_gte_hpc;

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -74,8 +74,8 @@ struct micro_params_t : trivially_serializable_t<micro_params_t> {
 
     int attn_mask_undef, attn_mask_buffer, attn_mask_top_left,
             attn_mask_bottom_right;
-    bool invert_scale, with_attn_scale, with_attn_mask, broadcast_mask_q,
-            with_causal_mask;
+    bool invert_scale, with_attn_scale, with_host_scale, with_attn_mask,
+            broadcast_mask_q, with_causal_mask;
     uint8_t padding1[3] = {0};
     int subgroup_size, d_max;
 

--- a/src/gpu/intel/sdpa/ref.hpp
+++ b/src/gpu/intel/sdpa/ref.hpp
@@ -94,7 +94,7 @@ struct ref_t : public primitive_t {
         def_data_type(kernel_ctx, pd()->val_md()->data_type, "VAL");
         def_data_type(kernel_ctx, pd()->dst_md()->data_type, "DST");
         def_data_type(kernel_ctx, pd()->attn_mask_md()->data_type, "MSK");
-        def_data_type(kernel_ctx, pd()->desc()->scale_dt, "SCALE");
+        def_data_type(kernel_ctx, pd()->scale_md()->data_type, "SCALE");
         CHECK(create_kernel(engine, &kernel_, "ref_sdpa", kernel_ctx));
         if (!kernel_) return status::runtime_error;
         return status::success;

--- a/src/graph/backend/dnnl/op_executable.hpp
+++ b/src/graph/backend/dnnl/op_executable.hpp
@@ -2918,12 +2918,11 @@ struct sdpa_executable_t : public op_executable_t {
         auto md_dst = make_dnnl_memory_desc(
                 op->get_output_value(0)->get_logical_tensor());
 
-        auto scale_dt = impl::data_type::undef;
+        auto md_scale = dnnl::memory::desc();
         size_t idx = 3;
         if (with_scale_)
-            scale_dt = op->get_input_value(idx++)
-                               ->get_logical_tensor()
-                               .data_type;
+            md_scale = make_dnnl_memory_desc(
+                    op->get_input_value(idx++)->get_logical_tensor());
 
         dnnl::memory::desc md_mask;
         with_explicit_mask_ = mask_type_ == attn_mask_type::buffer;
@@ -2955,9 +2954,9 @@ struct sdpa_executable_t : public op_executable_t {
                 ? alg_kind::softmax_accurate_inf_as_zero
                 : alg_kind::softmax_accurate;
         status_t s = create_sdpa_pd(sdpa_pd_, p_engine.get(), md_q.get(),
-                md_k.get(), md_v.get(), md_dst.get(), md_mask.get(), scale_dt,
-                is_invert_scale_, kv_head_number, mask_type_, softmax_alg,
-                attr.get(), qk_attr.get(), vs_attr.get());
+                md_k.get(), md_v.get(), md_dst.get(), md_mask.get(),
+                md_scale.get(), is_invert_scale_, kv_head_number, mask_type_,
+                softmax_alg, attr.get(), qk_attr.get(), vs_attr.get());
         if (s != dnnl::impl::status::success) {
             is_initialized_ = false;
         } else {

--- a/tests/gtests/internals/sdpa_internal.hpp
+++ b/tests/gtests/internals/sdpa_internal.hpp
@@ -40,7 +40,7 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         dnnl_primitive_desc_t *primitive_desc_iface, dnnl_engine_t engine,
         const_dnnl_memory_desc_t query_desc, const_dnnl_memory_desc_t key_desc,
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
-        const_dnnl_memory_desc_t mask_desc, dnnl_data_type_t scale_dt,
+        const_dnnl_memory_desc_t mask_desc, const_dnnl_memory_desc_t scale_desc,
         bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
         dnnl_alg_kind_t softmax_alg, const_dnnl_primitive_attr_t attr,
         const_dnnl_primitive_attr_t kq_attr,
@@ -59,21 +59,22 @@ struct sdpa : public dnnl::primitive {
 
         primitive_desc(const engine &aengine, const memory::desc &query_desc,
                 const memory::desc &key_desc, const memory::desc &value_desc,
-                const memory::desc *attn_mask_desc, memory::data_type scale_dt,
-                const memory::desc &output_desc, bool invert_scale,
-                memory::dim kv_head_number, int attn_mask_type, int softmax_alg,
+                const memory::desc *attn_mask_desc,
+                const memory::desc &scale_desc, const memory::desc &output_desc,
+                bool invert_scale, memory::dim kv_head_number,
+                int attn_mask_type, int softmax_alg,
                 const primitive_attr &attr = default_attr(),
                 const primitive_attr &kq_attr = default_attr(),
                 const primitive_attr &vs_attr = default_attr()) {
 
             dnnl_primitive_desc_t pd = nullptr;
-            dnnl_status_t status = sdpa_primitive_desc_create(&pd,
-                    aengine.get(), query_desc.get(), key_desc.get(),
-                    value_desc.get(), output_desc.get(),
-                    optional_arg(attn_mask_desc), (dnnl_data_type_t)scale_dt,
-                    invert_scale, kv_head_number, attn_mask_type,
-                    (dnnl_alg_kind_t)softmax_alg, attr.get(), kq_attr.get(),
-                    vs_attr.get());
+            dnnl_status_t status
+                    = sdpa_primitive_desc_create(&pd, aengine.get(),
+                            query_desc.get(), key_desc.get(), value_desc.get(),
+                            output_desc.get(), optional_arg(attn_mask_desc),
+                            scale_desc.get(), invert_scale, kv_head_number,
+                            attn_mask_type, (dnnl_alg_kind_t)softmax_alg,
+                            attr.get(), kq_attr.get(), vs_attr.get());
 
             dnnl::error::wrap_c_api(status,
                     "could not create a primitive descriptor for a sdpa "

--- a/tests/gtests/internals/test_sdpa.cpp
+++ b/tests/gtests/internals/test_sdpa.cpp
@@ -1807,6 +1807,52 @@ using sdpa_test_datatypes = sdpa_test_t<sdpa_dims_t_tuple>;
 
 // clang-format off
 
+INSTANTIATE_TEST_SUITE_P(ScaleTypes_f16, sdpa_test_datatypes,
+        testing::Combine(testing::Values(1), // mb
+                testing::Values(num_heads_t {2, 2}), // hd_num
+                testing::Values(seq_len_size_t {384, 384}, seq_len_size_t {1, 385}), // seq_len
+                testing::Values(head_group_size_t {128, 128, 128}), // hd_size
+                testing::Values(tensor_type_t("Q", mdt::f16)), // dt
+                testing::Values(tensor_type_t("K", mdt::f16)), // kdt
+                testing::Values(tensor_type_t("V", mdt::f16)), // vdt
+                testing::Values(quantize_type::per_token), // qtype
+                testing::Values(dnnl::memory::format_tag::abdc), // key_format_tag
+                testing::Values(mask_config_t {mask_type::no_mask}), // mask_type
+                testing::Values(scale_type::device_side,scale_type::host_side), // scale_type
+                testing::Values(accumulation_t {accumulation_mode::f32, accumulation_mode::f32}) // accumulation_mode
+                ),
+        &print_to_string2);
+INSTANTIATE_TEST_SUITE_P(ScaleTypes_bf16, sdpa_test_datatypes,
+        testing::Combine(testing::Values(1), // mb
+                testing::Values(num_heads_t {2, 2}), // hd_num
+                testing::Values(seq_len_size_t {384, 384}, seq_len_size_t {1, 385}), // seq_len
+                testing::Values(head_group_size_t {128, 128, 128}), // hd_size
+                testing::Values(tensor_type_t("Q", mdt::bf16)), // dt
+                testing::Values(tensor_type_t("K", mdt::bf16)), // kdt
+                testing::Values(tensor_type_t("V", mdt::bf16)), // vdt
+                testing::Values(quantize_type::per_token), // qtype
+                testing::Values(dnnl::memory::format_tag::abdc), // key_format_tag
+                testing::Values(mask_config_t {mask_type::no_mask}), // mask_type
+                testing::Values(scale_type::device_side,scale_type::host_side), // scale_type
+                testing::Values(accumulation_t {accumulation_mode::f32, accumulation_mode::f32}) // accumulation_mode
+                ),
+        &print_to_string2);
+INSTANTIATE_TEST_SUITE_P(ScaleTypes_f32, sdpa_test_datatypes,
+        testing::Combine(testing::Values(1), // mb
+                testing::Values(num_heads_t {2, 2}), // hd_num
+                testing::Values(seq_len_size_t {384, 384}, seq_len_size_t {1, 385}), // seq_len
+                testing::Values(head_group_size_t {128, 128, 128}), // hd_size
+                testing::Values(tensor_type_t("Q", mdt::f32)), // dt
+                testing::Values(tensor_type_t("K", mdt::f32)), // kdt
+                testing::Values(tensor_type_t("V", mdt::f32)), // vdt
+                testing::Values(quantize_type::per_token), // qtype
+                testing::Values(dnnl::memory::format_tag::abdc), // key_format_tag
+                testing::Values(mask_config_t {mask_type::no_mask}), // mask_type
+                testing::Values(scale_type::device_side,scale_type::host_side), // scale_type
+                testing::Values(accumulation_t {accumulation_mode::f32, accumulation_mode::f32}) // accumulation_mode
+                ),
+        &print_to_string2);
+
 INSTANTIATE_TEST_SUITE_P(DataTypes_f16_s8, sdpa_test_datatypes,
         testing::Combine(testing::Values(1), // mb
                 testing::Values(num_heads_t {2, 2}), // hd_num


### PR DESCRIPTION
PR implements host-side (and device-side) scalar support in SDPA primitive.
Addresses https://jira.devtools.intel.com/browse/MFDNN-13611 
based on https://github.com/uxlfoundation/oneDNN/pull/3506
