### PR TITLE
cpu: ppc64: enable build without MMA

### DIFF
--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -40,12 +40,23 @@ if((DNNL_TARGET_ARCH STREQUAL "X64") OR (DNNL_TARGET_ARCH STREQUAL "AARCH64"))
 endif()
 
 if(DNNL_TARGET_ARCH STREQUAL "PPC64")
-    file(GLOB FILES_REQUIRED_OPT
-        ${CMAKE_CURRENT_SOURCE_DIR}/gemm/*.[ch]pp
-    )
-    if(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
-        set_source_files_properties(${FILES_REQUIRED_OPT}
-            PROPERTIES COMPILE_FLAGS "-O3 -funroll-loops")
+    include(CheckSourceCompiles)
+
+    check_source_compiles(C [[
+      #if !defined(__MMA__)
+      #  error "MMA not available"
+      #endif
+      int main(void) { return 0; }
+    ]] DNNL_PPC64_HAS_MMA)
+    if(DNNL_PPC64_HAS_MMA)
+        add_definitions_with_host_compiler(-DDNNL_PPC64_HAS_MMA=1)
+        file(GLOB FILES_REQUIRED_OPT
+            ${CMAKE_CURRENT_SOURCE_DIR}/gemm/*.[ch]pp
+        )
+        if(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+            set_source_files_properties(${FILES_REQUIRED_OPT}
+                PROPERTIES COMPILE_FLAGS "-O3 -funroll-loops")
+        endif()
     endif()
 endif()
 
@@ -139,7 +150,9 @@ if (DNNL_TARGET_ARCH STREQUAL "AARCH64")
     add_subdirectory(aarch64)
 endif()
 if (DNNL_TARGET_ARCH STREQUAL "PPC64")
-    add_subdirectory(ppc64)
+    if(DNNL_PPC64_HAS_MMA)
+        add_subdirectory(ppc64)
+    endif()
 endif()
 if (DNNL_TARGET_ARCH STREQUAL "S390X")
     add_subdirectory(s390x)

--- a/src/cpu/reorder/cpu_reorder_regular_f32_u8.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_u8.cpp
@@ -36,7 +36,9 @@ const impl_list_map_t &regular_f32_u8_impl_list_map() {
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_blk_reorder_t))
             DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
 
+#ifdef DNNL_PPC64_HAS_MMA
 	    DNNL_PPC64_ONLY(CPU_REORDER_INSTANCE(ppc64::ppc64_matrixA_reorder_t))
+#endif
 
 	    REG_FAST_DIRECT_COPY(f32, u8)
 


### PR DESCRIPTION
# Description

Currently some accelerated code requires the MMA engine to be enabled in the compiler, which limits the supported hardware to Power10+. Add a configure check and omit the problematic code when building for older CPUs.

Fixes #3749 

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit? - I believe it doesn't cause any regression.
- [N/A] Have you formatted the code using clang-format? - No code added.

## Performance improvements

- [N/A] Have you submitted performance data that demonstrates performance improvements?

### New features

- [N/A] Have you published an RFC for the new feature?
- [N/A] Was the RFC approved?
- [N/A] Have you added relevant tests?

### Bug fixes

- [X] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [N/A] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [N/A] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [N/A] Have you added a link to the rendered document?
