### PR TITLE
cpu: rv64: nchw_pooling: fix: de-templatization

### DIFF
--- a/src/cpu/cpu_pooling_list.cpp
+++ b/src/cpu/cpu_pooling_list.cpp
@@ -34,7 +34,7 @@ using namespace dnnl::impl::cpu::aarch64;
 #include "cpu/aarch64/acl_pooling.hpp"
 #endif // DNNL_AARCH64_USE_ACL
 #elif DNNL_RV64
-#if DNNL_RISCV_USE_RVV_INTRINSICS
+#if defined(DNNL_RISCV_USE_RVV_INTRINSICS)
 #include "cpu/rv64/rvv_nchw_pooling.hpp"
 using namespace dnnl::impl::cpu::rv64;
 #endif // DNNL_RISCV_USE_RVV_INTRINSICS
@@ -66,7 +66,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64(jit_uni_pooling_fwd_t<sve_512, f32>)
             CPU_INSTANCE_AARCH64(jit_uni_pooling_fwd_t<sve_256, f32>)
             CPU_INSTANCE_AARCH64_ACL(acl_pooling_fwd_t)
-            CPU_INSTANCE_RV64GCV(riscv_nchw_pooling_fwd_t<f32>)
+            CPU_INSTANCE_RV64GCV(riscv_nchw_pooling_fwd_t)
             CPU_INSTANCE(nchw_pooling_fwd_t<bf16>)
             CPU_INSTANCE(nchw_pooling_fwd_t<f32>)
             CPU_INSTANCE(nchw_pooling_fwd_t<f16>)

--- a/src/cpu/rv64/rvv_nchw_pooling.cpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.cpp
@@ -263,15 +263,13 @@ void AvgPoolingExcludePadding(const float *src, float *dst, const dim_t batch,
 }
 } // namespace
 
-template <data_type_t d_type>
-riscv_nchw_pooling_fwd_t<d_type>::riscv_nchw_pooling_fwd_t(const pd_t *apd)
+riscv_nchw_pooling_fwd_t::riscv_nchw_pooling_fwd_t(const pd_t *apd)
     : primitive_t(apd) {}
 
-template <>
-status_t riscv_nchw_pooling_fwd_t<data_type::f32>::execute_forward(
+status_t riscv_nchw_pooling_fwd_t::execute_forward(
         const exec_ctx_t &ctx) const {
-    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
 
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper dst_d(pd()->dst_md());
@@ -318,8 +316,6 @@ status_t riscv_nchw_pooling_fwd_t<data_type::f32>::execute_forward(
 
     return status::success;
 }
-
-template struct riscv_nchw_pooling_fwd_t<data_type::f32>;
 
 } // namespace rv64
 } // namespace cpu


### PR DESCRIPTION
# Description

This PR fixes the templatization issue by:

- Removing template arguments
- Adding data type checking for proper dispatching

All other features remain unchanged.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

We test the changes using the RISC-V GNU toolchain(14.2) and verify the functionality under the QEMU RISCV64 emulator with cmd:

```
ONEDNN_VERBOSE=1 ./benchdnn --pool --dt=f32 --dir=FWD_I --batch=inputs/pool/set_all
```

All tests passed with proper dispatching confirmed. Calls to the implemented `rvv_nchw_pooling` can be traced by searching for `RISCV64GCV` in:

- [test_pool_ci_rvv.log](https://github.com/user-attachments/files/22354164/test_pool_ci_rvv.log)

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [N/A] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
