### PR TITLE
xe: jit: ir: layout simplification part 1: the unconstructoring

### DIFF
--- a/src/gpu/intel/conv/jit.cpp
+++ b/src/gpu/intel/conv/jit.cpp
@@ -139,7 +139,7 @@ public:
         int max_tries = 100;
         config_t cfg;
         layout_t zp_dst;
-        if (data.zp_pd) zp_dst = layout_t(zp_md_out(data), false);
+        if (data.zp_pd) zp_dst = make_layout(*zp_md_out(data));
 
         if (primitive->cache_blob()) {
             tiler->set_cur_version(primitive->version());

--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -81,7 +81,7 @@ layout_t init_layout(memory_desc_t &user_md, const std::string &optimal_tag) {
         // the user and return unimplemented later.
         if (user != optimal) return user;
     } else {
-        user_md = optimal.to_dnnl(user_md.dims);
+        user_md = to_md(optimal, user_md);
     }
     return optimal;
 }

--- a/src/gpu/intel/conv/jit/normalization.cpp
+++ b/src/gpu/intel/conv/jit/normalization.cpp
@@ -30,8 +30,8 @@ layout_t insert_dimension(const layout_t &layout, const pvar_t &dim) {
     for (auto &b : new_blocks) {
         if (b.dim.index() >= dim.index()) b.dim = pvar_t((dim_idx_t)b.dim + 1);
     }
-    return layout_t(layout.type(), layout.ndims() + 1, layout.offset(),
-            new_blocks,
+    return layout_t(layout.type(), new_blocks, layout.offset(),
+            layout.ndims() + 1,
             /*do_normalize=*/false);
 }
 
@@ -112,7 +112,7 @@ layout_t normalize_layout(const layout_t &_layout, bool with_groups,
 std::vector<dim_t> normalize_dims(std::vector<dim_t> &dims, bool with_groups,
         dim_t groups, bool is_dw, const std::array<int, 3> &dhw_map,
         bool add_groups, bool is_wei) {
-    layout_t dummy_layout(type_t::u8(), 0, dims);
+    layout_t dummy_layout(type_t::u8(), dims);
     return normalize_layout(dummy_layout, with_groups, groups, is_dw, dhw_map,
             add_groups, is_wei)
             .dims();
@@ -166,8 +166,8 @@ void maybe_reshape_dims(dim_idx_t ndims, layout_t &layout,
         std::vector<dim_t> &dims, std::vector<dim_t> &padded_dims) {
     gpu_assert(layout.ndims() == dim_idx_t(dims.size()));
     if (layout.ndims() < ndims) {
-        layout = layout_t(layout.type(), ndims, layout.offset(),
-                layout.blocks(), /*do_normalize=*/false);
+        layout = layout_t(layout.type(), layout.blocks(), layout.offset(),
+                ndims, /*do_normalize=*/false);
         dims.resize(ndims, 1);
         padded_dims.resize(ndims, 1);
     }

--- a/src/gpu/intel/conv/jit/normalization.cpp
+++ b/src/gpu/intel/conv/jit/normalization.cpp
@@ -248,7 +248,7 @@ view_t post_op_view_mapper_t::create_view(const memory_desc_t &md) const {
     gpu_assert(cp_ndims >= 3);
     // Add groups to match ngcdhw layout.
     bool add_groups = (cp_view().vvars()[1].as<var_t>().name == "g");
-    layout_t layout(md, /*do_normalize=*/false);
+    layout_t layout = make_layout(md);
     std::vector<dim_t> dims(md.dims, md.dims + md.ndims);
     std::vector<dim_t> padded_dims(md.padded_dims, md.padded_dims + md.ndims);
     maybe_reshape_dims(prb_.ndims, layout, dims, padded_dims);

--- a/src/gpu/intel/conv/jit/normalization.cpp
+++ b/src/gpu/intel/conv/jit/normalization.cpp
@@ -79,8 +79,7 @@ layout_t split_dimension(
         seen[it->dim] = true;
     }
     std::reverse(_new_blocks.begin(), _new_blocks.end());
-    return layout_t(layout.type(), layout.ndims(), layout.offset(), _new_blocks,
-            /*do_normalize=*/false);
+    return layout.with(_new_blocks, false);
 }
 
 layout_t normalize_conv_groups(const layout_t &layout, bool with_groups,
@@ -227,7 +226,7 @@ view_t post_op_view_mapper_t::create_src_zp_view(uint32_t mask) const {
         }
         new_blk.emplace_back(b);
     }
-    dst = layout_t(dst.type(), dst.ndims(), dst.offset(), new_blk, false);
+    dst = dst.with(new_blk, false);
 
     view_t view(vars, 6);
     view.set_vdim(vars[0], 1); // mb

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -1551,8 +1551,7 @@ layout_t pad_slm_layout(
         remaining_elems /= b.block;
         if (remaining_elems == 1) past_inner_block = true;
     }
-    return layout_t(
-            layout.type(), layout.ndims(), layout.offset(), padded_blocks);
+    return layout.with(padded_blocks);
 }
 
 layout_t get_slm_layout(const fma_context_t &fma_ctx, abc_kind_t abc,
@@ -1766,7 +1765,7 @@ layout_t add_batch(const layout_t &layout) {
     for (auto &b : blocks) {
         b.dim = b.dim + 1;
     }
-    return layout_t(layout.type(), layout.ndims(), layout.offset(), blocks);
+    return layout.with(blocks);
 }
 
 bool is_dpas_src1_compatible(int simd, bool transpose, const layout_t &layout) {
@@ -2316,7 +2315,7 @@ private:
                     }
                 }
                 std::swap(a_blocks[i0], a_blocks[i1]);
-                a = layout_t(a.type(), a.ndims(), a.offset(), a_blocks);
+                a = a.with(a_blocks);
                 return plan_status_t::success;
             }
         }

--- a/src/gpu/intel/conv/jit/plan.cpp
+++ b/src/gpu/intel/conv/jit/plan.cpp
@@ -920,7 +920,7 @@ void fma_plan_t::set_split(abc_kind_t abc, int factor) {
                     fma_kind_t::dpasw)) {
         auto blocks = a_layout.blocks();
         blocks.back().block /= factor;
-        auto layout = layout_t(a_layout.type(), blocks, 0, a_layout.ndims());
+        auto layout = layout_t(a_layout.type(), blocks);
         m_blk = get_dpas_block_rcount(layout, 1);
     }
 }
@@ -1343,8 +1343,8 @@ struct fma_context_t {
             }
             auto bmnk_layout
                     = mapper.map_to_bmnk(abc, bmnks, layout).retype(type);
-            auto fma_layout = bmnk_layout.make_with_block(
-                    layout_t(type, blocks, 0, bmnks.size()));
+            auto fma_layout
+                    = bmnk_layout.make_with_block(layout_t(type, blocks));
             auto abc_layout
                     = mapper.map_from_bmnk(abc, bmnks, fma_layout, layout);
             if (cvt_f16) return abc_layout.retype(type_t::f16());
@@ -1362,8 +1362,8 @@ struct fma_context_t {
             blocks.emplace_back(hint.vec_dim_idx, vec_size);
             auto bmnks = get_bmnk_kinds(abc, /*with_batch=*/true);
             auto bmnk_layout = mapper.map_to_bmnk(abc, bmnks, ret);
-            auto fma_layout = bmnk_layout.make_with_block(
-                    layout_t(ret.type(), blocks, 0, (int)bmnks.size()));
+            auto fma_layout
+                    = bmnk_layout.make_with_block(layout_t(ret.type(), blocks));
             auto abc_layout = mapper.map_from_bmnk(abc, bmnks, fma_layout, ret);
             if (layout.type().is_x8()) {
                 gpu_assert(abc_layout.type().is_s16());
@@ -2235,7 +2235,6 @@ private:
         auto l = plan_.fma.c_prb_layout;
         int ndims = l.ndims();
         auto blocks = l.blocks();
-        l = layout_t(l.type(), blocks, l.offset(), ndims + 1);
         l = l.add_outer_block(ndims, k_tg);
         int outer = 1;
         auto rem_dims = l.dims();

--- a/src/gpu/intel/conv/jit/problem.cpp
+++ b/src/gpu/intel/conv/jit/problem.cpp
@@ -73,8 +73,8 @@ pvar_t prb_stride(const pvar_t &dim, tensor_kind_t tensor_kind) {
     auto dims = layout_dims(tensor_kind, true);
     for (auto &d : dims) {
         if (d == dim) {
-            auto str = to_string(tensor_kind) + "_";
-            return pvar_t(str + dim.str() + "_stride");
+            auto prefix = to_string(tensor_kind)[0] + std::string("_");
+            return pvar_t(prefix + dim.str() + "_s");
         }
     }
     return pvar_t();

--- a/src/gpu/intel/conv/jit/v2/bridge.hpp
+++ b/src/gpu/intel/conv/jit/v2/bridge.hpp
@@ -23,6 +23,7 @@
 #include "gpu/intel/conv/jit/v2/tensor_utils.hpp"
 #include "gpu/intel/jit/ir/core.hpp"
 #include "gpu/intel/jit/ir/tensor.hpp"
+#include "gpu/intel/jit/ir/tensor_config.hpp"
 #include "gpu/intel/jit/ir/v2/tensor.hpp"
 
 namespace dnnl {
@@ -162,7 +163,7 @@ inline jit::layout_t to_layout(const layout_tag_t &_tag,
     while (tag.ndims() > into<dim_idx_t>(md.ndims)) {
         tag.remove_dim(dim_idx::as_tag(non_spatial_ndims));
     }
-    return jit::layout_t(md, tag.str(), /*do_normalize=*/false);
+    return jit::make_layout(md, tag.str());
 }
 
 inline jit::layout_t to_layout(const layout_tag_t &_tag, const tile_t &shape) {
@@ -173,7 +174,7 @@ inline jit::layout_t to_layout(const layout_tag_t &_tag, const tile_t &shape) {
         auto d = _tag.desc().prb_dim(i);
         dims[i] = shape.at(d);
     }
-    return jit::layout_t(_tag.type(), expr_t(0), tag.str(), dims);
+    return jit::make_layout(_tag.type(), expr_t(0), tag.str(), dims);
 }
 
 inline jit::grid_info_t to_grid_info(const grid_t &grid, const tile_t &tile) {

--- a/src/gpu/intel/conv/jit/zp_plan.cpp
+++ b/src/gpu/intel/conv/jit/zp_plan.cpp
@@ -562,7 +562,7 @@ private:
         for (auto &b : blocks) {
             if (b.dim.index() == ck_idx_) b.block = 1;
         }
-        comp_layout_ = layout_t(type_t::s32(), wei_layout_.ndims(), 0, blocks);
+        comp_layout_ = layout_t(type_t::s32(), blocks, 0, wei_layout_.ndims());
         comp_layout_ = comp_layout_.make_dense();
     }
 
@@ -1170,7 +1170,7 @@ private:
                     break;
                 }
         }
-        mask_layout_ = layout_t(type_t::s32(), 0, std::vector<dim_t>(ndims, 1));
+        mask_layout_ = layout_t(type_t::s32(), std::vector<dim_t>(ndims, 1));
         for (int i = 0; i < ndims; i++) {
             auto &name = vvars[i].as<var_t>().name;
             if (utils::one_of(name, "mb", "ow", "osp", "iw") && dims[i] != 1) {

--- a/src/gpu/intel/conv/jit_v2.cpp
+++ b/src/gpu/intel/conv/jit_v2.cpp
@@ -43,7 +43,7 @@ void maybe_init_layout(
     // The user layout should be set to a plain layout for consistency with
     // other layers.
     auto layout = to_layout(_tag, md, remove_a_dim);
-    md = layout.to_dnnl(md.dims);
+    md = to_md(layout, md);
 }
 
 status_t init_default_layouts(pd_t *pd) {

--- a/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
+++ b/src/gpu/intel/gemm/jit/generator_dsl/builder.cpp
@@ -96,12 +96,11 @@ struct transform_t {
 
         switch (normalized) {
             case kind_t::none:
-                return layout_t(
-                        type, 0, {{col_var, col, 1}, {row_var, row, col}});
+                return layout_t(type, {{col_var, col, 1}, {row_var, row, col}});
 
             case kind_t::block: {
                 int col_outer = (int)(col / col_inner);
-                return layout_t(type, 0,
+                return layout_t(type,
                         {{col_var, col_inner, 1}, {row_var, row, col_inner},
                                 {col_var, col_outer, row * col_inner}});
             }
@@ -110,7 +109,7 @@ struct transform_t {
                 int row_inner = 4 / t;
                 int row_outer = (int)(row / row_inner);
                 int col_outer = (int)(col / col_inner);
-                return layout_t(type, 0,
+                return layout_t(type,
                         {{row_var, row_inner, 1},
                                 {col_var, col_inner, row_inner},
                                 {row_var, row_outer, col_inner * row_inner},

--- a/src/gpu/intel/jit/codegen/reduce.hpp
+++ b/src/gpu/intel/jit/codegen/reduce.hpp
@@ -134,7 +134,7 @@ private:
             if (a0.block == 2) {
                 auto a_blocks = a.blocks();
                 a_blocks.erase(a_blocks.begin());
-                a = layout_t(a.type(), a.ndims(), 0, a_blocks);
+                a = a.with(a_blocks);
                 return find_1d_tile(std::move(a), std::move(b));
             }
             return tile_t(std::vector<dim_t>(b.ndims(), 1));

--- a/src/gpu/intel/jit/codegen/reorder.cpp
+++ b/src/gpu/intel/jit/codegen/reorder.cpp
@@ -362,7 +362,7 @@ void reorder_2d_impl_t::generate_all_layouts_impl(
         std::vector<layout_t> &layouts, std::vector<layout_block_t> &blocks,
         const type_t &type, dim_t a, dim_t b, dim_t stride) {
     if (a == 1 && b == 1) {
-        layouts.emplace_back(type, 2, 0, blocks);
+        layouts.emplace_back(type, blocks, 0, 2);
         return;
     }
     bool iterate_a = true;
@@ -668,7 +668,7 @@ layout_t reorder_impl_t::make_compact_layout(
             eb.second.stride = eb.second.stride * stride / inner_stride;
             new_blocks[eb.first] = eb.second;
         }
-        return {type, layout.ndims(), 0, new_blocks, /*do_normalize=*/false};
+        return {type, new_blocks, 0, layout.ndims(), /*do_normalize=*/false};
     }(dense_output_stride);
     auto dense_size = dense.elems() * type.size() / type.packing()
             * dense_output_stride;
@@ -694,7 +694,7 @@ layout_t reorder_impl_t::make_compact_layout(
         dense_output_stride = blocks.back().stride * block.block;
         dense_input_stride = input_stride * block.block;
     }
-    return {type, layout.ndims(), 0, blocks, /*do_normalize=*/false};
+    return {type, blocks, 0, layout.ndims(), /*do_normalize=*/false};
 }
 
 void reorder_impl_t::emit_1d(copy_plan_t &plan, const reorder_operand_t &dst,

--- a/src/gpu/intel/jit/codegen/reorder.cpp
+++ b/src/gpu/intel/jit/codegen/reorder.cpp
@@ -362,7 +362,7 @@ void reorder_2d_impl_t::generate_all_layouts_impl(
         std::vector<layout_t> &layouts, std::vector<layout_block_t> &blocks,
         const type_t &type, dim_t a, dim_t b, dim_t stride) {
     if (a == 1 && b == 1) {
-        layouts.emplace_back(type, blocks, 0, 2);
+        layouts.emplace_back(type, blocks);
         return;
     }
     bool iterate_a = true;

--- a/src/gpu/intel/jit/ir/epilogue.cpp
+++ b/src/gpu/intel/jit/ir/epilogue.cpp
@@ -130,7 +130,7 @@ public:
                 gpu_assert(type.is_f32()) << "Expected f32: " << mem_buf();
                 reg_buf_ = mem_buf();
                 reg_layout_ = layout_t(
-                        type, 0, std::vector<dim_t>(mem_view().nvdims(), 1));
+                        type, std::vector<dim_t>(mem_view().nvdims(), 1));
             }
         }
     }

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -90,8 +90,8 @@ layout_t dpas_t::a_layout() const {
     int m_blk = exec_size;
     int inner_blk = 4 / src1_type.size();
     int outer_blk = sdepth;
-    std::vector<std::pair<pvar_t, dim_t>> blocks
-            = {{1, outer_blk}, {0, m_blk}, {1, inner_blk}};
+    std::vector<layout_block_t> blocks
+            = {{1, inner_blk}, {0, m_blk}, {1, outer_blk}};
     return layout_t(src1_type, 0, 2, blocks);
 }
 
@@ -102,14 +102,14 @@ layout_t dpas_t::b_layout() const {
     int k_blk = sdepth * 4 / src2_type.size();
     std::vector<dim_t> blocks = {n_blk, k_blk};
     auto tmp = layout_t(src2_type, 0, blocks);
-    return tmp.transpose();
+    return tmp.transpose({0, 1});
 }
 
 layout_t dpas_t::c_layout() const {
     int m_blk = exec_size;
     int n_blk = rcount;
     std::vector<dim_t> dims = {n_blk, m_blk};
-    return layout_t(dst_type, 0, dims).transpose();
+    return layout_t(dst_type, 0, dims).transpose({0, 1});
 }
 
 bool dpas_t::matches(const multiply_desc_t &desc) const {

--- a/src/gpu/intel/jit/ir/fma.cpp
+++ b/src/gpu/intel/jit/ir/fma.cpp
@@ -92,7 +92,7 @@ layout_t dpas_t::a_layout() const {
     int outer_blk = sdepth;
     std::vector<layout_block_t> blocks
             = {{1, inner_blk}, {0, m_blk}, {1, outer_blk}};
-    return layout_t(src1_type, 0, 2, blocks);
+    return layout_t(src1_type, blocks);
 }
 
 layout_t dpas_t::b_layout() const {
@@ -100,16 +100,15 @@ layout_t dpas_t::b_layout() const {
 
     int n_blk = rcount;
     int k_blk = sdepth * 4 / src2_type.size();
-    std::vector<dim_t> blocks = {n_blk, k_blk};
-    auto tmp = layout_t(src2_type, 0, blocks);
-    return tmp.transpose({0, 1});
+    std::vector<layout_block_t> blocks = {{0, k_blk}, {1, n_blk}};
+    return layout_t(src2_type, blocks);
 }
 
 layout_t dpas_t::c_layout() const {
     int m_blk = exec_size;
     int n_blk = rcount;
-    std::vector<dim_t> dims = {n_blk, m_blk};
-    return layout_t(dst_type, 0, dims).transpose({0, 1});
+    std::vector<layout_block_t> blocks = {{0, m_blk}, {1, n_blk}};
+    return layout_t(dst_type, blocks);
 }
 
 bool dpas_t::matches(const multiply_desc_t &desc) const {

--- a/src/gpu/intel/jit/ir/gemm_schedule.cpp
+++ b/src/gpu/intel/jit/ir/gemm_schedule.cpp
@@ -44,7 +44,7 @@ layout_t bmnk_mapper_t::map_to_bmnk(abc_kind_t abc_kind,
         }
         if (!found) gpu_error_not_expected() << "MNK dimension not found.";
     }
-    return layout_t(layout.type(), int(bmnk_kinds.size()), 0, blocks);
+    return layout_t(layout.type(), blocks, 0, int(bmnk_kinds.size()));
 }
 
 layout_t bmnk_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
@@ -105,7 +105,7 @@ layout_t bmnk_block_mapper_t::map_from_bmnk(abc_kind_t abc_kind,
     }
 
     return layout_t(
-            bmnk_layout.type(), bmnk_mapper_.ndims(abc_kind), 0, blocks);
+            bmnk_layout.type(), blocks, 0, bmnk_mapper_.ndims(abc_kind));
 }
 
 bool bmnk_block_mapper_t::pop_block(std::vector<layout_block_t> &bmnk_blocks,

--- a/src/gpu/intel/jit/ir/message.cpp
+++ b/src/gpu/intel/jit/ir/message.cpp
@@ -355,7 +355,7 @@ private:
 
         std::vector<dim_t> sub_dims
                 = {(dim_t)size * type().packing() / type().size()};
-        layout_t sub_layout(type(), 0, sub_dims);
+        layout_t sub_layout(type(), sub_dims);
         mask_tensor_t sub_mask_tensor(sub_layout);
         int beg = (cur_off_ + off) * type().packing() / type().size();
         int end = (cur_off_ + off + size) * type().packing() / type().size();
@@ -663,7 +663,7 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
     tile[b0.dim] = count * width;
     tile[b1.dim] = height;
 
-    reg_layout_ = layout_t(type_factor == 1 ? mem_type_ : send_type, 0,
+    reg_layout_ = layout_t(type_factor == 1 ? mem_type_ : send_type,
             std::vector<dim_t>(vlayout.ndims(), 1));
     int h_inner = vnni ? 4 / send_type.size() : 1;
     int h_outer = ir_utils::safe_divide(height, h_inner);
@@ -684,8 +684,8 @@ bool access_builder_t::try_build_2d(send_params_t &send_params) {
 
     if (type_factor != 1) {
         auto blocks = reg_layout_.blocks();
-        reg_layout_ = layout_t(
-                mem_type_, 0, std::vector<dim_t>(vlayout.ndims(), 1));
+        reg_layout_
+                = layout_t(mem_type_, std::vector<dim_t>(vlayout.ndims(), 1));
         reg_layout_ = reg_layout_.add_outer_block(b0.dim, type_factor);
         for (auto &b : blocks)
             reg_layout_ = reg_layout_.add_outer_block(b.dim, b.block);

--- a/src/gpu/intel/jit/ir/post_ops.cpp
+++ b/src/gpu/intel/jit/ir/post_ops.cpp
@@ -120,7 +120,7 @@ post_op_context_t::post_op_context_t(const primitive_attr_t &attr,
                         utils::div_up(schedule.b_view().tlayout().size(),
                                 tlayout.type().size()));
                 view.set_tlayout(tlayout);
-                layout_t scalar(zp_cfg.src_zp_type, 0,
+                layout_t scalar(zp_cfg.src_zp_type,
                         std::vector<dim_t>(view.vvars().size(), 1), false);
                 auto zp = add_input_tensor(view_t(scalar, view.vvars()), buf);
                 auto in = add_input_tensor(view, wei);

--- a/src/gpu/intel/jit/ir/post_ops.hpp
+++ b/src/gpu/intel/jit/ir/post_ops.hpp
@@ -247,7 +247,7 @@ public:
                 bound_check_mask |= (1 << i);
             }
         }
-        return view_t(layout_t(type, 0, rhs_dims, /*do_normalize=*/false),
+        return view_t(layout_t(type, rhs_dims, /*do_normalize=*/false),
                 cp_view_.vvars(), bound_check_mask);
     }
 

--- a/src/gpu/intel/jit/ir/reduce.cpp
+++ b/src/gpu/intel/jit/ir/reduce.cpp
@@ -56,7 +56,7 @@ stmt_t create_reduce_stmt(const layout_t &src, const layout_t &dst,
             b.dim = dst2src[b.dim];
 
         // Create final layout.
-        dst_aligned = layout_t(dst.type(), ndims, dst.offset(), dst_blocks);
+        dst_aligned = layout_t(dst.type(), dst_blocks, dst.offset(), ndims);
     } else {
         dst_aligned = dst;
     }

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -97,7 +97,7 @@ protected:
             return false;
 
         front.stride = 4 * type.packing() / (front.block * type.size());
-        layout = {layout.type(), layout.ndims(), layout.offset(), blocks};
+        layout = layout.with(blocks);
         return true;
     }
 

--- a/src/gpu/intel/jit/ir/send_plan.cpp
+++ b/src/gpu/intel/jit/ir/send_plan.cpp
@@ -784,7 +784,7 @@ struct send_2d_params_t {
     }
 
     layout_t reg_layout(int grf_size, int ndims, const type_t &mem_type) const {
-        layout_t l(type, 0, std::vector<dim_t>(ndims, 1));
+        layout_t l(type, std::vector<dim_t>(ndims, 1));
         dim_t cur_stride = 1;
         enum class pad_kind_t {
             none,
@@ -2556,9 +2556,10 @@ send_group_t init_block(const view_info_t &info, view_iterator_t &it,
     ret.pad_bytes = info.hw().grf_size();
     auto &vlayout = info.vlayout();
     auto &blocks = vlayout.blocks();
-    reg_layout = layout_t(vlayout.type(), vlayout.ndims(), 0,
+    reg_layout = layout_t(vlayout.type(),
             std::vector<layout_block_t>(
-                    blocks.begin(), blocks.begin() + info.outer_idx()));
+                    blocks.begin(), blocks.begin() + info.outer_idx()),
+            0, vlayout.ndims());
     return ret;
 }
 
@@ -2600,9 +2601,10 @@ send_group_t init_scattered(const view_info_t &info,
     }
     ret.addr_inc = std::move(addr_base);
     ret.mask_inc = std::move(mask_base);
-    reg_layout = layout_t(vlayout.type(), vlayout.ndims(), 0,
+    reg_layout = layout_t(vlayout.type(),
             std::vector<layout_block_t>(
-                    blocks.begin(), blocks.begin() + info.outer_idx()));
+                    blocks.begin(), blocks.begin() + info.outer_idx()),
+            0, vlayout.ndims());
     reg_layout = reg_layout.make_dense();
     if (slot_stride != slot_size) {
         if (slot_size * type_packing == type_size) {

--- a/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
+++ b/src/gpu/intel/jit/ir/slm_reduce_builder.cpp
@@ -55,8 +55,8 @@ void slm_reduce_builder_t::build() {
 
     // Create SLM layout to store all intermediate buffers from the thread
     // group.
-    layout_t slm_layout(reg_layout_.type(), ndims + tg_ndims_,
-            reg_layout_.offset(), reg_layout_.blocks());
+    layout_t slm_layout(reg_layout_.type(), reg_layout_.blocks(),
+            reg_layout_.offset(), ndims + tg_ndims_);
     for (int i = tg_ndims_ - 1; i >= 0; i--) {
         slm_layout = slm_layout.add_outer_block(ndims + i, tg_grid_.dim(i));
     }

--- a/src/gpu/intel/jit/ir/tensor.cpp
+++ b/src/gpu/intel/jit/ir/tensor.cpp
@@ -129,8 +129,8 @@ layout_t layout_t::sub(const tile_t &tile, const coord_t &start) const {
         mapped_blocks.emplace_back(b.dim, block, b.stride);
     }
 
-    return layout_t(type(), ndims_, start.is_empty() ? 0 : operator()(start),
-            mapped_blocks);
+    return layout_t(type(), mapped_blocks,
+            start.is_empty() ? 0 : operator()(start), ndims_);
 }
 
 layout_t layout_t::reinterpret(
@@ -190,7 +190,8 @@ layout_t layout_t::reinterpret(
         }
     }
 
-    return layout_t(new_type, ndims(), new_offset, new_blocks, do_normalize);
+    return layout_t(
+            new_type, new_blocks, new_offset, ndims(false), do_normalize);
 }
 
 layout_t layout_t::split_block(const std::pair<int, layout_block_t> &eb,
@@ -211,8 +212,7 @@ layout_t layout_t::split_block(const std::pair<int, layout_block_t> &eb,
 
     new_blocks.insert(new_blocks.begin() + block_idx + 1, b1);
 
-    return layout_t(
-            type(), ndims_, offset(), new_blocks, /*do_normalize=*/false);
+    return with(new_blocks, false);
 }
 
 layout_t layout_t::split_into_multi_blocks(
@@ -249,7 +249,7 @@ layout_t layout_t::split_into_multi_blocks(
 tile_t layout_t::split_into_max_tile(
         dim_t max_tile_elems, bool is_dense_tile) const {
     stride_t dense_stride = 1;
-    tile_t tile;
+    std::vector<dim_t> tile_dims(ndims(), 1);
     dim_t cur_elems = 1;
     for (auto &eb : enumerated_blocks()) {
         auto &b = eb.second;
@@ -261,7 +261,7 @@ tile_t layout_t::split_into_max_tile(
                 dense_stride = b.block * b.stride;
             }
             cur_elems *= b.block;
-            tile[b.dim] *= b.block;
+            tile_dims[b.dim] *= b.block;
             continue;
         }
         dim_t max_block = utils::max_div(b.block, max_tile_elems / cur_elems);
@@ -269,7 +269,7 @@ tile_t layout_t::split_into_max_tile(
         auto tmp_layout = split_block(eb, max_block, b.block / max_block);
         return tmp_layout.split_into_max_tile(max_tile_elems, is_dense_tile);
     }
-    return tile;
+    return tile_t(tile_dims);
 }
 
 void layout_t::align_layouts(layout_t &a, layout_t &b) {
@@ -467,12 +467,12 @@ layout_t view_t::create_pseudo_vlayout(
         gpu_assert(rem_vdims[d] == 1) << "Can't create pseudo-layout.";
     }
 
-    layout_t ret(tlayout.type(), nvdims(), 0, blocks);
+    layout_t ret(tlayout.type(), blocks, 0, nvdims());
     if (!init_offset) return ret;
 
     auto targs = cvt_vargs_to_targs();
     auto off = tlayout.offset(targs);
-    return layout_t(tlayout.type(), nvdims(), off, blocks);
+    return layout_t(tlayout.type(), blocks, off, nvdims());
 }
 
 layout_t dim_assignment_t::map(const layout_t &layout) const {
@@ -486,7 +486,7 @@ layout_t dim_assignment_t::map(const layout_t &layout) const {
     }
     new_blocks = normalize_blocks(new_blocks,
             /*remove_size_1_blocks=*/false);
-    auto ret = layout_t(layout.type(), new_ndims(), layout.offset(), new_blocks,
+    auto ret = layout_t(layout.type(), new_blocks, layout.offset(), new_ndims(),
             /*do_normalize=*/false);
     gpu_assert(layout.elems() == ret.elems())
             << "Assignment doesn't preserve number of elements.";

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -662,12 +662,11 @@ public:
 
     layout_t make_with_block(const layout_t &inner) const {
         gpu_assert(type() == inner.type());
-        gpu_assert(ndims() == inner.ndims());
         auto cur_tile = tile();
         tile_t rem_tile;
         for (auto &d : cur_tile)
             rem_tile[d] = ir_utils::safe_divide(cur_tile.at(d), inner.elems(d));
-        auto ret = inner;
+        auto ret = with(inner.blocks_);
         for (auto &b : blocks()) {
             auto &d = cur_tile[b.dim];
             auto &r = rem_tile[b.dim];
@@ -709,9 +708,13 @@ public:
             }
         }
         gpu_assert(stride >= elems());
-        if (with_ndims()) gpu_assert(dim.index() < ndims());
         auto new_blocks = blocks();
         new_blocks.emplace_back(dim, block, stride);
+        auto ret = with(new_blocks);
+        if (ret.with_ndims()) {
+            if (dim.index() == ret.ndims_) ret.ndims_++;
+            gpu_assert(dim.index() < ret.ndims());
+        }
         return with(new_blocks);
     }
 

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -551,22 +551,7 @@ public:
         return is_outermost(eb, blocks_);
     }
 
-    bool is_plain() const {
-        pvar_map_t<bool> seen;
-        for (auto &b : blocks_) {
-            if (seen.has(b.dim)) return false;
-            seen[b.dim] = true;
-        }
-        return true;
-    }
-
     bool has_zero_offset() const { return offset_.is_equal(expr_t(0)); }
-
-    bool has_unknown_strides() const {
-        for (auto &b : blocks_)
-            if (b.stride.is_unknown()) return true;
-        return false;
-    }
 
     // Returns a canonical representation of the layout:
     // - Size one blocks are removed

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -270,25 +270,6 @@ public:
             const std::vector<dim_t> &dims = {}, bool do_normalize = true);
 
     layout_t(const type_t &type, const expr_t &offset,
-            const std::string &format, const std::vector<dim_t> &dims = {},
-            bool do_normalize = true)
-        : layout_t(type, offset, into<dim_idx_t>(dims.size()),
-                parse_format(format, into<dim_idx_t>(dims.size())), dims,
-                do_normalize) {}
-
-    layout_t(const memory_desc_wrapper &mdw, const std::string &format,
-            bool do_normalize = true)
-        : layout_t(to_ir(mdw.data_type()), mdw.offset0(), format,
-                std::vector<dim_t>(mdw.dims(), mdw.dims() + mdw.ndims()),
-                do_normalize) {}
-
-    layout_t(const memory_desc_wrapper &mdw, const char *format,
-            bool do_normalize = true)
-        : layout_t(mdw, std::string(format), do_normalize) {}
-
-    layout_t(const memory_desc_wrapper &mdw, bool do_normalize = true);
-
-    layout_t(const type_t &type, const expr_t &offset,
             const std::vector<dim_t> &dims, bool do_normalize = true)
         : type_(type), ndims_(into<dim_idx_t>(dims.size())), offset_(offset) {
         dim_t stride = 1;
@@ -536,8 +517,6 @@ public:
     }
 
     IR_DEFINE_DUMP()
-
-    memory_desc_t to_dnnl(const dim_t *dims_hint) const;
 
     // Returns a vector of <block index, block> pairs.
     // The innermost block (first) has index 0.
@@ -1026,14 +1005,6 @@ public:
     }
 
 private:
-    // Returns vector of <dimension index, block size> pairs.
-    static std::vector<std::pair<pvar_t, dim_t>> parse_format(
-            const std::string &format, int ndims_hint);
-
-    // Returns vector of <dimension letter, block size> pairs.
-    static std::vector<std::pair<char, dim_t>> parse_letter_blocks(
-            const std::string &format);
-
     void sanity_check() const;
 
     // Data type of the layout.
@@ -1048,6 +1019,8 @@ private:
     // Blocks ordered from innermost to outermost.
     std::vector<layout_block_t> blocks_;
 };
+
+memory_desc_t to_md(const layout_t &layout, const memory_desc_t &md_hint);
 
 // Helper class to incrementally increase a sub-layout of the given layout.
 // One step - adding the minimal factor of the next remaining block. Used

--- a/src/gpu/intel/jit/ir/tensor_config.cpp
+++ b/src/gpu/intel/jit/ir/tensor_config.cpp
@@ -112,7 +112,7 @@ std::vector<std::pair<char, dim_t>> parse_letter_blocks(
     return ret;
 }
 
-std::vector<std::pair<pvar_t, dim_t>> parse_format(
+std::vector<layout_block_t> parse_format(
         const std::string &format, int ndims_hint) {
     bool seen_letters[DNNL_MAX_NDIMS] = {};
     int letter_ndims = 0;
@@ -130,16 +130,16 @@ std::vector<std::pair<pvar_t, dim_t>> parse_format(
 
     auto letter_blocks = parse_letter_blocks(format);
 
-    std::vector<std::pair<pvar_t, dim_t>> parts;
-    for (auto &p : letter_blocks) {
-        char letter = p.first;
-        dim_t block = p.second;
+    std::vector<layout_block_t> parts;
+    for (int i = into<int>(letter_blocks.size() - 1); i >= 0; i--) {
+        char letter = letter_blocks[i].first;
+        dim_t block = letter_blocks[i].second;
         if (letter != 'x') {
             int dim_idx = std::tolower(letter) - 'a';
             parts.emplace_back(dim_idx, block);
         } else {
             gpu_assert(ndims_hint >= letter_ndims);
-            for (int i = letter_ndims; i < ndims_hint; i++) {
+            for (int i = ndims_hint - 1; i >= letter_ndims; i--) {
                 parts.emplace_back(i, 0);
             }
         }

--- a/src/gpu/intel/jit/ir/tensor_config.cpp
+++ b/src/gpu/intel/jit/ir/tensor_config.cpp
@@ -27,13 +27,13 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
         const memory_desc_t &dst_md, dim_t ic, dim_t oc,
         tensor_config_t &tensor_cfg) {
     if (!attr.rounding_mode_.has_default_values()) {
-        layout_t sround_seed_layout(type_t::u32(), 0, std::vector<dim_t> {1});
+        layout_t sround_seed_layout(type_t::u32(), std::vector<dim_t> {1});
         tensor_cfg.add_tensor("sround_seed", DNNL_ARG_ATTR_ROUNDING_SEED,
                 /*is_input=*/true, /*is_output=*/false, sround_seed_layout);
     }
     auto add_zp_buffer = [&](const std::string &name, type_t type, int arg_id,
                                  dim_t size) {
-        layout_t zp_layout(type, 0, std::vector<dim_t> {size});
+        layout_t zp_layout(type, std::vector<dim_t> {size});
         tensor_cfg.add_tensor(name, DNNL_ARG_ATTR_ZERO_POINTS | arg_id,
                 /*is_input=*/true, /*is_output=*/false, zp_layout);
     };
@@ -61,7 +61,7 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
         int arg = scale_args[i].second;
         if (attr.scales_.has_default_values(arg)) continue;
         std::vector<dim_t> dims = {(attr.scales_.get_mask(arg) == 0) ? 1 : oc};
-        layout_t layout(type_t::f32(), 0, dims);
+        layout_t layout(type_t::f32(), dims);
         int arg_key = DNNL_ARG_ATTR_SCALES | arg;
         tensor_cfg.add_tensor(scale_args[i].first, arg_key, /*is_input=*/true,
                 /*is_output=*/false, layout);
@@ -79,7 +79,7 @@ void init_extra_tensors(const zero_points_config_t &zp_cfg,
                     /*is_input=*/true,
                     /*is_output=*/false, layout);
         } else if (po.is_prelu()) {
-            layout_t layout(type_t::f32(), 0,
+            layout_t layout(type_t::f32(),
                     get_prelu_weights_dims(po.prelu.mask, dst_md));
             int arg_key = DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_WEIGHTS;
             tensor_cfg.add_tensor("prelu_rhs_" + std::to_string(i), arg_key,

--- a/src/gpu/intel/jit/ir/tensor_config.hpp
+++ b/src/gpu/intel/jit/ir/tensor_config.hpp
@@ -112,7 +112,7 @@ private:
 };
 
 // Returns vector of <dimension index, block size> pairs.
-std::vector<std::pair<pvar_t, dim_t>> parse_format(
+std::vector<layout_block_t> parse_format(
         const std::string &format, int ndims_hint);
 
 // Returns vector of <dimension letter, block size> pairs.
@@ -121,8 +121,14 @@ std::vector<std::pair<char, dim_t>> parse_letter_blocks(
 
 inline layout_t make_layout(const type_t &type, const expr_t &offset,
         const std::string &format, const std::vector<dim_t> &dims = {}) {
-    return layout_t(type, offset, into<dim_idx_t>(dims.size()),
-            parse_format(format, into<dim_idx_t>(dims.size())), dims,
+    auto blocks = parse_format(format, into<dim_idx_t>(dims.size()));
+    tile_t def;
+    for (auto &b : blocks) {
+        if (b.block == 0) b.block = utils::div_up(dims[b.dim], def[b.dim]);
+        def[b.dim] *= b.block;
+    }
+
+    return layout_t(type, dims.size(), offset, blocks,
             /*do_normalize=*/false);
 }
 

--- a/src/gpu/intel/jit/ir/tensor_config.hpp
+++ b/src/gpu/intel/jit/ir/tensor_config.hpp
@@ -128,7 +128,7 @@ inline layout_t make_layout(const type_t &type, const expr_t &offset,
         def[b.dim] *= b.block;
     }
 
-    return layout_t(type, dims.size(), offset, blocks,
+    return layout_t(type, blocks, offset, into<dim_idx_t>(dims.size()),
             /*do_normalize=*/false);
 }
 
@@ -152,7 +152,7 @@ inline layout_t make_layout(
         blocks.emplace_back(block.dim_idx, block.block, block.stride);
     }
 
-    return layout_t(to_ir(mdw.data_type()), mdw.ndims(), mdw.offset0(), blocks,
+    return layout_t(to_ir(mdw.data_type()), blocks, mdw.offset0(), mdw.ndims(),
             do_normalize);
 }
 

--- a/src/gpu/intel/jit/ir/v2/bridge.hpp
+++ b/src/gpu/intel/jit/ir/v2/bridge.hpp
@@ -78,7 +78,7 @@ inline jit::layout_t to_ir(const layout_t &layout) {
     }
 
     return jit::layout_t(
-            layout.type(), layout.desc().ndims(), layout.base(), blocks);
+            layout.type(), blocks, layout.base(), layout.desc().ndims());
 }
 
 } // namespace v2

--- a/src/gpu/intel/pool/jit.cpp
+++ b/src/gpu/intel/pool/jit.cpp
@@ -80,8 +80,8 @@ status_t gen_fwd_t::pd_t::init(impl::engine_t *engine) {
                               arch >= compute::gpu_arch_t::xe_hpc),
             VERBOSE_UNSUPPORTED_DT_CFG);
 
-    src = std::make_shared<layout_t>(invariant_src_md());
-    dst = std::make_shared<layout_t>(invariant_dst_md());
+    src = std::make_shared<layout_t>(make_layout(*invariant_src_md()));
+    dst = std::make_shared<layout_t>(make_layout(*invariant_dst_md()));
     VDISPATCH_POOLING(src->ndims() == dst->ndims(), VERBOSE_INCONSISTENT_NDIMS,
             "src->ndims()", "dst_ndims()");
 

--- a/src/gpu/intel/pool/jit/ir_builder.cpp
+++ b/src/gpu/intel/pool/jit/ir_builder.cpp
@@ -28,7 +28,7 @@
 #include "gpu/intel/jit/ir/ir.hpp"
 #include "gpu/intel/jit/ir/message.hpp"
 #include "gpu/intel/jit/ir/post_ops.hpp"
-#include "gpu/intel/jit/ir/tensor.hpp"
+#include "gpu/intel/jit/ir/tensor_config.hpp"
 #include "gpu/intel/jit/pass/pass.hpp"
 #include "gpu/intel/jit/utils/trace.hpp"
 
@@ -53,7 +53,7 @@ public:
     view_t create_view(const memory_desc_t &md) const override {
         dim_idx_t cp_ndims = cp_view().nvdims();
         gpu_assert(cp_ndims >= 3);
-        layout_t layout(md, /*do_normalize=*/false);
+        layout_t layout = make_layout(md);
         std::vector<dim_t> dims(md.dims, md.dims + md.ndims);
         std::vector<dim_t> pad_dims(md.padded_dims, md.padded_dims + md.ndims);
         maybe_reshape_dims(ndims_, layout, dims, pad_dims);

--- a/src/gpu/intel/pool/jit/ir_builder.cpp
+++ b/src/gpu/intel/pool/jit/ir_builder.cpp
@@ -80,15 +80,15 @@ private:
             std::vector<dim_t> &dims, std::vector<dim_t> &padded_dims) {
         gpu_assert(layout.ndims() == dims.size());
         if (layout.ndims() < ndims) {
-            layout = layout_t(layout.type(), ndims, layout.offset(),
-                    layout.blocks(), /*do_normalize=*/false);
+            layout = layout_t(layout.type(), layout.blocks(), layout.offset(),
+                    ndims, /*do_normalize=*/false);
             dims.resize(ndims, 1);
             padded_dims.resize(ndims, 1);
         }
     }
 
     static std::vector<dim_t> dims_to_3d(const std::vector<dim_t> &dims) {
-        layout_t dummy_layout(type_t::u8(), 0, dims);
+        layout_t dummy_layout(type_t::u8(), dims);
         return spatials_to_3d(dummy_layout, false, {0, 1, 2}).dims();
     }
 

--- a/src/gpu/intel/reorder/jit.cpp
+++ b/src/gpu/intel/reorder/jit.cpp
@@ -104,8 +104,8 @@ status_t gen_t::pd_t::init(impl::engine_t *engine, impl::engine_t *src_engine,
             VERBOSE_INCONSISTENT_MDS, "src", "dst");
     int ndims = src_mdw.ndims();
 
-    layout_t src_layout {src_mdw, /*do_normalize=*/false};
-    layout_t dst_layout {dst_mdw, /*do_normalize=*/false};
+    layout_t src_layout = make_layout(*src_md());
+    layout_t dst_layout = make_layout(*dst_md());
 
     VDISPATCH_REORDER(!(src_layout.elems() == 0 || dst_layout.elems() == 0),
             VERBOSE_EMPTY_TENSOR, "src_layout || dst_layout");

--- a/src/gpu/intel/reorder/jit/normalization.cpp
+++ b/src/gpu/intel/reorder/jit/normalization.cpp
@@ -146,7 +146,7 @@ struct layout_normalization_t {
     }
 
     layout_t layout() const {
-        return {type_, ndims_, offset_, blocks_, /*do_normalize=*/false};
+        return {type_, blocks_, offset_, ndims_, /*do_normalize=*/false};
     }
 
     iterator_t begin() const {

--- a/src/gpu/intel/reorder/jit/tiler.cpp
+++ b/src/gpu/intel/reorder/jit/tiler.cpp
@@ -165,7 +165,7 @@ std::vector<tile_t> tiles(const hw_t &hw, layout_t a, layout_t b) {
             }
             padded_blocks.push_back(b);
         }
-        l = {l.type(), l.ndims(), 0, padded_blocks, /*do_normalize=*/false};
+        l = l.with(padded_blocks, false);
     };
     pad_layout(a);
     pad_layout(b);


### PR DESCRIPTION
This PR largely focuses on removing `layout_t` constructors to enable simpler usage.