### PR TITLE
[GPU] jit: gemm: limited support of host scalar scales implemented via Alpha

### DIFF
--- a/src/gpu/intel/gemm/host_scalars.hpp
+++ b/src/gpu/intel/gemm/host_scalars.hpp
@@ -1,0 +1,80 @@
+/*******************************************************************************
+* Copyright 2020-2025 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GPU_INTEL_GEMM_HOST_SCALARS_HPP
+#define GPU_INTEL_GEMM_HOST_SCALARS_HPP
+
+#include "common/host_scalar_memory_storage.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace gpu {
+namespace intel {
+namespace gemm {
+
+// Host side scalars support for scales implemented via Alpha argument
+
+template <typename ScalarType>
+status_t update_alpha_by_scale_value(float &alpha,
+        const host_scalar_memory_storage_t *scale_storage, bool is_dst) {
+    ScalarType value = 0;
+    status_t status = scale_storage->get_scalar_value(&value, sizeof(value));
+    assert(status == status::success);
+    if (status != status::success) return status;
+
+    if (is_dst) {
+        alpha /= static_cast<float>(value);
+    } else {
+        alpha *= static_cast<float>(value);
+    }
+    return status::success;
+}
+
+static status_t maybe_convert_scales_to_alpha(
+        const memory_storage_t &scale_storage, float &alpha,
+        const bool is_dst = false) {
+#define SCALAR_DT_DISPATCH(sdt, vdt) \
+    case sdt: { \
+        CHECK(update_alpha_by_scale_value<vdt>( \
+                alpha, scalar_storage, is_dst)); \
+        break; \
+    }
+
+    using namespace data_type;
+    auto scalar_storage = utils::downcast<const host_scalar_memory_storage_t *>(
+            &scale_storage);
+    switch ((int)scalar_storage->data_type()) {
+        SCALAR_DT_DISPATCH(f32, float)
+        SCALAR_DT_DISPATCH(f16, float16_t)
+        SCALAR_DT_DISPATCH(bf16, bfloat16_t)
+        SCALAR_DT_DISPATCH(s32, int32_t)
+        SCALAR_DT_DISPATCH(s8, int8_t)
+        SCALAR_DT_DISPATCH(u8, uint8_t)
+        default:
+            assert(!"Support for requested data type is missing for "
+                    "host-side scalars");
+    }
+    return status::success;
+#undef SCALAR_DT_DISPATCH
+}
+
+} // namespace gemm
+} // namespace intel
+} // namespace gpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/gpu/intel/gemm/jit.cpp
+++ b/src/gpu/intel/gemm/jit.cpp
@@ -434,15 +434,19 @@ status_t gen_t::execute(const exec_ctx_t &ctx) const {
         const auto &b_scales_storage = GEMM_CTX_ARG_STORAGE(b_scales);
         const auto &c_scales_storage = GEMM_CTX_ARG_STORAGE(c_scales);
         alpha = 1.0f;
+        float scale_val = 0;
         if (a_scales.is_host_scalar()) {
-            CHECK(maybe_convert_scales_to_alpha(a_scales_storage, alpha));
+            CHECK(maybe_get_scale_as_float(a_scales_storage, scale_val));
+            alpha *= scale_val;
         }
         if (b_scales.is_host_scalar()) {
-            CHECK(maybe_convert_scales_to_alpha(b_scales_storage, alpha));
+            CHECK(maybe_get_scale_as_float(b_scales_storage, scale_val));
+            alpha *= scale_val;
         }
         // Limited support of host scalar dst scales
         if (c_scales.is_host_scalar() && pd()->attr()->post_ops_.len() == 0) {
-            CHECK(maybe_convert_scales_to_alpha(c_scales_storage, alpha, true));
+            CHECK(maybe_get_scale_as_float(c_scales_storage, scale_val));
+            alpha /= scale_val;
         }
     }
 

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -64,7 +64,7 @@ status_t pd_t::init_post_ops() {
 
     bool ok = true;
     int prelu_count = 0;
-    int num_orig_postops = attr()->post_ops_.len();
+    const int num_orig_postops = post_ops_.len();
     for (int i = 0; i < post_ops_.len(); i++) {
         const auto &e = post_ops_.entry_[i];
         switch (e.kind) {

--- a/src/gpu/intel/gemm/jit/pd.hpp
+++ b/src/gpu/intel/gemm/jit/pd.hpp
@@ -112,7 +112,17 @@ struct pd_t : public gemm::pd_t {
     bool eff_transa_ = false, eff_transb_ = false;
     bool with_sround_ = false;
 
-    float alpha() const { return 1.0f; }
+    float alpha() const {
+        auto attr_info = attr_info_t::create(attr());
+        bool host_scales_by_alpha = attr_info.with_host_src_scale
+                || attr_info.with_host_wei_scale
+                || (attr_info.with_host_dst_scale
+                        && attr()->post_ops_.len() == 0);
+        // Bogus non-one value for host scalar.
+        // Actual value will be passed on execution step
+        if (host_scales_by_alpha) return 9.99f;
+        return 1.0f;
+    }
 
     float beta() const { return beta_; }
 


### PR DESCRIPTION
PR addresses https://jira.devtools.intel.com/browse/MFDNN-14149.
Provided with limited (below) support of host side scalars for only scales attribute (zero points are still not supported yet). This feature is implemented via Alpha parameter what seemed to be the fastest way to give a chance frameworks to try it in the nearest release. Hopefully this way will be reworked later in order to find more standard method also applicable to convolution.
Limitation: host scalar dst scales are supported in jit gemm if there are no postops.
