### PR TITLE
revert: cpu: aarch64: "support arbitrary eltwise post-ops..." 

### DIFF
--- a/src/cpu/aarch64/acl_post_ops.cpp
+++ b/src/cpu/aarch64/acl_post_ops.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022-2025 Arm Ltd. and affiliates
+* Copyright 2022-2024 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,11 +53,40 @@ status_t acl_post_ops_t::execute(
         } else if (post_op->kind() == primitive_kind::eltwise) {
             // The post op at the sum index must be binary
             if (post_op_index == sum_index) return status::runtime_error;
-            exec_args_t eltwise_args;
-            eltwise_args[DNNL_ARG_DST] = ctx.args().at(DNNL_ARG_DST);
-            eltwise_args[DNNL_ARG_SRC] = ctx.args().at(DNNL_ARG_DST);
-            exec_ctx_t eltwise_ctx(ctx, std::move(eltwise_args));
-            CHECK(post_op->execute(eltwise_ctx));
+
+            auto eltwise_post_op
+                    = dynamic_cast<acl_eltwise_fwd_t *>(post_op.get());
+            if (eltwise_post_op == nullptr) return status::runtime_error;
+
+            if (dst_data_type == data_type::f16) {
+                // in this case we want to cast the src tensor up to fp32
+                arm_compute::TensorInfo src_info
+                        = eltwise_post_op->pd()->aep.data_info;
+                // new src tensor with fp32 datatype
+                arm_compute::Tensor src_tensor;
+                src_tensor.allocator()->init(src_info);
+                src_tensor.allocator()->allocate();
+                float *src_f32 = (float *)src_tensor.buffer();
+                // total_size gives the size in bytes, we divide by 4 because the src_tensor is fp32
+                size_t num_elements = src_tensor.info()->total_size() / 4;
+                // cast src up to fp32 and store the result in src_f32
+                cvt_float16_to_float(
+                        src_f32, (dnnl::impl::float16_t *)src, num_elements);
+                // perform the operation in fp32
+                status_t eltwise_status = eltwise_post_op->execute_forward(
+                        ctx, src_f32, src_f32);
+                if (eltwise_status == status::success) {
+                    // cast src_f32 down and store final result in src
+                    cvt_float_to_float16((dnnl::impl::float16_t *)src, src_f32,
+                            num_elements);
+                }
+                src_tensor.allocator()->free();
+                CHECK(eltwise_status);
+
+            } else {
+                CHECK(eltwise_post_op->execute_forward(ctx, src, src));
+            }
+
         } else {
             return status::runtime_error;
         }


### PR DESCRIPTION
# Description
This reverts commit 0abc32b19a9d7f48f3f76b097798a0ae7e968ffb.
Reverts #3767

Causes a segfault in lowp matmul:

```sh
$ ONEDNN_VERBOSE=profile_exec ./build/tests/benchdnn/benchdnn --graph --mode=R --in-shapes=0:16x256+1:256x1+2:1x1 --case=pattern/int8/int8_matmul_logistic_fusion.json
onednn_verbose,v1,info,oneDNN v3.10.0 (commit 216a37ebdc4efea56b2d8ca598980aa12bc8539e)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:1
onednn_verbose,v1,info,cpu,isa:AArch64 SVE (256 bits)
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:a::f0 dst:f32::blocked:a::f0,,,1,0.00219727
zsh: segmentation fault (core dumped)  ONEDNN_VERBOSE=profile_exec ./build/tests/benchdnn/benchdnn --graph --mode=R 
```

# Checklist

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?