### PR TITLE
cpu: gemm_x8s8s32x_conv: fix post_op application

### DIFF
--- a/.github/automation/aarch64/skipped-tests.sh
+++ b/.github/automation/aarch64/skipped-tests.sh
@@ -34,7 +34,4 @@ fi
 # Nightly failures
 SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_fusions_cpu"
 
-# c7g failures. TODO: scope these to c7g only. Better yet, fix them.
-SKIPPED_TEST_FAILURES+="|test_benchdnn_modeC_graph_int8_cpu"
-
 printf "${SKIPPED_TEST_FAILURES}"

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2017-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -307,7 +308,7 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
                 balance211(N * jcp.oc, nthr, ithr, _start, _end);
 
                 (*pp_ker_)(dst, acc, bia_base, scales, dst_scales[0], sum_scale,
-                        1.f / wei_adj_scale, g, _start, _end, zp,
+                        1.f / wei_adj_scale, g, n, _start, _end, zp,
                         post_ops_binary_rhs_arg_vec, dst_base, ctx,
                         *pd()->dst_md(), chunk_desc);
             });

--- a/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2025 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,7 +37,7 @@ struct pp_ker_t {
 
     virtual void operator()(void *dst, const acc_data_t *acc, const char *bias,
             const float *scales, float dst_scale, float sum_scale,
-            float signed_scale, int g, size_t start, size_t end,
+            float signed_scale, int g, int mb, size_t start, size_t end,
             const zero_point_call_params_t &zp,
             const void *post_ops_binary_rhs_arg_vec, const void *dst_orig,
             const exec_ctx_t &ctx, const memory_desc_t &dst_md,


### PR DESCRIPTION
# Description
Fixed an issue where minibatch was not used when calculating the offset
used by the `ref_post_ops kernel` for binary post-ops.

Also added a check for supported post-op `POLICY`/`MASK` values in
`gemm_x8s8s32x_convolution_utils::post_ops_ok()`

Fixes: #3803

# Checklist

## General


- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?