### PR TITLE
benchdnn: introduce implementation summary option support

### DIFF
--- a/src/cpu/x64/jit_uni_ncsp_convolution.hpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.hpp
@@ -76,7 +76,7 @@ struct jit_uni_ncsp_convolution_fwd_t : public primitive_t {
         status_t init_matmul(engine_t *engine);
         reduction_helper_t reduction_helper_;
         bool is_matmul_ = false;
-        std::string name_ = "jit_uni_ncsp_convolution:";
+        std::string name_ = "jit_uni_ncsp:";
         void init_name() {
             std::string suffix = is_matmul_ ? "matmul" : "conv";
             name_ += suffix + "+";
@@ -130,7 +130,7 @@ struct jit_uni_ncsp_convolution_bwd_weights_t : public primitive_t {
         std::string name_;
         void init_scratchpad();
         void init_name() {
-            name_ = "jit_uni_ncsp_convolution:conv+";
+            name_ = "jit_uni_ncsp:conv+";
             name_.append(nspc_conv_pd_->name());
         }
     };
@@ -182,7 +182,7 @@ struct jit_uni_ncsp_convolution_bwd_data_t : public primitive_t {
         void init_scratchpad();
         void init_name() {
             std::string suffix = is_matmul_ ? "matmul" : "conv";
-            name_ = "jit_uni_ncsp_convolution:" + suffix + "+";
+            name_ = "jit_uni_ncsp:" + suffix + "+";
             name_.append(is_matmul_ ? matmul_diff_src_pd_->name()
                                     : nspc_conv_pd_->name());
         }

--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -24,6 +24,7 @@
 #include "dnnl_common.hpp"
 #include "dnnl_memory.hpp"
 #include "utils/parser.hpp"
+#include "utils/summary.hpp"
 
 #include "binary/binary.hpp"
 #include "bnorm/bnorm.hpp"
@@ -58,7 +59,6 @@ bool canonical {false};
 bool mem_check {true};
 std::string skip_impl;
 stat_t benchdnn_stat {0};
-summary_t summary {};
 std::string driver_name;
 
 double max_ms_per_prb {default_max_ms_per_prb};
@@ -160,6 +160,10 @@ int main(int argc, char **argv) {
 
     total_time.stamp();
 
+    print_impl_names_summary();
+    print_impl_names_csv_summary();
+
+    // Failed cases summary.
     if (has_bench_mode_bit(mode_bit_t::corr) && summary.failed_cases
             && !benchdnn_stat.failed_cases.empty()) {
         printf("===========================================================\n");

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -179,6 +179,10 @@ void parse_result(res_t &res, const char *pstr) {
         // Only summary time is populated to the highest level report.
         bs.ms[t_name][bt::mode_t::sum] += t.sec(bt::mode_t::sum);
     }
+
+    // Append an impl name into the total stats.
+    // Skipped cases don't count.
+    if (!res.impl_name.empty()) bs.impl_names[res.impl_name]++;
 }
 
 /* misc */

--- a/tests/benchdnn/common.hpp
+++ b/tests/benchdnn/common.hpp
@@ -144,6 +144,8 @@ struct stat_t {
     std::unordered_map<std::string, double[timer::timer_t::mode_t::n_modes]> ms;
     // Key is the number of the test, value is the repro string.
     std::map<int, std::string> failed_cases;
+    // Key is an impl_name, value is the number of cases.
+    std::map<std::string, size_t> impl_names;
 };
 extern stat_t benchdnn_stat;
 
@@ -207,14 +209,6 @@ void print_dhw(bool &print_d, bool &print_h, bool &print_w, int ndims,
 
 int benchdnn_getenv_int(const char *name, int default_value);
 std::string benchdnn_getenv_string(const char *name);
-
-// Responsible for printing service information.
-struct summary_t {
-    // Prints up to 10 failed cases reproducers at the end of the run.
-    bool failed_cases = true;
-};
-
-extern summary_t summary;
 
 std::string smart_bytes(double bytes);
 #endif

--- a/tests/benchdnn/doc/knob_summary.md
+++ b/tests/benchdnn/doc/knob_summary.md
@@ -1,5 +1,16 @@
 # Summary information
 
+## Introduction
+Benchdnn is designed to operate with batch files, and while some of them can be
+small, some of them might be really large. While benchdnn provides tools to get
+information from a single test case, it might be challenging to acquire the
+interested data from the whole batch file, e.g., when running the benchmark
+manually, the screen buffer may not fit the whole output and the data is simply
+lost if not redirected to the file.
+
+This is where the summary options come in handy to provide the batch level
+statistics.
+
 ## Usage
 ```
     --summary=[no-]SETTING1[+[no-]SETTING2...]
@@ -7,30 +18,31 @@
 
 The `--summary` knob is a global state of benchdnn and provides the summary
 statistics at the end of the run. Different options are separated with `+`
-delimiter. To negate the effect of the option, use the "no-" prefix in front of
-the option value.
+delimiter. To negate the effect of the particular summary option, use the "no-"
+prefix in front of the option value.
 
 If the same setting is specified multiple times, only the latter value is
 considered.
 
 ## Failed cases summary
 
-### Introduction
-A batch file can contain a large number of test cases. Running the batch file
-may result in the data in the beginning of the list getting lost due to the
-short session screen buffer. Even if the buffer fits all the test cases in it,
-to find the specific failed or unimplemented cases in the middle of the output
-usually requires additional steps such as copying the whole screen buffer to a
-memory buffer, collecting the data in a file, and using the search functionality
-to scan through the file.
-
-The `failures` knob can improve usability in such scenarios.
-
 ### Usage
 ```
     --summary=[no-]failures
 ```
 
-By default, you can see the summary with up to ten failed cases.
+This knob provides a list of failures up to ten entries starting from the
+beginning of the run to help to identify problematic cases during the run
+without necessity to process the whole output manually. Enabled by default.
 
-To disable the summary output, use the "no-failures" input value.
+## Implementations summary
+
+### Usage
+```
+    --summary=[no-]impl
+    --summary=[no-]impl-csv
+```
+
+This knob provides a list of implementation names and the number of hits used
+for problems. A table view is enabled by default, and CSV-style output is
+disabled by default.

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -21,6 +21,7 @@
 #include "utils/fill.hpp"
 #include "utils/parser.hpp"
 #include "utils/stream_kind.hpp"
+#include "utils/summary.hpp"
 
 #include "dnnl_common.hpp"
 
@@ -496,6 +497,10 @@ summary_t parse_summary_str(const std::string &s) {
         auto option = parser::get_substr(subs, subs_pos, '\0');
         if (option == "failures") {
             v.failed_cases = !negate_option;
+        } else if (option == "impl") {
+            v.impl_names = !negate_option;
+        } else if (option == "impl-csv") {
+            v.impl_names_csv = !negate_option;
         } else {
             BENCHDNN_PRINT(0,
                     "Error: unsupported option-value combination "

--- a/tests/benchdnn/utils/summary.cpp
+++ b/tests/benchdnn/utils/summary.cpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "utils/summary.hpp"
+#include "common.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <string>
+
+summary_t summary {};
+
+// Prints the statistics summary over implementations used in the run in a
+// table.
+void print_impl_names_summary() {
+    if (!summary.impl_names) return;
+
+    // If there is no content in the table, just exit.
+    if (benchdnn_stat.impl_names.empty()) return;
+
+    std::string footer_text(
+            "= Implementation statistics (--summary=no-impl to disable) ");
+    // +1 for closing `=`.
+    const size_t footer_size = footer_text.size() + 1;
+
+    const auto swap_pair = [](const std::pair<std::string, size_t> &p) {
+        return std::pair<size_t, std::string>(p.second, p.first);
+    };
+
+    const auto swap_map = [swap_pair](const std::map<std::string, size_t> &m) {
+        std::multimap<size_t, std::string, std::greater<size_t>> sm;
+        std::transform(
+                m.begin(), m.end(), std::inserter(sm, sm.begin()), swap_pair);
+        return sm;
+    };
+
+    // Reverse original map's key-value pairs to sort by the number of hits.
+    std::multimap<size_t, std::string, std::greater<size_t>> swapped_map
+            = swap_map(benchdnn_stat.impl_names);
+
+    // Collect the biggest sizes across entries to properly pad for a nice view.
+    size_t longest_impl_length = 0;
+    size_t longest_count_length = 0;
+    size_t total_cases = 0;
+    for (const auto &impl_entry : swapped_map) {
+        longest_impl_length
+                = std::max(impl_entry.second.size(), longest_impl_length);
+        longest_count_length = std::max(
+                std::to_string(impl_entry.first).size(), longest_count_length);
+        total_cases += impl_entry.first;
+    }
+
+    // `extra_symbols` covers final string chars not covered by other variables,
+    // e.g., between entry's key and value, and entry borders `| ` and ` |`
+    constexpr size_t extra_symbols = 7;
+    // The largest percent format is ` (xxx%)`.
+    constexpr size_t largest_percent_length = 7;
+    // Must match `entry_length` from the loop below.
+    size_t longest_entry_length = std::max(footer_size,
+            longest_impl_length + longest_count_length + largest_percent_length
+                    + extra_symbols);
+
+    // Print the footer. Adjusted if content strings are larger.
+    std::string footer(longest_entry_length, '=');
+    std::string footer_text_pad(
+            std::max(longest_entry_length, footer_size) - footer_size, ' ');
+    printf("%s\n", footer.c_str());
+    printf("%s%s=\n", footer_text.c_str(), footer_text_pad.c_str());
+    printf("%s\n", footer.c_str());
+
+    // Print the table content.
+    // TODO: short terminal windows have the output skewed. There's a way to get
+    // the window width:
+    // ```
+    //     struct winsize w;
+    //     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == -1) { return 80; }
+    //     return static_cast<size_t>(w.ws_col);
+    // ```
+    // This size brings a hard limit on a printed line and the idea is to
+    // shorten the impl name string and end it with `~` or `...` instead of
+    // reporting the full name to fit a single line.
+    for (const auto &impl_entry : swapped_map) {
+        size_t percent = static_cast<size_t>(
+                std::round(100.f * impl_entry.first / total_cases));
+        std::string percent_str = " (" + std::to_string(percent) + "%)";
+
+        // Pad to the left of impl based on the longest impl name.
+        size_t left_pad_length = longest_impl_length - impl_entry.second.size();
+        std::string left_pad(left_pad_length, ' ');
+
+        // Get the entry length to properly pad it from left and right.
+        // Must be computed with same members as `longest_entry_length`.
+        size_t entry_length = /* impl_name = */ impl_entry.second.size() +
+                /* count_length = */ std::to_string(impl_entry.first).size() +
+                /* percent_length = */ percent_str.size() +
+                /* extra_symbols = */ extra_symbols;
+
+        // Pad to the right of numbers based on largest count.
+        size_t right_pad_length
+                = longest_entry_length - entry_length - left_pad_length;
+        std::string right_pad(right_pad_length, ' ');
+
+        printf("| %s%s : %zu%s%s |\n", left_pad.c_str(),
+                impl_entry.second.c_str(), impl_entry.first,
+                percent_str.c_str(), right_pad.c_str());
+    }
+    printf("%s\n", footer.c_str());
+}
+
+// Prints the statistics summary over implementations used in the run in CSV
+// format.
+void print_impl_names_csv_summary() {
+    if (!summary.impl_names_csv) return;
+
+    // If there is no content in the table, just exit.
+    if (benchdnn_stat.impl_names.empty()) return;
+
+    const auto swap_pair = [](const std::pair<std::string, size_t> &p) {
+        return std::pair<size_t, std::string>(p.second, p.first);
+    };
+
+    const auto swap_map = [swap_pair](const std::map<std::string, size_t> &m) {
+        std::multimap<size_t, std::string, std::greater<size_t>> sm;
+        std::transform(
+                m.begin(), m.end(), std::inserter(sm, sm.begin()), swap_pair);
+        return sm;
+    };
+
+    // Reverse original map's key-value pairs to sort by the number of hits.
+    std::multimap<size_t, std::string, std::greater<size_t>> swapped_map
+            = swap_map(benchdnn_stat.impl_names);
+
+    // Print the string content.
+    printf("benchdnn_summary,impl_names");
+    for (const auto &impl_entry : swapped_map) {
+        printf(",%s:%zu", impl_entry.second.c_str(), impl_entry.first);
+    }
+    printf("\n");
+}

--- a/tests/benchdnn/utils/summary.hpp
+++ b/tests/benchdnn/utils/summary.hpp
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright 2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef UTILS_SUMMARY_HPP
+#define UTILS_SUMMARY_HPP
+
+// Responsible for printing service information.
+struct summary_t {
+    // Prints up to 10 failed cases reproducers at the end of the run.
+    bool failed_cases = true;
+    // Prints statistics about implementations used over the run.
+    // CSV may be added on top of a table for mass search from distributed
+    // automated systems.
+    bool impl_names = true;
+    bool impl_names_csv = false;
+};
+
+extern summary_t summary;
+
+void print_impl_names_summary();
+void print_impl_names_csv_summary();
+
+#endif


### PR DESCRIPTION
A new summary option providing the statistics of implementations used over the selected batch, enabled by default.
Designed to help to validate dispatching (that a new version doesn't make optimized version called less times than it should).
It's also helpful to understand the status quo in automated validation.

Feature preview:
<img width="1265" height="704" alt="image" src="https://github.com/user-attachments/assets/01c2d647-397c-465e-a82e-0af09ebe41be" />
