### PR TITLE
cpu: aarch64: remove d_type compiletime arg from JIT

### DIFF
--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -260,7 +260,7 @@ private:
 
     /**
      * @brief Unpack two BFloat16 values from a single register into two target registers.
-    * 
+    *
     * ASIMD (NEON) version: unpack in low/high half order.
     * SVE version: unpack in even/odd element order.
     *
@@ -271,7 +271,7 @@ private:
 
     /**
      * @brief Pack two BFloat16 values from two registers into a single register.
-     * 
+     *
      * ASIMD (NEON) version: pack from low/high half order.
      * SVE version: pack from even/odd element order.
      *
@@ -282,7 +282,7 @@ private:
 
     /**
      * @brief Unpack two IEEE‑754 FP16 values from a single register into two target registers.
-     * 
+     *
      * ASIMD (NEON) version: unpack in low/high half order.
      * SVE version: unpack in even/odd element order.
      *
@@ -293,7 +293,7 @@ private:
 
     /**
      * @brief Pack two IEEE‑754 FP16 values from two registers into a single register.
-     * 
+     *
      * ASIMD (NEON) version: pack from low/high half order.
      * SVE version: pack from even/odd element order.
      *
@@ -396,15 +396,15 @@ inline void jit_uni_kernel_t<cpu_isa_t::sve_128>::pack_fp16(
 }
 } // namespace
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
+template <cpu_isa_t isa>
+status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(engine_t *engine) {
     using namespace alg_kind;
 
     const memory_desc_wrapper src_d(src_md());
 
     bool ok = mayiuse(isa) && is_fwd()
             && utils::everyone_is(
-                    d_type, src_md()->data_type, dst_md()->data_type)
+                    src_md()->data_type, dst_md()->data_type)
             && !has_zero_dim_memory() && src_d.is_dense(true)
             && eltwise_injector::is_supported(isa, desc_.alg_kind)
             // refer to a comment in jit_uni_kernel why this is needed
@@ -414,24 +414,28 @@ status_t jit_uni_eltwise_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     return ok ? status::success : status::unimplemented;
 }
 
-template <cpu_isa_t isa, data_type_t d_type>
-jit_uni_eltwise_fwd_t<isa, d_type>::jit_uni_eltwise_fwd_t(const pd_t *apd)
+template <cpu_isa_t isa>
+jit_uni_eltwise_fwd_t<isa>::jit_uni_eltwise_fwd_t(const pd_t *apd)
     : primitive_t(apd) {}
 
-template <cpu_isa_t isa, data_type_t d_type>
-jit_uni_eltwise_fwd_t<isa, d_type>::~jit_uni_eltwise_fwd_t() = default;
+template <cpu_isa_t isa>
+jit_uni_eltwise_fwd_t<isa>::~jit_uni_eltwise_fwd_t() = default;
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_fwd_t<isa, d_type>::init(engine_t *engine) {
+template <cpu_isa_t isa>
+status_t jit_uni_eltwise_fwd_t<isa>::init(engine_t *engine) {
     CHECK(safe_ptr_assign(kernel_, new jit_uni_kernel_t<isa>(pd())));
     return kernel_->create_kernel();
 }
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_fwd_t<isa, d_type>::execute(
+template <cpu_isa_t isa>
+status_t jit_uni_eltwise_fwd_t<isa>::execute(
         const exec_ctx_t &ctx) const {
-    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+
+    const data_type_t src_dt = pd()->src_md()->data_type;
+    const data_type_t dst_dt = pd()->dst_md()->data_type;
+
+    auto src = CTX_IN_MEM(const src_dt *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(dst_dt *, DNNL_ARG_DST);
 
     const memory_desc_wrapper data_d(pd()->src_md());
     const auto nelems = data_d.nelems(true);
@@ -459,14 +463,14 @@ status_t jit_uni_eltwise_fwd_t<isa, d_type>::execute(
     return status::success;
 }
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
+template <cpu_isa_t isa>
+status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(engine_t *engine) {
     using namespace alg_kind;
 
     const memory_desc_wrapper data_d(data_md());
 
     bool ok = mayiuse(isa) && !is_fwd()
-            && utils::everyone_is(d_type, data_md()->data_type,
+            && utils::everyone_is(data_md()->data_type,
                     diff_src_md()->data_type, diff_dst_md()->data_type)
             && !has_zero_dim_memory() && set_default_formats_common()
             && data_d.is_dense(true)
@@ -480,22 +484,23 @@ status_t jit_uni_eltwise_bwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     return ok ? status::success : status::unimplemented;
 }
 
-template <cpu_isa_t isa, data_type_t d_type>
-jit_uni_eltwise_bwd_t<isa, d_type>::jit_uni_eltwise_bwd_t(const pd_t *apd)
+template <cpu_isa_t isa>
+jit_uni_eltwise_bwd_t<isa>::jit_uni_eltwise_bwd_t(const pd_t *apd)
     : primitive_t(apd) {}
 
-template <cpu_isa_t isa, data_type_t d_type>
-jit_uni_eltwise_bwd_t<isa, d_type>::~jit_uni_eltwise_bwd_t() = default;
+template <cpu_isa_t isa>
+jit_uni_eltwise_bwd_t<isa>::~jit_uni_eltwise_bwd_t() = default;
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_bwd_t<isa, d_type>::init(engine_t *engine) {
+template <cpu_isa_t isa>
+status_t jit_uni_eltwise_bwd_t<isa>::init(engine_t *engine) {
     CHECK(safe_ptr_assign(kernel_, new jit_uni_kernel_t<isa>(pd())));
     return kernel_->create_kernel();
 }
 
-template <cpu_isa_t isa, data_type_t d_type>
-status_t jit_uni_eltwise_bwd_t<isa, d_type>::execute(
+template <cpu_isa_t isa>
+status_t jit_uni_eltwise_bwd_t<isa>::execute(
         const exec_ctx_t &ctx) const {
+    const data_type_t data_t = pd()->use_dst() ? pd()->dst_md()->data_type : pd()->src_md()->data_type;
     auto src = pd()->use_dst() ? CTX_IN_MEM(const data_t *, DNNL_ARG_DST)
                                : CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
     auto diff_dst = CTX_IN_MEM(const data_t *, DNNL_ARG_DIFF_DST);
@@ -531,13 +536,9 @@ status_t jit_uni_eltwise_bwd_t<isa, d_type>::execute(
 
 // Jit uni eltwise is fully vector length agnostic, so we use sve_128
 // as alias for VLA SVE.
-template struct jit_uni_eltwise_fwd_t<asimd, data_type::f32>;
-template struct jit_uni_eltwise_fwd_t<asimd, data_type::bf16>;
-template struct jit_uni_eltwise_fwd_t<asimd, data_type::f16>;
-template struct jit_uni_eltwise_fwd_t<sve_128, data_type::f32>;
-template struct jit_uni_eltwise_fwd_t<sve_128, data_type::bf16>;
-template struct jit_uni_eltwise_fwd_t<sve_128, data_type::f16>;
-template struct jit_uni_eltwise_bwd_t<sve_128, data_type::f32>;
+template struct jit_uni_eltwise_fwd_t<asimd>;
+template struct jit_uni_eltwise_fwd_t<sve_128>;
+template struct jit_uni_eltwise_bwd_t<sve_128>;
 
 } // namespace aarch64
 } // namespace cpu

--- a/src/cpu/aarch64/jit_uni_eltwise.hpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.hpp
@@ -37,7 +37,7 @@ namespace aarch64 {
 
 struct jit_uni_eltwise_kernel_t;
 
-template <cpu_isa_t isa, impl::data_type_t d_type>
+template <cpu_isa_t isa>
 struct jit_uni_eltwise_fwd_t : public primitive_t {
     struct pd_t : public cpu_eltwise_fwd_pd_t {
         using cpu_eltwise_fwd_pd_t::cpu_eltwise_fwd_pd_t;
@@ -51,8 +51,6 @@ struct jit_uni_eltwise_fwd_t : public primitive_t {
     jit_uni_eltwise_fwd_t(const pd_t *apd);
     ~jit_uni_eltwise_fwd_t() override;
 
-    using data_t = typename prec_traits_t<d_type>::type;
-
     status_t init(engine_t *engine) override;
 
     status_t execute(const exec_ctx_t &ctx) const override;
@@ -62,7 +60,7 @@ private:
     std::unique_ptr<jit_uni_eltwise_kernel_t> kernel_;
 };
 
-template <cpu_isa_t isa, impl::data_type_t d_type>
+template <cpu_isa_t isa>
 struct jit_uni_eltwise_bwd_t : public primitive_t {
     struct pd_t : public cpu_eltwise_bwd_pd_t {
         using cpu_eltwise_bwd_pd_t::cpu_eltwise_bwd_pd_t;
@@ -75,8 +73,6 @@ struct jit_uni_eltwise_bwd_t : public primitive_t {
 
     jit_uni_eltwise_bwd_t(const pd_t *apd);
     ~jit_uni_eltwise_bwd_t() override;
-
-    using data_t = typename prec_traits_t<d_type>::type;
 
     status_t init(engine_t *engine) override;
 


### PR DESCRIPTION
This removes the compiletime d_type arg from the eltwise kernel and fwd/bwd layer code and instead derives it from the src/dest memory descriptors instead.