### PR TITLE
cpu: aarch64: fix modernize-use-nullptr clang-tidy failures

### DIFF
--- a/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -640,7 +641,7 @@ void jit_sve_1x1_convolution_bwd_weights_t<diff_dst_type, wei_type,
     const auto scratchpad = ctx.get_scratchpad_grantor();
     auto rtus_space = pd()->rtus_.reduce_src_
             ? scratchpad.get<data_t>(key_conv_rtus_space)
-            : NULL;
+            : nullptr;
     const bool is_bias_padded
             = pd()->with_bias() && jcp.oc_without_padding % jcp.oc_block != 0;
 

--- a/src/cpu/aarch64/jit_sve_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_convolution.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -715,8 +716,8 @@ void jit_sve_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
                     }
 
                     jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src_w,
-                            diff_dst_w, wht_w, 0, ocb, 1, iwb, reduce_work,
-                            load_work);
+                            diff_dst_w, wht_w, nullptr, ocb, 1, iwb,
+                            reduce_work, load_work);
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
                 }
@@ -744,7 +745,7 @@ void jit_sve_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
         // here as call parameters to avoid execution of prefetch instructions
         // with nullptr, other parameters are not used in real jit call here
         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src, diff_dst,
-                weights, 0, 0, 0, 0, 0, 0);
+                weights, nullptr, 0, 0, 0, 0, 0);
     });
 }
 
@@ -885,8 +886,8 @@ void jit_sve_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
                         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, 0, ocb, k_len, iwb,
-                                reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
+                                k_len, iwb, reduce_work, load_work);
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -912,7 +913,7 @@ void jit_sve_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
         // here as call parameters to avoid execution of prefetch instructions
         // with nullptr, other parameters are not used in real jit call here
         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src, diff_dst,
-                weights, 0, 0, 0, 0, 0, 0);
+                weights, nullptr, 0, 0, 0, 0, 0);
     });
 }
 
@@ -1099,8 +1100,8 @@ void jit_sve_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
                         jit_sve_conv_3d_ker_pipeline(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, 0, ocb, k_len,
-                                d_len, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
+                                k_len, d_len, reduce_work, load_work);
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -1126,7 +1127,7 @@ void jit_sve_convolution_bwd_data_t<diff_dst_type, wei_type, diff_src_type,
         // here as call parameters to avoid execution of prefetch instructions
         // with nullptr, other parameters are not used in real jit call here
         jit_sve_conv_3d_ker_pipeline(jit_ker, par_conv, diff_src, diff_dst,
-                weights, 0, 0, 1, 1, 0, 0);
+                weights, nullptr, 0, 1, 1, 0, 0);
     });
 }
 
@@ -1306,8 +1307,9 @@ void jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
             jit_conv_ker_pipeline_bwd_w(jit_ker, p,
                     &ti->src[src_d.blk_off(img, ic_off_idx)],
                     &ti->diff_dst[diff_dst_d.blk_off(img, oc_off_idx)],
-                    diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b), 0,
-                    (img == ti->img_start), 0, ic_to_compute, oc_to_compute);
+                    diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
+                    nullptr, (img == ti->img_start), 0, ic_to_compute,
+                    oc_to_compute);
         }
 
         const int _oc = ti->g_start * jcp.nb_oc + ti->oc_b_start;
@@ -1329,7 +1331,7 @@ void jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
                 diff_wei
                         + wht_blk_off(diff_weights_d, ti->g_start,
                                 ti->oc_b_start, ti->ic_b_start),
-                0, 0, 0, 0, 0);
+                nullptr, 0, 0, 0, 0);
     }
 }
 


### PR DESCRIPTION
# Description

Fixes all failures of the "modernize-use-nullptr" clang-tidy check on the AArch64 path.
