### PR TITLE
cpu: x64: matmul: dispatch shapes with small K to gemm

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -1855,7 +1855,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     init_aux_values(bgmmc, src_d, weights_d, dst_d);
 
     if (!bgmmc.is_gemv && bm_conf_utils.is_f32()
-            && is_superset(bgmmc.isa, avx512_core)) {
+            && (bgmmc.isa == avx2 || is_superset(bgmmc.isa, avx512_core))) {
         // Dispatch the shapes with small K to gemm for better performance
         // The heuristic values are empirical
         const bool small_K = bgmmc.N <= 14528


### PR DESCRIPTION
According to the fix [PR 3628](https://github.com/uxlfoundation/oneDNN/pull/3628), calculations for fp32 data type were dispatched to gemm for AVX512 for some small shapes.  `brgemm_matmul_t<avx2>` implementation had lower priority than gemm. After enabling gemv code path [here](https://github.com/uxlfoundation/oneDNN/pull/3954), the priority of `brgemm_matmul_t<avx2>` increased, and calculations were dispatched to `brgemm_matmul_t<avx2>` for some non-gemv cases (dispatching gemv cases to this implementation is expected). This introduced performance regression on AVX512 CPUs. The regression was found during testing RNN+Matmul implementation. Measurements are added to [MFDNN-14270](https://jira.devtools.intel.com/browse/MFDNN-14270) (in comments, not description).

Primitives are not tested for fp32 data type on AVX512 CPUs using pre-commit perf-tests or during regular performance testing.

This change in dispatching has small impact for calculations on AVX2 CPUs (some cases are faster, some slower).

This PR restores the dispatching logic introduced by the fix [PR 3628](https://github.com/uxlfoundation/oneDNN/pull/3628) and related changes, that was changed after increasing priority of `brgemm_matmul_t<avx2>` implementation.

Note that possibility to fallback to gemm is tested a few lines down (caling can_use_gemm_fallback()).
