### PR TITLE
fixup: benchdnn: eltwise: clean up excessive memory objects

### DIFF
--- a/tests/benchdnn/eltwise/eltwise.cpp
+++ b/tests/benchdnn/eltwise/eltwise.cpp
@@ -411,13 +411,22 @@ std::vector<int> supported_exec_args(dir_t dir) {
             DNNL_ARG_DIFF_DST,
             DNNL_ARG_DIFF_SRC,
     };
+    // Since it costs much to enable a work around for `use_dst` at graph
+    // driver, just pass all of args there.
+    static const std::vector<int> exec_bwd_args_graph = {
+            DNNL_ARG_SRC,
+            DNNL_ARG_DST,
+            DNNL_ARG_DIFF_DST,
+            DNNL_ARG_DIFF_SRC,
+    };
     // This driver uses additional information coming only from `prb` through
     // the `dir` variable, which is not a clean solution, but the alternative
     // is to modify the `supported_exec_args` signature and introduce a `param`
     // struct to pass it to the call and fill according driver needs.
-    return (dir & FLAG_FWD)    ? exec_fwd_args
-            : (dir & FLAG_WEI) ? exec_bwd_use_dst_args
-                               : exec_bwd_args;
+    return (dir & FLAG_FWD)            ? exec_fwd_args
+            : (driver_name == "graph") ? exec_bwd_args_graph
+            : (dir & FLAG_WEI)         ? exec_bwd_use_dst_args
+                                       : exec_bwd_args;
 };
 
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,

--- a/tests/benchdnn/inputs/gnorm/shapes_ci
+++ b/tests/benchdnn/inputs/gnorm/shapes_ci
@@ -1,13 +1,13 @@
 # Instance normalization
-g2mb2ic2iw4
-g7mb2ic7ih3iw4
-g5mb2ic5id9ih1iw10
+g2mb2ic2iw4_n"gnorm_ci_1d:1"
+g7mb2ic7ih3iw4_n"gnorm_ci_2d:1"
+g5mb2ic5id9ih1iw10_n"gnorm_ci_3d:1"
 
 # Group normalization
-g1mb2ic2iw4
-g2mb2ic8ih3iw4
-g5mb2ic10id9ih1iw10
-g5mb2ic40id2ih1iw5
-g5mb2ic80id2ih1iw5
-g1mb1ic128ih2iw2
-g2mb2ic30ih1iw1
+g1mb2ic2iw4_n"gnorm_ci_1d:2"
+g2mb2ic8ih3iw4_n"gnorm_ci_2d:2"
+g5mb2ic10id9ih1iw10_n"gnorm_ci_3d:2"
+g5mb2ic40id2ih1iw5_n"gnorm_ci_3d:3"
+g5mb2ic80id2ih1iw5_n"gnorm_ci_3d:4"
+g1mb1ic128ih2iw2_n"gnorm_ci_2d:3"
+g2mb2ic30ih1iw1_n"gnorm_ci_2d:4"

--- a/tests/benchdnn/inputs/gnorm/test_gnorm_smoke
+++ b/tests/benchdnn/inputs/gnorm/test_gnorm_smoke
@@ -1,0 +1,32 @@
+--reset
+
+--match=.*gnorm_ci_2d.* # Use 2d problems only from shapes_ci
+--inplace=false
+--tag=axb
+
+# training
+--dir=FWD_D,BWD_DW
+--dt=f32,bf16,f16
+--flags=,G,CH
+--batch=shapes_ci
+## no scale or shift support for backward_data
+--dir=BWD_D
+--flags=,G
+--batch=shapes_ci
+
+# inference
+--dir=FWD_I
+
+--dt=f32,bf16,f16
+--flags=,G,CH
+--attr-post-ops=,add:f32
+--batch=shapes_ci
+--attr-post-ops=
+
+--dt=f16
+--flags=,G,CH
+--batch=shapes_ci
+
+--dt=s8
+--flags=G,GCH
+--batch=shapes_ci


### PR DESCRIPTION
Fixup for #4016, forgot about graph driver.
Since the implementation cost to pass a work around is huge, just restored the previous state for graph exclusively.

[MFDNN-14195](https://jira.devtools.intel.com/browse/MFDNN-14195)
[MFDNN-14261](https://jira.devtools.intel.com/browse/MFDNN-14261)
[MFDNN-14267](https://jira.devtools.intel.com/browse/MFDNN-14267)