### PR TITLE
scripts: update verbose to support grouped memory, --grouped 

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 ################################################################################
 
+import functools
 import logging
 from collections import defaultdict
 from typing import Dict, List, Mapping, Optional, Set, cast
@@ -89,6 +90,10 @@ class Converter(metaclass=ConverterMeta):
             if not md.tag:
                 continue
             return f"--tag={md.tag}"  # XXX: Don't use maybe_make_any_tag
+        return ""
+
+    @property
+    def grouped(self) -> str:
         return ""
 
     @property
@@ -371,8 +376,8 @@ class StridesMixin(TagTripletMixin):
         strides = []
 
         def add_strides_or_tag(arg, md):
-            if md.tag == "grouped":
-                return
+            if md.grouped is not None:
+                return  # grouped MDs go through --grouped
             tag = maybe_make_any_tag(md)
             if arg == "wei" and str(md.flags.value) != "f0":
                 tag = "any"
@@ -617,6 +622,24 @@ class MatmulConverter(StridesMixin, MultiDataTypeWithBiasMixin, Converter):
                 mask = md.flags.value.split("_")[1][4:]
                 return f"--bia_mask={mask}"
         return ""
+
+    @property
+    def grouped(self) -> str:
+        # grouped params come from the src variable dim
+        src_md = next((md for md in self.entry.mds if md.arg == "src"), None)
+        desc = src_md.grouped if src_md is not None else None
+        if desc is None:
+            return ""
+        var_idx, count = desc.variable_dim_idx, desc.group_count
+        # verbose omits per-group sizes, so split the src dim evenly
+        src_dims = self.entry.shapes.split(":")[0].split("x")
+        total_dim = int(src_dims[var_idx])
+        group_size, remainder = divmod(total_dim, count)
+        sizes = [group_size] * count
+        for i in range(remainder):
+            sizes[i] += 1
+        group_sizes = "+".join(map(str, sizes))
+        return f"--grouped={var_idx}:{count}:{group_sizes}"
 
     @property
     def aux(self):
@@ -980,9 +1003,23 @@ class InputGenerator:
     def __init__(self, logger: Optional[logging.Logger] = None):
         self.logger = logger
 
+    @staticmethod
+    @functools.lru_cache(maxsize=None)
+    def _warn_grouped(logger: Optional[logging.Logger]):
+        if not logger:
+            return
+        logger.warning(
+            "Verbose does not report per-group sizes; group sizes in"
+            " --grouped are inferred by dividing the total dimension"
+            " by the number of groups and may not match the original."
+        )
+
     def _generate_case(self, entry: ir.Entry):
         Converter = get_converter(entry.prim_kind)
         converter = Converter(entry)
+        grouped = converter.grouped
+        if grouped:
+            self._warn_grouped(self.logger)
         args = [
             "--reset",
             "--allow-enum-tags-only=0",
@@ -994,6 +1031,7 @@ class InputGenerator:
             converter.tags,
             converter.flags,
             converter.attrs,
+            grouped,
             converter.shapes,
         ]
         return converter.driver, " ".join(arg for arg in args if arg)

--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -92,6 +92,10 @@ class Converter(metaclass=ConverterMeta):
         return ""
 
     @property
+    def grouped(self) -> str:
+        return ""
+
+    @property
     def flags(self) -> str:
         return ""
 
@@ -371,8 +375,8 @@ class StridesMixin(TagTripletMixin):
         strides = []
 
         def add_strides_or_tag(arg, md):
-            if md.tag == "grouped":
-                return
+            if md.grouped is not None:
+                return  # grouped MDs go through --grouped
             tag = maybe_make_any_tag(md)
             if arg == "wei" and str(md.flags.value) != "f0":
                 tag = "any"
@@ -617,6 +621,24 @@ class MatmulConverter(StridesMixin, MultiDataTypeWithBiasMixin, Converter):
                 mask = md.flags.value.split("_")[1][4:]
                 return f"--bia_mask={mask}"
         return ""
+
+    @property
+    def grouped(self) -> str:
+        # grouped params come from the src variable dim
+        src_md = next((md for md in self.entry.mds if md.arg == "src"), None)
+        desc = src_md.grouped if src_md is not None else None
+        if desc is None:
+            return ""
+        var_idx, count = desc.variable_dim_idx, desc.group_count
+        # verbose omits per-group sizes, so split the src dim evenly
+        src_dims = self.entry.shapes.split(":")[0].split("x")
+        total_dim = int(src_dims[var_idx])
+        group_size, remainder = divmod(total_dim, count)
+        sizes = [group_size] * count
+        for i in range(remainder):
+            sizes[i] += 1
+        group_sizes = "+".join(map(str, sizes))
+        return f"--grouped={var_idx}:{count}:{group_sizes}"
 
     @property
     def aux(self):
@@ -979,10 +1001,19 @@ class InputGenerator:
 
     def __init__(self, logger: Optional[logging.Logger] = None):
         self.logger = logger
+        self._warned_grouped = False
 
     def _generate_case(self, entry: ir.Entry):
         Converter = get_converter(entry.prim_kind)
         converter = Converter(entry)
+        grouped = converter.grouped
+        if grouped and not self._warned_grouped and self.logger is not None:
+            self._warned_grouped = True
+            self.logger.warning(
+                "Verbose does not report per-group sizes; group sizes in"
+                " --grouped are inferred by dividing the total dimension"
+                " by the number of groups and may not match the original."
+            )
         args = [
             "--reset",
             "--allow-enum-tags-only=0",
@@ -994,6 +1025,7 @@ class InputGenerator:
             converter.tags,
             converter.flags,
             converter.attrs,
+            grouped,
             converter.shapes,
         ]
         return converter.driver, " ".join(arg for arg in args if arg)

--- a/scripts/verbose_converter/src/ir.py
+++ b/scripts/verbose_converter/src/ir.py
@@ -106,6 +106,14 @@ class MemoryDescriptor(Mapping):
                 my_str += f":sa{self.scale_adjust}"
             return my_str
 
+    @dataclass
+    class GroupedDesc:
+        variable_dim_idx: int
+        group_count: int
+
+        def __str__(self):
+            return f"grouped:{self.variable_dim_idx}:{self.group_count}"
+
     arg: str
     data_type: str
     properties: str
@@ -113,6 +121,7 @@ class MemoryDescriptor(Mapping):
     tag: str
     flags: Flags
     strides: str = ""  # Pre-v3.1 does not have strides
+    grouped: Optional[GroupedDesc] = None
 
     padding = alias("properties")
 
@@ -124,17 +133,12 @@ class MemoryDescriptor(Mapping):
         yield "padding"
 
     def _format(self, tag: str, convert) -> str:
-        header = f"{self.arg}:{self.data_type}"
-        return ":".join(
-            [
-                header,
-                self.properties,
-                self.format_kind,
-                tag,
-                self.strides,
-                convert(self.flags),
-            ]
-        )
+        arg_dt = f"{self.arg}:{self.data_type}"
+        layout = f"{self.properties}:{self.format_kind}"
+        body = f"{tag}:{self.strides}"
+        if self.grouped is not None:
+            body = f"{convert(self.grouped)}:"
+        return f"{arg_dt}:{layout}:{body}:{convert(self.flags)}"
 
     def __str__(self):
         return self._format(self.tag, str)

--- a/scripts/verbose_converter/src/ir.py
+++ b/scripts/verbose_converter/src/ir.py
@@ -106,6 +106,11 @@ class MemoryDescriptor(Mapping):
                 my_str += f":sa{self.scale_adjust}"
             return my_str
 
+    @dataclass
+    class GroupedDesc:
+        variable_dim_idx: int
+        group_count: int
+
     arg: str
     data_type: str
     properties: str
@@ -113,6 +118,7 @@ class MemoryDescriptor(Mapping):
     tag: str
     flags: Flags
     strides: str = ""  # Pre-v3.1 does not have strides
+    grouped: Optional[GroupedDesc] = None
 
     padding = alias("properties")
 
@@ -124,17 +130,19 @@ class MemoryDescriptor(Mapping):
         yield "padding"
 
     def _format(self, tag: str, convert) -> str:
-        header = f"{self.arg}:{self.data_type}"
-        return ":".join(
-            [
-                header,
-                self.properties,
-                self.format_kind,
-                tag,
-                self.strides,
-                convert(self.flags),
+        parts = [self.arg, self.data_type, self.properties, self.format_kind]
+        if self.grouped is not None:
+            g = self.grouped
+            parts += [
+                "grouped",
+                str(g.variable_dim_idx),
+                str(g.group_count),
+                "",
             ]
-        )
+        else:
+            parts += [tag, self.strides]
+        parts.append(convert(self.flags))
+        return ":".join(parts)
 
     def __str__(self):
         return self._format(self.tag, str)

--- a/scripts/verbose_converter/src/parse.py
+++ b/scripts/verbose_converter/src/parse.py
@@ -602,15 +602,31 @@ class LegacyParserImpl(ParserImpl):
 @register(version=1)
 class V1ParserImpl(ParserImpl):
     def parse_md(self, descriptor):
-        fields = descriptor.split(":")
+        grouped: Optional[ir.MemoryDescriptor.GroupedDesc] = None
+        tag = strides = ""
+        arg, dt, props, format_kind, *others = descriptor.split(":")
+        if format_kind == "sparse" and others[:1] == ["grouped"]:
+            # arg:dt:props:sparse:grouped:var_dim_idx:group_count::flags
+            _, dim, count, _empty, flags, *fields = others
+            grouped = self.parse_md_grouped_desc(dim, count)
+        else:
+            # non-grouped sparse (csr/coo) puts its encoding in the tag field
+            tag, strides, flags, *fields = others
         return ir.MemoryDescriptor(
-            arg=fields[0],
-            data_type=fields[1],
-            properties=fields[2],
-            format_kind=fields[3],
-            tag=fields[4],
-            strides=fields[5],
-            flags=self.parse_md_flags(fields[6], fields[7:]),
+            arg=arg,
+            data_type=dt,
+            properties=props,
+            format_kind=format_kind,
+            tag=tag,
+            strides=strides,
+            flags=self.parse_md_flags(flags, fields),
+            grouped=grouped,
+        )
+
+    def parse_md_grouped_desc(self, dim: str, count: str):
+        return ir.MemoryDescriptor.GroupedDesc(
+            variable_dim_idx=int(dim),
+            group_count=int(count),
         )
 
 

--- a/scripts/verbose_converter/src/parse.py
+++ b/scripts/verbose_converter/src/parse.py
@@ -603,11 +603,40 @@ class LegacyParserImpl(ParserImpl):
 class V1ParserImpl(ParserImpl):
     def parse_md(self, descriptor):
         fields = descriptor.split(":")
+        format_kind = fields[3]
+
+        if (
+            format_kind == "sparse"
+            and len(fields) > 4
+            and fields[4] == "grouped"
+        ):
+            # arg:dt:props:sparse:grouped:var_dim_idx:group_count::flags
+            if len(fields) < 9:
+                raise ParseError(
+                    f"grouped MD '{descriptor}' is missing "
+                    "var_dim_idx:group_count"
+                )
+            flags = self.parse_md_flags(fields[8], fields[9:])
+            return ir.MemoryDescriptor(
+                arg=fields[0],
+                data_type=fields[1],
+                properties=fields[2],
+                format_kind=format_kind,
+                tag="",
+                strides="",
+                flags=flags,
+                grouped=ir.MemoryDescriptor.GroupedDesc(
+                    variable_dim_idx=int(fields[5]),
+                    group_count=int(fields[6]),
+                ),
+            )
+
+        # non-grouped sparse (csr/coo) puts its encoding in the tag field
         return ir.MemoryDescriptor(
             arg=fields[0],
             data_type=fields[1],
             properties=fields[2],
-            format_kind=fields[3],
+            format_kind=format_kind,
             tag=fields[4],
             strides=fields[5],
             flags=self.parse_md_flags(fields[6], fields[7:]),

--- a/scripts/verbose_converter/tests/dataset_simple
+++ b/scripts/verbose_converter/tests/dataset_simple
@@ -27,6 +27,7 @@ ip,shapes_ci
 lnorm,shapes_ci
 lrn,shapes_ci
 matmul,shapes_2d_ci
+matmul,test_matmul_grouped_ci
 pool,shapes_basic
 prelu,shapes_ci
 reduction,shapes_ci

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -560,7 +560,15 @@ std::string md2fmt_str(
         case format_kind::rnn_packed:
         case format_kind::zen_packed:
         case format_kind::opaque: ss << "::"; break;
-        case format_kind::sparse: ss << ":" << mdw.encoding() << ":"; break;
+        case format_kind::sparse: ss << ":" << mdw.encoding();
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+            if (mdw.is_grouped_desc()) {
+                ss << ":" << mdw.sparse_desc().grouped_desc.variable_dim_idx;
+                ss << ":" << mdw.sparse_desc().grouped_desc.group_count;
+            }
+#endif
+            ss << ":";
+            break;
         case format_kind::any: ss << ":any:"; break;
         default:
             assert(!"unsupported format_kind");

--- a/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
@@ -197,7 +197,7 @@
 --dt=f16:f16:f16
 --wtag=abc
 --grouped=0:4:8+8+8+8
---attr-post-ops=eltwise_swish:1.0,mul:f32:1:ab,mul:f16:1:ab,mul:bf16:1:ab,mul:f32:3:grouped,mul:f16:3:grouped,mul:bf16:3:grouped
+--attr-post-ops=eltwise_swish:1.0,mul:f32:1,mul:f16:1,mul:bf16:1,mul:f32:3:grouped,mul:f16:3:grouped,mul:bf16:3:grouped
 32x64:4x64x32
 
 # Post-ops: eltwise_swish /eltwise_gelu_tanh / eltwise_gelu_erf + binary_mul (grouped)
@@ -205,7 +205,7 @@
 --dt=f16:f16:f16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8,0:4:8+0+16+8
---attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped,eltwise_swish:1.0+mul:f16:3:grouped,eltwise_swish:1.0+mul:bf16:3:grouped,eltwise_swish:1.0+mul:f32:1:ab,eltwise_swish:1.0+mul:f16:1:ab,eltwise_gelu_tanh:1.0+mul:f16:3:grouped,eltwise_gelu_erf:1.0+mul:f16:3:grouped
+--attr-post-ops=eltwise_swish:1.0+mul:f32:3:grouped,eltwise_swish:1.0+mul:f16:3:grouped,eltwise_swish:1.0+mul:bf16:3:grouped,eltwise_swish:1.0+mul:f32:1,eltwise_swish:1.0+mul:f16:1,eltwise_gelu_tanh:1.0+mul:f16:3:grouped,eltwise_gelu_erf:1.0+mul:f16:3:grouped
 32x64:4x64x32
 
 # Post-ops: all eltwise
@@ -222,7 +222,7 @@
 --wtag=abc
 --grouped=0:4:8+8+8+8
 --bia-dt=f32 --bia_mask=2
---attr-post-ops=mul:f32:1:ab,mul:f32:3:grouped,mul:bf16:3:grouped,mul:f16:3:grouped
+--attr-post-ops=mul:f32:1,mul:f32:3:grouped,mul:bf16:3:grouped,mul:f16:3:grouped
 32x64:4x64x32
 
 # Post-ops + quantization: binary_mul per-row and grouped with WOQ scales
@@ -232,7 +232,7 @@
 --grouped=0:4:8+8+8+8
 --attr-fpmath=f16:true
 --attr-scales=wei:7:f16:32x1
---attr-post-ops=mul:f32:1:ab,mul:f16:1:ab,mul:f32:3:grouped,mul:f16:3:grouped
+--attr-post-ops=mul:f32:1,mul:f16:1,mul:f32:3:grouped,mul:f16:3:grouped
 32x128:4x128x64
 
 # Post-ops: multi-binary chains (grouped + dense, 3-op)
@@ -240,7 +240,7 @@
 --dt=f16:f16:f16
 --wtag=abc
 --grouped=0:4:8+8+8+8
---attr-post-ops=mul:f16:3:grouped+mul:f32:1:ab,eltwise_swish:1.0+mul:f16:3:grouped+mul:f32:1:ab
+--attr-post-ops=mul:f16:3:grouped+mul:f32:1,eltwise_swish:1.0+mul:f16:3:grouped+mul:f32:1
 32x64:4x64x32
 
 # Per-group binary_mul (mask 0) with variable group sizes


### PR DESCRIPTION
The goal is to make verbose converter understand grouped matmul output from verbose log.
- Also updated memory descriptor to have information about number of groups and variable dim indx (technically both could be skipped and inferred from the configuration, but this seems clearer).
- `ab` is dropped from binary_mul in inputs as not needed and caused failures in script tests.
