### PR TITLE
cpu: aarch64: readbility fixes - excl. identifier-naming

### DIFF
--- a/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/aarch64/brgemm/jit_brdgmm_kernel.hpp
@@ -98,26 +98,28 @@ private:
 
     bool with_binary_non_scalar_bcast_ = false;
 
-    inline int M() { return brg.bcast_dim; }
-    inline int N() { return brg.load_dim; }
-    inline int m_block1() { return brg.bd_block; }
-    inline int nb_m_block1() { return brg.bdb; }
-    inline int m_block1_tail() { return brg.bdb_tail; }
-    inline int m_block2() { return brg.bd_block2; }
-    inline int nb_m_block2() { return brg.bdb2; }
-    inline int m_block2_tail() { return brg.bdb2_tail; }
+    inline int M() const { return brg.bcast_dim; }
+    inline int N() const { return brg.load_dim; }
+    inline int m_block1() const { return brg.bd_block; }
+    inline int nb_m_block1() const { return brg.bdb; }
+    inline int m_block1_tail() const { return brg.bdb_tail; }
+    inline int m_block2() const { return brg.bd_block2; }
+    inline int nb_m_block2() const { return brg.bdb2; }
+    inline int m_block2_tail() const { return brg.bdb2_tail; }
 
-    inline int n_block1() { return brg.ld_block; }
-    inline int nb_n_block1() { return brg.ldb; }
-    inline int n_block1_tail() { return brg.ldb_tail; }
-    inline int n_block2() { return brg.ld_block2; }
-    inline int nb_n_block2() { return brg.ldb2; }
-    inline int n_block2_tail() { return brg.ldb2_tail; }
+    inline int n_block1() const { return brg.ld_block; }
+    inline int nb_n_block1() const { return brg.ldb; }
+    inline int n_block1_tail() const { return brg.ldb_tail; }
+    inline int n_block2() const { return brg.ld_block2; }
+    inline int nb_n_block2() const { return brg.ldb2; }
+    inline int n_block2_tail() const { return brg.ldb2_tail; }
 
     int tail_length() { return n_block1_tail() % simd_w_; }
-    bool is_fma_embd() { return brg.is_f32; }
-    bool is_fast_vnni_int8() { return is_fast_vnni_int8(brg); }
-    int vnni_substep() { return brg.isa_impl == sve_256 && brg.is_f16 ? 2 : 1; }
+    bool is_fma_embd() const { return brg.is_f32; }
+    bool is_fast_vnni_int8() const { return is_fast_vnni_int8(brg); }
+    int vnni_substep() const {
+        return brg.isa_impl == sve_256 && brg.is_f16 ? 2 : 1;
+    }
     int get_substep_simd(int n_i, int v_i, bool has_n_tail) {
         const int last_n_block_sz
                 = n_block2_tail() > 0 ? n_block2_tail() : n_block2();
@@ -204,7 +206,7 @@ private:
     void store_accumulators_apply_post_ops(
             int m_blocks, int n_blocks, bool has_n_tail);
 
-    bool has_vpad() {
+    bool has_vpad() const {
         return brg.brgattr.max_top_vpad > 0 || brg.brgattr.max_bottom_vpad > 0;
     }
     bool check_effective_padding() { return has_vpad() && M() > m_block2(); }

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -242,7 +242,7 @@ private:
     PReg ld_full_mask = PReg(2);
     PReg ld_tail_mask = PReg(3);
 
-    ZReg accm(int ld_block, int bd, int ld) {
+    ZReg accm(int ld_block, int bd, int ld) const {
         return ZReg(max_effective_vregs - 1 - (bd * ld_block + ld));
     }
 

--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -181,7 +181,7 @@ inline const Xbyak_aarch64::util::Cpu &cpu() {
 
 namespace {
 
-static inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
+inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
     using namespace Xbyak_aarch64::util;
 
     unsigned cpu_isa_mask = aarch64::get_max_cpu_isa_mask(soft);
@@ -207,7 +207,7 @@ static inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
     return false;
 }
 
-static inline int isa_max_vlen(cpu_isa_t isa) {
+inline int isa_max_vlen(cpu_isa_t isa) {
     if (isa == sve_512)
         return cpu_isa_traits<sve_512>::vlen;
     else if (isa == sve_256)
@@ -219,25 +219,25 @@ static inline int isa_max_vlen(cpu_isa_t isa) {
 };
 
 // SVE length in bytes
-static inline uint64_t get_sve_length() {
+inline uint64_t get_sve_length() {
     return cpu().getSveLen();
 }
 
-static inline bool mayiuse_atomic() {
+inline bool mayiuse_atomic() {
     using namespace Xbyak_aarch64::util;
     return cpu().isAtomicSupported();
 }
 
-static inline bool isa_has_s8s8(cpu_isa_t isa) {
+inline bool isa_has_s8s8(cpu_isa_t isa) {
     return is_superset(isa, sve_128);
 }
 
-static inline bool mayiuse_bf16() {
+inline bool mayiuse_bf16() {
     using namespace Xbyak_aarch64::util;
     return cpu().isBf16Supported();
 }
 
-static inline int isa_num_vregs(cpu_isa_t isa) {
+inline int isa_num_vregs(cpu_isa_t isa) {
     if (isa == sve_512)
         return cpu_isa_traits<sve_512>::n_vregs;
     else if (isa == sve_256)

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
 * Copyright 2022-2024 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1857,8 +1858,9 @@ void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
             host_->uni_fmin(dst.s, lhs.s, z_rhs.s);
             break;
         case alg_kind::binary_div:
-            host_->uni_fdiv(
-                    dst.s, lhs.s, z_rhs.s, Vmm(host_->DUMMY_IDX).s, mask);
+            host_->uni_fdiv(dst.s, lhs.s, z_rhs.s,
+                    Vmm(dnnl::impl::cpu::aarch64::jit_generator::DUMMY_IDX).s,
+                    mask);
             break;
         case alg_kind::binary_sub:
             host_->uni_fsub(dst.s, lhs.s, z_rhs.s);

--- a/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_transpose_utils.hpp
@@ -95,7 +95,7 @@ private:
             row_step_;
     const dim_t data_stride_, tr_data_stride_;
 
-    inline size_t addr_offset(int row_idx) {
+    inline size_t addr_offset(int row_idx) const {
         return row_idx * row_step_ * typesize_;
     }
     inline Xbyak_aarch64::ZReg get_zmm_copy(int row_idx) const {

--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -139,7 +139,9 @@ public:
     constexpr static size_t translator_stack_offset = 1024 * 128;
     constexpr static uint32_t DUMMY_IDX = 99;
 
-    inline size_t get_size_of_abi_save_regs() { return size_of_abi_save_regs; }
+    inline size_t get_size_of_abi_save_regs() const {
+        return size_of_abi_save_regs;
+    }
 
     void preamble() {
         using namespace Xbyak_aarch64::util;
@@ -670,7 +672,6 @@ public:
 
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_generator);
 
-public:
     jit_generator(void *code_ptr = nullptr, size_t code_size = MAX_CODE_SIZE,
             bool use_autogrow = true, cpu_isa_t max_cpu_isa = isa_all)
         : Xbyak_aarch64::CodeGenerator(code_size,

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_conv_kernel.hpp
@@ -164,12 +164,12 @@ private:
                 < (jcp.is_depthwise ? ker_dw_reg_base_idx : ker_reg_base_idx));
         return ZReg(idx);
     }
-    ZReg vmm_inp(int i_ic, int nb_x_blocking) {
+    ZReg vmm_inp(int i_ic, int nb_x_blocking) const {
         int idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
         return ZReg(idx);
     }
-    ZReg zmm_inp(int i_ic, int nb_x_blocking) {
+    ZReg zmm_inp(int i_ic, int nb_x_blocking) const {
         int idx = i_ic + nb_x_blocking * jcp.ur_w;
         const int max_idx = ker_dw_reg_base_idx;
         assert(idx < max_idx);
@@ -187,11 +187,11 @@ private:
                 = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
         return ZReg(nb_c_block * jcp.ur_w);
     }
-    int get_ow_start(int ki, int pad_l) {
+    int get_ow_start(int ki, int pad_l) const {
         return nstl::max(0,
                 utils::div_up(pad_l - ki * (jcp.dilate_w + 1), jcp.stride_w));
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
                 - nstl::max(0,
                         utils::div_up(

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -148,7 +148,8 @@ struct jit_bnorm_conf_t {
     // given nthr and shape of problem, choose the thread partition
     // to use (ie set N_nthr, C_nthr, and S_nthr)
     bool thread_partition(bool spatial_thr_allowed, int nthr, dim_t N,
-            dim_t C_blks, dim_t SP, int &C_nthr, int &N_nthr, int &S_nthr) {
+            dim_t C_blks, dim_t SP, int &C_nthr, int &N_nthr,
+            int &S_nthr) const {
         if (((nthr <= C_blks) && IMPLICATION(is_nspc_, N == 1))
                 || !dnnl_thr_syncable()) {
             C_nthr = nthr;

--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2022-2023 Intel Corporation
 * Copyright 2022-2023 FUJITSU LIMITED
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,8 +35,7 @@ static bcast_set_t get_supported_postops_bcast_strategies() {
 
 binary_kernel_t::binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
         const jit_binary_conf_t conf, bool tail_kernel)
-    : jit_generator()
-    , vlen_(vlen)
+    : vlen_(vlen)
     , simd_w_(vlen / sizeof(float))
     , pd_(pd)
     , conf_(conf)

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -2088,8 +2088,7 @@ struct jit_single_blk_kernel_t : public jit_generator {
     }
 
     jit_single_blk_kernel_t(const tr::prb_t &prb)
-        : jit_generator()
-        , prb_(prb)
+        : prb_(prb)
         , itype_sz_(data_type_size(prb_.itype))
         , otype_sz_(data_type_size(prb_.otype))
         , block_sz(prb.nodes[0].n) {}

--- a/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_copy_utils.cpp
@@ -237,7 +237,6 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
 
     jit_brgemm_matmul_copy_a_transposed_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
-        , jit_generator()
         , typesize(conf_->a_dt_sz)
         , tr_typesize(conf_->tr_a_dt_sz)
         , src_stride(conf_->copy_A_src_stride)
@@ -503,7 +502,6 @@ struct jit_brgemm_matmul_copy_b_f32_t : public jit_brgemm_matmul_copy_b_t,
 
     jit_brgemm_matmul_copy_b_f32_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
-        , jit_generator()
         , dt_in_(data_type::f32)
         , typesize_in_(types::data_type_size(dt_in_))
         , src_stride_(conf_->wei_tag == acbd ? conf_->copy_B_wei_stride

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
@@ -103,7 +103,7 @@ struct jit_bf16_matmul_kernel_t : public jit_generator {
 
     ZReg loadb(int ld) { return ZReg(ld + 1); }
 
-    ZReg acc(int bd, int ld) {
+    ZReg acc(int bd, int ld) const {
         return ZReg(bd * brg.ld_block + ld + brg.ld_block + 1);
     }
 

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -125,7 +125,7 @@ struct jit_int8_matmul_kernel_t : public jit_generator {
     }
 
     ZReg loadb(int ld) { return ZReg(ld + 1); }
-    ZReg acc(int bd, int ld) {
+    ZReg acc(int bd, int ld) const {
         return ZReg(bd * brg_.ld_block + ld + brg_.ld_block + 1);
     }
     void zero_regs() {


### PR DESCRIPTION
# Description

clang-tidy fixes to all readbility warnings except for readability-identifier-naming

Fixes # (github issue)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?