### PR TITLE
gpu: concat: zero initialize params for proper caching

### DIFF
--- a/src/gpu/intel/concat/simple.hpp
+++ b/src/gpu/intel/concat/simple.hpp
@@ -44,15 +44,15 @@ struct simple_params_t : trivially_serializable_t<simple_params_t> {
     compute::kernel_ctx_t get_kernel_ctx() const;
 
     dim_t n_blocks;
-    dim_t blocks[6];
-    dim_t strides[6];
+    dim_t blocks[6] = {0};
+    dim_t strides[6] = {0};
 
     dim_t read_block;
     dim_t write_block;
     int n;
     int simd;
     int data_type_size;
-    int bytes_per_workitem;
+    int bytes_per_workitem = 0;
     bool use_large_index = true;
     bool use_internal_padding_kernel = false;
     uint8_t padding[6] = {0};


### PR DESCRIPTION
# Description

Concat op's params are not fully zero initialized, and later `init_conf_common` is not initializting all the fields in some cases.

Kernel Caching is simply copying the whole param and calculate hashing. Those uninitialized fields lead to failure of caching and cause some redundant compilations.

More specifically, `blocks` and `strides` only get assigned in covered dimensions, but should be fully deterministic like `padding`.
`bytes_per_workitem` is only assigned in `try_normalize_internal_padding`

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
