### PR TITLE
tests: fix clang-tidy failures

### DIFF
--- a/tests/gtests/test_ip_formats.cpp
+++ b/tests/gtests/test_ip_formats.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,11 +15,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <memory>
-#include <numeric>
-#include <utility>
-#include <type_traits>
-
 #include "dnnl_test_common.hpp"
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
@@ -28,7 +24,6 @@
 #include "gtest/gtest.h"
 
 #include "oneapi/dnnl/dnnl.hpp"
-#include "oneapi/dnnl/dnnl_debug.h"
 
 namespace dnnl {
 
@@ -40,7 +35,7 @@ using ip_fwd = inner_product_forward;
 using ip_bwd_d = inner_product_backward_data;
 using ip_bwd_w = inner_product_backward_weights;
 
-class ip_formats_test : public ::testing::Test {
+class ip_formats_test_t : public ::testing::Test {
 public:
     engine e;
 
@@ -208,6 +203,6 @@ protected:
     }
 };
 
-TEST_F(ip_formats_test, TestChecksAllFormats) {}
+TEST_F(ip_formats_test_t, TestChecksAllFormats) {}
 
 } // namespace dnnl

--- a/tests/gtests/test_reorder_formats.cpp
+++ b/tests/gtests/test_reorder_formats.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2020-2023 Intel Corporation
+* Copyright 2025 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,11 +15,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <memory>
-#include <numeric>
-#include <utility>
-#include <type_traits>
-
 #include "dnnl_test_common.hpp"
 
 #if DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
@@ -28,7 +24,6 @@
 #include "gtest/gtest.h"
 
 #include "oneapi/dnnl/dnnl.hpp"
-#include "oneapi/dnnl/dnnl_debug.h"
 
 namespace dnnl {
 
@@ -36,7 +31,7 @@ using dt = memory::data_type;
 using tag = memory::format_tag;
 using md = memory::desc;
 
-class reorder_formats_test : public ::testing::Test {
+class reorder_formats_test_t : public ::testing::Test {
 public:
     engine e;
 
@@ -161,6 +156,6 @@ protected:
     }
 };
 
-TEST_F(reorder_formats_test, TestChecksAllFormats) {}
+TEST_F(reorder_formats_test_t, TestChecksAllFormats) {}
 
 } // namespace dnnl


### PR DESCRIPTION
# Description

Looks like some test files might have been previously missed when making the library clang-tidy compliant. This PR fixes the failures I am aware of.

# Checklist

## General

- [X] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?