### PR TITLE
cpu: aarch64: fix cppcoreguidelines-prefer-member-initializer failures

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -910,9 +911,8 @@ void jit_brdgmm_kernel_base_t::generate() {
     if (is_fast_vnni_int8()) { assert(!"unsupported\n"); }
 }
 
-brdgmm_kernel_t::brdgmm_kernel_t(const brgemm_t abrd) {
-    brgemm_kernel_ = new jit_brdgmm_kernel_base_t(abrd);
-}
+brdgmm_kernel_t::brdgmm_kernel_t(const brgemm_t abrd)
+    : brgemm_kernel_(new jit_brdgmm_kernel_base_t(abrd)) {}
 
 status_t brdgmm_kernel_t::create_kernel() {
     return brgemm_kernel_->create_kernel();

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -2019,9 +2019,8 @@ brgemm_attr_t::brgemm_attr_t()
     , bd_mask(nullptr)
     , static_offsets(nullptr) {}
 
-brgemm_kernel_common_t::brgemm_kernel_common_t(const brgemm_t abrd) {
-    brgemm_kernel_ = new jit_brgemm_kernel_t(abrd);
-}
+brgemm_kernel_common_t::brgemm_kernel_common_t(const brgemm_t abrd)
+    : brgemm_kernel_(new jit_brgemm_kernel_t(abrd)) {}
 
 status_t brgemm_kernel_common_t::create_kernel() {
     return brgemm_kernel_->create_kernel();

--- a/src/cpu/aarch64/cpu_reducer.cpp
+++ b/src/cpu/aarch64/cpu_reducer.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2021 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -574,9 +575,8 @@ template struct cpu_reducer_2d_t<data_type::s32, sve_256>;
 /* accumulator section */
 
 template <impl::data_type_t data_type, cpu_isa_t isa>
-cpu_accumulator_1d_t<data_type, isa>::cpu_accumulator_1d_t() : drv_(nullptr) {
-    drv_ = create_reduce_2d_drv<data_type, isa>(1, 0, 0, 0, false);
-}
+cpu_accumulator_1d_t<data_type, isa>::cpu_accumulator_1d_t()
+    : drv_(create_reduce_2d_drv<data_type, isa>(1, 0, 0, 0, false)) {}
 
 template <impl::data_type_t data_type, cpu_isa_t isa>
 cpu_accumulator_1d_t<data_type, isa>::~cpu_accumulator_1d_t() {

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -36,18 +37,17 @@ namespace jit_sve_core_brgemm_conv_trans_kernel {
 jit_sve_core_brgemm_conv_trans_kernel_t::
         jit_sve_core_brgemm_conv_trans_kernel_t(
                 const jit_brgemm_conv_conf_t &ajcp)
-    : jcp(ajcp) {
-    inp_dsz = jcp.src_dsz;
-    ic_block_sz = inp_dsz * jcp.ic_block;
-    dst_w_block = dst_w(jcp, jcp.ow_block);
-    dst_stride = jcp.copy_block_only ? dst_w_block : jcp.iwp;
-    dst_w_offset = jcp.kh_sets * jcp.kw_sets * ic_block_sz;
-    dst_h_offset = dst_stride * dst_w_offset;
-    iw_size = inp_dsz * jcp.ngroups * jcp.ic_without_padding;
-    VL = cpu_isa_traits<sve_512>::vlen;
-    n_vec = jcp.ic_block / jcp.simd_w;
-    n_tail_vec = (jcp.ic_without_padding % jcp.ic_block) / jcp.simd_w;
-}
+    : jcp(ajcp)
+    , inp_dsz(jcp.src_dsz)
+    , ic_block_sz(inp_dsz * jcp.ic_block)
+    , dst_w_block(dst_w(jcp, jcp.ow_block))
+    , dst_stride(jcp.copy_block_only ? dst_w_block : jcp.iwp)
+    , dst_w_offset(jcp.kh_sets * jcp.kw_sets * ic_block_sz)
+    , dst_h_offset(dst_stride * dst_w_offset)
+    , iw_size(inp_dsz * jcp.ngroups * jcp.ic_without_padding)
+    , VL(cpu_isa_traits<sve_512>::vlen)
+    , n_vec(jcp.ic_block / jcp.simd_w)
+    , n_tail_vec((jcp.ic_without_padding % jcp.ic_block) / jcp.simd_w) {}
 
 int get_inp_size(int dst_size, int ext_k, int stride, int dilate) {
     const auto res = calculate_end_padding(0, dst_size, 0, stride, ext_k);

--- a/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_trans_kernel.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021-2023 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,8 +51,9 @@ protected:
     jit_brgemm_conv_conf_t jcp;
     dim_t inp_dsz;
     dim_t ic_block_sz;
-    dim_t iw_size, dst_w_block, dst_stride;
-    dim_t dst_h_offset, dst_w_offset;
+    dim_t dst_w_block, dst_stride;
+    dim_t dst_w_offset, dst_h_offset;
+    dim_t iw_size;
     dim_t VL, n_vec, n_tail_vec;
 
     const XReg inp_ptr = x15;

--- a/src/cpu/aarch64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/aarch64/jit_brgemm_post_ops.hpp
@@ -58,13 +58,10 @@ struct jit_brgemm_kernel_diff_bias_t : public jit_generator {
         , ddst_dt_(ajbgp.dst_dt)
         , bia_dt_(ajbgp.bia_dt)
         , acc_dt_(ajbgp.acc_dt)
+        , ddst_typesize_(types::data_type_size(ddst_dt_))
         , bia_typesize_(types::data_type_size(bia_dt_))
-        , acc_typesize_(types::data_type_size(acc_dt_)) {
-
-        ddst_dt_ = ajbgp.dst_dt;
-        ddst_typesize_ = types::data_type_size(ddst_dt_);
-        mult_ = data_type_vnni_granularity(ddst_dt_);
-    }
+        , acc_typesize_(types::data_type_size(acc_dt_))
+        , mult_(data_type_vnni_granularity(ddst_dt_)) {}
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_diff_bias_t)
 

--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -626,11 +626,11 @@ struct jit_softmax_base_t : public jit_generator {
         , pd_(pd)
         , src_d_(pd_->is_fwd() ? pd_->src_md() : pd_->diff_src_md())
         , dst_d_(pd_->dst_md())
-        , diff_dst_d_(pd_->diff_dst_md()) {
-        simd_w_ = vlen / sizeof(float); // bf16 works on ymms
-        need_scratchpad_ = utils::one_of(
-                dst_d_.data_type(), data_type::u8, data_type::s8);
-    }
+        , diff_dst_d_(pd_->diff_dst_md())
+        , need_scratchpad_(utils::one_of(
+                  dst_d_.data_type(), data_type::u8, data_type::s8))
+        , simd_w_(vlen / sizeof(float)) // bf16 works on ymms
+    {}
 };
 
 template <cpu_isa_t isa>


### PR DESCRIPTION
# Description

This commit fixes the "cppcoreguidelines-prefer-member-initializer" clang-tidy failures on the AArch64 path. 

Where necessary, the updated constructor initializer list follows the prior order of member initializations from the constructor body. Otherwise, it follows the class member declaration order to prevent "-Wreorder" warnings.