### PR TITLE
graph: support f32 host scalar and use it in the gqa example

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -59,6 +59,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
     });
     pass_pipeline_t pipeline = pass_pipeline_t(vis);
     BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    BACKEND_DNNL_ADD_PASS(pipeline, insert_host_scalar);
     BACKEND_DNNL_ADD_PASS(pipeline, fuse_reshape_for_gqa);
     // Fusion and canonicalization passes begin
     if (quantized) {

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -4387,7 +4387,7 @@ status_t fuse_sdpa(std::shared_ptr<subgraph_t> &sg) {
                 default: valid_pattern = false;
             }
 
-            if (!valid_pattern) break;
+            if (!valid_pattern) return status::unimplemented;
 
             auto out_val = walker->get_output_value(0);
             if (out_val->get_consumers().size() != 1) break;

--- a/src/graph/backend/dnnl/subgraph.cpp
+++ b/src/graph/backend/dnnl/subgraph.cpp
@@ -154,6 +154,7 @@ std::string property2str(property_type_t ptype) {
         case property_type::undef: str = "undef"; break;
         case property_type::variable: str = "variable"; break;
         case property_type::constant: str = "constant"; break;
+        case property_type::host_scalar: str = "host_scalar"; break;
         default: break;
     }
     return str;

--- a/src/graph/interface/logical_tensor.cpp
+++ b/src/graph/interface/logical_tensor.cpp
@@ -20,7 +20,13 @@
 #include "graph/interface/logical_tensor.hpp"
 #include "graph/interface/partition_hashing.hpp"
 
+#include "common/verbose.hpp"
+
 using namespace dnnl::impl::graph;
+
+#define VCHECK_LOGICAL_TENSOR(cond, stat, msg, ...) \
+    VCONDCHECK(graph, create, check, logical_tensor, (cond), stat, msg, \
+            ##__VA_ARGS__)
 
 size_t logical_tensor_wrapper_t::size() const {
     if (is_strided()) {
@@ -191,10 +197,12 @@ status_t DNNL_API dnnl_graph_logical_tensor_init(
 
     // currently only supports s32 and f32 host scalar.
     if (ptype == property_type::host_scalar) {
-        if (!utils::one_of(dtype, data_type::s32, data_type::f32)
-                || ndims != 0) {
-            return status::invalid_arguments;
-        }
+        VCHECK_LOGICAL_TENSOR(ndims == 0, status::invalid_arguments,
+                "host scalar tensor should have zero ndims");
+        VCHECK_LOGICAL_TENSOR(
+                utils::one_of(dtype, data_type::s32, data_type::f32),
+                status::invalid_arguments,
+                "host scalar tensor should have s32 or f32 dtype");
     }
 
     auto val = logical_tensor_t();
@@ -227,10 +235,12 @@ status_t DNNL_API dnnl_graph_logical_tensor_init_with_dims(
 
     // currently only supports s32 and f32 host scalar.
     if (ptype == property_type::host_scalar) {
-        if (!utils::one_of(dtype, data_type::s32, data_type::f32)
-                || ndims != 0) {
-            return status::invalid_arguments;
-        }
+        VCHECK_LOGICAL_TENSOR(ndims == 0, status::invalid_arguments,
+                "host scalar tensor should have zero ndims");
+        VCHECK_LOGICAL_TENSOR(
+                utils::one_of(dtype, data_type::s32, data_type::f32),
+                status::invalid_arguments,
+                "host scalar tensor should have s32 or f32 dtype");
     }
 
     auto val = logical_tensor_t();
@@ -277,10 +287,12 @@ status_t DNNL_API dnnl_graph_logical_tensor_init_with_strides(
 
     // currently only supports s32 and f32 host scalar.
     if (ptype == property_type::host_scalar) {
-        if (!utils::one_of(dtype, data_type::s32, data_type::f32)
-                || ndims != 0) {
-            return status::invalid_arguments;
-        }
+        VCHECK_LOGICAL_TENSOR(ndims == 0, status::invalid_arguments,
+                "host scalar tensor should have zero ndims");
+        VCHECK_LOGICAL_TENSOR(
+                utils::one_of(dtype, data_type::s32, data_type::f32),
+                status::invalid_arguments,
+                "host scalar tensor should have s32 or f32 dtype");
     }
 
     auto val = logical_tensor_t();

--- a/src/graph/interface/logical_tensor.cpp
+++ b/src/graph/interface/logical_tensor.cpp
@@ -189,9 +189,12 @@ status_t DNNL_API dnnl_graph_logical_tensor_init(
         return status::invalid_arguments;
     }
 
-    // currently only supports s32 host scalar.
-    if (ptype == property_type::host_scalar && dtype != data_type::s32) {
-        return status::invalid_arguments;
+    // currently only supports s32 and f32 host scalar.
+    if (ptype == property_type::host_scalar) {
+        if (!utils::one_of(dtype, data_type::s32, data_type::f32)
+                || ndims != 0) {
+            return status::invalid_arguments;
+        }
     }
 
     auto val = logical_tensor_t();
@@ -222,9 +225,12 @@ status_t DNNL_API dnnl_graph_logical_tensor_init_with_dims(
         property_type_t ptype) {
     if (!logical_tensor || ndims < 0) return status::invalid_arguments;
 
-    // currently only supports s32 host scalar.
-    if (ptype == property_type::host_scalar && dtype != data_type::s32) {
-        return status::invalid_arguments;
+    // currently only supports s32 and f32 host scalar.
+    if (ptype == property_type::host_scalar) {
+        if (!utils::one_of(dtype, data_type::s32, data_type::f32)
+                || ndims != 0) {
+            return status::invalid_arguments;
+        }
     }
 
     auto val = logical_tensor_t();
@@ -269,9 +275,12 @@ status_t DNNL_API dnnl_graph_logical_tensor_init_with_strides(
         property_type_t ptype) {
     if (!logical_tensor || ndims < 0) return status::invalid_arguments;
 
-    // currently only supports s32 host scalar.
-    if (ptype == property_type::host_scalar && dtype != data_type::s32) {
-        return status::invalid_arguments;
+    // currently only supports s32 and f32 host scalar.
+    if (ptype == property_type::host_scalar) {
+        if (!utils::one_of(dtype, data_type::s32, data_type::f32)
+                || ndims != 0) {
+            return status::invalid_arguments;
+        }
     }
 
     auto val = logical_tensor_t();

--- a/src/graph/interface/tensor.cpp
+++ b/src/graph/interface/tensor.cpp
@@ -125,6 +125,9 @@ dnnl_graph_tensor::dnnl_graph_tensor(
         if (lt.data_type == data_type::s32) {
             scalar_.s32_value = *static_cast<int32_t *>(handle);
             handle_.reset(&scalar_.s32_value, dummy_destructor);
+        } else if (lt.data_type == data_type::f32) {
+            scalar_.f32_value = *static_cast<float *>(handle);
+            handle_.reset(&scalar_.f32_value, dummy_destructor);
         } else {
             assertm(false, "Unsupported data type for host scalar");
         }

--- a/src/graph/interface/tensor.hpp
+++ b/src/graph/interface/tensor.hpp
@@ -63,6 +63,7 @@ private:
         // this field is valid when logical tensor's
         // property is host_scalar
         int32_t s32_value = 0;
+        float f32_value;
         // TODO: add more dtype support
     } scalar_;
 };


### PR DESCRIPTION
- Support f32 host scalar in logical tensor and tensor. Previously only s32 was supported and used to pass sequence length.
- Updated the existing GQA example to define attention scale as a host scalar.