### PR TITLE
cpu: aarch64: ensure LDR_ASSERT and STR_ASSERT are expanded fully

### DIFF
--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -37,11 +37,15 @@
 
 #define IDX(a) static_cast<uint32_t>((a).getIdx())
 #define LDR_ASSERT(r, addr, offt) \
-    assert((offt) < 256); \
-    ldr(r, ptr(addr, (int)(offt)));
+    do { \
+        assert((offt) < 256); \
+        ldr(r, ptr(addr, (int)(offt))); \
+    } while (0)
 #define STR_ASSERT(r, addr, offt) \
-    assert((offt) < 256); \
-    str(r, ptr(addr, (int)(offt)));
+    do { \
+        assert((offt) < 256); \
+        str(r, ptr(addr, (int)(offt))); \
+    } while (0)
 
 namespace dnnl {
 namespace impl {
@@ -2001,8 +2005,10 @@ struct jit_bnorm_t : public jit_generator {
         }
         if (jbp_->is_nspc_) {
             // comeback
-            if (!pd_->use_global_stats())
+            if (!pd_->use_global_stats()) {
                 LDR_ASSERT(reg_src, sp, (int)stack_off_src);
+            }
+
             LDR_ASSERT(reg_diff_dst, sp, (int)stack_off_diff_dst);
             LDR_ASSERT(reg_diff_src, sp, (int)stack_off_diff_src);
             if (with_relu) { LDR_ASSERT(reg_ws, sp, (int)stack_off_ws); }


### PR DESCRIPTION
# Description

In this one-line if statement only the first line of the `LDR_ASSERT` macro would be conditionally handled & not the second.

This fix ensures that upon macro expansion the second line is also only ran if use_global_stats() is false by encapsulating `LDR_ASSERT` in `do { ... } while(0)` (and similarly with `STR_ASSERT` to prevent a similar bug from occurring).

This was flagged after running clang-tidy with the bugprone-multiple-statement-macro check.