### PR TITLE
cmake: enable stdlib debug mode for debug builds

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -290,6 +290,15 @@ if(MSVC)
         append(CMAKE_CCXX_FLAGS "-Wno-unknown-warning-option")
     endif()
 elseif(UNIX OR MINGW)
+
+    # Enable debug checks for common C++ standard libraries
+    if(DNNL_DEV_MODE OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # Enable debug checks for libstdc++
+        append(CMAKE_CCXX_FLAGS "-D_GLIBCXX_ASSERTIONS")
+        # Enable debug checks for libc++
+        append(CMAKE_CCXX_FLAGS "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE")
+    endif()
+
     if(DNNL_WITH_SYCL OR CMAKE_BASE_NAME STREQUAL "icx" OR CMAKE_BASE_NAME STREQUAL "icpx")
         # When using Debug build mode CMake adds "-g" option without "-O0"
         # causing the warning. This probably happens because clang/gcc compilers


### PR DESCRIPTION
In [MFDNN-14221](https://jira.devtools.intel.com/browse/MFDNN-14221), we caught a vector OOB access with the MSVC debug C++ library. This PR enables similar checks for Debug and ONEDNN_DEV_MODE builds on Linux to improved cross-platform debugging.

As an example for the aforementioned bug caught by this:
```Bash
$  ctest -R gpu-cnn-inference-f32-cpp --output-on-failure
Test project /nfs/pdx/home/rjoursle/dnnl/build
    Start 6: gpu-cnn-inference-f32-cpp
1/1 Test #6: gpu-cnn-inference-f32-cpp ........Subprocess aborted***Exception:   1.60 sec
/usr/include/c++/13/bits/stl_vector.h:1128: constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = long int; _Alloc = std::allocator<long int>; reference = long int&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   1.65 sec

The following tests FAILED:
          6 - gpu-cnn-inference-f32-cpp (Subprocess aborted)
```