### PR TITLE
cpu: aarch64: fix remaining modernize-use clang-tidy failures

### DIFF
--- a/src/cpu/aarch64/acl_benchmark_scheduler.hpp
+++ b/src/cpu/aarch64/acl_benchmark_scheduler.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ class BenchmarkScheduler final : public arm_compute::IScheduler {
 public:
     BenchmarkScheduler(IScheduler &real_scheduler);
 
-    ~BenchmarkScheduler();
+    ~BenchmarkScheduler() override;
 
     void set_num_threads(unsigned int num_threads) override;
     unsigned int num_threads() const override;

--- a/src/cpu/aarch64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_containers.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,7 +35,7 @@ namespace brgemm_containers {
 
 struct brgemm_desc_container_t {
 public:
-    brgemm_desc_container_t() {}
+    brgemm_desc_container_t() = default;
     brgemm_desc_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_t *operator[](int idx) const { return refs_[idx]; }
@@ -59,7 +60,7 @@ private:
 #define BRGEMM_KERNEL_GLOBAL_STORAGE
 
 struct brgemm_kernel_container_t {
-    brgemm_kernel_container_t() {}
+    brgemm_kernel_container_t() = default;
     brgemm_kernel_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_kernel_t *operator[](int idx) const {

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -341,8 +341,8 @@ struct jit_brdgmm_kernel_base_t;
 class jit_generator;
 
 struct brgemm_kernel_t {
-    brgemm_kernel_t() {};
-    virtual ~brgemm_kernel_t() {};
+    brgemm_kernel_t() = default;
+    virtual ~brgemm_kernel_t() = default;
     virtual status_t create_kernel() = 0;
     virtual void operator()(brgemm_kernel_params_t *) const = 0;
     virtual const jit_generator *get_jit_generator() const = 0;
@@ -350,11 +350,11 @@ struct brgemm_kernel_t {
 
 struct brgemm_kernel_common_t : public brgemm_kernel_t {
     brgemm_kernel_common_t(const brgemm_t abrd);
-    ~brgemm_kernel_common_t();
+    ~brgemm_kernel_common_t() override;
 
-    status_t create_kernel();
-    void operator()(brgemm_kernel_params_t *) const;
-    virtual const jit_generator *get_jit_generator() const;
+    status_t create_kernel() override;
+    void operator()(brgemm_kernel_params_t *) const override;
+    const jit_generator *get_jit_generator() const override;
 
 private:
     jit_brgemm_kernel_t *brgemm_kernel_ = nullptr;
@@ -364,11 +364,11 @@ private:
 
 struct brdgmm_kernel_t : public brgemm_kernel_t {
     brdgmm_kernel_t(const brgemm_t abrd);
-    ~brdgmm_kernel_t();
+    ~brdgmm_kernel_t() override;
 
-    status_t create_kernel();
-    void operator()(brgemm_kernel_params_t *) const;
-    virtual const jit_generator *get_jit_generator() const;
+    status_t create_kernel() override;
+    void operator()(brgemm_kernel_params_t *) const override;
+    const jit_generator *get_jit_generator() const override;
 
 private:
     jit_brdgmm_kernel_base_t *brgemm_kernel_ = nullptr;

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
 * Copyright 2023 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,7 +28,7 @@ namespace cpu {
 namespace aarch64 {
 
 // The type defines organization of batch of matrices
-typedef enum {
+enum brgemm_batch_kind_t {
     // Undefined brgemm batch kind
     brgemm_batch_kind_undef = 0,
     // A and B arrays of pointers
@@ -38,22 +39,22 @@ typedef enum {
     brgemm_strd = 3,
     // Base address and static array of fixed offsets.
     brgemm_static_offs = 4,
-} brgemm_batch_kind_t;
+};
 
 // The type defines the storage format of matrix
-typedef enum {
+enum brgemm_layout_t {
     brgemm_layout_undef = 0,
     brgemm_col_major = 1,
     brgemm_row_major = 2,
-} brgemm_layout_t;
+};
 
-typedef enum {
+enum brgemm_broadcast_t {
     none = 0,
     per_tensor = 1,
     per_m = 2,
     per_n = 3,
     per_k = 4,
-} brgemm_broadcast_t;
+};
 
 struct brgemm_strides_t {
     // Stride between A matrices
@@ -62,29 +63,29 @@ struct brgemm_strides_t {
     dim_t stride_b;
 };
 
-typedef enum {
+enum brgemm_kernel_loop_order_t {
     brgemm_lo_default = 0,
     brgemm_lo_bl_1load,
     brgemm_lo_bl_1bcst,
-} brgemm_kernel_loop_order_t;
+};
 
-typedef enum {
+enum brgemm_kernel_prefetching_t {
     brgemm_prf_default = 1,
     brgemm_prf1,
     brgemm_prf2,
-} brgemm_kernel_prefetching_t;
+};
 
-typedef enum {
+enum brgemm_kernel_innermost_loop_t {
     brgemm_innermost_undef = 0,
     brgemm_bd_loop_innermost,
     brgemm_ld_loop_innermost,
-} brgemm_kernel_innermost_loop_t;
+};
 
-typedef enum {
+enum brgemm_kernel_hint_nt_t {
     brgemm_hint_nt_undef = 0,
     brgemm_hint_nt_false,
     brgemm_hint_nt_true,
-} brgemm_kernel_hint_nt_t;
+};
 
 struct brgemm_prf_t {
     int dist1 = -1;

--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -140,11 +140,11 @@ struct cpu_isa_traits<isa_all> {
 
 template <>
 struct cpu_isa_traits<asimd> {
-    typedef Xbyak_aarch64::VReg TReg;
-    typedef Xbyak_aarch64::VReg16B TRegB;
-    typedef Xbyak_aarch64::VReg8H TRegH;
-    typedef Xbyak_aarch64::VReg4S TRegS;
-    typedef Xbyak_aarch64::VReg2D TRegD;
+    using TReg = Xbyak_aarch64::VReg;
+    using TRegB = Xbyak_aarch64::VReg16B;
+    using TRegH = Xbyak_aarch64::VReg8H;
+    using TRegS = Xbyak_aarch64::VReg4S;
+    using TRegD = Xbyak_aarch64::VReg2D;
     static constexpr int vlen_shift = 4;
     static constexpr int vlen = 16;
     static constexpr int n_vregs = 32;

--- a/src/cpu/aarch64/cpu_reducer.hpp
+++ b/src/cpu/aarch64/cpu_reducer.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -169,7 +170,7 @@ struct reducer_2d_driver_t;
  */
 template <impl::data_type_t data_type, cpu_isa_t isa = sve_512>
 struct cpu_reducer_t {
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     struct conf_t {
         conf_t() = default;
@@ -249,7 +250,7 @@ private:
 
 template <impl::data_type_t data_type, cpu_isa_t isa = sve_512>
 struct cpu_reducer_2d_t {
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     struct conf_t {
         conf_t() = default;
@@ -334,7 +335,7 @@ private:
 /** simple 1d accumulator: y[:] += x[:] */
 template <impl::data_type_t data_type, cpu_isa_t isa = sve_512>
 struct cpu_accumulator_1d_t {
-    typedef typename prec_traits_t<data_type>::type data_t;
+    using data_t = typename prec_traits_t<data_type>::type;
 
     cpu_accumulator_1d_t();
     ~cpu_accumulator_1d_t();

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -81,7 +82,7 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
     brgemm_1x1_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd), bias_d(pd()->weights_md(1)) {}
 
-    ~brgemm_1x1_convolution_fwd_t() {}
+    ~brgemm_1x1_convolution_fwd_t() override = default;
 
     status_t execute(const exec_ctx_t &ctx) const override {
         execute_forward_all(ctx);

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024-2025 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -166,7 +167,7 @@ struct brgemm_convolution_fwd_t : public primitive_t {
 
     brgemm_convolution_fwd_t(const pd_t *apd);
 
-    ~brgemm_convolution_fwd_t() = default;
+    ~brgemm_convolution_fwd_t() override = default;
 
     status_t execute(const exec_ctx_t &ctx) const override;
 

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2024 Arm Ltd. and affiliates
+* Copyright 2024-2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ struct jit_uni_brgemm_conv_comp_pad_kernel_t : public jit_generator {
 
     jit_uni_brgemm_conv_comp_pad_kernel_t(const jit_brgemm_conv_conf_t &ajcp);
 
-    ~jit_uni_brgemm_conv_comp_pad_kernel_t() = default;
+    ~jit_uni_brgemm_conv_comp_pad_kernel_t() override = default;
 
 protected:
     static constexpr bool is_ymm_ = true;

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -334,7 +334,7 @@ struct jit_brgemm_kernel_post_ops : public jit_generator {
         bia_typesize_ = (jcp.with_bias) ? types::data_type_size(bia_dt_) : 0;
     }
 
-    ~jit_brgemm_kernel_post_ops() = default;
+    ~jit_brgemm_kernel_post_ops() override = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_post_ops)
 

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -140,10 +141,7 @@ struct jit_brgemm_trans_to_vnni_t {
         dim_t current_col_size, current_row_size;
     };
 
-    typedef enum matrix_to_transform {
-        matrix_B,
-        matrix_C
-    } matrix_to_transform_t;
+    enum matrix_to_transform_t { matrix_B, matrix_C };
 
     virtual void operator()(ctx_t *ctx) = 0;
     virtual status_t create_kernel() = 0;

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
@@ -41,7 +41,7 @@ struct jit_brgemm_trans_src_t {
 
     jit_brgemm_trans_src_t(const jit_brgemm_primitive_conf_t *conf)
         : conf_(conf) {}
-    virtual ~jit_brgemm_trans_src_t() {}
+    virtual ~jit_brgemm_trans_src_t() = default;
 
     const jit_brgemm_primitive_conf_t *conf_;
 };
@@ -79,7 +79,7 @@ struct jit_brgemm_copy_to_coarse_t : public jit_generator {
 
         MAYBE_UNUSED(row_granularity_);
     }
-    ~jit_brgemm_copy_to_coarse_t() {}
+    ~jit_brgemm_copy_to_coarse_t() override = default;
 
 private:
     enum {
@@ -149,7 +149,7 @@ struct jit_brgemm_trans_to_vnni_t {
     jit_brgemm_trans_to_vnni_t(const jit_brgemm_primitive_conf_t *conf,
             matrix_to_transform_t matrix_to_transform)
         : conf_(conf), matrix_to_transform_(matrix_to_transform) {}
-    virtual ~jit_brgemm_trans_to_vnni_t() {}
+    virtual ~jit_brgemm_trans_to_vnni_t() = default;
 
     const jit_brgemm_primitive_conf_t *conf_;
     matrix_to_transform_t matrix_to_transform_;
@@ -169,7 +169,7 @@ struct jit_brgemm_trans_wei_t {
 
     jit_brgemm_trans_wei_t(const jit_brgemm_primitive_conf_t *conf)
         : conf_(conf) {}
-    virtual ~jit_brgemm_trans_wei_t() {}
+    virtual ~jit_brgemm_trans_wei_t() = default;
 
     const jit_brgemm_primitive_conf_t *conf_;
 };

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2016-2023 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -48,9 +49,9 @@ namespace aarch64 {
 // TODO: move this to jit_generator class?
 namespace {
 
-typedef enum {
+enum max_code_size_t {
     MAX_CODE_SIZE = 256 * 1024,
-} max_code_size_t;
+};
 
 // Callee-saved registers
 constexpr Xbyak_aarch64::Operand::Code abi_save_gpr_regs[]

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -674,10 +674,11 @@ public:
     jit_generator(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
             bool use_autogrow = true, cpu_isa_t max_cpu_isa = isa_all)
         : Xbyak_aarch64::CodeGenerator(code_size,
-                (code_ptr == nullptr && use_autogrow) ? Xbyak_aarch64::AutoGrow
-                                                      : code_ptr)
+                  (code_ptr == nullptr && use_autogrow)
+                          ? Xbyak_aarch64::AutoGrow
+                          : code_ptr)
         , max_cpu_isa_(max_cpu_isa) {}
-    virtual ~jit_generator() {}
+    ~jit_generator() override = default;
 
     virtual const char *name() const = 0;
     virtual const char *source_file() const = 0;

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -674,9 +674,8 @@ public:
     jit_generator(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
             bool use_autogrow = true, cpu_isa_t max_cpu_isa = isa_all)
         : Xbyak_aarch64::CodeGenerator(code_size,
-                  (code_ptr == nullptr && use_autogrow)
-                          ? Xbyak_aarch64::AutoGrow
-                          : code_ptr)
+                (code_ptr == nullptr && use_autogrow) ? Xbyak_aarch64::AutoGrow
+                                                      : code_ptr)
         , max_cpu_isa_(max_cpu_isa) {}
     ~jit_generator() override = default;
 

--- a/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_1x1_convolution.hpp
@@ -323,9 +323,9 @@ struct jit_sve_1x1_convolution_fwd_t : public primitive_t {
 
     jit_sve_1x1_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -478,9 +478,9 @@ struct jit_sve_1x1_convolution_bwd_data_t : public primitive_t {
 
     jit_sve_1x1_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -636,7 +636,7 @@ struct jit_sve_1x1_convolution_bwd_weights_t : public primitive_t {
 
     jit_sve_1x1_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type data_t;
+    using data_t = typename prec_traits_t<data_type::f32>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2018-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,11 +43,11 @@ namespace aarch64 {
 
 using namespace Xbyak_aarch64;
 
-typedef enum {
+enum ker_block_t {
     no_last_block = 0x1U,
     last_ic_block = 0x2U,
     last_sp_block = 0x4U,
-} ker_block_t;
+};
 
 struct ur_w_blks_params_t {
     struct single_ur_w_blk_params_t {

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -80,7 +80,7 @@ struct jit_sve_512_core_x8s8s32x_deconv_fwd_kernel : public jit_generator {
 
     jit_sve_512_core_x8s8s32x_deconv_fwd_kernel(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
-    ~jit_sve_512_core_x8s8s32x_deconv_fwd_kernel();
+    ~jit_sve_512_core_x8s8s32x_deconv_fwd_kernel() override;
 
     const jit_conv_conf_t &jcp;
     const primitive_attr_t &attr_;

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
@@ -51,7 +51,7 @@ struct jit_sve_512_x8s8s32x_fwd_kernel : public jit_generator {
         }
     }
 
-    ~jit_sve_512_x8s8s32x_fwd_kernel() {}
+    ~jit_sve_512_x8s8s32x_fwd_kernel() override = default;
 
     jit_conv_conf_t jcp;
     const primitive_attr_t &attr_;

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -71,11 +72,11 @@ private:
         ker_dw_reg_base_idx = 30,
         ker_zp_reg_base_idx = 26,
     };
-    typedef enum {
+    enum ic_block_t {
         no_last_block,
         last_ic_block,
         last_sp_block,
-    } ic_block_t;
+    };
 
     /* data regs */
     const XReg reg_ptr_scales = x7;

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -73,9 +74,9 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
     jit_sve_512_x8s8s32x_convolution_fwd_t(const pd_t *apd)
         : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<data_type::s8>::type wei_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using wei_data_t = typename prec_traits_t<data_type::s8>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/aarch64/jit_sve_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_conv_kernel.hpp
@@ -53,7 +53,7 @@ struct jit_sve_conv_fwd_kernel : public jit_generator {
                     this, jcp.eltwise);
     }
 
-    ~jit_sve_conv_fwd_kernel() = default;
+    ~jit_sve_conv_fwd_kernel() override = default;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_sve_conv_fwd_kernel)
 

--- a/src/cpu/aarch64/jit_sve_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_convolution.hpp
@@ -79,9 +79,9 @@ struct jit_sve_convolution_fwd_t : public primitive_t {
 
     jit_sve_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -151,9 +151,9 @@ struct jit_sve_convolution_bwd_data_t : public primitive_t {
 
     jit_sve_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<wei_type>::type wei_data_t;
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using wei_data_t = typename prec_traits_t<wei_type>::type;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -238,9 +238,9 @@ struct jit_sve_convolution_bwd_weights_t : public primitive_t {
 
     jit_sve_convolution_bwd_weights_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using diff_weights_data_t = typename prec_traits_t<diff_weights_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/aarch64/jit_uni_1x1_conv_utils.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2021-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -569,7 +570,7 @@ inline int best_divider(int value, int min_divider, int max_divider,
     return x_divider;
 }
 
-typedef jit_1x1_conv_conf_t jcp_t;
+using jcp_t = jit_1x1_conv_conf_t;
 
 inline bool is_bcast_layout_nxc(const jcp_t &jcp) {
     switch (jcp.prop_kind) {

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -2057,7 +2057,7 @@ struct jit_bnorm_t : public jit_generator {
 
     void operator()(const call_params_t *p) { jit_generator::operator()(p); }
 
-    ~jit_bnorm_t() override {}
+    ~jit_bnorm_t() override = default;
 };
 
 namespace bnorm_impl {

--- a/src/cpu/aarch64/jit_uni_batch_normalization.hpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2017-2022 Intel Corporation
 * Copyright 2020-2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -53,7 +54,7 @@ struct jit_uni_batch_normalization_fwd_t : public primitive_t {
     };
 
     jit_uni_batch_normalization_fwd_t(const pd_t *apd);
-    ~jit_uni_batch_normalization_fwd_t();
+    ~jit_uni_batch_normalization_fwd_t() override;
 
     status_t init(engine_t *engine) override;
 
@@ -79,7 +80,7 @@ struct jit_uni_batch_normalization_bwd_t : public primitive_t {
     };
 
     jit_uni_batch_normalization_bwd_t(const pd_t *apd);
-    ~jit_uni_batch_normalization_bwd_t();
+    ~jit_uni_batch_normalization_bwd_t() override;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.hpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.hpp
@@ -54,7 +54,7 @@ struct jit_uni_batch_normalization_s8_fwd_t : public primitive_t {
     using data_t = int8_t;
 
     jit_uni_batch_normalization_s8_fwd_t(const pd_t *apd);
-    ~jit_uni_batch_normalization_s8_fwd_t();
+    ~jit_uni_batch_normalization_s8_fwd_t() override;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.hpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ struct jit_uni_batch_normalization_s8_fwd_t : public primitive_t {
         status_t init(engine_t *engine);
     };
 
-    typedef int8_t data_t;
+    using data_t = int8_t;
 
     jit_uni_batch_normalization_s8_fwd_t(const pd_t *apd);
     ~jit_uni_batch_normalization_s8_fwd_t();

--- a/src/cpu/aarch64/jit_uni_binary.hpp
+++ b/src/cpu/aarch64/jit_uni_binary.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2023 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -69,7 +70,7 @@ struct jit_uni_binary_t : public primitive_t {
     };
 
     jit_uni_binary_t(const pd_t *apd);
-    ~jit_uni_binary_t() = default;
+    ~jit_uni_binary_t() override = default;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_conv_kernel_f32.hpp
@@ -47,7 +47,7 @@ struct jit_uni_dw_conv_fwd_kernel_f32_t : public jit_generator {
                     this, jcp.eltwise);
     }
 
-    ~jit_uni_dw_conv_fwd_kernel_f32_t() = default;
+    ~jit_uni_dw_conv_fwd_kernel_f32_t() override = default;
 
     jit_conv_conf_t jcp;
 

--- a/src/cpu/aarch64/jit_uni_dw_convolution.hpp
+++ b/src/cpu/aarch64/jit_uni_dw_convolution.hpp
@@ -77,10 +77,10 @@ struct jit_uni_dw_convolution_fwd_t : public primitive_t {
 
     jit_uni_dw_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits_t<src_type>::type data_t;
-    typedef typename prec_traits_t<dst_type>::type dst_data_t;
+    using f32_data_t = typename prec_traits_t<data_type::f32>::type;
+    using bf16_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using data_t = typename prec_traits_t<src_type>::type;
+    using dst_data_t = typename prec_traits_t<dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -161,9 +161,9 @@ struct jit_uni_dw_convolution_bwd_data_t : public primitive_t {
 
     jit_uni_dw_convolution_bwd_data_t(const pd_t *apd) : primitive_t(apd) {}
 
-    typedef typename prec_traits_t<diff_src_type>::type diff_src_data_t;
-    typedef typename prec_traits_t<diff_dst_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<diff_dst_type>::type wei_data_t;
+    using diff_src_data_t = typename prec_traits_t<diff_src_type>::type;
+    using diff_dst_data_t = typename prec_traits_t<diff_dst_type>::type;
+    using wei_data_t = typename prec_traits_t<diff_dst_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,
@@ -255,11 +255,11 @@ struct jit_uni_dw_convolution_bwd_weights_t : public primitive_t {
 
     jit_uni_dw_convolution_bwd_weights_t(const pd_t *apd);
 
-    typedef typename prec_traits_t<data_type::bf16>::type bf16_data_t;
-    typedef typename prec_traits_t<data_type::f32>::type f32_data_t;
-    typedef typename prec_traits_t<src_type>::type src_data_t;
-    typedef typename prec_traits_t<src_type>::type diff_dst_data_t;
-    typedef typename prec_traits_t<diff_weights_type>::type diff_weights_data_t;
+    using bf16_data_t = typename prec_traits_t<data_type::bf16>::type;
+    using f32_data_t = typename prec_traits_t<data_type::f32>::type;
+    using src_data_t = typename prec_traits_t<src_type>::type;
+    using diff_dst_data_t = typename prec_traits_t<src_type>::type;
+    using diff_weights_data_t = typename prec_traits_t<diff_weights_type>::type;
 
     status_t init(engine_t *engine) override {
         CHECK(safe_ptr_assign(kernel_,

--- a/src/cpu/aarch64/jit_uni_eltwise.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.hpp
@@ -49,7 +49,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
     };
 
     jit_uni_eltwise_fwd_t(const pd_t *apd);
-    virtual ~jit_uni_eltwise_fwd_t();
+    ~jit_uni_eltwise_fwd_t() override;
 
     using data_t = typename prec_traits_t<d_type>::type;
 
@@ -74,7 +74,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
     };
 
     jit_uni_eltwise_bwd_t(const pd_t *apd);
-    virtual ~jit_uni_eltwise_bwd_t();
+    ~jit_uni_eltwise_bwd_t() override;
 
     using data_t = typename prec_traits_t<d_type>::type;
 

--- a/src/cpu/aarch64/jit_uni_eltwise.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2017-2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
     jit_uni_eltwise_fwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_fwd_t();
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 
@@ -75,7 +76,7 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
     jit_uni_eltwise_bwd_t(const pd_t *apd);
     virtual ~jit_uni_eltwise_bwd_t();
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);
     ~jit_uni_eltwise_int_fwd_t();
 
-    typedef typename prec_traits_t<d_type>::type data_t;
+    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_eltwise_int.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.hpp
@@ -49,7 +49,7 @@ struct jit_uni_eltwise_int_fwd_t : public primitive_t {
     };
 
     jit_uni_eltwise_int_fwd_t(const pd_t *apd);
-    ~jit_uni_eltwise_int_fwd_t();
+    ~jit_uni_eltwise_int_fwd_t() override;
 
     using data_t = typename prec_traits_t<d_type>::type;
 

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2020-2021 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -76,7 +77,7 @@ struct jit_uni_i8i8_pooling_fwd_t : public primitive_t {
     };
 
     jit_uni_i8i8_pooling_fwd_t(const pd_t *apd);
-    ~jit_uni_i8i8_pooling_fwd_t();
+    ~jit_uni_i8i8_pooling_fwd_t() override;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/aarch64/jit_uni_pool_kernel.hpp
@@ -2,6 +2,7 @@
 * Copyright 2017-2022 Intel Corporation
 * Copyright 2018 YANDEX LLC
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ struct jit_uni_pool_kernel : public jit_generator {
     jit_uni_pool_kernel(
             const jit_pool_conf_t &ajpp, const memory_desc_t *dst_md);
     jit_pool_conf_t jpp;
-    ~jit_uni_pool_kernel();
+    ~jit_uni_pool_kernel() override;
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_pool_kernel)
 

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2017-2022 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -80,7 +81,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
     explicit jit_uni_pooling_fwd_t(const pd_t *apd);
     jit_uni_pooling_fwd_t(jit_uni_pooling_fwd_t &&) = default;
     jit_uni_pooling_fwd_t &operator=(jit_uni_pooling_fwd_t &&) = default;
-    ~jit_uni_pooling_fwd_t();
+    ~jit_uni_pooling_fwd_t() override;
 
     using data_t = typename prec_traits_t<d_type>::type;
 
@@ -149,7 +150,7 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
     explicit jit_uni_pooling_bwd_t(const pd_t *apd);
     jit_uni_pooling_bwd_t(jit_uni_pooling_bwd_t &&) = default;
     jit_uni_pooling_bwd_t &operator=(jit_uni_pooling_bwd_t &&) = default;
-    ~jit_uni_pooling_bwd_t();
+    ~jit_uni_pooling_bwd_t() override;
 
     using data_t = typename prec_traits_t<d_type>::type;
 

--- a/src/cpu/aarch64/jit_uni_reorder.hpp
+++ b/src/cpu/aarch64/jit_uni_reorder.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018-2023 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022 Arm Ltd. and affiliates
+* Copyright 2022, 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ struct kernel_t {
     virtual void operator()(const call_param_t *c) const = 0;
     virtual void operator()(const tail_call_param_t *c) const = 0;
     virtual status_t create_kernel() = 0;
-    virtual ~kernel_t() {}
+    virtual ~kernel_t() = default;
 
     /** inits kernel descriptor:
      *      desc            -- kernel descriptor (output)
@@ -300,7 +300,7 @@ struct jit_blk_reorder_t : public primitive_t {
     status_t execute(const exec_ctx_t &ctx) const override;
 
     jit_blk_reorder_t(const pd_t *apd);
-    ~jit_blk_reorder_t();
+    ~jit_blk_reorder_t() override;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/aarch64/jit_uni_softmax.hpp
+++ b/src/cpu/aarch64/jit_uni_softmax.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2019-2022 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -112,7 +113,7 @@ struct jit_uni_softmax_fwd_t : public primitive_t {
     };
 
     jit_uni_softmax_fwd_t(const pd_t *apd);
-    ~jit_uni_softmax_fwd_t();
+    ~jit_uni_softmax_fwd_t() override;
 
     status_t init(engine_t *engine) override;
 
@@ -185,7 +186,7 @@ struct jit_uni_softmax_bwd_t : public primitive_t {
     };
 
     jit_uni_softmax_bwd_t(const pd_t *apd);
-    ~jit_uni_softmax_bwd_t();
+    ~jit_uni_softmax_bwd_t() override;
 
     status_t init(engine_t *engine) override;
 

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.hpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.hpp
@@ -1,6 +1,8 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
+*
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
@@ -43,7 +45,7 @@ struct jit_brgemm_matmul_copy_b_t {
 
     jit_brgemm_matmul_copy_b_t(const brgemm_matmul_conf_t *conf)
         : conf_(conf) {}
-    virtual ~jit_brgemm_matmul_copy_b_t() {}
+    virtual ~jit_brgemm_matmul_copy_b_t() = default;
 
     const brgemm_matmul_conf_t *conf_;
 };
@@ -68,7 +70,7 @@ struct jit_brgemm_matmul_copy_a_t {
 
     jit_brgemm_matmul_copy_a_t(const brgemm_matmul_conf_t *conf)
         : conf_(conf) {}
-    virtual ~jit_brgemm_matmul_copy_a_t() {}
+    virtual ~jit_brgemm_matmul_copy_a_t() = default;
 
     const brgemm_matmul_conf_t *conf_;
 };

--- a/src/cpu/aarch64/matmul/jit_int8_kernel_types.hpp
+++ b/src/cpu/aarch64/matmul/jit_int8_kernel_types.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,13 +24,13 @@ namespace cpu {
 namespace aarch64 {
 namespace matmul {
 
-typedef enum {
+enum jit_int8_broadcast_t {
     none = 0,
     per_tensor = 1,
     per_m = 2,
     per_n = 3,
     per_k = 4,
-} jit_int8_broadcast_t;
+};
 
 struct dyn_vals_t {
     int f = 0;

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2022 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -52,7 +53,7 @@ struct jit_uni_shuffle_t : public primitive_t {
 
     jit_uni_shuffle_t(const pd_t *apd);
 
-    ~jit_uni_shuffle_t();
+    ~jit_uni_shuffle_t() override;
 
     status_t init(engine_t *engine) override;
 


### PR DESCRIPTION
# Description

This commit fixes the rest of the "modernize-use-*" clang-tidy failures on the AArch64 path.  
More specifically, it addresses these checks:
 - modernize-use-using
 - modernize-use-override
 - modernize-use-equals-default