### PR TITLE
[GPU] LBR GRU regression on DG2

### DIFF
--- a/src/gpu/intel/rnn/utils.cpp
+++ b/src/gpu/intel/rnn/utils.cpp
@@ -165,7 +165,11 @@ void init_conf(conf_t &conf, const desc_t &rd,
         bool can_fuse_gemm = !conf.is_int8
                 && conf.wei_iter_type == conf.wei_layer_type && conf.is_fwd
                 && utils::one_of(rd.cell_kind, alg_kind::vanilla_rnn,
-                        alg_kind::vanilla_lstm, alg_kind::lbr_gru);
+                        alg_kind::vanilla_lstm);
+        bool is_xe_hpg = device_info.gpu_arch() == gpu_arch_t::xe_hpg;
+        bool can_fuse_lbr_gemm
+                = (rd.cell_kind == alg_kind::lbr_gru) && !is_xe_hpg;
+        can_fuse_gemm = can_fuse_gemm && can_fuse_lbr_gemm;
         // Poor implementation performance if dhc % subgroup_size != 0
         bool tail_dhc = conf.dhc % device_info.min_subgroup_size() != 0;
         // Since RNN cells may result in very small workloads the CPU overhead


### PR DESCRIPTION
# Description

LBR GRU was improved for MTL. This enabled cell-fusion for all platforms by default. Certain tests from the customer side aren't performing well on DG2 as of recently. This PR disables LBR GRU for DG2, and will check for any regression that can occur as a result.

` --mode=p --cold-cache=wei --memory-kind=usm_device --rnn --reset --allow-enum-tags-only=0 --engine=gpu:0 --prop=FWD_I --alg=LBR_GRU --direction=right2left --flags= --cfg=f16 --tag=abc:abcde:abc --trivial-strides=true --attr-scales= --attr-zero-points= l1t35456mb1sic256slc384dhc256dic256
`
Fixes # (MFDNN-14190)

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

