### PR TITLE
cpu: x64: brgconv: inp buffer size reduction

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -2245,6 +2245,15 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     bool try_exec_type_res = false;
 
+    // Avoid exec_trans when iw is very large and trans_dim_koef==1, as this
+    // would lead to excessive scratchpad size proportional to iw.
+    // The value is empirical
+    constexpr dim_t max_iw_for_exec_trans = 100000;
+    if (try_exec_trans && jcp.trans_dim_koef == 1
+            && jcp.iw > max_iw_for_exec_trans) {
+        try_exec_trans = false;
+    }
+
     if (try_exec_type_res == false && try_exec_trans) {
         jcp.exec_type = exec_trans;
         if (try_relo_whi) {


### PR DESCRIPTION
[MFDNN-12544](https://jira.devtools.intel.com/browse/MFDNN-12544)
The fix in [#8073](https://github.com/intel-innersource/libraries.performance.math.onednn/pull/8073) added stricter requirements for finding `trans_dim_koef`, making it harder to transform dimensions. When `trans_dim_koef == 1` (no transformation), large `iw` causes huge scratchpad growth.

I fixed it by disabling `exec_trans` when `trans_dim_koef == 1` and `iw > 100000`. The threshold was chosen empirically to avoid regressions - validation with `test_conv_all` confirmed no execution path changes for existing workloads.
