### PR TITLE
common: remove exec_ctx member from grantor

### DIFF
--- a/src/common/primitive.cpp
+++ b/src/common/primitive.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2016-2022 Intel Corporation
+* Copyright 2016-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -43,11 +43,12 @@ namespace impl {
 
 nested_scratchpad_t::nested_scratchpad_t(const exec_ctx_t &master_ctx, int key,
         const std::shared_ptr<primitive_t> &nested_p) {
-    auto scratchpad = master_ctx.get_scratchpad_grantor();
-    scratchpad_mem_storage_ = scratchpad.get_memory_storage(key);
+    auto master_grantor = master_ctx.get_scratchpad_grantor();
+    scratchpad_mem_storage_ = master_grantor.get_memory_storage(key);
     grantor_ = utils::make_unique<memory_tracking::grantor_t>(
             nested_p->pd()->scratchpad_registry().grantor(
-                    scratchpad_mem_storage_.get(), master_ctx));
+                    scratchpad_mem_storage_.get(),
+                    master_grantor.get_base_mem_storage_host_ptr()));
 #ifdef DNNL_ENABLE_MEM_DEBUG
     if (scratchpad_debug::is_protect_scratchpad()) {
         scratchpad_debug::protect_scratchpad_buffer(

--- a/src/common/primitive_exec_types.cpp
+++ b/src/common/primitive_exec_types.cpp
@@ -140,7 +140,8 @@ void *exec_ctx_t::host_ptr(
     return host_ptr(mem_storage);
 }
 
-void *exec_ctx_t::host_ptr(const memory_storage_t *mem_storage) const {
+void *exec_ctx_t::host_ptr(
+        const memory_storage_t *mem_storage, bool require_host_ptr) const {
     if (!mem_storage || mem_storage->is_null()) return nullptr;
 
     void *handle = mem_storage->root_storage()->data_handle();
@@ -150,8 +151,7 @@ void *exec_ctx_t::host_ptr(const memory_storage_t *mem_storage) const {
         base_ptr = reinterpret_cast<char *>(base_ptr)
                 + mem_storage->base_offset();
     } else {
-        assert(mem_storage->is_host_accessible());
-        base_ptr = handle;
+        base_ptr = require_host_ptr ? nullptr : handle;
     }
     return base_ptr;
 }


### PR DESCRIPTION
This PR removes grantor dependency on exec_ctx which appeared with adding CPU SYCL support. There are a bunch of comments explaining dependencies and purposes.

`exec_ctx_t` must be removed from the grantor to unblock PImpl implementation that will be introduced for `exec_ctx_t` to support Async runtime, otherwise, there'll be double capture of the same context leading to a memory leak.