### PR TITLE
x64: brdgmm kernel: fix temporal registers usage

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -540,8 +540,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     for (int m = 0; m < m_blocks; m++) {
         auto vmm_lbound = vmm_tmp(0);
-        auto vmm_ubound = vmm_tmp(1);
         if (dt_requires_saturation) {
+            auto vmm_ubound = vmm_tmp(1);
             for_(int n = 0; n < n_blocks; n++)
             for (int v_i = 0; v_i < v_substep; ++v_i) {
                 if (get_substep_simd(n, v_i, has_n_tail) <= 0) continue;
@@ -565,6 +565,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
             const Vmm_low_t r_vmm_low = maybe_mask(vmm_low, mask_flag, true);
             const Xmm r_xmm = maybe_mask(xmm, mask_flag, true);
             if (use_sat_cvt) {
+                auto vmm_ubound = vmm_tmp(1);
                 assert(one_of(brg.dt_d, data_type::s8, data_type::u8));
                 auto vmm_perm = Vmm(vmm_ubound.getIdx());
                 vpermb(vmm, vmm_perm, vmm);


### PR DESCRIPTION
brdgmm kernel: request temporal register only if needed. In brdgmm initialization in `vmm_allocator_helper_t` we reserve temporal registers only for certain conditions. So we must use these registers only under these conditions.
This is a fix for [MFDNN-14146](https://jira.devtools.intel.com/browse/MFDNN-14146)