### PR TITLE
gpu: conv: jit: add early slm check to skip ngen jitting

### DIFF
--- a/src/gpu/intel/conv/jit/tiler.hpp
+++ b/src/gpu/intel/conv/jit/tiler.hpp
@@ -46,6 +46,7 @@ public:
     void set_params(config_t &cfg);
     void notify_out_of_registers(const config_t &cfg);
     bool is_grf_limit_ok(const config_t &cfg) const;
+    bool is_slm_limit_ok(const config_t &cfg, const int tg_size) const;
     static void after_create_hook(
             const config_t &cfg, const impl::primitive_t *primitive);
     static void before_exec_hook(


### PR DESCRIPTION
# Description

Convolution's jit kernel could fail due to SLM usage exceeding limit:
https://github.com/uxlfoundation/oneDNN/blob/05b4b09de057482a0b324cf8938476400418905b/src/gpu/intel/jit/codegen/codegen.cpp#L1752-L1758

The common usage of SLM in conv is for reduce of k slicing:
https://github.com/uxlfoundation/oneDNN/blob/05b4b09de057482a0b324cf8938476400418905b/src/gpu/intel/conv/jit/ir_builder.cpp#L513-L517

And this size is known with the config, no need to spend time in IR generation.

This PR calculates this SLM usage and perform early check, should save some compilation time wasting on unsuitable config.

Code could be better by abstracting logic into functions rather than copy-pasting, but that introduce a bigger change...

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
