### PR TITLE
xe: gemm: revert gemmstone API changes

### DIFF
--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -314,7 +314,7 @@ struct gen_t : public primitive_t {
 
             bool print_verbose = get_verbose(verbose_t::debuginfo) >= 5;
             bool kernel_success = false;
-            auto entries = kernel_desc_.select_kernel(arch_, stepping,
+            auto entries = kernel_desc_.collect_kernels(arch_, stepping,
                     dev_info_->eu_count(), has_systolic, is_integrated, mode,
                     batch_dims(), eff_transa(), eff_transb(), eff_trans_bias(),
                     swap_ab(), swapped_a_quant, swapped_b_quant, c_quant,

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -21,6 +21,7 @@
 #include "gemmstone/driver_info.hpp"
 #include "gemmstone/kernel_catalog.hpp"
 #include "gemmstone/kernel_evaluator.hpp"
+#include "gemmstone/kernel_selector.hpp"
 #include "gemmstone/problem.hpp"
 #include "gemmstone/strategy.hpp"
 #include "gemmstone/type.hpp"
@@ -91,7 +92,10 @@ struct gen_desc_t {
         return *entry_;
     }
 
-    void set_entry(const gemmstone::kcatalog::Entry *entry) { entry_ = entry; }
+    void set_entry(const gemmstone::EntryData &data) {
+        entry_ = data.entry;
+        aux_params_ = data.aux;
+    }
 
 protected:
     compute::gpu_arch_t arch_;
@@ -131,11 +135,10 @@ struct gen_nocopy_desc_t : public gen_desc_t {
         mode = static_cast<compute_mode>(mode | flag);
     }
 
-    std::vector<const gemmstone::kcatalog::Entry *> select_kernel(
-            compute::gpu_arch_t arch, int stepping, int eu_count,
-            bool has_systolic, bool is_integrated, compute_mode mode,
-            int batch_dims, bool trans_a, bool trans_b, bool trans_co,
-            bool swap_ab, const quant_params &a_quant,
+    std::vector<gemmstone::EntryData> collect_kernels(compute::gpu_arch_t arch,
+            int stepping, int eu_count, bool has_systolic, bool is_integrated,
+            compute_mode mode, int batch_dims, bool trans_a, bool trans_b,
+            bool trans_co, bool swap_ab, const quant_params &a_quant,
             const quant_params &b_quant, const quant_params &c_quant,
             bool mx_scales, bool dst_sround, bool c_offset, bool bias,
             sum_ab_t reduce_ab, float alpha, float beta, data_type_t a_type,

--- a/src/gpu/intel/gemm/jit/include/gemmstone/kernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/kernel_selector.hpp
@@ -21,7 +21,6 @@
 #include "gemmstone/kernel_catalog.hpp"
 #include "gemmstone/kernel_evaluator.hpp"
 
-#include <algorithm>
 #include <functional>
 
 GEMMSTONE_NAMESPACE_START
@@ -94,8 +93,21 @@ struct MatchParams : public MatchParamsBase
 
 using SelectionObserver = std::function<void (const kcatalog::Entry *entry, double score, EvaluateAuxOutput aux)>;
 
-const std::vector<const kcatalog::Entry *> select(const kcatalog::Catalog &catalog, const MatchParams &pattern, const EvaluateParams &eparams, EvaluateAuxOutput &aux, SelectionObserver *observer = nullptr);
-const std::vector<const kcatalog::Entry *> select(const kcatalog::Catalog &catalog, int npatterns, const MatchParams *patterns, const EvaluateParams &eparams, EvaluateAuxOutput &aux, SelectionObserver *observer = nullptr);
+struct EntryData {
+    EntryData(const kcatalog::Entry *entry_, EvaluateAuxOutput aux_, double score_) : entry(entry_), aux(std::move(aux_)), score(score_) {}
+    const kcatalog::Entry *entry;
+    EvaluateAuxOutput aux;
+    double score;
+    bool operator<(const EntryData& other) const;
+};
+
+// Returns the best catalog entry only
+const kcatalog::Entry* select(const kcatalog::Catalog &catalog, const MatchParams &pattern, const EvaluateParams &eparams, EvaluateAuxOutput &aux, SelectionObserver *observer = nullptr);
+const kcatalog::Entry* select(const kcatalog::Catalog &catalog, int npatterns, const MatchParams *patterns, const EvaluateParams &eparams, EvaluateAuxOutput &aux, SelectionObserver *observer = nullptr);
+
+// Returns a sorted list of catalog entries that match the MatchParams
+const std::vector<EntryData> collect_kernels(const kcatalog::Catalog &catalog, const MatchParams &pattern, const EvaluateParams &eparams, SelectionObserver *observer = nullptr);
+const std::vector<EntryData> collect_kernels(const kcatalog::Catalog &catalog, int npatterns, const MatchParams *patterns, const EvaluateParams &eparams, SelectionObserver *observer = nullptr);
 
 // Extended API for iterating over all matching kernels.
 bool matches(const kcatalog::Entry &e, const MatchParams &pattern);


### PR DESCRIPTION
Recent changes alter a user-facing API in gemmstone (the kernel selector's select function) which other teams use. Since the change in API is unnecessary, this PR reverts that change and instead adds a new API:
- `select`: Earlier API, unchanged. Returns the lowest-scoring (best) matching kernel from the catalog.
- `collect_kernels`: Returns a vector of entries, sorted by score. Also includes additional information in the form of `EvaluateAuxOutput` and score, for later use.

This also is the first step to simplifying `gen_desc_t`, as the `set_entry` function sets both `aux_params_` and `entry`, guaranteeing consistency in the state.