### PR TITLE
xe: sdpa: add separate configs for f16 accumulate

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -53,7 +53,8 @@ std::string to_string(const config_query_t &q) {
       << ((bool)(q.prop & property::quantized) ? " quant" : "")
       << ((bool)(q.prop & property::integrated) ? " [integ]" : "")
       << ((bool)(q.prop & property::fma) ? " fma" : "")
-      << ((bool)(q.prop & property::f32) ? " [f32]" : "");
+      << ((bool)(q.prop & property::f32) ? " [f32]" : "")
+      << ((bool)(q.prop & property::f16_accumulate) ? " [f16_acc]" : "");
     return s.str();
 }
 std::string to_string(const config_criteria_t &c) {
@@ -64,7 +65,8 @@ std::string to_string(const config_criteria_t &c) {
       << ((bool)(c.prop & property::quantized) ? " quant" : "")
       << ((bool)(c.prop & property::integrated) ? " integ" : "")
       << ((bool)(c.prop & property::fma) ? " fma" : "")
-      << ((bool)(c.prop & property::f32) ? " f32" : "");
+      << ((bool)(c.prop & property::f32) ? " f32" : "")
+      << ((bool)(c.prop & property::f16_accumulate) ? " f16_acc" : "");
     return s.str();
 }
 std::string to_string(const config_t &c) {
@@ -97,6 +99,11 @@ bool operator==(const config_record_t &key, const config_query_t &query) {
                     && (((key.criteria.prop & property::f32) == property::none)
                             || ((query.prop & property::f32)
                                     == (key.criteria.prop & property::f32)))
+                    && (((key.criteria.prop & property::f16_accumulate)
+                                == property::none)
+                            || ((query.prop & property::f16_accumulate)
+                                    == (key.criteria.prop
+                                            & property::f16_accumulate)))
                     && (((key.criteria.prop & property::integrated)
                                 == property::none)
                             || ((query.prop & property::integrated)
@@ -115,6 +122,7 @@ bool operator<(const config_criteria_t &lhs, const config_criteria_t &rhs) {
         if ((int)(crit.prop & property::integrated)) { set_fields++; }
         if ((int)(crit.prop & property::fma)) { set_fields++; }
         if ((int)(crit.prop & property::f32)) { set_fields++; }
+        if ((int)(crit.prop & property::f16_accumulate)) { set_fields++; }
         return set_fields;
     };
 
@@ -123,7 +131,8 @@ bool operator<(const config_criteria_t &lhs, const config_criteria_t &rhs) {
                 || ((bool)(crit.prop & property::quantized))
                 || ((bool)(crit.prop & property::integrated))
                 || ((bool)(crit.prop & property::fma))
-                || ((bool)(crit.prop & property::f32)));
+                || ((bool)(crit.prop & property::f32))
+                || ((bool)(crit.prop & property::f16_accumulate)));
     };
 
     int l_set_fields = num_set_fields(lhs);
@@ -160,6 +169,9 @@ bool operator<(const config_criteria_t &lhs, const config_criteria_t &rhs) {
         return static_cast<bool>(lhs.prop & property::integrated);
     else if ((lhs.prop & property::f32) != (rhs.prop & property::f32))
         return static_cast<bool>(lhs.prop & property::f32);
+    else if ((lhs.prop & property::f16_accumulate)
+            != (rhs.prop & property::f16_accumulate))
+        return static_cast<bool>(lhs.prop & property::f16_accumulate);
     return false;
 }
 
@@ -172,6 +184,7 @@ static auto constexpr quantized = property::quantized;
 static auto constexpr integrated = property::integrated;
 static auto constexpr fma = property::fma;
 static auto constexpr f32 = property::f32;
+static auto constexpr f16_accumulate = property::f16_accumulate;
 
 // Kernel configurations: [ arch, head_size, {sequence length}, {properties} ] -> config
 static std::vector<config_record_t> sorted_configs = []() {
@@ -218,6 +231,7 @@ static std::vector<config_record_t> sorted_configs = []() {
 
 
         {{compute::gpu_arch_t::xe_hpg, 80, fma}, {16, 16, 16, 16, 5, 4, 5, 4}},
+        {{compute::gpu_arch_t::xe_hpg, 80, fma | f16_accumulate}, {8, 16, 16, 16, 8, 4, 8, 4}},
 
         {{compute::gpu_arch_t::xe_hpg, 128},                    {16, 16, 32, 8, 8, 4, 4, 8}},
         {{compute::gpu_arch_t::xe_hpg, 128, 32},                {16, 16, 16, 8, 16, 2, 8, 4}},
@@ -232,10 +246,11 @@ static std::vector<config_record_t> sorted_configs = []() {
         {{compute::gpu_arch_t::xe_hpg, 128,      quantized | second_token}, {16, 16, 16, 8, 16, 2, 8, 4}},
 
         {{compute::gpu_arch_t::xe_hpg, 128, fma},                {8, 16, 16, 16, 8, 4, 8, 4}},
-        {{compute::gpu_arch_t::xe_hpg, 128, 448, fma},           {8, 16, 16, 16, 8, 2, 8, 2}},
+        {{compute::gpu_arch_t::xe_hpg, 128, 448, fma},           {8, 16, 16, 16, 8, 4, 8, 4}},
+        {{compute::gpu_arch_t::xe_hpg, 128, 448, fma | f16_accumulate}, {8, 16, 16, 16, 8, 2, 8, 2}},
         {{compute::gpu_arch_t::xe_hpg, 128, fma | second_token}, {32, 16, 32, 8, 16, 2, 8, 4}},
 
-        {{compute::gpu_arch_t::xe_hpg, 128, fma | f32},                            { 8, 32,  8, 32, 32, 1, 32, 1 }},
+        {{compute::gpu_arch_t::xe_hpg, 128, fma | f32},                            { 8, 16, 16, 16,  8, 4,  8, 4 }},
         {{compute::gpu_arch_t::xe_hpg, 128, second_token | fma | f32},             { 8, 16, 32,  8, 16, 1,  8, 2 }},
         {{compute::gpu_arch_t::xe_hpg, 128, quantized | fma | f32},                { 8, 16, 16, 16,  8, 1,  8, 1 }},
         {{compute::gpu_arch_t::xe_hpg, 128, second_token | quantized | fma | f32}, {16, 16, 16,  8, 32, 1, 16, 2 }},

--- a/src/gpu/intel/sdpa/configs.hpp
+++ b/src/gpu/intel/sdpa/configs.hpp
@@ -44,6 +44,7 @@ enum class property : int {
     integrated = 0x4,
     fma = 0x8,
     f32 = 0x10,
+    f16_accumulate = 0x20,
 };
 
 property operator|(property a, property b);


### PR DESCRIPTION
# Description

F16 accumulate uses additional registers for conversion and in some cases good tile sizes for FMA with f32 accumulate will not be optimal for f16 accumulate. For example:
```sh
# f32 acc mode is faster
--mode=P --graph --engine=gpu --allow-enum-tags-only=false --dt=2:f32+5:f32 --in-shapes=0:1x16x1024x80*acbd+1:1x16x1024x80*acbd+9:1x16x1024x80*acbd --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json,2.69719,2.92919
# than f16 acc mode
--mode=P --graph --engine=gpu --allow-enum-tags-only=false --dt=2:f32+5:f32 --in-shapes=0:1x16x1024x80*acbd+1:1x16x1024x80*acbd+9:1x16x1024x80*acbd --op-attrs=3:accumulation_mode:f16+11:accumulation_mode:f16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json,2.81094,3.08006

# with proposed config f16 accumulate is faster as expected
# SDPA_CONFIG=8,16,16,16,8,4,8,4
--mode=P --graph --engine=gpu --allow-enum-tags-only=false --dt=2:f32+5:f32 --in-shapes=0:1x16x1024x80*acbd+1:1x16x1024x80*acbd+9:1x16x1024x80*acbd --op-attrs=3:accumulation_mode:f16+11:accumulation_mode:f16 --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json,2.48906,2.70803
# but config isn't applicable to f32 accumulate
--mode=P --graph --engine=gpu --allow-enum-tags-only=false --dt=2:f32+5:f32 --in-shapes=0:1x16x1024x80*acbd+1:1x16x1024x80*acbd+9:1x16x1024x80*acbd --case=complex_fusion/mha/sdpa-plain-wo-mask-f16.json,3.06865,3.36723
```

This PR adds f16 accumulate as a property for SDPA configurations.
