### PR TITLE
[GPU] host scalars in with_post_ops implementation of GEMM

### DIFF
--- a/src/gpu/intel/gemm/with_post_ops.cl
+++ b/src/gpu/intel/gemm/with_post_ops.cl
@@ -28,9 +28,41 @@
 
 __kernel void gemm_post_ops(__global SRC_DATA_T *src,
         __global BIAS_DATA_T *bias, __global DST_DATA_T *dst POST_OP_ARGS,
-        global float *a_scales, global WEI_SCALES_DATA_T *b_scales,
-        global DST_SCALES_DATA_T *c_scales, int scale_stride,
-        global int *dst_zp) {
+#if WITH_HOST_SRC_SCALE
+        float a_scale_value,
+#else
+        global float *a_scales,
+#endif
+#if WITH_HOST_WEI_SCALE
+        WEI_SCALES_DATA_T b_scale_value,
+#else
+        global WEI_SCALES_DATA_T *b_scales,
+#endif
+#if WITH_HOST_DST_SCALE
+        DST_SCALES_DATA_T c_scale_value,
+#else
+        global DST_SCALES_DATA_T *c_scales,
+#endif
+        int scale_stride,
+#if WITH_HOST_DST_ZP
+        int dst_zp_value
+#else
+        global int *dst_zp
+#endif
+) {
+#if WITH_HOST_SRC_SCALE
+    float *a_scales = &a_scale_value;
+#endif
+#if WITH_HOST_WEI_SCALE
+    WEI_SCALES_DATA_T *b_scales = &b_scale_value;
+#endif
+#if WITH_HOST_DST_SCALE
+    DST_SCALES_DATA_T *c_scales = &c_scale_value;
+#endif
+#if WITH_HOST_DST_ZP
+    int *dst_zp = &dst_zp_value;
+#endif
+
     const uint d0 = GWS_GET_D0();
     const uint d1 = GWS_GET_D1();
     const uint d2 = GWS_GET_D2();

--- a/src/gpu/intel/gemm/with_post_ops.cpp
+++ b/src/gpu/intel/gemm/with_post_ops.cpp
@@ -43,10 +43,6 @@ status_t with_post_ops_t::pd_t::init(impl::engine_t *engine) {
     VDISPATCH_GEMM(attr()->has_default_values(attr_skip_mask),
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_GEMM(!utils::one_of(d->c_type(), u4, s4), VERBOSE_UNSUPPORTED_DT);
-    VDISPATCH_GEMM(!attr()->scales_.has_host_scalars(),
-            VERBOSE_UNSUPPORTED_SCALES_CFG);
-    VDISPATCH_GEMM(!attr()->zero_points_.has_host_scalars(),
-            VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     const primitive_attr_t *attributes_with_po = attr();
     for (int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -274,6 +274,7 @@ struct gemm_t : public primitive_t {
                                             const memory_desc_t &reshaped_md,
                                             int diff_dims) -> status_t {
                     const quant_entry_t &entry = entries.get(arg);
+                    if (entry.is_host_scalar()) return status::success;
                     memory_desc_t qmd;
                     CHECK(entry.get_md(qmd, md));
                     dims_t qdims;


### PR DESCRIPTION
PR adds host scalars support to the with_post_ops GEMM implementation. Also fixes an related issue within attr reshaping.
kind of pre-requisite for https://jira.devtools.intel.com/browse/MFDNN-14149. 