### PR TITLE
benchdnn: fix mem check (yet another time)

### DIFF
--- a/tests/benchdnn/dnnl_common.cpp
+++ b/tests/benchdnn/dnnl_common.cpp
@@ -1321,12 +1321,20 @@ void add_md_size(const_dnnl_memory_desc_t md,
     check_mem_size_args.total_size_device += mem_size;
 
     // GPU mapped memory factor.
-    // All memory is mapped once it is created and unmapped only before
-    // primitive execution. Device memory requires additional buffer for mapped
-    // memory allocated on host (CPU).
+    // All memory is mapped once it is created and unmapped only for primitive
+    // execution mapped back again right after. Device memory requires
+    // additional buffer for mapped memory allocated on host (CPU).
+    //
     // Note: When oneDNN uses USM shared memory on an iGPU, additional buffers
     // are not required, so map factor could be equal to 0. This is not
     // accounted for to maintain simplicity.
+    //
+    // This might be improved by switching to lazy mapping when it happens upon
+    // direct data accessing and unmapping right after the access completed.
+    // In such case it requires only the biggest buffer among all to be
+    // accounted for total memory check, with scratchpad not included among
+    // those.
+    // ANCHOR: LAZY_MAPPING.
     const bool mapped_mem_factor = !is_cpu()
             && !has_bench_mode_modifier(mode_modifier_t::no_ref_memory);
 
@@ -1470,6 +1478,12 @@ int collect_mem_size(check_mem_size_args_t &mem_size_args,
     check_mem_size_args.sizes.push_back(scratchpad_size);
     check_mem_size_args.total_size_device += scratchpad_size;
     check_mem_size_args.scratchpad_size = scratchpad_size;
+    //   Add mapped size for scratchpad due to it gets mapped unconditionally
+    //   when it gets created and then after the execution ends followed by
+    //   comparison which creates a memory object and may trigger a memory
+    //   over-consumption error message.
+    //   ANCHOR: LAZY_MAPPING.
+    check_mem_size_args.total_size_mapped += scratchpad_size;
 
     // Get output sizes.
     check_mem_size_args.want_input = false;

--- a/tests/benchdnn/dnnl_common.hpp
+++ b/tests/benchdnn/dnnl_common.hpp
@@ -915,12 +915,6 @@ void init_memory_args(dnn_mem_map_t &mem_map, const prb_t *prb,
     const auto &scratch_md = query_md(const_pd, DNNL_ARG_SCRATCHPAD);
     mem_map.emplace(DNNL_ARG_SCRATCHPAD,
             dnn_mem_t(scratch_md, test_engine, /* prefill = */ true));
-    // Scratchpad memory is not accounted towards mapped as it's write-only
-    // memory. Manually unmap it here.
-    // TODO: if lazy mapping is enabled, this should be removed.
-    if (mem_map.at(DNNL_ARG_SCRATCHPAD).is_mapped()) {
-        mem_map.at(DNNL_ARG_SCRATCHPAD).unmap();
-    }
 
     // Binary post-op.
     // TODO: currently run-time dimensions are not supported in binary post-op.

--- a/tests/benchdnn/eltwise/ref_eltwise.cpp
+++ b/tests/benchdnn/eltwise/ref_eltwise.cpp
@@ -54,7 +54,7 @@ void compute_ref_bwd(const prb_t *prb, const args_t &args) {
     const dnn_mem_t &d_src = args.find(DNNL_ARG_DIFF_SRC);
 
     float *d_src_ptr = (float *)d_src;
-    const auto nelems = src.nelems();
+    const auto nelems = source.nelems();
 
     benchdnn_parallel_nd(nelems, [&](int64_t i) {
         d_src_ptr[i] = compute_eltwise_bwd(prb->alg, d_dst.get_f32_elem(i),


### PR DESCRIPTION
#3888 didn't help since after execution scratchpad gets mapped back and new compare memory could still trigger a check error.
So this PR reverts that PR and just counts scratchpad towards mapped memory with a note that it can be reverted if/when lazy mapping is implemented for benchdnn memories.

A valid warning popped in eltwise driver where an excessive memory was kept. This was adjusted though a trick, and also extra reorder on backward path was removed.

Fixes [MFDNN-14232](https://jira.devtools.intel.com/browse/MFDNN-14232)