### PR TITLE
src: gpu: intel: jit: enable tiled grf allocation for buffers

### DIFF
--- a/src/gpu/intel/conv/jit/ir_builder.cpp
+++ b/src/gpu/intel/conv/jit/ir_builder.cpp
@@ -770,6 +770,7 @@ void builder_t::build() {
     stmt_ = optimize_barrier(stmt_, ir_ctx);
     if (cfg_.fma_kind() == fma_kind_t::dp4a) stmt_ = inject_dp4a(stmt_, ir_ctx);
     stmt_ = inject_bank_conflict_attribute(stmt_, ir_ctx);
+    stmt_ = inject_access_map_attribute(stmt_, ir_ctx);
     stmt_ = stmt_group_t::make(stmt_label_t::kernel(), stmt_);
 
 #if !defined(NDEBUG) || defined(DNNL_DEV_MODE)

--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/codegen.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/codegen.cpp
@@ -125,8 +125,10 @@ public:
                 const int regs = div_up(obj.size, ngen::GRF::bytes(hw()));
                 if (is_header(obj.buf)) {
                     rbd = alloc_header(scope, regs);
+                } else if (obj.has_attr<access_map_alloc_attr_t>()) {
+                    rbd = alloc_with_access_map(obj, scope, regs);
                 } else {
-                    rbd = scope.alloc_reg_buf(regs);
+                    rbd = alloc_unmapped(obj, scope, regs);
                 }
             }
             if (obj.has_attr<grf_permute_attr_t>()) {
@@ -370,6 +372,95 @@ private:
     bool is_header(const expr_t &buf) const {
         auto &name = buf.as<var_t>().name;
         return name == "h" || name.find("h_") == 0;
+    }
+
+    // Allocates buffers that are only contiguous in places where the ops that
+    // access it need them to be.
+    reg_buf_t alloc_with_access_map(const alloc_t &obj,
+            ngen_register_scope_t &scope, int regs,
+            ngen::Bundle base_bundle = ngen::Bundle()) {
+        UNUSED(regs);
+        using acc_info_t = access_map_alloc_attr_t::accesses_t::value_type;
+        const int grf_size = ngen::GRF::bytes(hw());
+        auto accs = obj.get_attr<access_map_alloc_attr_t>().accs;
+        gpu_assert(!accs.empty());
+        // align bases and sizes to grf boundary
+        for (auto &a : accs) {
+            auto first = round_down(a.first, grf_size);
+            a.second = round_up(a.first + a.second, grf_size) - first;
+            a.first = first;
+        }
+        // sort accesses by base
+        std::sort(accs.begin(), accs.end(),
+                [](const acc_info_t &a, const acc_info_t &b) {
+            return a.first < b.first;
+        });
+        // merge overlapping accesses and erase overlaps
+        for (int prev = 0, i = 1; i < (int)accs.size(); i++)
+            if (accs[prev].first + accs[prev].second > accs[i].first) {
+                accs[prev].second = std::max(accs[prev].second,
+                        accs[i].first + accs[i].second - accs[prev].first);
+                accs[i].second = 0;
+            } else {
+                prev = i;
+            }
+        for (auto it = accs.begin(); it != accs.end();)
+            it = (it->second) ? std::next(it) : accs.erase(it);
+        // sort accesses by size, largest to smallest
+        std::sort(accs.begin(), accs.end(),
+                [](const acc_info_t &a, const acc_info_t &b) {
+            return a.second > b.second;
+        });
+        // perform the allocations
+        std::vector<std::pair<int, ngen::GRFRange>> allocs;
+        auto &ra = scope.register_allocator();
+        for (auto &a : accs)
+            if (a.second) {
+                auto regs = utils::safe_divide(a.second, grf_size);
+                allocs.emplace_back(a.first, ra.alloc_range(regs, base_bundle));
+            }
+        // sort the allocations by their corresponding buffer bases
+        std::sort(allocs.begin(), allocs.end(),
+                [](const std::pair<int, ngen::GRFRange> &a,
+                        const std::pair<int, ngen::GRFRange> &b) {
+            return a.first < b.first;
+        });
+        // print the allocation map to debug output
+        dsl_trace() << "Allocation for '" << obj.buf << "' (" << obj.size
+                    << " bytes), mapped as:";
+        for (auto &a : allocs)
+            if (a.second.getLen() == 1)
+                dsl_trace()
+                        << "    offset: " << a.first << ", size: " << grf_size
+                        << " (r" << a.second.getBase() << ")";
+            else if (!a.second.isInvalid())
+                dsl_trace()
+                        << "    offset: " << a.first
+                        << ", size: " << a.second.getLen() * grf_size << " (r"
+                        << a.second.getBase() << " - r"
+                        << a.second.getBase() + a.second.getLen() - 1 << ")";
+        // merge the allocations together
+        std::vector<int> tiles;
+        for (auto &a : allocs) {
+            for (int i = a.second.getBase(), size = i + a.second.getLen();
+                    i < size; i++)
+                tiles.emplace_back(i);
+            ra.safeRelease(a.second);
+        }
+        for (auto &t : tiles)
+            scope.claim(ngen::GRFRange(t, 1));
+        return reg_buf_t(hw(), 1, tiles);
+    }
+
+    // Allocates buffers with no access map, keeping it in one piece
+    reg_buf_t alloc_unmapped(const alloc_t &obj, ngen_register_scope_t &scope,
+            int regs, ngen::Bundle base_bundle = ngen::Bundle()) {
+        auto retn = scope.alloc_reg_buf(regs, base_bundle);
+        dsl_trace() << "Allocation for '" << obj.buf << "' (" << obj.size
+                    << " bytes), unmapped:";
+        dsl_trace() << "    offset: 0, size: " << ngen::GRF::bytes(hw()) * regs
+                    << " (" << retn.str() << ")";
+        return retn;
     }
 
     // Allocates headers using heuristics to reduce back-to-back header reuse -

--- a/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
@@ -1119,6 +1119,28 @@ public:
     }
 };
 
+class access_map_alloc_attr_t : public alloc_attr_impl_t,
+                                public object::info_t<access_map_alloc_attr_t> {
+public:
+    using accesses_t = std::vector<std::pair<int, int>>;
+
+    static alloc_attr_t make(const accesses_t &accs) {
+        return alloc_attr_t(new access_map_alloc_attr_t(accs));
+    }
+
+    bool is_equal(const object::impl_t &obj) const override {
+        return this == &obj;
+    }
+
+    size_t get_hash() const override { return hash(accs); }
+
+    accesses_t accs;
+
+private:
+    access_map_alloc_attr_t(const accesses_t &accs)
+        : alloc_attr_impl_t(get_info()), accs(accs) {}
+};
+
 // Allocation attribute to store extra information to avoid bank conflicts.
 class bank_conflict_attr_t : public alloc_attr_impl_t,
                              public object::info_t<bank_conflict_attr_t> {

--- a/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
@@ -1123,6 +1123,28 @@ public:
     }
 };
 
+class access_map_alloc_attr_t : public alloc_attr_impl_t,
+                                public object::info_t<access_map_alloc_attr_t> {
+public:
+    using accesses_t = std::vector<std::pair<int, int>>;
+
+    static alloc_attr_t make(const accesses_t &accs) {
+        return alloc_attr_t(new access_map_alloc_attr_t(accs));
+    }
+
+    bool is_equal(const object::impl_t &obj) const override {
+        return this == &obj;
+    }
+
+    size_t get_hash() const override { return hash(accs); }
+
+    accesses_t accs;
+
+private:
+    access_map_alloc_attr_t(const accesses_t &accs)
+        : alloc_attr_impl_t(get_info()), accs(accs) {}
+};
+
 // Allocation attribute to store extra information to avoid bank conflicts.
 class bank_conflict_attr_t : public alloc_attr_impl_t,
                              public object::info_t<bank_conflict_attr_t> {

--- a/src/gpu/intel/gemm/jit/include/internal/utils.hpp
+++ b/src/gpu/intel/gemm/jit/include/internal/utils.hpp
@@ -295,6 +295,14 @@ private:
         return h;
     }
 
+    template <typename A, typename B>
+    size_t get_hash(const std::pair<A, B> &p) {
+        size_t h = 0;
+        h = hash_combine(h, get_hash(p.first));
+        h = hash_combine(h, get_hash(p.second));
+        return h;
+    }
+
     template <typename Key, typename T, typename Compare, typename Allocator>
     size_t get_hash(const std::map<Key, T, Compare, Allocator> &m) {
         size_t h = 0;

--- a/src/gpu/intel/jit/pass/alloc.cpp
+++ b/src/gpu/intel/jit/pass/alloc.cpp
@@ -17,6 +17,7 @@
 #include "gpu/intel/jit/pass/alloc.hpp"
 
 #include "gemmstone/../../dsl/ir/pass/trace.hpp"
+#include "gpu/intel/jit/ir/eltwise.hpp"
 #include "gpu/intel/jit/ir/legacy.hpp"
 
 namespace dnnl {
@@ -431,6 +432,102 @@ stmt_t inject_let_stmts(const stmt_t &stmt, const std::vector<stmt_t> &lets) {
     return ret;
 }
 
+class access_map_attribute_injector_t : public ir_mutator_t {
+public:
+    access_map_attribute_injector_t(ir_context_t &ir_ctx) : ir_ctx_(ir_ctx) {}
+
+    object_t _mutate(const alloc_t &obj) override {
+        auto new_obj = ir_mutator_t::_mutate(obj);
+        if (bufs_.count(obj.buf) == 0) return new_obj;
+        auto new_attrs = obj.attrs;
+        new_attrs.emplace_back(bufs_.at(obj.buf));
+        return alloc_t::make(obj.buf, obj.size, obj.kind, new_attrs,
+                new_obj.as<alloc_t>().body);
+    }
+
+    object_t _mutate(const load_t &obj) override {
+        auto stride = (obj.has_default_stride()) ? obj.type.base().size()
+                                                 : obj.stride;
+        auto off = (obj.off.is<int_imm_t>()) ? to_int(obj.off) : 0;
+        append_access(obj.buf, off, obj.type.elems() * stride);
+        return ir_mutator_t::_mutate(obj);
+    }
+
+    object_t _mutate(const store_t &obj) override {
+        auto stride = (obj.has_default_stride())
+                ? obj.value.type().base().size()
+                : obj.stride;
+        auto off = (obj.off.is<int_imm_t>()) ? to_int(obj.off) : 0;
+        append_access(obj.buf, off, obj.value.type().elems() * stride);
+        return ir_mutator_t::_mutate(obj);
+    }
+
+    object_t _mutate(const func_call_t &obj) override {
+        auto layout_size = [](int64_t e, const dsl::layout_t &l) {
+            return utils::div_up(int(e) * l.type().base().bitsize(), 8);
+        };
+        auto append_block = [](int64_t s, const dsl::layout_t::block_t &b) {
+            return ((b.stride.is_fixed()) ? int64_t(b.stride) : s) * b.size;
+        };
+        auto min_grf = [&]() { return ir_ctx_.grf_size() * 2; };
+        auto append_access_ = [&](const expr_t &e, const dsl::layout_t &l) {
+            int total_blk = 1, inner_blk = 1;
+            for (auto &b : l.blocks()) {
+                total_blk = int(append_block(total_blk, b));
+                if (layout_size(inner_blk, l) < min_grf())
+                    inner_blk = int(append_block(inner_blk, b));
+            }
+            if (total_blk % inner_blk == 0) {
+                for (int i = 0; i < total_blk; i += inner_blk)
+                    append_access(
+                            e, layout_size(i, l), layout_size(inner_blk, l));
+            } else {
+                append_access(e, 0, layout_size(l.elems(), l));
+            }
+        };
+        // DPAS/MAD SRC0-SRC2 are covered by bank conflict alloc but DST isn't
+        if (auto *send = obj.func.as_ptr<send_t>()) {
+            append_access(send_t::arg_reg_buf(obj), 0, send->payload_size());
+        } else if (auto *mad = obj.func.as_ptr<mad_t>()) {
+            append_access(mad_t::arg_dst(obj), 0, mad->dst_size());
+        } else if (auto *dpas = obj.func.as_ptr<dpas_t>()) {
+            append_access(dpas_t::arg_dst(obj), 0, dpas->dst_size());
+        } else if (auto *reorder = obj.func.as_ptr<reorder_t>()) {
+            append_access_(reorder_t::arg_src_buf(obj), reorder->src_layout);
+            append_access_(reorder_t::arg_dst_buf(obj), reorder->dst_layout);
+        } else if (auto *reduce = obj.func.as_ptr<reduce_t>()) {
+            append_access_(reduce_t::arg_src_buf(obj), reduce->src_layout);
+            append_access_(reduce_t::arg_dst_buf(obj), reduce->dst_layout);
+        } else if (auto *eltwise = obj.func.as_ptr<eltwise_t>()) {
+            const auto dst_dt = (eltwise->dst_dt != ngen::DataType::invalid)
+                    ? dsl::type_t(eltwise->dst_dt)
+                    : dsl::type_t::f32();
+            auto size = to_int(eltwise_t::arg_elems(obj)) * dst_dt.size();
+            auto buf = eltwise_t::arg_data(obj);
+            for (int i = 0; i < size; i += min_grf())
+                append_access(buf, i, std::min(size - i, min_grf()));
+        }
+        return ir_mutator_t::_mutate(obj);
+    }
+
+private:
+    void append_access(const expr_t &buf, int off, int size) {
+        ir::access_map_alloc_attr_t::accesses_t accs;
+        auto it = bufs_.find(get_base(buf));
+        if (it != bufs_.end())
+            accs = it->second.as<ir::access_map_alloc_attr_t>().accs;
+        else
+            it = bufs_.insert({get_base(buf), {}}).first;
+        if (buf.is<ptr_t>() && is_const(buf.as<ptr_t>().off))
+            off += to_int(buf.as<ptr_t>().off);
+        accs.emplace_back(off, size);
+        it->second = ir::access_map_alloc_attr_t::make(accs);
+    }
+
+    object_eq_map_t<expr_t, alloc_attr_t> bufs_;
+    ir_context_t &ir_ctx_;
+};
+
 class var_counter_t : public ir_visitor_t {
 public:
     var_counter_t(const object_set_t<expr_t> &vars) {
@@ -544,6 +641,13 @@ private:
 
 stmt_t inject_dangling_let_stmts(const stmt_t &stmt) {
     return let_injector_t().mutate(stmt);
+}
+
+stmt_t inject_access_map_attribute(const stmt_t &stmt, ir_context_t &ir_ctx) {
+    ir::trace_start();
+    auto retn = access_map_attribute_injector_t(ir_ctx).mutate(stmt);
+    ir::trace_pass("inject_access_map_attribute", retn, ir_ctx);
+    return retn;
 }
 
 } // namespace jit

--- a/src/gpu/intel/jit/pass/alloc.hpp
+++ b/src/gpu/intel/jit/pass/alloc.hpp
@@ -68,6 +68,12 @@ stmt_t inject_let_stmts(const stmt_t &stmt, const std::vector<stmt_t> &lets);
 //     }
 stmt_t inject_dangling_let_stmts(const stmt_t &stmt);
 
+// Injects an allocation attribute to document the buffer access patterns; this
+// information is then used during nGEN lowering to better utilize the register
+// space by splitting the buffer into potentially several chunks which are only
+// contiguous where the operations accessing the buffer need them to be.
+stmt_t inject_access_map_attribute(const stmt_t &stmt, ir_context_t &ir_ctx);
+
 } // namespace jit
 } // namespace intel
 } // namespace gpu

--- a/src/gpu/intel/jit/pass/bank_conflict.cpp
+++ b/src/gpu/intel/jit/pass/bank_conflict.cpp
@@ -25,26 +25,6 @@ namespace gpu {
 namespace intel {
 namespace jit {
 
-// FIXME: Use convolution-agnostic mechanism to skip zero-points related calls.
-static bool is_zero_points_call(const stmt_t &s) {
-    auto is_zp_var = [&](const expr_t &e) {
-        auto &base = get_base(e);
-        auto &name = base.as<var_t>().name;
-        return name.find("zp_") == 0;
-    };
-    if (is_func_call<dpas_t>(s)) {
-        auto &src1 = dpas_t::arg_src1(s);
-        auto &src2 = dpas_t::arg_src2(s);
-        return is_zp_var(src1) || is_zp_var(src2);
-    }
-    if (is_func_call<mad_t>(s)) {
-        auto &src1 = mad_t::arg_src1(s);
-        auto &src2 = mad_t::arg_src2(s);
-        return is_zp_var(src1) || is_zp_var(src2);
-    }
-    return false;
-}
-
 class bank_conflict_attribute_injector_t : public ir_mutator_t {
 public:
     object_t _mutate(const alloc_t &obj) override {
@@ -63,7 +43,6 @@ public:
 
     object_t _mutate(const func_call_t &obj) override {
         if (is_frozen) return ir_mutator_t::_mutate(obj);
-        if (is_zero_points_call(obj)) return ir_mutator_t::_mutate(obj);
 
         bool is_mad = obj.func.is<mad_t>();
         bool is_dpas = obj.func.is<dpas_t>();
@@ -71,7 +50,6 @@ public:
         bool is_load = send && (send->is_load() || send->is_load_2d());
 
         if (is_mad || is_dpas) {
-            auto dst_buf = ptr_base(obj.args[0]);
             auto src0_buf = ptr_base(obj.args[1]);
             auto src1_buf = ptr_base(obj.args[2]);
             auto src2_buf = ptr_base(obj.args[3]);

--- a/src/gpu/intel/pool/jit/ir_builder.cpp
+++ b/src/gpu/intel/pool/jit/ir_builder.cpp
@@ -552,6 +552,7 @@ stmt_t builder_t::try_build(builder_t &pb, const kernel_info_t &ki,
             stmt, ir_ctx, exec.regs() * exec.grf_size());
     stmt = simplify(stmt, ir_ctx);
     stmt = optimize_alloc_let(stmt, ir_ctx);
+    stmt = inject_access_map_attribute(stmt, ir_ctx);
     stmt = stmt_group_t::make(stmt_label_t::kernel(), stmt);
 
     const int regs = get_peak_regs(stmt, exec.grf_size());


### PR DESCRIPTION
Another byproduct of #4540, formerly a part of #4650.
Buffers can now be allocated non-contiguously, mitigating the GRF fragmentation and enabling larger blocks.