### PR TITLE
[GPU] GEMM: Enable `-` alpha/beta policy in debug

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -88,6 +88,16 @@ compute::scalar_type_t gen_desc_t::scalar_type() const {
     }
 }
 
+#ifdef DNNL_DEV_MODE
+static gemmstone::Scalar stringToScalar(std::string val) {
+    using namespace gemmstone;
+    switch (val.c_str()[0]) {
+        case '-': return Scalar(Scalar::Variable);
+        default: return Scalar(std::stoi(val));
+    }
+}
+#endif
+
 status_t gen_desc_t::finalize(const char *tags) {
     // Update problem alignments to match catalog entry.
     if (!isPacked(problem_.A.layout)
@@ -148,9 +158,9 @@ status_t gen_desc_t::finalize(const char *tags) {
         ss >> strategy_.unroll[LoopN];
 
         ss >> val;
-        problem_.alpha = std::stoi(val);
+        problem_.alpha = stringToScalar(val);
         ss >> val;
-        problem_.beta = std::stoi(val);
+        problem_.beta = stringToScalar(val);
 
         ovr_strategy = ss.str().substr(ss.tellg()); // remaining string
         parseStrategy(ovr_strategy.c_str(), hw_, problem_, strategy_);


### PR DESCRIPTION
# Description

Some strategies use `variable` beta strategies: 

```
onednn_verbose,v1,info,gpu,gemm,catalog entry:E gemm SSS TNN 16 4 aB4x2 aB4x2 aB wg 2x8x4 kr kc4 cab4 ks8 nse bo bk0 sm sn kb sr dm
onednn_verbose,v1,info,gpu,gemm,kernel:gemm SSS TNN 16 4 1 - aB4x2{cc} aB4x2{cc} aB{cc/bb} cab4 ks8 wg 2x8x4 kr kc4 k32 sm sn nse di dm sr kb fm np bm16777216 bn16777216 bk16777216
```

This commit allows `-` to be provided as a policy to `GEMM_KERNEL` during debug. 

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
