### PR TITLE
examples: added missing GPU engine check to OpenCL examples

### DIFF
--- a/examples/gpu_opencl_interop.cpp
+++ b/examples/gpu_opencl_interop.cpp
@@ -117,7 +117,7 @@ void gpu_opencl_interop_tutorial() {
     ///
     /// @snippet  gpu_opencl_interop.cpp Initialize engine
     // [Initialize engine]
-    engine eng(engine::kind::gpu, 0);
+    engine eng(validate_engine_kind(engine::kind::gpu), 0);
     // [Initialize engine]
 
     /// In addition to an engine, all primitives require a @ref dnnl::stream

--- a/examples/graph/gpu_opencl_getting_started.cpp
+++ b/examples/graph/gpu_opencl_getting_started.cpp
@@ -190,7 +190,7 @@ void ocl_getting_started_tutorial() {
     ///
     /// @snippet gpu_opencl_getting_started.cpp Create graph and add ops
     //[Create graph and add ops]
-    graph g(engine::kind::gpu);
+    graph g(validate_engine_kind(engine::kind::gpu));
 
     g.add_op(conv0);
     g.add_op(conv0_bias_add);


### PR DESCRIPTION
We have a couple examples that unlike others fail when GPU is not found. This changes aligns the behavior.

Fixes #1961.
