### PR TITLE
xe: gemm: copy_plan: backport int4 special case

### DIFF
--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -36,7 +36,7 @@ int quant_entry_ndims(
         const quant_entry_t &entry, const memory_desc_t &qmd, int k_idx) {
     if (entry.has_default_values()) return -1;
 
-    // C unt the number of nontrivial (dim > 1) dimensions present
+    // Count the number of nontrivial (dim > 1) dimensions present
     int count = 0;
     for (int i = qmd.ndims - 2; i < qmd.ndims; ++i) {
         if (qmd.dims[i] > 1) { count++; }


### PR DESCRIPTION
# Description

Backport 4-bit reorder handling from upstream, replace `(i4-i4)->copythrough(w)->upconvert->downconvert`  conversion steps with `(i4-i4)->upconvert->downconvert`. 

Adds a shorter path for reorders that start from at least byte-strided int4 values.  

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
