### PR TITLE
cpu: aarch64: Extend vector loads for AArch64 jit:uni reorder

### DIFF
--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -712,11 +712,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
         /* check whether loading 4 values at once is possible */
         static constexpr int xmm_vlen = 4;
         bool can_load_xmm = reg_unroll % xmm_vlen == 0;
-        for (int ur = 1; ur < reg_unroll; ++ur)
-            if (i_off[ur] != i_off[ur - 1] + 1) {
-                can_load_xmm = false;
-                break;
-            }
+        int registers_total = reg_unroll / 4;
+        for (int reg = 0; reg < registers_total; reg++) {
+            for (int ur = 1 + (reg * 4); ur < ((reg + 1) * 4); ur++)
+                if (i_off[ur] != i_off[ur - 1] + 1) {
+                    can_load_xmm = false;
+                    break;
+                }
+        }
         const int load_step = can_load_xmm ? xmm_vlen : 1;
 
         /* check whether storing 4 values at once is possible */


### PR DESCRIPTION

# Description

Enables vector loads for AArch64 jit:uni reorder when inner blocking size differs from reg_unroll parameter. This enables for example reorder fp32 ba -> bf16 BA8b4a to use ldr(QReg…) instead of ld1(vX.s[0]…). 

Example code snippet generated for each load before this patch:
8c:	0d4082e0 	ld1	{v0.s}[0], [x23]
90:	0d409300 	ld1	{v0.s}[1], [x24]
94:	4d408320 	ld1	{v0.s}[2], [x25]
98:	4d409340 	ld1	{v0.s}[3], [x26]
And after:
88:	3dc002e0 	ldr	q0, [x23]

**Performance improvement:**

Command: `benchdnn --reorder --allow-enum-tags-only=0 --sdt=f32 --ddt=bf16 --stag=ba --dtag=BA8b4a --mode=p 4096x4096`

OMP_NUM_THREADS=1 is ~4.1x faster and OMP_NUM_THREADS=16 is ~1.7x faster after patch.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?

ctest:
Only `191 - test_benchdnn_modeC_matmul_multidims_cpu` fails before and after patch.

benchdnn --reorder --batch=inputs/reorder/test_reorder_all:
`tests:20939 passed:16103 skipped:4836 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 10.59s; create_pd: 0.15s (1%); create_prim: 1.07s (10%); fill: 2.48s (23%); execute: 0.74s (7%); compute_ref: 1.10s (10%); compare: 2.39s (23%);`
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?