### PR TITLE
cpu: aarch64: fix readability-container-size-empty

### DIFF
--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -239,7 +239,7 @@ status_t acl_lowp_matmul_t::pd_t::init_scratchpad(
         memory_tracking::registrar_t &scratchpad,
         const arm_compute::experimental::MemoryRequirements &aux_mem_req) {
 
-    if (aux_mem_req.size() != 0) {
+    if (!aux_mem_req.empty()) {
         for (size_t id = 0; id < lowp_matmul_keys.size(); id++) {
             if (aux_mem_req[id].size > 0) {
                 scratchpad.book(lowp_matmul_keys[id], aux_mem_req[id].size, 1,

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -221,7 +221,7 @@ status_t acl_lowp_matmul_sq_t::pd_t::init_scratchpad(engine_t *engine,
     CHECK(post_ops.init(engine, attr_post_ops, dst_md, act_info));
 
     // Book temp mem.
-    if (aux_mem_req.size() != 0) {
+    if (!aux_mem_req.empty()) {
         for (size_t id = 0; id < lowp_matmul_keys.size(); id++) {
             if (aux_mem_req[id].size > 0) {
                 scratchpad.book(lowp_matmul_keys[id], aux_mem_req[id].size, 1,

--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
@@ -201,7 +201,7 @@ status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
                 dst_d.nelems(), dst_d.data_type_size());
     }
-    if (aux_mem_req.size() != 0) {
+    if (!aux_mem_req.empty()) {
         for (const auto &key : matmul_keys) {
             const auto id = key.first;
             if (aux_mem_req[id].size > 0) {


### PR DESCRIPTION
# Description

clang-tidy fixes for readability-container-size-empty warning

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?