### PR TITLE
gpu: intel: extend ref ocl gemm to support host zero points

### DIFF
--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -284,6 +284,8 @@ bool pd_t::zp_ok() {
                        && dy_quant_enabled_)
                     || wei_decomp_);
 
+    if (attr_zps.has_host_scalars()) return false;
+
     if (!a_zps.has_default_values()) {
         // Groups determine supported masks.
         if (!a_zps.has_default_groups()) {
@@ -362,6 +364,8 @@ bool pd_t::scales_ok() {
     const auto &scales = attr()->scales_;
     int ndims = desc()->a_desc.ndims;
     using namespace data_type;
+
+    if (scales.has_host_scalars()) return false;
 
     for (auto s : {DNNL_ARG_A, DNNL_ARG_B, DNNL_ARG_C}) {
         if (scales.has_default_values(s)) continue;

--- a/src/gpu/intel/gemm/ref.cl
+++ b/src/gpu/intel/gemm/ref.cl
@@ -36,7 +36,22 @@ __kernel void ref_gemm(__global A_DATA_T *a, __global B_DATA_T *b,
         int transb, long MB, long M, long N, long K, long stride_a_mb,
         long stride_b_mb, long stride_c, long lda, long ldb, long ldc,
         float eltwise_alpha, float eltwise_beta, float eltwise_scale,
-        int bias_mask, __global int *ao, __global int *bo, __global int *c0,
+        int bias_mask,
+#if WITH_HOST_WEI_ZP
+        int ao_value,
+#else
+        __global int *ao,
+#endif
+#if WITH_HOST_SRC_ZP
+        int bo_value,
+#else
+        __global int *bo,
+#endif
+#if WITH_HOST_DST_ZP
+        int c0_value,
+#else
+        __global int *c0,
+#endif
         int c0_mask, float beta) {
 
 // See note in src/gpu/intel/gemm/primitive.hpp wrt args swap
@@ -50,6 +65,16 @@ __kernel void ref_gemm(__global A_DATA_T *a, __global B_DATA_T *b,
 #define ATTR_B0 bo[0]
 #else
 #define ATTR_B0 0
+#endif
+
+#if WITH_HOST_SRC_ZP
+    int *bo = &bo_value;
+#endif
+#if WITH_HOST_WEI_ZP
+    int *ao = &ao_value;
+#endif
+#if WITH_HOST_DST_ZP
+    int *c0 = &c0_value;
 #endif
 
     long n = get_global_id(0);

--- a/src/gpu/intel/gemm/ref.hpp
+++ b/src/gpu/intel/gemm/ref.hpp
@@ -63,6 +63,9 @@ struct ref_jit_params_t : public trivially_serializable_t<ref_jit_params_t> {
         kernel_ctx.define_int("WITH_SRC_ZPOINTS", with_src_zpoints);
         kernel_ctx.define_int("WITH_WEI_ZPOINTS", with_wei_zpoints);
         kernel_ctx.define_int("WITH_DST_ZPOINTS", with_dst_zpoints);
+        kernel_ctx.define_int("WITH_HOST_SRC_ZP", with_host_src_zp);
+        kernel_ctx.define_int("WITH_HOST_WEI_ZP", with_host_wei_zp);
+        kernel_ctx.define_int("WITH_HOST_DST_ZP", with_host_dst_zp);
 
         return kernel_ctx;
     };
@@ -77,9 +80,12 @@ struct ref_jit_params_t : public trivially_serializable_t<ref_jit_params_t> {
     bool with_src_zpoints = {};
     bool with_wei_zpoints = {};
     bool with_dst_zpoints = {};
+    bool with_host_src_zp = {};
+    bool with_host_wei_zp = {};
+    bool with_host_dst_zp = {};
     // NOTE: Padding required for trivial serialization alignment.
     // When adding bool fields, might need to adjust padding.
-    uint8_t pad[3] = {};
+    // uint8_t pad[0] = {};
     int eltwise_alg = {};
 };
 
@@ -188,6 +194,9 @@ struct ref_t : public primitive_t {
             conf.with_src_zpoints = attr_info.with_src_zpoints;
             conf.with_wei_zpoints = attr_info.with_wei_zpoints;
             conf.with_dst_zpoints = attr_info.with_dst_zpoints;
+            conf.with_host_src_zp = attr_info.with_host_src_zp;
+            conf.with_host_wei_zp = attr_info.with_host_wei_zp;
+            conf.with_host_dst_zp = attr_info.with_host_dst_zp;
             conf.eltwise_alg = attr_info.eltwise_alg;
 
             return status::success;

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -43,6 +43,10 @@ status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
     VDISPATCH_GEMM(attr()->has_default_values(attr_skip_mask),
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_GEMM(!utils::one_of(d->c_type(), u4, s4), VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_GEMM(!attr()->scales_.has_host_scalars(),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VDISPATCH_GEMM(!attr()->zero_points_.has_host_scalars(),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     const primitive_attr_t *attributes_with_po = attr();
     for (int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -53,10 +53,6 @@ struct gemm_t : public primitive_t {
             gemm_attr.scales_ = attr()->scales_;
             gemm_attr.precomputed_reductions_ = attr()->precomputed_reductions_;
             gemm_attr.zero_points_ = attr()->zero_points_;
-            if (attr()->zero_points_.has_host_scalars()
-                    || attr()->scales_.has_host_scalars()) {
-                return status::unimplemented;
-            }
             gemm_attr.post_ops_ = attr()->post_ops_;
             VDISPATCH_MATMUL(attr()->dropout_.has_default_values(),
                     VERBOSE_UNSUPPORTED_ATTR);


### PR DESCRIPTION
... also disallow gemm w post ops impl and jit impls
continuation of [MFDNN-14148](https://jira.devtools.intel.com/browse/MFDNN-14148)
optimized impls would be covered in [MFDNN-14149](https://jira.devtools.intel.com/browse/MFDNN-14149)