### PR TITLE
[GPU][GEMM] Avoid ub in quant attr 

### DIFF
--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -35,6 +35,7 @@ namespace {
 int quant_entry_ndims(
         const quant_entry_t &entry, const memory_desc_t &qmd, int k_idx) {
     if (entry.has_default_values()) return -1;
+    if (qmd.ndims < 2) return 0;
 
     // C unt the number of nontrivial (dim > 1) dimensions present
     int count = 0;


### PR DESCRIPTION
# Description

Cases with host scalars can result in common scales to hit dim count, added handling to avoid invalid loop bounds.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?
