### PR TITLE
cpu, conv: fix L2 blocking for AVX2

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1619,13 +1619,16 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     // take L1 as 7/8 of the real size for L1
     brg_blocking_t::L1 = (platform::get_per_core_cache_size(1) * 7) / 8;
-    brg_blocking_t::L2 = platform::get_per_core_cache_size(2);
-    // here is hard-coded L2 size for avx2 performance cores
-    // TODO: get L2 size from the platform
-    if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2))
-        brg_blocking_t::L2 = 2 * 1024 * 1024;
-    // take L2 as 3/4 of the real size for L2
-    brg_blocking_t::L2 = (brg_blocking_t::L2 * 3) / 4;
+    // The L2 cache size appears to return smaller than expected for blocking
+    // purposes. When using avx2, the full size of L2 is used for blocking
+    // for other isa 3/4 of the size is used for blocking
+    // TODO : investigate the L2 cache size reporting issue
+    if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)) {
+        brg_blocking_t::L2 = platform::get_per_core_cache_size(2);
+    } else {
+        // take L2 as 3/4 of the real size for L2
+        brg_blocking_t::L2 = (platform::get_per_core_cache_size(2) * 3) / 4;
+    }
 
     // These are rough estimates of the latency (relative) of access to various
     // cache levels. This is enough for an estimation of data access cost.


### PR DESCRIPTION
[MFDNN-14078](https://jira.devtools.intel.com/browse/MFDNN-14078)
Removed the hard coded 2 MB L2 blocking when AVX2 isa is used for the brgemm conv. Replaced it with value read from cpuid.

For MTL and PTL systems the hard coded value was too large and resulted in poor performance for some input shapes.

MTL system:
```
sdpmkl170254
$ lscpu
Architecture:             x86_64
  CPU op-mode(s):         32-bit, 64-bit
  Address sizes:          46 bits physical, 48 bits virtual
  Byte Order:             Little Endian
CPU(s):                   22
  On-line CPU(s) list:    0-21
Vendor ID:                GenuineIntel
  Model name:             Intel(R) Core(TM) Ultra 7 1003H
    CPU family:           6
    Model:                170
    Thread(s) per core:   2
    Core(s) per socket:   16
    Socket(s):            1
    Stepping:             4
    CPU(s) scaling MHz:   14%
    CPU max MHz:          4800.0000
    CPU min MHz:          400.0000
    BogoMIPS:             5990.40
```
###main
```
./benchdnn --fix-times-per-prb=10 --mode=p --cold-cache=all --conv --reset --allow-enum-tags-only=0 --engine=cpu --dir=FWD_I --alg=direct --dt=f32:f32:f32 --bia-dt=f32 --stag=acdb --wtag=any --dtag=acdb --attr-post-ops=eltwise_relu --attr-scratchpad=user mb1_ic1024oc512_ih46oh46kh3sh1dh0ph1_iw60ow60kw3sw1dw0pw1
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,brg_conv_fwd:avx2,,--mode=P --fix-times-per-prb=10 --conv --allow-enum-tags-only=false --cold-cache=all --dir=FWD_I --bia-dt=f32 --stag=acdb --dtag=acdb --attr-post-ops=relu --attr-scratchpad=user mb1ic1024ih46iw60oc512oh46ow60kh3kw3ph1pw1,25.3839,1.52271,63.353,400.674,73.9081,343.453
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brg_conv_fwd:avx2 : 1 (100%)                             |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):63.353 avg(ms):73.9081
total: 0.89s; create_pd: 0.00s (0%); create_prim: 0.00s (0%); fill: 0.03s (3%); execute: 0.07s (8%);
```
###PR
```
./benchdnn --fix-times-per-prb=10 --mode=p --cold-cache=all --conv --reset --allow-enum-tags-only=0 --engine=cpu --dir=FWD_I --alg=direct --dt=f32:f32:f32 --bia-dt=f32 --stag=acdb --wtag=any --dtag=acdb --attr-post-ops=eltwise_relu --attr-scratchpad=user mb1_ic1024oc512_ih46oh46kh3sh1dh0ph1_iw60ow60kw3sw1dw0pw1
Output template: perf,%engine%,%impl%,%name%,%prb%,%Gops%,%+ctime%,%-time%,%-Gflops%,%0time%,%0Gflops%
perf,cpu,brg_conv_fwd:avx2,,--mode=P --fix-times-per-prb=10 --conv --allow-enum-tags-only=false --cold-cache=all --dir=FWD_I --bia-dt=f32 --stag=acdb --dtag=acdb --attr-post-ops=relu --attr-scratchpad=user mb1ic1024ih46iw60oc512oh46ow60kh3kw3ph1pw1,25.3839,108.092,41.6938,608.817,44.1903,574.423
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brg_conv_fwd:avx2 : 1 (100%)                             |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total perf: min(ms):41.6938 avg(ms):44.1903
total: 0.75s; create_pd: 0.08s (11%); create_prim: 0.03s (4%); fill: 0.07s (9%); execute: 0.05s (7%);
```
Results of performance testing on ADL system. (all shapes that showed 100% were hidden)
<img width="1808" height="726" alt="image" src="https://github.com/user-attachments/assets/84bc6e18-637f-4885-84c3-fa156649f667" />
