### PR TITLE
ci: aarch64: Fix git bisect false positives and wiki failure

### DIFF
--- a/.github/automation/aarch64/test.sh
+++ b/.github/automation/aarch64/test.sh
@@ -22,6 +22,8 @@
 set -o errexit -o pipefail -o noclobber
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+OUTPUT_XML=$1
+OUTPUT_LOG=$2
 
 # Defines MP, CC, CXX and OS.
 source ${SCRIPT_DIR}/common.sh
@@ -32,5 +34,5 @@ if [[ "$ONEDNN_THREADING" == "SEQ" ]]; then
 fi
 
 set -x
-ctest --no-tests=error --output-on-failure -E $("${SCRIPT_DIR}"/skipped-tests.sh) --output-junit $1
+ctest --no-tests=error --output-on-failure -E $("${SCRIPT_DIR}"/skipped-tests.sh) --output-junit ${OUTPUT_XML} | tee ${OUTPUT_LOG}
 set +x

--- a/.github/automation/aarch64/wiki_utils.py
+++ b/.github/automation/aarch64/wiki_utils.py
@@ -121,7 +121,7 @@ def main():
     unit_parser.add_argument(
         "--title", required=True, help="title of unit test run"
     )
-    # xml is the only machine-readable output format from ctest
+    # xml required for machine-readable unit test results
     unit_parser.add_argument(
         "--in-file", required=True, help="xml file storing test results"
     )

--- a/.github/workflows/ci-aarch64.yml
+++ b/.github/workflows/ci-aarch64.yml
@@ -172,7 +172,7 @@ jobs:
           ONEDNN_ACTION: build
 
       - name: Run oneDNN tests
-        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh ${{ github.workspace }}/test_results.xml
+        run: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh ${{ github.workspace }}/test_results.xml ${{ github.workspace }}/test_results.log
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
           CTEST_PARALLEL_LEVEL: 6

--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run oneDNN tests
         run: |
           set -o pipefail
-          ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh ${{ github.workspace }}/test_results.xml
+          ${{ github.workspace }}/oneDNN/.github/automation/aarch64/test.sh ${{ github.workspace }}/test_results.xml ${{ github.workspace }}/test_results.log
         working-directory: ${{ github.workspace }}/oneDNN/build
         env:
           BUILD_TOOLSET: ${{ matrix.config.toolset }}
@@ -143,16 +143,6 @@ jobs:
           CTEST_PARALLEL_LEVEL: 8
           DYLD_LIBRARY_PATH: ${{ github.workspace }}/ComputeLibrary/build
           ONEDNN_THREADING: ${{ matrix.config.threading }}
-
-      - name: Create hash file
-        working-directory: ${{ github.workspace }}/oneDNN
-        run: echo "$(git rev-parse --short HEAD)" > .github/automation/aarch64/stable.sha
-
-      - name: Save hash
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          key: latest-nightly-success-sha
-          path: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/stable.sha
 
       - name: Find last successful run
         if: failure()
@@ -175,9 +165,14 @@ jobs:
         if: failure()
         shell: bash
         working-directory: ${{ github.workspace }}/oneDNN
-        run: python .github/automation/aarch64/bisect_ctest.py --unique ${{ steps.get-stable.outputs.stable-hash }} ${{ github.workspace }}/test_results.xml
+        run: python .github/automation/aarch64/bisect_ctest.py --unique ${{ steps.get-stable.outputs.stable-hash }} ${{ github.workspace }}/test_results.log
         env:
           ACL_ROOT_DIR: ${{ github.workspace }}/ComputeLibrary
+      
+      - name: Reset to HEAD
+        if: failure()
+        working-directory: ${{ github.workspace }}/oneDNN
+        run: git bisect reset
 
       - name: Update wiki
         if: ${{ (success() || failure()) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ryo-not-rio/wiki') }}
@@ -186,6 +181,25 @@ jobs:
           command: add-unit
           title: ${{ matrix.config.name }}
           in-file: ${{ github.workspace }}/test_results.xml
+  
+  save-success-hash:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - name: Checkout oneDNN
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          path: oneDNN
+      
+      - name: Create hash file
+        working-directory: ${{ github.workspace }}/oneDNN
+        run: echo "$(git rev-parse --short HEAD)" > .github/automation/aarch64/stable.sha
+
+      - name: Save hash
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          key: latest-nightly-success-sha
+          path: ${{ github.workspace }}/oneDNN/.github/automation/aarch64/stable.sha
 
   #* This job adds a check named "Nightly AArch64" that represents overall
   #* workflow status and can be used in branch rulesets


### PR DESCRIPTION
- add a fix for the git bisect conflicting with the wiki causing the wiki update to fail
- add a fix for git bisect picking up on non-failing tests due to output truncation
- fix edge case where success status hash was being updated when one of the ci matrices succeeded