### PR TITLE
cpu: aarch64: Optimize RNN by introduce BRGEMM RNN utilities and common cell helpers (non-JIT first)

### DIFF
--- a/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.cpp
@@ -1,0 +1,517 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp"
+
+#include "common/dnnl_thread.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+using namespace dnnl::impl::utils;
+
+template <typename weights_t, typename scratch_t, typename gemm_acc_t>
+brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
+        gemm_acc_t>::brgemm_diff_src_layer_iter_t(const ref_rnn_brgemm_t
+                                                          &rnn_brgemm,
+        const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position, scratch_t *scratch_gates,
+        weights_t *w_iter, weights_t *w_layer, gemm_acc_t *diff_src_iter,
+        gemm_acc_t *diff_src_layer,
+        aarch64::brgemm_batch_element_t *addr_batch_global)
+    : rnn_brgemm_(rnn_brgemm)
+    , rnn_(rnn)
+    , A_(scratch_gates)
+    , B_wei_iter_(w_iter)
+    , B_wei_layer_(w_layer)
+    , C_diff_iter_(diff_src_iter)
+    , C_diff_layer_(diff_src_layer)
+    , k_blocks_n_gates_(rnn.diff_src_brgemm.K_blocks)
+    , k_blocks_(rnn.diff_src_brgemm.K_blocks / rnn.n_gates)
+    , k_tail_(rnn.diff_src_brgemm.k_tail)
+    , k_block_(rnn.diff_src_brgemm.k_block)
+    , A_k_tail_offset_(k_blocks_ * k_block_)
+    , B_k_tail_offset_(A_k_tail_offset_ * rnn.diff_src_brgemm.n_block)
+    , B_nb_offset_(rnn.diff_src_brgemm.Kpadded * rnn.diff_src_brgemm.n_block)
+    , B_kb_offset_(k_block_ * rnn.diff_src_brgemm.n_block)
+    , B_gb_iter_offset_(rnn.diff_src_brgemm.Kpadded
+              * rnn.diff_src_brgemm.n_block * rnn.diff_src_brgemm.N_iter_blocks)
+    , B_gb_layer_offset_(rnn.diff_src_brgemm.Kpadded
+              * rnn.diff_src_brgemm.n_block
+              * rnn.diff_src_brgemm.N_layer_blocks)
+    , LDA_(rnn.diff_src_brgemm.LDA)
+    , LDC_(rnn.diff_src_brgemm.LDC)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn.nthr))
+    , n_blocking_(rnn.diff_src_brgemm.N_blocks)
+    , m_blocking_(rnn.diff_src_brgemm.M_blocks)
+    , work_amount_(n_blocking_ * m_blocking_)
+    , max_n_layer_blocks_(rnn.diff_src_brgemm.N_layer_blocks)
+    , max_n_iter_blocks_(rnn.diff_src_brgemm.N_iter_blocks)
+    , gemm_layer_needed_(rnn.need_gemm_layer(cell_position))
+    , kernel_iter_full_blocks_b0_(
+              rnn_brgemm_.diff_src_.kernel_iter_layer_beta0_.get())
+    , kernel_iter_n_tail_b0_(
+              rnn_brgemm_.diff_src_.kernel_iter_N_tail_beta0_.get())
+    , kernel_iter_k_tail_(
+              rnn_brgemm_.diff_src_.kernel_iter_layer_K_tail_beta1_.get())
+    , kernel_iter_nk_tail_(
+              rnn_brgemm_.diff_src_.kernel_iter_NK_tail_beta1_.get())
+    , kernel_layer_full_blocks_b0_(
+              rnn_brgemm_.diff_src_.kernel_iter_layer_beta0_.get())
+    , kernel_layer_n_tail_b0_(
+              rnn_brgemm_.diff_src_.kernel_layer_N_tail_beta0_.get())
+    , kernel_layer_k_tail_(
+              rnn_brgemm_.diff_src_.kernel_iter_layer_K_tail_beta1_.get())
+    , kernel_layer_nk_tail_(
+              rnn_brgemm_.diff_src_.kernel_layer_NK_tail_beta1_.get())
+    , addr_batch_global_(addr_batch_global) {}
+
+template <typename weights_t, typename scratch_t, typename gemm_acc_t>
+void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::execute()
+        const {
+    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        this->kernel(ithr, nthr);
+    });
+}
+
+template <typename weights_t, typename scratch_t, typename gemm_acc_t>
+void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel(
+        const int ithr, const int nthr) const {
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    int n_block_id = 0, m_block_id = 0;
+    nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
+
+    aarch64::brgemm_batch_element_t *const addr_batch
+            = addr_batch_global_ + ithr * (k_blocks_n_gates_ + 1);
+
+    const auto n_gates = rnn_.n_gates;
+
+    while (start < end) {
+        const int m = m_block_id * rnn_.diff_src_brgemm.m_block;
+        const int n = n_block_id * rnn_.diff_src_brgemm.n_block;
+
+        const scratch_t *const A_m = A_ + m * LDA_;
+        const auto B_n_offset = n_block_id * B_nb_offset_;
+        const weights_t *const B_wei_iter_n = B_wei_iter_ + B_n_offset;
+        const weights_t *const B_wei_layer_n = B_wei_layer_ + B_n_offset;
+
+        const auto C_offset = m * LDC_ + n;
+        gemm_acc_t *const C_diff_iter_n = C_diff_iter_ + C_offset;
+        gemm_acc_t *const C_diff_layer_n = C_diff_layer_ + C_offset;
+
+        const brgemm_kernel_t *kernel_iter = kernel_iter_full_blocks_b0_;
+        const brgemm_kernel_t *kernel_iter_k_tail = kernel_iter_k_tail_;
+        const brgemm_kernel_t *kernel_layer = kernel_layer_full_blocks_b0_;
+        const brgemm_kernel_t *kernel_layer_k_tail = kernel_layer_k_tail_;
+
+        const bool should_calc_diff_src_layer
+                = gemm_layer_needed_ && n_block_id < max_n_layer_blocks_;
+        const bool should_calc_diff_src_iter = n_block_id < max_n_iter_blocks_;
+
+        if (should_calc_diff_src_iter) {
+            const bool do_n_iter_tail = (n + rnn_.diff_src_brgemm.n_block)
+                    > rnn_.diff_src_brgemm.N_iter;
+            if (do_n_iter_tail) {
+                kernel_iter = kernel_iter_n_tail_b0_;
+                kernel_iter_k_tail = kernel_iter_nk_tail_;
+            }
+
+            for (int gate_id = 0; gate_id < n_gates; gate_id++) {
+                const auto g_block_id = gate_id * k_blocks_;
+                const auto A_gb_offset = gate_id * rnn_.diff_src_brgemm.K;
+                const auto B_gb_offset = gate_id * B_gb_iter_offset_;
+                const auto A_gm = A_m + A_gb_offset;
+                const auto B_wei_iter_gn = B_wei_iter_n + B_gb_offset;
+
+                for (int k_block_id = 0; k_block_id < k_blocks_; k_block_id++) {
+                    addr_batch[g_block_id + k_block_id].ptr.A
+                            = A_gm + k_block_id * k_block_;
+                    addr_batch[g_block_id + k_block_id].ptr.B
+                            = B_wei_iter_gn + k_block_id * B_kb_offset_;
+                }
+            }
+            brgemm_kernel_execute(kernel_iter, k_blocks_n_gates_, addr_batch,
+                    reinterpret_cast<void *>(C_diff_iter_n), nullptr);
+        }
+
+        if (should_calc_diff_src_layer) {
+            const bool do_n_layer_tail = (n + rnn_.diff_src_brgemm.n_block)
+                    > rnn_.diff_src_brgemm.N_layer;
+            if (do_n_layer_tail) {
+                kernel_layer = kernel_layer_n_tail_b0_;
+                kernel_layer_k_tail = kernel_layer_nk_tail_;
+            }
+
+            for (int gate_id = 0; gate_id < n_gates; gate_id++) {
+                const auto g_block_id = gate_id * k_blocks_;
+                const auto A_gb_offset = gate_id * rnn_.diff_src_brgemm.K;
+                const auto B_gb_offset = gate_id * B_gb_layer_offset_;
+                const auto A_gm = A_m + A_gb_offset;
+                const auto B_wei_layer_gn = B_wei_layer_n + B_gb_offset;
+
+                for (int k_block_id = 0; k_block_id < k_blocks_; k_block_id++) {
+                    addr_batch[g_block_id + k_block_id].ptr.A
+                            = A_gm + k_block_id * k_block_;
+                    addr_batch[g_block_id + k_block_id].ptr.B
+                            = B_wei_layer_gn + k_block_id * B_kb_offset_;
+                }
+            }
+            brgemm_kernel_execute(kernel_layer, k_blocks_n_gates_, addr_batch,
+                    reinterpret_cast<void *>(C_diff_layer_n), nullptr);
+        }
+
+        if (should_calc_diff_src_iter && k_tail_) {
+            for (int gate_id = 0; gate_id < n_gates; gate_id++) {
+                const auto A_gb_offset = gate_id * rnn_.diff_src_brgemm.K;
+                const auto B_gb_offset = gate_id * B_gb_iter_offset_;
+                addr_batch[gate_id].ptr.A
+                        = A_m + A_gb_offset + A_k_tail_offset_;
+                addr_batch[gate_id].ptr.B
+                        = B_wei_iter_n + B_gb_offset + B_k_tail_offset_;
+            }
+            brgemm_kernel_execute(kernel_iter_k_tail, n_gates, addr_batch,
+                    reinterpret_cast<void *>(C_diff_iter_n), nullptr);
+        }
+
+        if (should_calc_diff_src_layer && k_tail_) {
+            for (int gate_id = 0; gate_id < n_gates; gate_id++) {
+                const auto A_gb_offset = gate_id * rnn_.diff_src_brgemm.K;
+                const auto B_gb_offset = gate_id * B_gb_layer_offset_;
+                addr_batch[gate_id].ptr.A
+                        = A_m + A_gb_offset + A_k_tail_offset_;
+                addr_batch[gate_id].ptr.B
+                        = B_wei_layer_n + B_gb_offset + B_k_tail_offset_;
+            }
+            brgemm_kernel_execute(kernel_layer_k_tail, n_gates, addr_batch,
+                    reinterpret_cast<void *>(C_diff_layer_n), nullptr);
+        }
+
+        ++start;
+        nd_iterator_step(n_block_id, n_blocking_, m_block_id, m_blocking_);
+    }
+}
+
+template <typename src_layer_t, typename src_iter_t, typename scratch_t,
+        typename gemm_acc_t>
+brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
+        gemm_acc_t>::brgemm_diff_weights_layer_iter_t(const ref_rnn_brgemm_t
+                                                              &rnn_brgemm,
+        const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position, const src_layer_t *src_iter,
+        scratch_t *const A_iter_transposed_scratch, const src_iter_t *src_layer,
+        scratch_t *const A_layer_transposed_scratch, const scratch_t *scratch,
+        scratch_t *scratch_gates_blocked, gemm_acc_t *diff_weights_iter,
+        gemm_acc_t *diff_weights_layer, gemm_acc_t *diff_bias,
+        aarch64::brgemm_batch_element_t *addr_batch_global)
+    : rnn_brgemm_(rnn_brgemm)
+    , rnn_(rnn)
+    , A_iter_(src_iter)
+    , A_iter_transposed_scratch_(A_iter_transposed_scratch)
+    , A_layer_(src_layer)
+    , A_layer_transposed_scratch_(A_layer_transposed_scratch)
+    , B_(scratch)
+    , B_blocked_scratch_(scratch_gates_blocked)
+    , C_iter_(diff_weights_iter)
+    , C_layer_(diff_weights_layer)
+    , diff_bias_(diff_bias)
+    , LDA_iter_(rnn.diff_wei_brgemm.LDA_iter)
+    , LDA_layer_(rnn.diff_wei_brgemm.LDA_layer)
+    , LDC_iter_(rnn.diff_wei_brgemm.LDC_iter)
+    , LDC_layer_(rnn.diff_wei_brgemm.LDC_layer)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn.nthr))
+    , n_blocking_(rnn.diff_wei_brgemm.N_blocks)
+    , m_blocking_(rnn.diff_wei_brgemm.M_blocks)
+    , k_blocks_(rnn.diff_wei_brgemm.K_blocks)
+    , k_tail_(rnn.diff_wei_brgemm.k_tail)
+    , k_block_(rnn.diff_wei_brgemm.k_block)
+    , m_iter_block_(rnn.slc == rnn.sic ? rnn.diff_wei_brgemm.m_block
+                                       : rnn.diff_wei_brgemm.M_iter)
+    , m_layer_block_(rnn.slc == rnn.sic ? rnn.diff_wei_brgemm.m_block
+                                        : rnn.diff_wei_brgemm.M_layer)
+    , A_k_iter_tail_offset_(k_blocks_ * k_block_)
+    , A_k_layer_tail_offset_(k_blocks_ * k_block_)
+    , B_kb_offset_(k_block_ * rnn.diff_wei_brgemm.n_block)
+    , B_k_tail_offset_(k_blocks_ * k_block_ * rnn.scratch_gates_ld)
+    , B_k_tail_offset_blocked_(
+              k_blocks_ * k_block_ * rnn.diff_wei_brgemm.n_block)
+    , work_amount_(n_blocking_ * m_blocking_)
+    , kernel_iter_full_blocks_(rnn_brgemm.diff_wei_.kernel_iter_beta1_.get())
+    , kernel_iter_n_tail_(rnn_brgemm.diff_wei_.kernel_iter_N_tail_beta1_.get())
+    , kernel_iter_k_tail_(rnn_brgemm.diff_wei_.kernel_iter_K_tail_beta1_.get())
+    , kernel_iter_nk_tail_(
+              rnn_brgemm.diff_wei_.kernel_iter_NK_tail_beta1_.get())
+    , kernel_layer_full_blocks_(rnn_brgemm.diff_wei_.kernel_layer_beta1_.get())
+    , kernel_layer_n_tail_(
+              rnn_brgemm.diff_wei_.kernel_layer_N_tail_beta1_.get())
+    , kernel_layer_k_tail_(
+              rnn_brgemm.diff_wei_.kernel_layer_K_tail_beta1_.get())
+    , kernel_layer_nk_tail_(
+              rnn_brgemm.diff_wei_.kernel_layer_NK_tail_beta1_.get())
+    , cell_position_(cell_position)
+    , addr_batch_global_(addr_batch_global) {}
+
+template <typename src_layer_t, typename src_iter_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
+        gemm_acc_t>::execute() const {
+    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        this->kernel(ithr, nthr);
+    });
+}
+
+template <typename src_layer_t, typename src_iter_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
+        gemm_acc_t>::reorder_scratch_gates(const scratch_t *src, scratch_t *dst,
+        const bool do_n_tail) const {
+
+    assert(!"AArch64 JIT scratch gates reorder not available in Phase A");
+}
+
+template <typename src_layer_t, typename src_iter_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
+        gemm_acc_t>::kernel(const int ithr, const int nthr) const {
+
+    const bool global_transpose = rnn_.diff_wei_brgemm.global_transpose;
+
+    scratch_t *const B_blocked = B_blocked_scratch_
+            + ithr * rnn_.diff_wei_brgemm.Kpadded
+                    * rnn_.diff_wei_brgemm.n_block;
+
+    scratch_t *const A_iter_transposed_ithr = global_transpose
+            ? A_iter_transposed_scratch_
+            : (A_iter_transposed_scratch_
+                      + ithr * rnn_.diff_wei_brgemm.Kpadded * m_iter_block_);
+
+    scratch_t *const A_layer_transposed_ithr = global_transpose
+            ? A_layer_transposed_scratch_
+            : A_layer_transposed_scratch_
+                    + ithr * rnn_.diff_wei_brgemm.Kpadded * m_layer_block_;
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    int n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
+        last_m_block_id = -1;
+    nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
+
+    aarch64::brgemm_batch_element_t *const addr_batch
+            = addr_batch_global_ + ithr * (k_blocks_ + 1);
+
+    while (start < end) {
+        const bool should_reorder_gates = last_n_block_id != n_block_id;
+        const bool transpose_needed
+                = !(rnn_.mb == 1 && std::is_same<float, src_iter_t>::value);
+        const bool should_transpose_src = transpose_needed && !global_transpose
+                && (last_m_block_id != m_block_id);
+
+        const int m_iter = m_block_id * m_iter_block_;
+        const int m_layer = m_block_id * m_layer_block_;
+
+        const src_iter_t *const A_iter_m = global_transpose
+                ? A_iter_transposed_ithr + m_iter * LDA_iter_
+                : A_iter_ + m_iter;
+        const src_layer_t *const A_layer_m = global_transpose
+                ? A_layer_transposed_ithr + m_layer * LDA_layer_
+                : A_layer_ + m_layer;
+
+        src_iter_t *const A_iter_transposed
+                = (global_transpose || !transpose_needed)
+                ? const_cast<src_iter_t *>(A_iter_m)
+                : A_iter_transposed_ithr;
+        src_layer_t *const A_layer_transposed
+                = (global_transpose || !transpose_needed)
+                ? const_cast<src_layer_t *>(A_layer_m)
+                : A_layer_transposed_ithr;
+
+        const int n = n_block_id * rnn_.diff_wei_brgemm.n_block;
+        const scratch_t *const B_n = B_ + n;
+        const auto C_iter_offset = m_iter * LDC_iter_ + n;
+        const auto C_layer_offset = m_layer * LDC_layer_ + n;
+        gemm_acc_t *const C_diff_iter_n = C_iter_ + C_iter_offset;
+        gemm_acc_t *const C_diff_layer_n = C_layer_ + C_layer_offset;
+
+        const bool do_n_tail
+                = (n + rnn_.diff_wei_brgemm.n_block) > rnn_.diff_wei_brgemm.N;
+
+        const brgemm_kernel_t *kernel_iter = kernel_iter_full_blocks_;
+        const brgemm_kernel_t *kernel_iter_k_tail = kernel_iter_k_tail_;
+        const brgemm_kernel_t *kernel_layer = kernel_layer_full_blocks_;
+        const brgemm_kernel_t *kernel_layer_k_tail = kernel_layer_k_tail_;
+
+        if (do_n_tail) {
+            kernel_iter = kernel_iter_n_tail_;
+            kernel_iter_k_tail = kernel_iter_nk_tail_;
+            kernel_layer = kernel_layer_n_tail_;
+            kernel_layer_k_tail = kernel_layer_nk_tail_;
+        }
+
+        if (should_reorder_gates) {
+            reorder_scratch_gates(B_n, B_blocked, do_n_tail);
+
+            if (m_block_id == 0) {
+
+                // JIT gates reduction not yet implemented
+                // TODO: Add aarch64 jit_gates_reduction_t
+                assert(!"JIT gates reduction kernel not available till now");
+            }
+        }
+
+        for (int k_block_id = 0; k_block_id < k_blocks_; k_block_id++) {
+            addr_batch[k_block_id].ptr.A
+                    = A_iter_transposed + k_block_id * k_block_;
+            addr_batch[k_block_id].ptr.B
+                    = B_blocked + k_block_id * B_kb_offset_;
+        }
+
+        if (should_transpose_src) {
+
+            // JIT transpose not yet implemented
+            // TODO: Add aarch64 jit_brgemm_transpose_single_row_t
+            assert(!"JIT transpose iter kernel not available till now");
+        }
+
+        brgemm_kernel_execute(kernel_iter, k_blocks_, addr_batch,
+                reinterpret_cast<void *>(C_diff_iter_n), nullptr);
+
+        for (int k_block_id = 0; k_block_id < k_blocks_; k_block_id++) {
+            addr_batch[k_block_id].ptr.A
+                    = A_layer_transposed + k_block_id * k_block_;
+            addr_batch[k_block_id].ptr.B
+                    = B_blocked + k_block_id * B_kb_offset_;
+        }
+
+        if (should_transpose_src) {
+
+            // JIT transpose not yet implemented
+            // TODO: Add aarch64 jit_brgemm_transpose_single_row_t
+            assert(!"JIT transpose layer kernel not available till now");
+        }
+
+        brgemm_kernel_execute(kernel_layer, k_blocks_, addr_batch,
+                reinterpret_cast<void *>(C_diff_layer_n), nullptr);
+
+        if (k_tail_) {
+            const auto B_blocked_k_tail = B_blocked + B_k_tail_offset_blocked_;
+
+            addr_batch[0].ptr.A = A_iter_transposed + A_k_iter_tail_offset_;
+            addr_batch[0].ptr.B = B_blocked_k_tail;
+            brgemm_kernel_execute(kernel_iter_k_tail, 1, addr_batch,
+                    reinterpret_cast<void *>(C_diff_iter_n), nullptr);
+
+            addr_batch[0].ptr.A = A_layer_transposed + A_k_layer_tail_offset_;
+            addr_batch[0].ptr.B = B_blocked_k_tail;
+            brgemm_kernel_execute(kernel_layer_k_tail, 1, addr_batch,
+                    reinterpret_cast<void *>(C_diff_layer_n), nullptr);
+        }
+
+        if (should_reorder_gates) { last_n_block_id = n_block_id; }
+        if (should_transpose_src) { last_m_block_id = m_block_id; }
+
+        ++start;
+        nd_iterator_step(n_block_id, n_blocking_, m_block_id, m_blocking_);
+    }
+}
+
+template <typename scratch_t>
+brgemm_diff_wei_peep_t<scratch_t>::brgemm_diff_wei_peep_t(
+        const ref_rnn_brgemm_t &rnn_brgemm, const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position,
+        const scratch_t *scratch_gates, const void *src_iter_c,
+        const void *dst_iter_c, float *diff_weights_peephole)
+    : rnn_(rnn)
+    , scratch_gates_(scratch_gates)
+    , src_iter_c_(src_iter_c)
+    , dst_iter_c_(dst_iter_c)
+    , diff_weights_peephole_(diff_weights_peephole)
+    , work_amount_(n_gates_ * rnn_.dhc_blocks_peephole)
+    , dst_iter_c_ld_(rnn.dst_iter_c_ld(cell_position))
+    , src_iter_c_ld_(rnn.src_iter_c_ld(cell_position)) {}
+
+template <typename scratch_t>
+void brgemm_diff_wei_peep_t<scratch_t>::execute() const {
+    parallel(rnn_.nthr, [this](const int ithr, const int nthr) {
+        this->kernel(ithr, nthr);
+    });
+}
+
+template <typename scratch_t>
+void brgemm_diff_wei_peep_t<scratch_t>::kernel(
+        const int ithr, const int nthr) const {
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    int g = 0, dhc_block_id = 0;
+    nd_iterator_init(
+            start, g, n_gates_, dhc_block_id, rnn_.dhc_blocks_peephole);
+
+    const auto dst_iter_c = rnn_utils::make_raw_aoc(dst_iter_c_,
+            types::data_type_size(rnn_.dst_iter_c_dt),
+            rnn_.ws_states_iter_c_nld, dst_iter_c_ld_);
+    const auto src_iter_c = rnn_utils::make_raw_aoc(src_iter_c_,
+            types::data_type_size(rnn_.src_iter_c_dt),
+            rnn_.ws_states_iter_c_nld, src_iter_c_ld_);
+
+    const rnn_utils::scratch_gates_aoc_t<const scratch_t> scratch_gates(
+            rnn_, scratch_gates_);
+    const rnn_utils::weights_peephole_aoc_t<float> diff_weights_peephole(
+            rnn_, diff_weights_peephole_);
+
+    MAYBE_UNUSED(dst_iter_c);
+    MAYBE_UNUSED(src_iter_c);
+    MAYBE_UNUSED(scratch_gates);
+    MAYBE_UNUSED(diff_weights_peephole);
+
+    while (start < end) {
+
+        // JIT peephole not yet implemented
+        // TODO: Add aarch64 jit_diff_weights_peephole_t
+        assert(!"JIT peephole kernel not available till now");
+
+        ++start;
+        nd_iterator_step(g, n_gates_, dhc_block_id, rnn_.dhc_blocks_peephole);
+    }
+}
+
+template class brgemm_diff_src_layer_iter_t<float, float, float>;
+template class brgemm_diff_src_layer_iter_t<bfloat16_t, bfloat16_t, float>;
+template class brgemm_diff_src_layer_iter_t<float16_t, float16_t, float>;
+
+template class brgemm_diff_weights_layer_iter_t<float, float, float, float>;
+template class brgemm_diff_weights_layer_iter_t<bfloat16_t, bfloat16_t,
+        bfloat16_t, float>;
+template class brgemm_diff_weights_layer_iter_t<float16_t, float16_t, float16_t,
+        float>;
+
+template class brgemm_diff_wei_peep_t<bfloat16_t>;
+template class brgemm_diff_wei_peep_t<float16_t>;
+template class brgemm_diff_wei_peep_t<float>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.cpp
@@ -36,8 +36,8 @@ brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
         const rnn_utils::rnn_conf_t &rnn,
         rnn_utils::cell_position_t cell_position, scratch_t *scratch_gates,
         weights_t *w_iter, weights_t *w_layer, gemm_acc_t *diff_src_iter,
-        gemm_acc_t *diff_src_layer,
-        aarch64::brgemm_batch_element_t *addr_batch_global)
+        gemm_acc_t *diff_src_layer, gemm_acc_t *gemm_acc_scratchpad,
+        brgemm_batch_element_t *addr_batch_global)
     : rnn_brgemm_(rnn_brgemm)
     , rnn_(rnn)
     , A_(scratch_gates)
@@ -83,6 +83,7 @@ brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
               rnn_brgemm_.diff_src_.kernel_iter_layer_K_tail_beta1_.get())
     , kernel_layer_nk_tail_(
               rnn_brgemm_.diff_src_.kernel_layer_NK_tail_beta1_.get())
+    , gemm_acc_scratchpad_(gemm_acc_scratchpad)
     , addr_batch_global_(addr_batch_global) {}
 
 template <typename weights_t, typename scratch_t, typename gemm_acc_t>
@@ -103,7 +104,7 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel(
     int n_block_id = 0, m_block_id = 0;
     nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
 
-    aarch64::brgemm_batch_element_t *const addr_batch
+    brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * (k_blocks_n_gates_ + 1);
 
     const auto n_gates = rnn_.n_gates;
@@ -224,7 +225,8 @@ brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         scratch_t *const A_layer_transposed_scratch, const scratch_t *scratch,
         scratch_t *scratch_gates_blocked, gemm_acc_t *diff_weights_iter,
         gemm_acc_t *diff_weights_layer, gemm_acc_t *diff_bias,
-        aarch64::brgemm_batch_element_t *addr_batch_global)
+        gemm_acc_t *gemm_acc_scratchpad,
+        brgemm_batch_element_t *addr_batch_global)
     : rnn_brgemm_(rnn_brgemm)
     , rnn_(rnn)
     , A_iter_(src_iter)
@@ -270,6 +272,7 @@ brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
     , kernel_layer_nk_tail_(
               rnn_brgemm.diff_wei_.kernel_layer_NK_tail_beta1_.get())
     , cell_position_(cell_position)
+    , gemm_acc_scratchpad_(gemm_acc_scratchpad)
     , addr_batch_global_(addr_batch_global) {}
 
 template <typename src_layer_t, typename src_iter_t, typename scratch_t,
@@ -318,7 +321,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         last_m_block_id = -1;
     nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
 
-    aarch64::brgemm_batch_element_t *const addr_batch
+    brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * (k_blocks_ + 1);
 
     while (start < end) {

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp
@@ -1,0 +1,208 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_BWD_HPP
+#define CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_BWD_HPP
+
+#include "common/bfloat16.hpp"
+#include "cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp"
+#include "cpu/aarch64/rnn/rnn_brgemm_utils.hpp"
+#include "cpu/rnn/rnn_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <typename weights_t, typename scratch_t, typename gemm_acc_t>
+class brgemm_diff_src_layer_iter_t {
+public:
+    using ref_rnn_brgemm_t
+            = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::backward>;
+
+    brgemm_diff_src_layer_iter_t(const ref_rnn_brgemm_t &rnn_brgemm_,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position, scratch_t *scratch_gates,
+            weights_t *w_iter, weights_t *w_layer, gemm_acc_t *diff_src_iter,
+            gemm_acc_t *diff_src_layer,
+            aarch64::brgemm_batch_element_t *addr_batch_global);
+
+    void execute() const;
+
+private:
+    void kernel(const int ithr, const int nthr) const;
+
+    const ref_rnn_brgemm_t &rnn_brgemm_;
+    const rnn_utils::rnn_conf_t &rnn_;
+
+    const scratch_t *const A_;
+
+    const weights_t *const B_wei_iter_;
+    const weights_t *const B_wei_layer_;
+
+    gemm_acc_t *const C_diff_iter_;
+    gemm_acc_t *const C_diff_layer_;
+
+    const dim_t k_blocks_n_gates_;
+    const dim_t k_blocks_;
+    const dim_t k_tail_;
+    const dim_t k_block_;
+
+    const dim_t A_k_tail_offset_;
+    const dim_t B_k_tail_offset_;
+    const dim_t B_nb_offset_;
+    const dim_t B_kb_offset_;
+    const dim_t B_gb_iter_offset_;
+    const dim_t B_gb_layer_offset_;
+
+    const dim_t LDA_;
+    const dim_t LDC_;
+    const dim_t max_nthr_;
+
+    const dim_t n_blocking_;
+    const dim_t m_blocking_;
+    const int work_amount_;
+
+    const dim_t max_n_layer_blocks_;
+    const dim_t max_n_iter_blocks_;
+
+    const bool gemm_layer_needed_;
+
+    const brgemm_kernel_t *const kernel_iter_full_blocks_b0_;
+    const brgemm_kernel_t *const kernel_iter_n_tail_b0_;
+    const brgemm_kernel_t *const kernel_iter_k_tail_;
+    const brgemm_kernel_t *const kernel_iter_nk_tail_;
+
+    const brgemm_kernel_t *const kernel_layer_full_blocks_b0_;
+    const brgemm_kernel_t *const kernel_layer_n_tail_b0_;
+    const brgemm_kernel_t *const kernel_layer_k_tail_;
+    const brgemm_kernel_t *const kernel_layer_nk_tail_;
+
+    brgemm_batch_element_t *const addr_batch_global_;
+};
+
+template <typename src_layer_t, typename src_iter_t, typename scratch_t,
+        typename gemm_acc_t>
+class brgemm_diff_weights_layer_iter_t {
+public:
+    using ref_rnn_brgemm_t
+            = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::backward>;
+
+    brgemm_diff_weights_layer_iter_t(const ref_rnn_brgemm_t &rnn_brgemm_,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position,
+            const src_layer_t *src_iter,
+            scratch_t *const A_iter_transposed_scratch,
+            const src_iter_t *src_layer,
+            scratch_t *const A_layer_transposed_scratch,
+            const scratch_t *scratch, scratch_t *scratch_gates_blocked,
+            gemm_acc_t *diff_weights_iter, gemm_acc_t *diff_weights_layer,
+            gemm_acc_t *diff_bias,
+            aarch64::brgemm_batch_element_t *addr_batch_global);
+
+    void execute() const;
+
+private:
+    const ref_rnn_brgemm_t &rnn_brgemm_;
+    const rnn_utils::rnn_conf_t &rnn_;
+
+    const src_iter_t *const A_iter_;
+    scratch_t *const A_iter_transposed_scratch_;
+    const src_layer_t *const A_layer_;
+    scratch_t *const A_layer_transposed_scratch_;
+
+    const scratch_t *const B_;
+    scratch_t *const B_blocked_scratch_;
+
+    gemm_acc_t *const C_iter_;
+    gemm_acc_t *const C_layer_;
+    gemm_acc_t *const diff_bias_;
+
+    const dim_t LDA_iter_;
+    const dim_t LDA_layer_;
+    const dim_t LDC_iter_;
+    const dim_t LDC_layer_;
+
+    const dim_t max_nthr_;
+
+    const dim_t n_blocking_;
+    const dim_t m_blocking_;
+    const dim_t k_blocks_;
+    const dim_t k_tail_;
+    const dim_t k_block_;
+    const dim_t m_iter_block_;
+    const dim_t m_layer_block_;
+
+    const dim_t A_k_iter_tail_offset_;
+    const dim_t A_k_layer_tail_offset_;
+    const dim_t B_kb_offset_;
+    const dim_t B_k_tail_offset_;
+    const dim_t B_k_tail_offset_blocked_;
+    const int work_amount_;
+
+    const brgemm_kernel_t *const kernel_iter_full_blocks_;
+    const brgemm_kernel_t *const kernel_iter_n_tail_;
+    const brgemm_kernel_t *const kernel_iter_k_tail_;
+    const brgemm_kernel_t *const kernel_iter_nk_tail_;
+    const brgemm_kernel_t *const kernel_layer_full_blocks_;
+    const brgemm_kernel_t *const kernel_layer_n_tail_;
+    const brgemm_kernel_t *const kernel_layer_k_tail_;
+    const brgemm_kernel_t *const kernel_layer_nk_tail_;
+
+    const rnn_utils::cell_position_t cell_position_;
+
+    brgemm_batch_element_t *const addr_batch_global_;
+
+    void kernel(const int ithr, const int nthr) const;
+    void reorder_scratch_gates(
+            const scratch_t *src, scratch_t *dst, const bool do_n_tail) const;
+};
+
+template <typename scratch_t>
+class brgemm_diff_wei_peep_t {
+public:
+    using ref_rnn_brgemm_t
+            = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::backward>;
+
+    brgemm_diff_wei_peep_t(const ref_rnn_brgemm_t &rnn_brgemm,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position,
+            const scratch_t *scratch_gates, const void *src_iter_c,
+            const void *dst_iter_c, float *diff_weights_peephole);
+
+    void execute() const;
+
+private:
+    void kernel(const int ithr, const int nthr) const;
+
+    const int n_gates_ = 3;
+    const rnn_utils::rnn_conf_t &rnn_;
+    const scratch_t *scratch_gates_;
+    const void *src_iter_c_;
+    const void *dst_iter_c_;
+    float *diff_weights_peephole_;
+    const int work_amount_;
+    const int dst_iter_c_ld_;
+    const int src_iter_c_ld_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_BWD_HPP

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp
@@ -28,6 +28,24 @@ namespace impl {
 namespace cpu {
 namespace aarch64 {
 
+/*
+ * Calculations:
+ * scratch * w_iter = dff_src_iter
+ * A (mb x rnn.n_gates * rnn.dhc) * B (rnn.n_gates * rnn.dhc, rnn.sic) =
+ * C (mb x rnn.sic)
+ *
+ * scratch * w_layer = dff_src_layer
+ * A (mb x rnn.n_gates * rnn.dhc) * B (rnn.n_gates * rnn.dhc, rnn.slc) =
+ * C (mb x rnn.slc)
+ *
+ * Data formats:
+ * scratch = igo (mb, n_gates, rnn.dhc)
+ * w_iter = gIo32i (n_gates, rnn.sic, rnn.dhc)
+ * w_layer = gIo32i (n_gates, rnn.slc, rnn.dhc)
+ * diff_src_layer = io (mb, rnn.slc)
+ * diff_src_iter = io (mb, rnn.sic)
+ */
+
 template <typename weights_t, typename scratch_t, typename gemm_acc_t>
 class brgemm_diff_src_layer_iter_t {
 public:
@@ -95,6 +113,26 @@ private:
     gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
 };
+
+/*
+ * Calculations:
+ * src_layer^T * scratch = dff_weights_layer
+ * A before transpose (rnn.mb, rnn.slc) - layout in memory
+ * A (rnn.slc, rnn.mb) * B (rnn.mb, rnn.n_gates * rnn.dhc) =
+ * C (rnn.slc, rnn.n_gates * rnn.dhc)
+ * src_iter^T * scratch = dff_weights_iter
+ * A (rnn.sic, rnn.mb) * B (rnn.mb, rnn.n_gates * rnn.dhc) =
+ * C (rnn.sic, rnn.n_gates * rnn.dhc)
+ *
+ * Data formats:
+ * src_iter  = io (mb,  rnn.sic) -> transposed oi (rnn.sic, mb)
+ * src_layer = io (mb, rnn.slc) -> transposed oi (rnn.sic, mb)
+ *
+ * scratch = igo (mb, n_gates, rnn.dhc)
+ *
+ * dff_weights_iter = igo (rnn.sic, rnn.n_gates, rnn.dhc)
+ * dff_weights_layer = igo (rnn.slc, rnn.n_gates, rnn.dhc)
+ */
 
 template <typename src_layer_t, typename src_iter_t, typename scratch_t,
         typename gemm_acc_t>

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp
@@ -38,8 +38,8 @@ public:
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, scratch_t *scratch_gates,
             weights_t *w_iter, weights_t *w_layer, gemm_acc_t *diff_src_iter,
-            gemm_acc_t *diff_src_layer,
-            aarch64::brgemm_batch_element_t *addr_batch_global);
+            gemm_acc_t *diff_src_layer, gemm_acc_t *gemm_acc_scratchpad,
+            brgemm_batch_element_t *addr_batch_global);
 
     void execute() const;
 
@@ -92,6 +92,7 @@ private:
     const brgemm_kernel_t *const kernel_layer_k_tail_;
     const brgemm_kernel_t *const kernel_layer_nk_tail_;
 
+    gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
 };
 
@@ -111,8 +112,8 @@ public:
             scratch_t *const A_layer_transposed_scratch,
             const scratch_t *scratch, scratch_t *scratch_gates_blocked,
             gemm_acc_t *diff_weights_iter, gemm_acc_t *diff_weights_layer,
-            gemm_acc_t *diff_bias,
-            aarch64::brgemm_batch_element_t *addr_batch_global);
+            gemm_acc_t *diff_bias, gemm_acc_t *gemm_acc_scratchpad,
+            brgemm_batch_element_t *addr_batch_global);
 
     void execute() const;
 
@@ -165,6 +166,7 @@ private:
 
     const rnn_utils::cell_position_t cell_position_;
 
+    gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
 
     void kernel(const int ithr, const int nthr) const;

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
@@ -1,0 +1,900 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp"
+
+#include "common/dnnl_thread.hpp"
+#include "common/utils.hpp"
+
+using namespace dnnl::impl::utils;
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
+        gemm_acc_t>::brgemm_dst_layer_iter_t(const ref_rnn_brgemm_t &rnn_brgemm,
+        const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position, const src_t *src_iter,
+        const src_t *src_layer, weights_t *w_iter, weights_t *w_layer,
+        scratch_t *scratch_gates, scratch_t *scratch_cell,
+        aarch64::brgemm_batch_element_t *addr_batch_global,
+        const postgemm_fused_t &fused_postgemm)
+    : rnn_brgemm_(rnn_brgemm)
+    , rnn_(rnn)
+    , need_gemm_layer_(rnn_.need_gemm_layer(cell_position))
+    , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
+    , iter_desc_idx_(rnn_.iter_brgemm_desc(cell_position))
+    , Al_(src_layer)
+    , Ai_(src_iter)
+    , Bl_(w_layer)
+    , Bi_(w_iter)
+    , C_gates_(scratch_gates)
+    , C_cell_(scratch_cell)
+    , LDAl_(rnn_.src_layer_ld(cell_position))
+    , LDAi_(rnn_.src_iter_ld(cell_position))
+    , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
+                                           : rnn_.N_blocks)
+    , m_blocking_(rnn_.M_blocks)
+    , work_amount_(n_blocking_ * m_blocking_)
+    , Bl_n_offset_(rnn_.K1padded * rnn_.n_block)
+    , Bi_n_offset_(rnn_.K2padded * rnn_.n_block)
+    , Bl_g_offset_(rnn_.N_blocks * Bl_n_offset_)
+    , Bi_g_offset_(rnn_.N_blocks * Bi_n_offset_)
+    , Al_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
+    , Ai_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block)
+    , Bl_kb_offset_(rnn_.k1_block * rnn_.n_block)
+    , Bi_kb_offset_(rnn_.k2_block * rnn_.n_block)
+    , Bl_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
+    , Bi_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block * rnn_.n_block)
+    , n_gates_(rnn.unfused_post_gemm ? 1 : rnn.n_gates)
+    , brgemm_kernel_iter_main_(need_gemm_layer_
+                      ? rnn_brgemm_.kernel_iter_b1_[iter_desc_idx_].get()
+                      : rnn_brgemm_.kernel_iter_b0_[iter_desc_idx_].get())
+    , brgemm_kernel_iter_n_tail_(need_gemm_layer_
+                      ? rnn_brgemm_.kernel_iter_N_tail_b1_[iter_desc_idx_].get()
+                      : rnn_brgemm_.kernel_iter_N_tail_b0_[iter_desc_idx_]
+                                .get())
+    , brgemm_kernel_iter_k_tail_(
+              rnn_brgemm_.kernel_iter_K2_tail_b1_[iter_desc_idx_].get())
+    , brgemm_kernel_iter_nk_tail_(
+              rnn_brgemm_.kernel_iter_NK2_tail_b1_[iter_desc_idx_].get())
+    , brgemm_kernel_layer_main_(
+              rnn_brgemm_.kernel_layer_b0_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_n_tail_(
+              rnn_brgemm_.kernel_layer_N_tail_b0_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_k_tail_(
+              rnn_brgemm_.kernel_layer_K1_tail_b1_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_nk_tail_(
+              rnn_brgemm_.kernel_layer_NK1_tail_b1_[layer_desc_idx_].get())
+    , addr_batch_global_(addr_batch_global)
+    , fused_postgemm_(fused_postgemm)
+    , is_fused_layer_iter_brgemm_(!rnn_.is_lbr && rnn_.sic == rnn_.slc
+              && LDAi_ == LDAl_ && need_gemm_layer_)
+    , max_nthr_(calculate_nthr()) {}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::execute()
+        const {
+    if (is_fused_layer_iter_brgemm_) {
+        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+            this->kernel_fused_iter_layer(ithr, nthr);
+        });
+    } else {
+        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+            this->kernel(ithr, nthr);
+        });
+    }
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+int brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
+        gemm_acc_t>::calculate_nthr() const {
+    const auto max_nthr = nstl::min(dnnl_get_current_num_threads(), rnn_.nthr);
+
+    // TODO: tune thresholds for aarch64 microarchitectures.
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB
+    constexpr dim_t k2_i8_asimd = 192;
+    constexpr dim_t k2_f32_asimd = 112;
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+    constexpr dim_t k2_i8_asimd = 176;
+    constexpr dim_t k2_f32_asimd = 96;
+#endif
+#if (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB) \
+        || (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP)
+    if (rnn_.brgemm_isa == aarch64::asimd && !need_gemm_layer_ && rnn_.M == 1
+            && utils::one_of(rnn_.cell_kind, alg_kind::vanilla_lstm,
+                    alg_kind::lbr_gru)) {
+        if (std::is_same<src_t, uint8_t>::value
+                && std::is_same<weights_t, int8_t>::value) {
+            return rnn_.K2 <= k2_i8_asimd ? 1 : max_nthr;
+        } else if (std::is_same<src_t, float>::value
+                && std::is_same<weights_t, float>::value) {
+            return rnn_.K2 <= k2_f32_asimd ? 1 : max_nthr;
+        }
+    }
+#endif
+    return max_nthr;
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
+        const int ithr, const int nthr) const {
+
+    using namespace cpu::rnn_utils;
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+            nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
+    brgemm_batch_element_t *const addr_batch
+            = addr_batch_global_ + ithr * max_K_Block;
+
+    dim_t nb_i = 0, mb = 0;
+    switch (rnn_.loop_order) {
+        case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+            nd_iterator_init(start, mb, m_blocking_, nb_i, n_blocking_);
+            break;
+        case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+            nd_iterator_init(start, nb_i, n_blocking_, mb, m_blocking_);
+            break;
+        default: assert(!"unsupported loop order");
+    }
+
+    while (start < end) {
+        const auto m = mb * rnn_.m_block;
+        const auto nb = (rnn_.unfused_post_gemm) ? nb_i / rnn_.n_gates : nb_i;
+        const auto n = nb * rnn_.n_block;
+        const auto g_unfused
+                = (rnn_.unfused_post_gemm) ? nb_i % rnn_.n_gates : 0;
+
+        const auto *const Al_m = Al_ + m * LDAl_;
+        const auto *const Ai_m = Ai_ + m * LDAi_;
+        const auto *const Bl_n = Bl_ + nb * Bl_n_offset_;
+        const auto *const Bi_n = Bi_ + nb * Bi_n_offset_;
+        auto *const C_n = C_gates_ + m * rnn_.LDC + n;
+
+        const auto cell_stride = rnn_.LDC;
+        auto *const C_cell_i
+                = C_cell_ ? C_cell_ + m * cell_stride + n : C_cell_;
+
+        assert(rnn_.LDC == rnn_.scratch_gates_ld);
+
+        const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
+
+        const brgemm_kernel_t *brgemm_kernel_layer_b0 = do_n_tail
+                ? brgemm_kernel_layer_n_tail_
+                : brgemm_kernel_layer_main_;
+        const brgemm_kernel_t *brgemm_kernel_iter = do_n_tail
+                ? brgemm_kernel_iter_n_tail_
+                : brgemm_kernel_iter_main_;
+        const brgemm_kernel_t *brgemm_kernel_layer_k_tail = do_n_tail
+                ? brgemm_kernel_layer_nk_tail_
+                : brgemm_kernel_layer_k_tail_;
+        const brgemm_kernel_t *brgemm_kernel_iter_k_tail = do_n_tail
+                ? brgemm_kernel_iter_nk_tail_
+                : brgemm_kernel_iter_k_tail_;
+
+        if (rnn_.is_lbr) {
+            for (dim_t i = 0; i < rnn_.m_block; ++i) {
+                auto *C_o = C_cell_i + i * cell_stride;
+                PRAGMA_OMP_SIMD()
+                for (dim_t j = 0; j < nstl::min(rnn_.n_block, cell_stride); ++j)
+                    C_o[j] = 0;
+            }
+        }
+
+        for (int g = 0; g < n_gates_; g++) {
+            const int lg = g + g_unfused;
+            const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
+            const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
+            auto *C_g = C_n + lg * rnn_.N;
+
+            if (need_gemm_layer_) {
+                for (int i = 0; i < rnn_.KB1_blocks; i++) {
+                    addr_batch[i].ptr.A = Al_m + i * rnn_.k1_block;
+                    addr_batch[i].ptr.B = Bl_g + i * Bl_kb_offset_;
+                }
+                brgemm_kernel_execute(brgemm_kernel_layer_b0, rnn_.KB1_blocks,
+                        addr_batch, reinterpret_cast<void *>(C_g), nullptr);
+            }
+
+            if (rnn_.is_lbr && g == n_gates_ - 1) C_g = C_cell_i;
+
+            for (int i = 0; i < rnn_.KB2_blocks; i++) {
+                addr_batch[i].ptr.A = Ai_m + i * rnn_.k2_block;
+                addr_batch[i].ptr.B = Bi_g + i * Bi_kb_offset_;
+            }
+            brgemm_kernel_execute(brgemm_kernel_iter, rnn_.KB2_blocks,
+                    addr_batch, reinterpret_cast<void *>(C_g), nullptr);
+        }
+
+        if (rnn_.k1_tail && need_gemm_layer_) {
+            for (int g = 0; g < n_gates_; g++) {
+                const int lg = g + g_unfused;
+                const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
+                auto *const C_g = C_n + lg * rnn_.N;
+                addr_batch[0].ptr.A = Al_m + Al_k_tail_offset_;
+                addr_batch[0].ptr.B = Bl_g + Bl_k_tail_offset_;
+                brgemm_kernel_execute(brgemm_kernel_layer_k_tail, 1, addr_batch,
+                        reinterpret_cast<void *>(C_g), nullptr);
+            }
+        }
+
+        if (rnn_.k2_tail) {
+            for (int g = 0; g < n_gates_; g++) {
+                const int lg = g + g_unfused;
+                const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
+                auto *C_g = C_n + lg * rnn_.N;
+                if (rnn_.is_lbr && g == n_gates_ - 1) C_g = C_cell_i;
+                addr_batch[0].ptr.A = Ai_m + Ai_k_tail_offset_;
+                addr_batch[0].ptr.B = Bi_g + Bi_k_tail_offset_;
+                brgemm_kernel_execute(brgemm_kernel_iter_k_tail, 1, addr_batch,
+                        reinterpret_cast<void *>(C_g), nullptr);
+            }
+        }
+
+        if (!rnn_.unfused_post_gemm) {
+            const int n_elems = do_n_tail ? rnn_.n_tail : rnn_.n_block;
+            const int block_step_bytes = n_elems * (int)sizeof(scratch_t);
+            fused_postgemm_(m, n, nb_i, Ai_m, C_n, C_cell_i, block_step_bytes);
+        }
+
+        ++start;
+        switch (rnn_.loop_order) {
+            case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+                nd_iterator_step(mb, m_blocking_, nb_i, n_blocking_);
+                break;
+            case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+                nd_iterator_step(nb_i, n_blocking_, mb, m_blocking_);
+                break;
+            default: assert(!"unsupported loop order");
+        }
+    }
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
+        gemm_acc_t>::kernel_fused_iter_layer(const int ithr,
+        const int nthr) const {
+
+    using namespace cpu::rnn_utils;
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    const int max_K_Block = 2
+            * nstl::max(rnn_.KB1_blocks + 1,
+                    nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
+    brgemm_batch_element_t *const addr_batch
+            = addr_batch_global_ + ithr * max_K_Block;
+
+    dim_t nb_i = 0, mb = 0;
+    switch (rnn_.loop_order) {
+        case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+            nd_iterator_init(start, mb, m_blocking_, nb_i, n_blocking_);
+            break;
+        case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+            nd_iterator_init(start, nb_i, n_blocking_, mb, m_blocking_);
+            break;
+        default: assert(!"unsupported loop order");
+    }
+
+    const auto LDA = LDAl_;
+    const auto B_n_offset = Bl_n_offset_;
+    const auto B_g_offset = Bl_g_offset_;
+    const auto B_kb_offset = Bl_kb_offset_;
+    const auto KB_blocks
+            = (need_gemm_layer_ ? rnn_.KB1_blocks : 0) + rnn_.KB2_blocks;
+    const auto KB_blocks_tail = (need_gemm_layer_ ? 1 : 0) + 1;
+    const auto A_k_tail_offset = Al_k_tail_offset_;
+    const auto B_k_tail_offset = Bl_k_tail_offset_;
+
+    while (start < end) {
+        const auto m = mb * rnn_.m_block;
+        const auto nb = (rnn_.unfused_post_gemm) ? nb_i / rnn_.n_gates : nb_i;
+        const auto n = nb * rnn_.n_block;
+        const auto g_unfused
+                = (rnn_.unfused_post_gemm) ? nb_i % rnn_.n_gates : 0;
+
+        const auto *const Al_m = Al_ + m * LDA;
+        const auto *const Ai_m = Ai_ + m * LDA;
+        const auto *const Bl_n = Bl_ + nb * B_n_offset;
+        const auto *const Bi_n = Bi_ + nb * B_n_offset;
+        auto *const C_n = C_gates_ + m * rnn_.LDC + n;
+
+        const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
+
+        const brgemm_kernel_t *brgemm_kernel = do_n_tail
+                ? brgemm_kernel_layer_n_tail_
+                : brgemm_kernel_layer_main_;
+        const brgemm_kernel_t *brgemm_kernel_k_tail = do_n_tail
+                ? brgemm_kernel_layer_nk_tail_
+                : brgemm_kernel_layer_k_tail_;
+
+        for (int g = 0; g < n_gates_; g++) {
+            const int lg = g + g_unfused;
+            const auto *const Bl_g = Bl_n + lg * B_g_offset;
+            const auto *const Bi_g = Bi_n + lg * B_g_offset;
+            auto *const C_g = C_n + lg * rnn_.N;
+
+            int batch_idx = 0;
+            if (need_gemm_layer_) {
+                for (; batch_idx < rnn_.KB1_blocks; batch_idx++) {
+                    addr_batch[batch_idx].ptr.A
+                            = Al_m + batch_idx * rnn_.k1_block;
+                    addr_batch[batch_idx].ptr.B
+                            = Bl_g + batch_idx * B_kb_offset;
+                }
+            }
+
+            int iter_idx = 0;
+            for (; batch_idx < KB_blocks; batch_idx++) {
+                addr_batch[batch_idx].ptr.A = Ai_m + iter_idx * rnn_.k2_block;
+                addr_batch[batch_idx].ptr.B = Bi_g + iter_idx * B_kb_offset;
+                iter_idx++;
+            }
+
+            brgemm_kernel_execute(brgemm_kernel, KB_blocks, addr_batch,
+                    reinterpret_cast<void *>(C_g), nullptr);
+        }
+
+        if (rnn_.k2_tail) {
+            for (int g = 0; g < n_gates_; g++) {
+                const int lg = g + g_unfused;
+                auto *const C_g = C_n + lg * rnn_.N;
+
+                int batch_idx = 0;
+                if (need_gemm_layer_) {
+                    const auto *const Bl_g = Bl_n + lg * B_g_offset;
+                    addr_batch[batch_idx].ptr.A = Al_m + A_k_tail_offset;
+                    addr_batch[batch_idx].ptr.B = Bl_g + B_k_tail_offset;
+                    batch_idx++;
+                }
+                const auto *const Bi_g = Bi_n + lg * B_g_offset;
+                addr_batch[batch_idx].ptr.A = Ai_m + A_k_tail_offset;
+                addr_batch[batch_idx].ptr.B = Bi_g + B_k_tail_offset;
+
+                brgemm_kernel_execute(brgemm_kernel_k_tail, KB_blocks_tail,
+                        addr_batch, reinterpret_cast<void *>(C_g), nullptr);
+            }
+        }
+
+        if (!rnn_.unfused_post_gemm) {
+            const auto block_step = (do_n_tail ? rnn_.n_tail : rnn_.n_block)
+                    * sizeof(scratch_t);
+            fused_postgemm_(m, n, nb_i, Ai_m, C_n, C_cell_, block_step);
+        }
+
+        ++start;
+        switch (rnn_.loop_order) {
+            case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+                nd_iterator_step(mb, m_blocking_, nb_i, n_blocking_);
+                break;
+            case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+                nd_iterator_step(nb_i, n_blocking_, mb, m_blocking_);
+                break;
+            default: assert(!"unsupported loop order");
+        }
+    }
+}
+
+template <typename src_t, typename weights_t, typename gemm_acc_t>
+brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::brgemm_dst_proj_t(
+        const ref_rnn_brgemm_t &rnn_brgemm, const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position, const src_t *proj_ht,
+        const weights_t *w_projection, gemm_acc_t *output,
+        aarch64::brgemm_batch_element_t *addr_batch_global,
+        const postgemm_fused_t &fused_postgemm)
+    : rnn_brgemm_(rnn_brgemm)
+    , rnn_(rnn)
+    , proj_desc_idx_(rnn_.is_cell_dt_f32()
+                      ? rnn_.dst_brgemm_desc(cell_position, true)
+                      : 0)
+    , A_(proj_ht)
+    , B_(w_projection)
+    , C_(output)
+    , LDC_(rnn_.is_cell_dt_f32() ? rnn_.dst_layer_ld(cell_position, true)
+                                 : rnn_.scratch_gates_ld)
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
+    , work_amount_proj_(rnn_.Nproj_blocks * rnn_.M_blocks)
+    , B_n_offset_(rnn_.Kprojpadded * rnn_.n_block)
+    , Bp_kb_offset_(rnn_.kproj_block * rnn_.n_block)
+    , addr_batch_global_(addr_batch_global)
+    , brgemm_kernel_main_(rnn_brgemm_.kernel_proj_b0_[proj_desc_idx_].get())
+    , brgemm_kernel_n_tail_(
+              rnn_brgemm_.kernel_proj_N_tail_b0_[proj_desc_idx_].get())
+    , fused_postgemm_(fused_postgemm) {}
+
+template <typename src_t, typename weights_t, typename gemm_acc_t>
+void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::execute() const {
+    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        this->kernel(ithr, nthr);
+    });
+}
+
+template <typename src_t, typename weights_t, typename gemm_acc_t>
+void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
+        const int ithr, const int nthr) const {
+
+    using namespace cpu::rnn_utils;
+
+    int start = 0, end = 0;
+    balance211(work_amount_proj_, nthr, ithr, start, end);
+
+    auto *const addr_batch = addr_batch_global_ + ithr;
+
+    int nb = 0, mb = 0;
+    switch (rnn_.loop_order) {
+        case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+            nd_iterator_init(start, mb, rnn_.M_blocks, nb, rnn_.Nproj_blocks);
+            break;
+        case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+            nd_iterator_init(start, nb, rnn_.Nproj_blocks, mb, rnn_.M_blocks);
+            break;
+        default: assert(!"unsupported loop order");
+    }
+
+    while (start < end) {
+        const int n = nb * rnn_.n_block;
+        const int m = mb * rnn_.m_block;
+        const bool do_n_tail = (n + rnn_.n_block) > rnn_.Nproj;
+        const int block_step = ((do_n_tail) ? rnn_.nproj_tail : rnn_.n_block)
+                * sizeof(src_t);
+
+        const auto *const Ap_m = A_ + m * rnn_.LDAproj;
+        const auto *const Bp_n = B_ + nb * B_n_offset_;
+        auto *const Cp_n = C_ + m * LDC_ + n;
+
+        const brgemm_kernel_t *const brgemm_kernel_proj_b0
+                = do_n_tail ? brgemm_kernel_n_tail_ : brgemm_kernel_main_;
+
+        addr_batch[0].ptr.A = Ap_m;
+        addr_batch[0].ptr.B = Bp_n;
+        brgemm_kernel_execute(brgemm_kernel_proj_b0, 1, addr_batch,
+                reinterpret_cast<void *>(Cp_n), nullptr);
+
+        if (!rnn_.unfused_post_gemm) {
+            fused_postgemm_(m, n, Cp_n, block_step);
+        }
+
+        ++start;
+        switch (rnn_.loop_order) {
+            case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+                nd_iterator_step(mb, rnn_.M_blocks, nb, rnn_.Nproj_blocks);
+                break;
+            case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+                nd_iterator_step(nb, rnn_.Nproj_blocks, mb, rnn_.M_blocks);
+                break;
+            default: assert(!"unsupported loop order");
+        }
+    }
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::brgemm_gru_t(
+        const ref_rnn_brgemm_t &rnn_brgemm, const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position, const src_t *src_iter,
+        const src_t *src_layer, weights_t *w_iter0, weights_t *w_iter1,
+        weights_t *w_layer, src_t *d_layer, scratch_t *scratch_gates,
+        scratch_t *scratch_cell,
+        aarch64::brgemm_batch_element_t *addr_batch_global,
+        const postgemm_fused_t &fused_postgemm_part1,
+        const postgemm_fused_t &fused_postgemm_part2)
+    : rnn_brgemm_(rnn_brgemm)
+    , rnn_(rnn)
+    , need_gemm_layer_(rnn_.need_gemm_layer(cell_position))
+    , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
+    , iter_desc_idx_(rnn_.iter_brgemm_desc(cell_position))
+    , iter_part2_desc_idx_(rnn_.iter_part2_brgemm_desc(cell_position))
+    , Al_(src_layer)
+    , Ai_(src_iter)
+    , Bl_(w_layer)
+    , Bi_(w_iter0)
+    , Bi2_(w_iter1)
+    , C_gates_(scratch_gates)
+    , C_cell_(scratch_cell)
+    , Dl_(d_layer)
+    , LDAl_(rnn_.src_layer_ld(cell_position))
+    , LDAi_p1_(rnn_.src_iter_ld(cell_position))
+    , LDAi_p2_(rnn_.dst_iter_part2_ld(cell_position))
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
+    , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
+                                           : rnn_.N_blocks)
+    , m_blocking_(rnn_.M_blocks)
+    , work_amount_(m_blocking_)
+    , Bl_n_offset_(rnn_.K1padded * rnn_.n_block)
+    , Bi_n_offset_(rnn_.K2padded * rnn_.n_block)
+    , Bl_g_offset_(rnn_.N_blocks * Bl_n_offset_)
+    , Bi_g_offset_(rnn_.N_blocks * Bi_n_offset_)
+    , Al_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
+    , Ai_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block)
+    , Bl_kb_offset_(rnn_.k1_block * rnn_.n_block)
+    , Bi_kb_offset_(rnn_.k2_block * rnn_.n_block)
+    , Bl_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
+    , Bi_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block * rnn_.n_block)
+    , n_gates_(rnn.unfused_post_gemm ? 1 : rnn.n_gates)
+    , brgemm_kernel_iter_p0_main_(need_gemm_layer_
+                      ? rnn_brgemm_.kernel_iter_b1_[iter_desc_idx_].get()
+                      : rnn_brgemm_.kernel_iter_b0_[iter_desc_idx_].get())
+    , brgemm_kernel_iter_p0_n_tail_(need_gemm_layer_
+                      ? rnn_brgemm_.kernel_iter_N_tail_b1_[iter_desc_idx_].get()
+                      : rnn_brgemm_.kernel_iter_N_tail_b0_[iter_desc_idx_]
+                                .get())
+    , brgemm_kernel_iter_p0_k_tail_(
+              rnn_brgemm_.kernel_iter_K2_tail_b1_[iter_desc_idx_].get())
+    , brgemm_kernel_iter_p0_nk_tail_(
+              rnn_brgemm_.kernel_iter_NK2_tail_b1_[iter_desc_idx_].get())
+    , brgemm_kernel_iter_p1_main_(
+              rnn_brgemm_.kernel_iter_p2_b1_[iter_part2_desc_idx_].get())
+    , brgemm_kernel_iter_p1_n_tail_(
+              rnn_brgemm_.kernel_iter_p2_N_tail_b1_[iter_part2_desc_idx_].get())
+    , brgemm_kernel_iter_p1_k_tail_(
+              rnn_brgemm_.kernel_iter_p2_K2_tail_b1_[iter_part2_desc_idx_]
+                      .get())
+    , brgemm_kernel_iter_p1_nk_tail_(
+              rnn_brgemm_.kernel_iter_p2_NK2_tail_b1_[iter_part2_desc_idx_]
+                      .get())
+    , brgemm_kernel_layer_main_(
+              rnn_brgemm_.kernel_layer_b0_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_n_tail_(
+              rnn_brgemm_.kernel_layer_N_tail_b0_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_k_tail_(
+              rnn_brgemm_.kernel_layer_K1_tail_b1_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_nk_tail_(
+              rnn_brgemm_.kernel_layer_NK1_tail_b1_[layer_desc_idx_].get())
+    , addr_batch_global_(addr_batch_global)
+    , fused_postgemm_part1_(fused_postgemm_part1)
+    , fused_postgemm_part2_(fused_postgemm_part2)
+    , is_fused_layer_iter_brgemm_(false) {}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::execute() const {
+    assert(is_fused_layer_iter_brgemm_);
+    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        this->kernel(ithr, nthr);
+    });
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
+        const int ithr, const int nthr) const {
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+            nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
+    brgemm_batch_element_t *const addr_batch
+            = addr_batch_global_ + ithr * max_K_Block;
+
+    while (start < end) {
+        dim_t mb = start;
+        const auto m = mb * rnn_.m_block;
+
+        const auto *const Al_m = Al_ + m * LDAl_;
+        const auto *const Ai_m = Ai_ + m * LDAi_p1_;
+        const auto *const Ai2_m = Dl_ + m * LDAi_p2_;
+
+        for (dim_t nb_i = 0; nb_i < n_blocking_; nb_i++) {
+            const auto nb
+                    = (rnn_.unfused_post_gemm) ? nb_i / rnn_.n_gates : nb_i;
+            const auto n = nb * rnn_.n_block;
+            const auto *const Bl_n = Bl_ + nb * Bl_n_offset_;
+            const auto *const Bi_n = Bi_ + nb * Bi_n_offset_;
+            auto *const C_gates_n = C_gates_ + m * rnn_.LDC + n;
+            auto *const C_cell_n = C_cell_ + m * rnn_.LDC + n;
+
+            const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
+
+            const brgemm_kernel_t *brgemm_kernel_layer = do_n_tail
+                    ? brgemm_kernel_layer_n_tail_
+                    : brgemm_kernel_layer_main_;
+            const brgemm_kernel_t *brgemm_kernel_layer_k_tail = do_n_tail
+                    ? brgemm_kernel_layer_nk_tail_
+                    : brgemm_kernel_layer_k_tail_;
+            const brgemm_kernel_t *brgemm_kernel_iter_p0 = do_n_tail
+                    ? brgemm_kernel_iter_p0_n_tail_
+                    : brgemm_kernel_iter_p0_main_;
+            const brgemm_kernel_t *brgemm_kernel_iter_p0_k_tail = do_n_tail
+                    ? brgemm_kernel_iter_p0_nk_tail_
+                    : brgemm_kernel_iter_p0_k_tail_;
+
+            if (need_gemm_layer_) {
+                for (int g = 0; g < n_gates_; g++) {
+                    const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+                    auto *const C_gates_g = C_gates_n + g * rnn_.N;
+                    for (int batch_idx = 0; batch_idx < rnn_.KB1_blocks;
+                            batch_idx++) {
+                        addr_batch[batch_idx].ptr.A
+                                = Al_m + batch_idx * rnn_.k1_block;
+                        addr_batch[batch_idx].ptr.B
+                                = Bl_g + batch_idx * Bl_kb_offset_;
+                    }
+                    brgemm_kernel_execute(brgemm_kernel_layer, rnn_.KB1_blocks,
+                            addr_batch, reinterpret_cast<void *>(C_gates_g),
+                            nullptr);
+                }
+            }
+
+            if (need_gemm_layer_ && rnn_.k1_tail > 0) {
+                for (int g = 0; g < n_gates_; g++) {
+                    const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+                    auto *const C_gates_g = C_gates_n + g * rnn_.N;
+                    addr_batch[0].ptr.A
+                            = Al_m + rnn_.KB1_blocks * rnn_.k1_block;
+                    addr_batch[0].ptr.B
+                            = Bl_g + rnn_.KB1_blocks * Bl_kb_offset_;
+                    brgemm_kernel_execute(brgemm_kernel_layer_k_tail, 1,
+                            addr_batch, reinterpret_cast<void *>(C_gates_g),
+                            nullptr);
+                }
+            }
+
+            for (int g = 0; g < n_gates_ - 1; g++) {
+                const auto *const Bi_g = Bi_n + g * Bi_g_offset_;
+                auto *const C_gates_g = C_gates_n + g * rnn_.N;
+                for (int batch_idx = 0; batch_idx < rnn_.KB2_blocks;
+                        batch_idx++) {
+                    addr_batch[batch_idx].ptr.A
+                            = Ai_m + batch_idx * rnn_.k2_block;
+                    addr_batch[batch_idx].ptr.B
+                            = Bi_g + batch_idx * Bi_kb_offset_;
+                }
+                brgemm_kernel_execute(brgemm_kernel_iter_p0, rnn_.KB2_blocks,
+                        addr_batch, reinterpret_cast<void *>(C_gates_g),
+                        nullptr);
+            }
+
+            if (rnn_.k2_tail > 0) {
+                for (int g = 0; g < n_gates_ - 1; g++) {
+                    const auto *const Bi_g = Bi_n + g * Bi_g_offset_;
+                    auto *const C_gates_g = C_gates_n + g * rnn_.N;
+                    addr_batch[0].ptr.A
+                            = Ai_m + rnn_.KB2_blocks * rnn_.k2_block;
+                    addr_batch[0].ptr.B
+                            = Bi_g + rnn_.KB2_blocks * Bi_kb_offset_;
+                    brgemm_kernel_execute(brgemm_kernel_iter_p0_k_tail, 1,
+                            addr_batch, reinterpret_cast<void *>(C_gates_g),
+                            nullptr);
+                }
+            }
+
+            if (!rnn_.unfused_post_gemm) {
+                const int n_elems = do_n_tail ? rnn_.n_tail : rnn_.n_block;
+                const int block_step_bytes = n_elems * (int)sizeof(scratch_t);
+                fused_postgemm_part1_(m, n, nb_i, Ai_m, C_gates_n, C_cell_n,
+                        block_step_bytes);
+            }
+        }
+
+        for (dim_t nb_i = 0; nb_i < n_blocking_; nb_i++) {
+            const auto nb
+                    = (rnn_.unfused_post_gemm) ? nb_i / rnn_.n_gates : nb_i;
+            const auto n = nb * rnn_.n_block;
+            const auto *const Bi2_n = Bi2_ + nb * Bi_n_offset_;
+            auto *const C_gates_n = C_gates_ + m * rnn_.LDC + n;
+
+            const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
+
+            const brgemm_kernel_t *brgemm_kernel_iter_p1 = do_n_tail
+                    ? brgemm_kernel_iter_p1_n_tail_
+                    : brgemm_kernel_iter_p1_main_;
+            const brgemm_kernel_t *brgemm_kernel_iter_p1_k_tail = do_n_tail
+                    ? brgemm_kernel_iter_p1_nk_tail_
+                    : brgemm_kernel_iter_p1_k_tail_;
+
+            for (int g = 0; g < 1; g++) {
+                const auto *const Bi2_g = Bi2_n + g * Bi_g_offset_;
+                auto *const C_gates_g = C_gates_n + (n_gates_ - 1) * rnn_.N;
+                for (int batch_idx = 0; batch_idx < rnn_.KB2_blocks;
+                        batch_idx++) {
+                    addr_batch[batch_idx].ptr.A
+                            = Ai2_m + batch_idx * rnn_.k2_block;
+                    addr_batch[batch_idx].ptr.B
+                            = Bi2_g + batch_idx * Bi_kb_offset_;
+                }
+                brgemm_kernel_execute(brgemm_kernel_iter_p1, rnn_.KB2_blocks,
+                        addr_batch, reinterpret_cast<void *>(C_gates_g),
+                        nullptr);
+            }
+
+            if (rnn_.k2_tail > 0) {
+                for (int g = 0; g < 1; g++) {
+                    const auto *const Bi2_g = Bi2_n + g * Bi_g_offset_;
+                    auto *const C_gates_g = C_gates_n + (n_gates_ - 1) * rnn_.N;
+                    addr_batch[0].ptr.A
+                            = Ai2_m + rnn_.KB2_blocks * rnn_.k2_block;
+                    addr_batch[0].ptr.B
+                            = Bi2_g + rnn_.KB2_blocks * Bi_kb_offset_;
+                    brgemm_kernel_execute(brgemm_kernel_iter_p1_k_tail, 1,
+                            addr_batch, reinterpret_cast<void *>(C_gates_g),
+                            nullptr);
+                }
+            }
+
+            if (!rnn_.unfused_post_gemm && nb_i == n_blocking_ - 1) {
+                fused_postgemm_part2_(m, 0, 0, Ai_m, C_gates_ + m * rnn_.LDC,
+                        C_cell_ + m * rnn_.LDC, rnn_.N);
+            }
+        }
+
+        ++start;
+    }
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+brgemm_merged_layer_t<src_t, weights_t, scratch_t,
+        gemm_acc_t>::brgemm_merged_layer_t(const ref_rnn_brgemm_t &rnn_brgemm,
+        const rnn_utils::rnn_conf_t &rnn,
+        rnn_utils::cell_position_t cell_position, const src_t *src_layer,
+        weights_t *w_layer, scratch_t *scratch_gates,
+        aarch64::brgemm_batch_element_t *addr_batch_global)
+    : rnn_brgemm_(rnn_brgemm)
+    , rnn_(rnn)
+    , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
+    , Al_(src_layer)
+    , Bl_(w_layer)
+    , C_(scratch_gates)
+    , LDAl_(rnn_.src_layer_ld(cell_position))
+    , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
+    , n_blocking_(rnn_.N_blocks * rnn_.n_gates)
+    , m_blocking_(rnn_.Mlayermerged_blocks)
+    , work_amount_(n_blocking_ * m_blocking_)
+    , Bl_n_offset_(rnn_.K1padded * rnn_.n_block)
+    , Bl_g_offset_(rnn_.N_blocks * Bl_n_offset_)
+    , Al_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
+    , Bl_kb_offset_(rnn_.k1_block * rnn_.n_block)
+    , Bl_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
+    , brgemm_kernel_layer_main_(
+              rnn_brgemm_.kernel_layermerged_b0_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_n_tail_(
+              rnn_brgemm_.kernel_layermerged_N_tail_b0_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_k_tail_(
+              rnn_brgemm_.kernel_layermerged_K1_tail_b1_[layer_desc_idx_].get())
+    , brgemm_kernel_layer_nk_tail_(
+              rnn_brgemm_.kernel_layermerged_NK1_tail_b1_[layer_desc_idx_]
+                      .get())
+    , addr_batch_global_(addr_batch_global) {}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::execute()
+        const {
+    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        this->kernel(ithr, nthr);
+    });
+}
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
+        const int ithr, const int nthr) const {
+
+    using namespace cpu::rnn_utils;
+
+    int start = 0, end = 0;
+    balance211(work_amount_, nthr, ithr, start, end);
+
+    const auto m_block = rnn_.mlayermerged_block;
+
+    const int max_K_Block = rnn_.KB1_blocks + 1;
+    brgemm_batch_element_t *const addr_batch
+            = addr_batch_global_ + ithr * max_K_Block;
+
+    dim_t nb_i = 0, mb = 0;
+    switch (rnn_.loop_order) {
+        case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+            nd_iterator_init(start, mb, m_blocking_, nb_i, n_blocking_);
+            break;
+        case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+            nd_iterator_init(start, nb_i, n_blocking_, mb, m_blocking_);
+            break;
+        default: assert(!"unsupported loop order");
+    }
+
+    while (start < end) {
+        const auto m = mb * m_block;
+        const auto nb = nb_i / rnn_.n_gates;
+        const auto n = nb * rnn_.n_block;
+        const auto g = nb_i % rnn_.n_gates;
+
+        const auto *const Al_m = Al_ + m * LDAl_;
+        const auto *const Bl_n = Bl_ + nb * Bl_n_offset_;
+        auto *const C_n = C_ + m * rnn_.LDC + n;
+
+        const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
+
+        const brgemm_kernel_t *brgemm_kernel_layer_b0 = do_n_tail
+                ? brgemm_kernel_layer_n_tail_
+                : brgemm_kernel_layer_main_;
+        const brgemm_kernel_t *brgemm_kernel_layer_k_tail = do_n_tail
+                ? brgemm_kernel_layer_nk_tail_
+                : brgemm_kernel_layer_k_tail_;
+
+        const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+        auto *const C_g = C_n + g * rnn_.N;
+
+        for (int i = 0; i < rnn_.KB1_blocks; i++) {
+            addr_batch[i].ptr.A = Al_m + i * rnn_.k1_block;
+            addr_batch[i].ptr.B = Bl_g + i * Bl_kb_offset_;
+        }
+        brgemm_kernel_execute(brgemm_kernel_layer_b0, rnn_.KB1_blocks,
+                addr_batch, reinterpret_cast<void *>(C_g), nullptr);
+
+        if (rnn_.k1_tail) {
+            const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+            auto *const C_g = C_n + g * rnn_.N;
+            addr_batch[0].ptr.A = Al_m + Al_k_tail_offset_;
+            addr_batch[0].ptr.B = Bl_g + Bl_k_tail_offset_;
+            brgemm_kernel_execute(brgemm_kernel_layer_k_tail, 1, addr_batch,
+                    reinterpret_cast<void *>(C_g), nullptr);
+        }
+
+        ++start;
+        switch (rnn_.loop_order) {
+            case brgemm_rnn_execute_loop_order_t::mblk_nblk:
+                nd_iterator_step(mb, m_blocking_, nb_i, n_blocking_);
+                break;
+            case brgemm_rnn_execute_loop_order_t::nblk_mblk:
+                nd_iterator_step(nb_i, n_blocking_, mb, m_blocking_);
+                break;
+            default: assert(!"unsupported loop order");
+        }
+    }
+}
+
+template class brgemm_dst_layer_iter_t<uint8_t, int8_t, int32_t, int32_t>;
+template class brgemm_dst_layer_iter_t<int8_t, int8_t, int32_t, int32_t>;
+template class brgemm_dst_layer_iter_t<float, float, float, float>;
+template class brgemm_dst_layer_iter_t<bfloat16_t, bfloat16_t, float, float>;
+template class brgemm_dst_layer_iter_t<float16_t, float16_t, float, float>;
+
+template class brgemm_dst_proj_t<float, float, float>;
+template class brgemm_dst_proj_t<bfloat16_t, bfloat16_t, float>;
+template class brgemm_dst_proj_t<float16_t, float16_t, float>;
+template class brgemm_dst_proj_t<int8_t, int8_t, int32_t>;
+template class brgemm_dst_proj_t<uint8_t, int8_t, int32_t>;
+
+template class brgemm_gru_t<uint8_t, int8_t, int32_t, int32_t>;
+template class brgemm_gru_t<int8_t, int8_t, int32_t, int32_t>;
+template class brgemm_gru_t<float, float, float, float>;
+template class brgemm_gru_t<bfloat16_t, bfloat16_t, float, float>;
+template class brgemm_gru_t<float16_t, float16_t, float, float>;
+
+template class brgemm_merged_layer_t<uint8_t, int8_t, int32_t, int32_t>;
+template class brgemm_merged_layer_t<int8_t, int8_t, int32_t, int32_t>;
+template class brgemm_merged_layer_t<float, float, float, float>;
+template class brgemm_merged_layer_t<bfloat16_t, bfloat16_t, float, float>;
+template class brgemm_merged_layer_t<float16_t, float16_t, float, float>;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
@@ -111,31 +111,13 @@ template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>
 int brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         gemm_acc_t>::calculate_nthr() const {
-    const auto max_nthr = nstl::min(dnnl_get_current_num_threads(), rnn_.nthr);
-
-    // TODO: tune thresholds for aarch64 microarchitectures.
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB
-    constexpr dim_t k2_i8_asimd = 192;
-    constexpr dim_t k2_f32_asimd = 112;
-#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
-    constexpr dim_t k2_i8_asimd = 176;
-    constexpr dim_t k2_f32_asimd = 96;
-#endif
-#if (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB) \
-        || (DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP)
-    if (rnn_.brgemm_isa == aarch64::asimd && !need_gemm_layer_ && rnn_.M == 1
-            && utils::one_of(rnn_.cell_kind, alg_kind::vanilla_lstm,
-                    alg_kind::lbr_gru)) {
-        if (std::is_same<src_t, uint8_t>::value
-                && std::is_same<weights_t, int8_t>::value) {
-            return rnn_.K2 <= k2_i8_asimd ? 1 : max_nthr;
-        } else if (std::is_same<src_t, float>::value
-                && std::is_same<weights_t, float>::value) {
-            return rnn_.K2 <= k2_f32_asimd ? 1 : max_nthr;
-        }
-    }
-#endif
-    return max_nthr;
+    // TODO(aarch64): the serial/parallel crossover for small problems
+    // (M == 1, no layer GEMM, LSTM/LBR-GRU) has not been measured on
+    // AArch64. The x64 path returned 1 below an ISA-specific K2 threshold
+    // tuned on AVX2; those constants do not transfer to AArch64, so no
+    // small-problem heuristic is applied here yet. Until a sweep is done
+    // on target hardware, always use the full thread count.
+    return nstl::min(dnnl_get_current_num_threads(), rnn_.nthr);
 }
 
 template <typename src_t, typename weights_t, typename scratch_t,
@@ -574,7 +556,7 @@ brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::brgemm_gru_t(
     , addr_batch_global_(addr_batch_global)
     , fused_postgemm_part1_(fused_postgemm_part1)
     , fused_postgemm_part2_(fused_postgemm_part2)
-    , is_fused_layer_iter_brgemm_(false) {}
+    , is_fused_layer_iter_brgemm_(true) {}
 
 template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
@@ -43,28 +43,28 @@ brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
     , need_gemm_layer_(rnn_.need_gemm_layer(cell_position))
     , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
     , iter_desc_idx_(rnn_.iter_brgemm_desc(cell_position))
-    , Al_(src_layer)
-    , Ai_(src_iter)
-    , Bl_(w_layer)
-    , Bi_(w_iter)
+    , A_layer_(src_layer)
+    , A_iter_(src_iter)
+    , B_layer_(w_layer)
+    , B_iter_(w_iter)
     , C_gates_(scratch_gates)
     , C_cell_(scratch_cell)
-    , LDAl_(rnn_.src_layer_ld(cell_position))
-    , LDAi_(rnn_.src_iter_ld(cell_position))
+    , LDA_layer_(rnn_.src_layer_ld(cell_position))
+    , LDA_iter_(rnn_.src_iter_ld(cell_position))
     , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
                                            : rnn_.N_blocks)
     , m_blocking_(rnn_.M_blocks)
     , work_amount_(n_blocking_ * m_blocking_)
-    , Bl_n_offset_(rnn_.K1padded * rnn_.n_block)
-    , Bi_n_offset_(rnn_.K2padded * rnn_.n_block)
-    , Bl_g_offset_(rnn_.N_blocks * Bl_n_offset_)
-    , Bi_g_offset_(rnn_.N_blocks * Bi_n_offset_)
-    , Al_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
-    , Ai_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block)
-    , Bl_kb_offset_(rnn_.k1_block * rnn_.n_block)
-    , Bi_kb_offset_(rnn_.k2_block * rnn_.n_block)
-    , Bl_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
-    , Bi_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block * rnn_.n_block)
+    , B_layer_n_offset_(rnn_.K1padded * rnn_.n_block)
+    , B_iter_n_offset_(rnn_.K2padded * rnn_.n_block)
+    , B_layer_g_offset_(rnn_.N_blocks * B_layer_n_offset_)
+    , B_iter_g_offset_(rnn_.N_blocks * B_iter_n_offset_)
+    , A_layer_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
+    , A_iter_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block)
+    , B_layer_kb_offset_(rnn_.k1_block * rnn_.n_block)
+    , B_iter_kb_offset_(rnn_.k2_block * rnn_.n_block)
+    , B_layer_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
+    , B_iter_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block * rnn_.n_block)
     , n_gates_(rnn.unfused_post_gemm ? 1 : rnn.n_gates)
     , brgemm_kernel_iter_main_(need_gemm_layer_
                       ? rnn_brgemm_.kernel_iter_b1_[iter_desc_idx_].get()
@@ -89,7 +89,7 @@ brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
     , addr_batch_global_(addr_batch_global)
     , fused_postgemm_(fused_postgemm)
     , is_fused_layer_iter_brgemm_(!rnn_.is_lbr && rnn_.sic == rnn_.slc
-              && LDAi_ == LDAl_ && need_gemm_layer_)
+              && LDA_iter_ == LDA_layer_ && need_gemm_layer_)
     , max_nthr_(calculate_nthr()) {}
 
 template <typename src_t, typename weights_t, typename scratch_t,
@@ -153,10 +153,10 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const auto g_unfused
                 = (rnn_.unfused_post_gemm) ? nb_i % rnn_.n_gates : 0;
 
-        const auto *const Al_m = Al_ + m * LDAl_;
-        const auto *const Ai_m = Ai_ + m * LDAi_;
-        const auto *const Bl_n = Bl_ + nb * Bl_n_offset_;
-        const auto *const Bi_n = Bi_ + nb * Bi_n_offset_;
+        const auto *const A_layer_m = A_layer_ + m * LDA_layer_;
+        const auto *const A_iter_m = A_iter_ + m * LDA_iter_;
+        const auto *const B_layer_n = B_layer_ + nb * B_layer_n_offset_;
+        const auto *const B_iter_n = B_iter_ + nb * B_iter_n_offset_;
         auto *const C_n = C_gates_ + m * rnn_.LDC + n;
 
         const auto cell_stride = rnn_.LDC;
@@ -191,14 +191,14 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
 
         for (int g = 0; g < n_gates_; g++) {
             const int lg = g + g_unfused;
-            const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
-            const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
+            const auto *const B_layer_g = B_layer_n + lg * B_layer_g_offset_;
+            const auto *const B_iter_g = B_iter_n + lg * B_iter_g_offset_;
             auto *C_g = C_n + lg * rnn_.N;
 
             if (need_gemm_layer_) {
                 for (int i = 0; i < rnn_.KB1_blocks; i++) {
-                    addr_batch[i].ptr.A = Al_m + i * rnn_.k1_block;
-                    addr_batch[i].ptr.B = Bl_g + i * Bl_kb_offset_;
+                    addr_batch[i].ptr.A = A_layer_m + i * rnn_.k1_block;
+                    addr_batch[i].ptr.B = B_layer_g + i * B_layer_kb_offset_;
                 }
                 brgemm_kernel_execute(brgemm_kernel_layer_b0, rnn_.KB1_blocks,
                         addr_batch, reinterpret_cast<void *>(C_g), nullptr);
@@ -207,8 +207,8 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             if (rnn_.is_lbr && g == n_gates_ - 1) C_g = C_cell_i;
 
             for (int i = 0; i < rnn_.KB2_blocks; i++) {
-                addr_batch[i].ptr.A = Ai_m + i * rnn_.k2_block;
-                addr_batch[i].ptr.B = Bi_g + i * Bi_kb_offset_;
+                addr_batch[i].ptr.A = A_iter_m + i * rnn_.k2_block;
+                addr_batch[i].ptr.B = B_iter_g + i * B_iter_kb_offset_;
             }
             brgemm_kernel_execute(brgemm_kernel_iter, rnn_.KB2_blocks,
                     addr_batch, reinterpret_cast<void *>(C_g), nullptr);
@@ -217,10 +217,11 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         if (rnn_.k1_tail && need_gemm_layer_) {
             for (int g = 0; g < n_gates_; g++) {
                 const int lg = g + g_unfused;
-                const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
+                const auto *const B_layer_g
+                        = B_layer_n + lg * B_layer_g_offset_;
                 auto *const C_g = C_n + lg * rnn_.N;
-                addr_batch[0].ptr.A = Al_m + Al_k_tail_offset_;
-                addr_batch[0].ptr.B = Bl_g + Bl_k_tail_offset_;
+                addr_batch[0].ptr.A = A_layer_m + A_layer_k_tail_offset_;
+                addr_batch[0].ptr.B = B_layer_g + B_layer_k_tail_offset_;
                 brgemm_kernel_execute(brgemm_kernel_layer_k_tail, 1, addr_batch,
                         reinterpret_cast<void *>(C_g), nullptr);
             }
@@ -229,11 +230,11 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         if (rnn_.k2_tail) {
             for (int g = 0; g < n_gates_; g++) {
                 const int lg = g + g_unfused;
-                const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
+                const auto *const B_iter_g = B_iter_n + lg * B_iter_g_offset_;
                 auto *C_g = C_n + lg * rnn_.N;
                 if (rnn_.is_lbr && g == n_gates_ - 1) C_g = C_cell_i;
-                addr_batch[0].ptr.A = Ai_m + Ai_k_tail_offset_;
-                addr_batch[0].ptr.B = Bi_g + Bi_k_tail_offset_;
+                addr_batch[0].ptr.A = A_iter_m + A_iter_k_tail_offset_;
+                addr_batch[0].ptr.B = B_iter_g + B_iter_k_tail_offset_;
                 brgemm_kernel_execute(brgemm_kernel_iter_k_tail, 1, addr_batch,
                         reinterpret_cast<void *>(C_g), nullptr);
             }
@@ -242,7 +243,8 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         if (!rnn_.unfused_post_gemm) {
             const int n_elems = do_n_tail ? rnn_.n_tail : rnn_.n_block;
             const int block_step_bytes = n_elems * (int)sizeof(scratch_t);
-            fused_postgemm_(m, n, nb_i, Ai_m, C_n, C_cell_i, block_step_bytes);
+            fused_postgemm_(
+                    m, n, nb_i, A_iter_m, C_n, C_cell_i, block_step_bytes);
         }
 
         ++start;
@@ -286,15 +288,15 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         default: assert(!"unsupported loop order");
     }
 
-    const auto LDA = LDAl_;
-    const auto B_n_offset = Bl_n_offset_;
-    const auto B_g_offset = Bl_g_offset_;
-    const auto B_kb_offset = Bl_kb_offset_;
+    const auto LDA = LDA_layer_;
+    const auto B_n_offset = B_layer_n_offset_;
+    const auto B_g_offset = B_layer_g_offset_;
+    const auto B_kb_offset = B_layer_kb_offset_;
     const auto KB_blocks
             = (need_gemm_layer_ ? rnn_.KB1_blocks : 0) + rnn_.KB2_blocks;
     const auto KB_blocks_tail = (need_gemm_layer_ ? 1 : 0) + 1;
-    const auto A_k_tail_offset = Al_k_tail_offset_;
-    const auto B_k_tail_offset = Bl_k_tail_offset_;
+    const auto A_k_tail_offset = A_layer_k_tail_offset_;
+    const auto B_k_tail_offset = B_layer_k_tail_offset_;
 
     while (start < end) {
         const auto m = mb * rnn_.m_block;
@@ -303,10 +305,10 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         const auto g_unfused
                 = (rnn_.unfused_post_gemm) ? nb_i % rnn_.n_gates : 0;
 
-        const auto *const Al_m = Al_ + m * LDA;
-        const auto *const Ai_m = Ai_ + m * LDA;
-        const auto *const Bl_n = Bl_ + nb * B_n_offset;
-        const auto *const Bi_n = Bi_ + nb * B_n_offset;
+        const auto *const A_layer_m = A_layer_ + m * LDA;
+        const auto *const A_iter_m = A_iter_ + m * LDA;
+        const auto *const B_layer_n = B_layer_ + nb * B_n_offset;
+        const auto *const B_iter_n = B_iter_ + nb * B_n_offset;
         auto *const C_n = C_gates_ + m * rnn_.LDC + n;
 
         const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
@@ -320,24 +322,25 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
 
         for (int g = 0; g < n_gates_; g++) {
             const int lg = g + g_unfused;
-            const auto *const Bl_g = Bl_n + lg * B_g_offset;
-            const auto *const Bi_g = Bi_n + lg * B_g_offset;
+            const auto *const B_layer_g = B_layer_n + lg * B_g_offset;
+            const auto *const B_iter_g = B_iter_n + lg * B_g_offset;
             auto *const C_g = C_n + lg * rnn_.N;
 
             int batch_idx = 0;
             if (need_gemm_layer_) {
                 for (; batch_idx < rnn_.KB1_blocks; batch_idx++) {
                     addr_batch[batch_idx].ptr.A
-                            = Al_m + batch_idx * rnn_.k1_block;
+                            = A_layer_m + batch_idx * rnn_.k1_block;
                     addr_batch[batch_idx].ptr.B
-                            = Bl_g + batch_idx * B_kb_offset;
+                            = B_layer_g + batch_idx * B_kb_offset;
                 }
             }
 
             int iter_idx = 0;
             for (; batch_idx < KB_blocks; batch_idx++) {
-                addr_batch[batch_idx].ptr.A = Ai_m + iter_idx * rnn_.k2_block;
-                addr_batch[batch_idx].ptr.B = Bi_g + iter_idx * B_kb_offset;
+                addr_batch[batch_idx].ptr.A
+                        = A_iter_m + iter_idx * rnn_.k2_block;
+                addr_batch[batch_idx].ptr.B = B_iter_g + iter_idx * B_kb_offset;
                 iter_idx++;
             }
 
@@ -352,14 +355,14 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
 
                 int batch_idx = 0;
                 if (need_gemm_layer_) {
-                    const auto *const Bl_g = Bl_n + lg * B_g_offset;
-                    addr_batch[batch_idx].ptr.A = Al_m + A_k_tail_offset;
-                    addr_batch[batch_idx].ptr.B = Bl_g + B_k_tail_offset;
+                    const auto *const B_layer_g = B_layer_n + lg * B_g_offset;
+                    addr_batch[batch_idx].ptr.A = A_layer_m + A_k_tail_offset;
+                    addr_batch[batch_idx].ptr.B = B_layer_g + B_k_tail_offset;
                     batch_idx++;
                 }
-                const auto *const Bi_g = Bi_n + lg * B_g_offset;
-                addr_batch[batch_idx].ptr.A = Ai_m + A_k_tail_offset;
-                addr_batch[batch_idx].ptr.B = Bi_g + B_k_tail_offset;
+                const auto *const B_iter_g = B_iter_n + lg * B_g_offset;
+                addr_batch[batch_idx].ptr.A = A_iter_m + A_k_tail_offset;
+                addr_batch[batch_idx].ptr.B = B_iter_g + B_k_tail_offset;
 
                 brgemm_kernel_execute(brgemm_kernel_k_tail, KB_blocks_tail,
                         addr_batch, reinterpret_cast<void *>(C_g), nullptr);
@@ -369,7 +372,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         if (!rnn_.unfused_post_gemm) {
             const auto block_step = (do_n_tail ? rnn_.n_tail : rnn_.n_block)
                     * sizeof(scratch_t);
-            fused_postgemm_(m, n, nb_i, Ai_m, C_n, C_cell_, block_step);
+            fused_postgemm_(m, n, nb_i, A_iter_m, C_n, C_cell_, block_step);
         }
 
         ++start;
@@ -496,32 +499,32 @@ brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::brgemm_gru_t(
     , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
     , iter_desc_idx_(rnn_.iter_brgemm_desc(cell_position))
     , iter_part2_desc_idx_(rnn_.iter_part2_brgemm_desc(cell_position))
-    , Al_(src_layer)
-    , Ai_(src_iter)
-    , Bl_(w_layer)
-    , Bi_(w_iter0)
-    , Bi2_(w_iter1)
+    , A_layer_(src_layer)
+    , A_iter_(src_iter)
+    , B_layer_(w_layer)
+    , B_iter_(w_iter0)
+    , B_iter_part2_(w_iter1)
     , C_gates_(scratch_gates)
     , C_cell_(scratch_cell)
-    , Dl_(d_layer)
-    , LDAl_(rnn_.src_layer_ld(cell_position))
-    , LDAi_p1_(rnn_.src_iter_ld(cell_position))
-    , LDAi_p2_(rnn_.dst_iter_part2_ld(cell_position))
+    , D_layer_(d_layer)
+    , LDA_layer_(rnn_.src_layer_ld(cell_position))
+    , LDA_iter_part1_(rnn_.src_iter_ld(cell_position))
+    , LDA_iter_part2_(rnn_.dst_iter_part2_ld(cell_position))
     , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
     , n_blocking_((rnn_.unfused_post_gemm) ? rnn_.N_blocks * rnn_.n_gates
                                            : rnn_.N_blocks)
     , m_blocking_(rnn_.M_blocks)
     , work_amount_(m_blocking_)
-    , Bl_n_offset_(rnn_.K1padded * rnn_.n_block)
-    , Bi_n_offset_(rnn_.K2padded * rnn_.n_block)
-    , Bl_g_offset_(rnn_.N_blocks * Bl_n_offset_)
-    , Bi_g_offset_(rnn_.N_blocks * Bi_n_offset_)
-    , Al_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
-    , Ai_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block)
-    , Bl_kb_offset_(rnn_.k1_block * rnn_.n_block)
-    , Bi_kb_offset_(rnn_.k2_block * rnn_.n_block)
-    , Bl_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
-    , Bi_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block * rnn_.n_block)
+    , B_layer_n_offset_(rnn_.K1padded * rnn_.n_block)
+    , B_iter_n_offset_(rnn_.K2padded * rnn_.n_block)
+    , B_layer_g_offset_(rnn_.N_blocks * B_layer_n_offset_)
+    , B_iter_g_offset_(rnn_.N_blocks * B_iter_n_offset_)
+    , A_layer_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
+    , A_iter_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block)
+    , B_layer_kb_offset_(rnn_.k1_block * rnn_.n_block)
+    , B_iter_kb_offset_(rnn_.k2_block * rnn_.n_block)
+    , B_layer_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
+    , B_iter_k_tail_offset_(rnn_.KB2_blocks * rnn_.k2_block * rnn_.n_block)
     , n_gates_(rnn.unfused_post_gemm ? 1 : rnn.n_gates)
     , brgemm_kernel_iter_p0_main_(need_gemm_layer_
                       ? rnn_brgemm_.kernel_iter_b1_[iter_desc_idx_].get()
@@ -584,16 +587,16 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         dim_t mb = start;
         const auto m = mb * rnn_.m_block;
 
-        const auto *const Al_m = Al_ + m * LDAl_;
-        const auto *const Ai_m = Ai_ + m * LDAi_p1_;
-        const auto *const Ai2_m = Dl_ + m * LDAi_p2_;
+        const auto *const A_layer_m = A_layer_ + m * LDA_layer_;
+        const auto *const A_iter_m = A_iter_ + m * LDA_iter_part1_;
+        const auto *const A_iter_part2_m = D_layer_ + m * LDA_iter_part2_;
 
         for (dim_t nb_i = 0; nb_i < n_blocking_; nb_i++) {
             const auto nb
                     = (rnn_.unfused_post_gemm) ? nb_i / rnn_.n_gates : nb_i;
             const auto n = nb * rnn_.n_block;
-            const auto *const Bl_n = Bl_ + nb * Bl_n_offset_;
-            const auto *const Bi_n = Bi_ + nb * Bi_n_offset_;
+            const auto *const B_layer_n = B_layer_ + nb * B_layer_n_offset_;
+            const auto *const B_iter_n = B_iter_ + nb * B_iter_n_offset_;
             auto *const C_gates_n = C_gates_ + m * rnn_.LDC + n;
             auto *const C_cell_n = C_cell_ + m * rnn_.LDC + n;
 
@@ -614,14 +617,15 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
 
             if (need_gemm_layer_) {
                 for (int g = 0; g < n_gates_; g++) {
-                    const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+                    const auto *const B_layer_g
+                            = B_layer_n + g * B_layer_g_offset_;
                     auto *const C_gates_g = C_gates_n + g * rnn_.N;
                     for (int batch_idx = 0; batch_idx < rnn_.KB1_blocks;
                             batch_idx++) {
                         addr_batch[batch_idx].ptr.A
-                                = Al_m + batch_idx * rnn_.k1_block;
+                                = A_layer_m + batch_idx * rnn_.k1_block;
                         addr_batch[batch_idx].ptr.B
-                                = Bl_g + batch_idx * Bl_kb_offset_;
+                                = B_layer_g + batch_idx * B_layer_kb_offset_;
                     }
                     brgemm_kernel_execute(brgemm_kernel_layer, rnn_.KB1_blocks,
                             addr_batch, reinterpret_cast<void *>(C_gates_g),
@@ -631,12 +635,13 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
 
             if (need_gemm_layer_ && rnn_.k1_tail > 0) {
                 for (int g = 0; g < n_gates_; g++) {
-                    const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+                    const auto *const B_layer_g
+                            = B_layer_n + g * B_layer_g_offset_;
                     auto *const C_gates_g = C_gates_n + g * rnn_.N;
                     addr_batch[0].ptr.A
-                            = Al_m + rnn_.KB1_blocks * rnn_.k1_block;
+                            = A_layer_m + rnn_.KB1_blocks * rnn_.k1_block;
                     addr_batch[0].ptr.B
-                            = Bl_g + rnn_.KB1_blocks * Bl_kb_offset_;
+                            = B_layer_g + rnn_.KB1_blocks * B_layer_kb_offset_;
                     brgemm_kernel_execute(brgemm_kernel_layer_k_tail, 1,
                             addr_batch, reinterpret_cast<void *>(C_gates_g),
                             nullptr);
@@ -644,14 +649,14 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             }
 
             for (int g = 0; g < n_gates_ - 1; g++) {
-                const auto *const Bi_g = Bi_n + g * Bi_g_offset_;
+                const auto *const B_iter_g = B_iter_n + g * B_iter_g_offset_;
                 auto *const C_gates_g = C_gates_n + g * rnn_.N;
                 for (int batch_idx = 0; batch_idx < rnn_.KB2_blocks;
                         batch_idx++) {
                     addr_batch[batch_idx].ptr.A
-                            = Ai_m + batch_idx * rnn_.k2_block;
+                            = A_iter_m + batch_idx * rnn_.k2_block;
                     addr_batch[batch_idx].ptr.B
-                            = Bi_g + batch_idx * Bi_kb_offset_;
+                            = B_iter_g + batch_idx * B_iter_kb_offset_;
                 }
                 brgemm_kernel_execute(brgemm_kernel_iter_p0, rnn_.KB2_blocks,
                         addr_batch, reinterpret_cast<void *>(C_gates_g),
@@ -660,12 +665,13 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
 
             if (rnn_.k2_tail > 0) {
                 for (int g = 0; g < n_gates_ - 1; g++) {
-                    const auto *const Bi_g = Bi_n + g * Bi_g_offset_;
+                    const auto *const B_iter_g
+                            = B_iter_n + g * B_iter_g_offset_;
                     auto *const C_gates_g = C_gates_n + g * rnn_.N;
                     addr_batch[0].ptr.A
-                            = Ai_m + rnn_.KB2_blocks * rnn_.k2_block;
+                            = A_iter_m + rnn_.KB2_blocks * rnn_.k2_block;
                     addr_batch[0].ptr.B
-                            = Bi_g + rnn_.KB2_blocks * Bi_kb_offset_;
+                            = B_iter_g + rnn_.KB2_blocks * B_iter_kb_offset_;
                     brgemm_kernel_execute(brgemm_kernel_iter_p0_k_tail, 1,
                             addr_batch, reinterpret_cast<void *>(C_gates_g),
                             nullptr);
@@ -675,7 +681,7 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             if (!rnn_.unfused_post_gemm) {
                 const int n_elems = do_n_tail ? rnn_.n_tail : rnn_.n_block;
                 const int block_step_bytes = n_elems * (int)sizeof(scratch_t);
-                fused_postgemm_part1_(m, n, nb_i, Ai_m, C_gates_n, C_cell_n,
+                fused_postgemm_part1_(m, n, nb_i, A_iter_m, C_gates_n, C_cell_n,
                         block_step_bytes);
             }
         }
@@ -684,7 +690,8 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             const auto nb
                     = (rnn_.unfused_post_gemm) ? nb_i / rnn_.n_gates : nb_i;
             const auto n = nb * rnn_.n_block;
-            const auto *const Bi2_n = Bi2_ + nb * Bi_n_offset_;
+            const auto *const B_iter_part2_n
+                    = B_iter_part2_ + nb * B_iter_n_offset_;
             auto *const C_gates_n = C_gates_ + m * rnn_.LDC + n;
 
             const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
@@ -697,14 +704,15 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
                     : brgemm_kernel_iter_p1_k_tail_;
 
             for (int g = 0; g < 1; g++) {
-                const auto *const Bi2_g = Bi2_n + g * Bi_g_offset_;
+                const auto *const B_iter_part2_g
+                        = B_iter_part2_n + g * B_iter_g_offset_;
                 auto *const C_gates_g = C_gates_n + (n_gates_ - 1) * rnn_.N;
                 for (int batch_idx = 0; batch_idx < rnn_.KB2_blocks;
                         batch_idx++) {
                     addr_batch[batch_idx].ptr.A
-                            = Ai2_m + batch_idx * rnn_.k2_block;
+                            = A_iter_part2_m + batch_idx * rnn_.k2_block;
                     addr_batch[batch_idx].ptr.B
-                            = Bi2_g + batch_idx * Bi_kb_offset_;
+                            = B_iter_part2_g + batch_idx * B_iter_kb_offset_;
                 }
                 brgemm_kernel_execute(brgemm_kernel_iter_p1, rnn_.KB2_blocks,
                         addr_batch, reinterpret_cast<void *>(C_gates_g),
@@ -713,12 +721,13 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
 
             if (rnn_.k2_tail > 0) {
                 for (int g = 0; g < 1; g++) {
-                    const auto *const Bi2_g = Bi2_n + g * Bi_g_offset_;
+                    const auto *const B_iter_part2_g
+                            = B_iter_part2_n + g * B_iter_g_offset_;
                     auto *const C_gates_g = C_gates_n + (n_gates_ - 1) * rnn_.N;
                     addr_batch[0].ptr.A
-                            = Ai2_m + rnn_.KB2_blocks * rnn_.k2_block;
-                    addr_batch[0].ptr.B
-                            = Bi2_g + rnn_.KB2_blocks * Bi_kb_offset_;
+                            = A_iter_part2_m + rnn_.KB2_blocks * rnn_.k2_block;
+                    addr_batch[0].ptr.B = B_iter_part2_g
+                            + rnn_.KB2_blocks * B_iter_kb_offset_;
                     brgemm_kernel_execute(brgemm_kernel_iter_p1_k_tail, 1,
                             addr_batch, reinterpret_cast<void *>(C_gates_g),
                             nullptr);
@@ -726,8 +735,9 @@ void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             }
 
             if (!rnn_.unfused_post_gemm && nb_i == n_blocking_ - 1) {
-                fused_postgemm_part2_(m, 0, 0, Ai_m, C_gates_ + m * rnn_.LDC,
-                        C_cell_ + m * rnn_.LDC, rnn_.N);
+                fused_postgemm_part2_(m, 0, 0, A_iter_m,
+                        C_gates_ + m * rnn_.LDC, C_cell_ + m * rnn_.LDC,
+                        rnn_.N);
             }
         }
 
@@ -747,19 +757,19 @@ brgemm_merged_layer_t<src_t, weights_t, scratch_t,
     : rnn_brgemm_(rnn_brgemm)
     , rnn_(rnn)
     , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
-    , Al_(src_layer)
-    , Bl_(w_layer)
+    , A_layer_(src_layer)
+    , B_layer_(w_layer)
     , C_(scratch_gates)
-    , LDAl_(rnn_.src_layer_ld(cell_position))
+    , LDA_layer_(rnn_.src_layer_ld(cell_position))
     , max_nthr_(nstl::min(dnnl_get_current_num_threads(), rnn_.nthr))
     , n_blocking_(rnn_.N_blocks * rnn_.n_gates)
     , m_blocking_(rnn_.Mlayermerged_blocks)
     , work_amount_(n_blocking_ * m_blocking_)
-    , Bl_n_offset_(rnn_.K1padded * rnn_.n_block)
-    , Bl_g_offset_(rnn_.N_blocks * Bl_n_offset_)
-    , Al_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
-    , Bl_kb_offset_(rnn_.k1_block * rnn_.n_block)
-    , Bl_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
+    , B_layer_n_offset_(rnn_.K1padded * rnn_.n_block)
+    , B_layer_g_offset_(rnn_.N_blocks * B_layer_n_offset_)
+    , A_layer_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block)
+    , B_layer_kb_offset_(rnn_.k1_block * rnn_.n_block)
+    , B_layer_k_tail_offset_(rnn_.KB1_blocks * rnn_.k1_block * rnn_.n_block)
     , brgemm_kernel_layer_main_(
               rnn_brgemm_.kernel_layermerged_b0_[layer_desc_idx_].get())
     , brgemm_kernel_layer_n_tail_(
@@ -814,8 +824,8 @@ void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const auto n = nb * rnn_.n_block;
         const auto g = nb_i % rnn_.n_gates;
 
-        const auto *const Al_m = Al_ + m * LDAl_;
-        const auto *const Bl_n = Bl_ + nb * Bl_n_offset_;
+        const auto *const A_layer_m = A_layer_ + m * LDA_layer_;
+        const auto *const B_layer_n = B_layer_ + nb * B_layer_n_offset_;
         auto *const C_n = C_ + m * rnn_.LDC + n;
 
         const bool do_n_tail = (n + rnn_.n_block) > rnn_.N;
@@ -827,23 +837,24 @@ void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
                 ? brgemm_kernel_layer_nk_tail_
                 : brgemm_kernel_layer_k_tail_;
 
-        const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
+        const auto *const B_layer_g = B_layer_n + g * B_layer_g_offset_;
         auto *const C_g = C_n + g * rnn_.N;
 
         for (int i = 0; i < rnn_.KB1_blocks; i++) {
-            addr_batch[i].ptr.A = Al_m + i * rnn_.k1_block;
-            addr_batch[i].ptr.B = Bl_g + i * Bl_kb_offset_;
+            addr_batch[i].ptr.A = A_layer_m + i * rnn_.k1_block;
+            addr_batch[i].ptr.B = B_layer_g + i * B_layer_kb_offset_;
         }
         brgemm_kernel_execute(brgemm_kernel_layer_b0, rnn_.KB1_blocks,
                 addr_batch, reinterpret_cast<void *>(C_g), nullptr);
 
         if (rnn_.k1_tail) {
-            const auto *const Bl_g = Bl_n + g * Bl_g_offset_;
-            auto *const C_g = C_n + g * rnn_.N;
-            addr_batch[0].ptr.A = Al_m + Al_k_tail_offset_;
-            addr_batch[0].ptr.B = Bl_g + Bl_k_tail_offset_;
+            const auto *const B_layer_g_tail
+                    = B_layer_n + g * B_layer_g_offset_;
+            auto *const C_g_tail = C_n + g * rnn_.N;
+            addr_batch[0].ptr.A = A_layer_m + A_layer_k_tail_offset_;
+            addr_batch[0].ptr.B = B_layer_g_tail + B_layer_k_tail_offset_;
             brgemm_kernel_execute(brgemm_kernel_layer_k_tail, 1, addr_batch,
-                    reinterpret_cast<void *>(C_g), nullptr);
+                    reinterpret_cast<void *>(C_g_tail), nullptr);
         }
 
         ++start;

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.cpp
@@ -20,12 +20,12 @@
 #include "common/dnnl_thread.hpp"
 #include "common/utils.hpp"
 
-using namespace dnnl::impl::utils;
-
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace aarch64 {
+
+using namespace dnnl::impl::utils;
 
 template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>
@@ -35,7 +35,8 @@ brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         rnn_utils::cell_position_t cell_position, const src_t *src_iter,
         const src_t *src_layer, weights_t *w_iter, weights_t *w_layer,
         scratch_t *scratch_gates, scratch_t *scratch_cell,
-        aarch64::brgemm_batch_element_t *addr_batch_global,
+        gemm_acc_t *gemm_acc_scratchpad,
+        brgemm_batch_element_t *addr_batch_global,
         const postgemm_fused_t &fused_postgemm)
     : rnn_brgemm_(rnn_brgemm)
     , rnn_(rnn)
@@ -84,6 +85,7 @@ brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
               rnn_brgemm_.kernel_layer_K1_tail_b1_[layer_desc_idx_].get())
     , brgemm_kernel_layer_nk_tail_(
               rnn_brgemm_.kernel_layer_NK1_tail_b1_[layer_desc_idx_].get())
+    , gemm_acc_scratchpad_(gemm_acc_scratchpad)
     , addr_batch_global_(addr_batch_global)
     , fused_postgemm_(fused_postgemm)
     , is_fused_layer_iter_brgemm_(!rnn_.is_lbr && rnn_.sic == rnn_.slc
@@ -406,7 +408,8 @@ brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::brgemm_dst_proj_t(
         const ref_rnn_brgemm_t &rnn_brgemm, const rnn_utils::rnn_conf_t &rnn,
         rnn_utils::cell_position_t cell_position, const src_t *proj_ht,
         const weights_t *w_projection, gemm_acc_t *output,
-        aarch64::brgemm_batch_element_t *addr_batch_global,
+        gemm_acc_t *gemm_acc_scratchpad,
+        brgemm_batch_element_t *addr_batch_global,
         const postgemm_fused_t &fused_postgemm)
     : rnn_brgemm_(rnn_brgemm)
     , rnn_(rnn)
@@ -422,6 +425,7 @@ brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::brgemm_dst_proj_t(
     , work_amount_proj_(rnn_.Nproj_blocks * rnn_.M_blocks)
     , B_n_offset_(rnn_.Kprojpadded * rnn_.n_block)
     , Bp_kb_offset_(rnn_.kproj_block * rnn_.n_block)
+    , gemm_acc_scratchpad_(gemm_acc_scratchpad)
     , addr_batch_global_(addr_batch_global)
     , brgemm_kernel_main_(rnn_brgemm_.kernel_proj_b0_[proj_desc_idx_].get())
     , brgemm_kernel_n_tail_(
@@ -500,8 +504,8 @@ brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::brgemm_gru_t(
         rnn_utils::cell_position_t cell_position, const src_t *src_iter,
         const src_t *src_layer, weights_t *w_iter0, weights_t *w_iter1,
         weights_t *w_layer, src_t *d_layer, scratch_t *scratch_gates,
-        scratch_t *scratch_cell,
-        aarch64::brgemm_batch_element_t *addr_batch_global,
+        scratch_t *scratch_cell, gemm_acc_t *gemm_acc_scratchpad,
+        brgemm_batch_element_t *addr_batch_global,
         const postgemm_fused_t &fused_postgemm_part1,
         const postgemm_fused_t &fused_postgemm_part2)
     : rnn_brgemm_(rnn_brgemm)
@@ -566,6 +570,7 @@ brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::brgemm_gru_t(
               rnn_brgemm_.kernel_layer_K1_tail_b1_[layer_desc_idx_].get())
     , brgemm_kernel_layer_nk_tail_(
               rnn_brgemm_.kernel_layer_NK1_tail_b1_[layer_desc_idx_].get())
+    , gemm_acc_scratchpad_(gemm_acc_scratchpad)
     , addr_batch_global_(addr_batch_global)
     , fused_postgemm_part1_(fused_postgemm_part1)
     , fused_postgemm_part2_(fused_postgemm_part2)
@@ -755,7 +760,8 @@ brgemm_merged_layer_t<src_t, weights_t, scratch_t,
         const rnn_utils::rnn_conf_t &rnn,
         rnn_utils::cell_position_t cell_position, const src_t *src_layer,
         weights_t *w_layer, scratch_t *scratch_gates,
-        aarch64::brgemm_batch_element_t *addr_batch_global)
+        gemm_acc_t *gemm_acc_scratchpad,
+        brgemm_batch_element_t *addr_batch_global)
     : rnn_brgemm_(rnn_brgemm)
     , rnn_(rnn)
     , layer_desc_idx_(rnn_.layer_brgemm_desc(cell_position))
@@ -781,6 +787,7 @@ brgemm_merged_layer_t<src_t, weights_t, scratch_t,
     , brgemm_kernel_layer_nk_tail_(
               rnn_brgemm_.kernel_layermerged_NK1_tail_b1_[layer_desc_idx_]
                       .get())
+    , gemm_acc_scratchpad_(gemm_acc_scratchpad)
     , addr_batch_global_(addr_batch_global) {}
 
 template <typename src_t, typename weights_t, typename scratch_t,

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp
@@ -1,0 +1,294 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_FWD_HPP
+#define CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_FWD_HPP
+
+#include <functional>
+
+#include "common/bfloat16.hpp"
+#include "cpu/aarch64/rnn/rnn_brgemm_utils.hpp"
+#include "cpu/rnn/rnn_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+class brgemm_dst_layer_iter_t {
+public:
+    using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
+    using postgemm_fused_t = std::function<void(
+            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, int)>;
+
+    brgemm_dst_layer_iter_t(const ref_rnn_brgemm_t &rnn_brgemm_,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position, const src_t *src_iter,
+            const src_t *src_layer, weights_t *w_iter, weights_t *w_layer,
+            scratch_t *scratch_gates, scratch_t *scratch_cell_,
+            aarch64::brgemm_batch_element_t *addr_batch_global,
+            const postgemm_fused_t &fused_postgemm);
+
+    void execute() const;
+
+private:
+    int calculate_nthr() const;
+    void kernel(const int ithr, const int nthr) const;
+    void kernel_fused_iter_layer(const int ithr, const int nthr) const;
+
+    const ref_rnn_brgemm_t &rnn_brgemm_;
+    const rnn_utils::rnn_conf_t &rnn_;
+
+    const bool need_gemm_layer_;
+
+    const dim_t layer_desc_idx_;
+    const dim_t iter_desc_idx_;
+
+    const src_t *const Al_;
+    const src_t *const Ai_;
+
+    const weights_t *const Bl_;
+    const weights_t *const Bi_;
+
+    scratch_t *const C_gates_;
+    scratch_t *const C_cell_;
+
+    const dim_t LDAl_;
+    const dim_t LDAi_;
+
+    const dim_t n_blocking_;
+    const dim_t m_blocking_;
+    const int work_amount_;
+
+    const dim_t Bl_n_offset_;
+    const dim_t Bi_n_offset_;
+    const dim_t Bl_g_offset_;
+    const dim_t Bi_g_offset_;
+    const dim_t Al_k_tail_offset_;
+    const dim_t Ai_k_tail_offset_;
+    const dim_t Bl_kb_offset_;
+    const dim_t Bi_kb_offset_;
+    const dim_t Bl_k_tail_offset_;
+    const dim_t Bi_k_tail_offset_;
+
+    const dim_t n_gates_;
+
+    const brgemm_kernel_t *const brgemm_kernel_iter_main_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_n_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_k_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_nk_tail_;
+
+    const brgemm_kernel_t *const brgemm_kernel_layer_main_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_n_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_k_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_nk_tail_;
+
+    brgemm_batch_element_t *const addr_batch_global_;
+    const postgemm_fused_t fused_postgemm_;
+
+    const bool is_fused_layer_iter_brgemm_;
+
+    const int max_nthr_;
+};
+
+template <typename src_t, typename weights_t, typename gemm_acc_t>
+class brgemm_dst_proj_t {
+public:
+    using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
+
+    using postgemm_fused_t
+            = std::function<void(dim_t, dim_t, gemm_acc_t *, int)>;
+
+    brgemm_dst_proj_t(const ref_rnn_brgemm_t &rnn_brgemm_,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position, const src_t *proj_ht,
+            const weights_t *w_projection, gemm_acc_t *output,
+            aarch64::brgemm_batch_element_t *addr_batch_global,
+            const postgemm_fused_t &fused_postgemm);
+
+    void execute() const;
+
+private:
+    void kernel(const int ithr, const int nthr) const;
+
+    const ref_rnn_brgemm_t &rnn_brgemm_;
+    const rnn_utils::rnn_conf_t &rnn_;
+
+    const int proj_desc_idx_;
+
+    const src_t *const A_;
+    const weights_t *const B_;
+    gemm_acc_t *const C_;
+
+    const dim_t LDC_;
+    const dim_t max_nthr_;
+    const int work_amount_proj_;
+
+    const dim_t B_n_offset_;
+    const dim_t Bp_kb_offset_;
+
+    brgemm_batch_element_t *const addr_batch_global_;
+
+    const brgemm_kernel_t *const brgemm_kernel_main_;
+    const brgemm_kernel_t *const brgemm_kernel_n_tail_;
+
+    const postgemm_fused_t fused_postgemm_;
+};
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+class brgemm_gru_t {
+public:
+    using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
+    using postgemm_fused_t = std::function<void(
+            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, int)>;
+
+    brgemm_gru_t(const ref_rnn_brgemm_t &rnn_brgemm_,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position, const src_t *src_iter,
+            const src_t *src_layer, weights_t *w_iter, weights_t *w_iter1,
+            weights_t *w_layer, src_t *d_layer, scratch_t *scratch_gates,
+            scratch_t *scratch_cell,
+            aarch64::brgemm_batch_element_t *addr_batch_global,
+            const postgemm_fused_t &fused_postgemm_part1,
+            const postgemm_fused_t &fused_postgemm_part2);
+
+    void execute() const;
+
+private:
+    void kernel(const int ithr, const int nthr) const;
+
+    const ref_rnn_brgemm_t &rnn_brgemm_;
+    const rnn_utils::rnn_conf_t &rnn_;
+
+    const bool need_gemm_layer_;
+
+    const dim_t layer_desc_idx_;
+    const dim_t iter_desc_idx_;
+    const dim_t iter_part2_desc_idx_;
+
+    const src_t *const Al_;
+    const src_t *const Ai_;
+
+    const weights_t *const Bl_;
+    const weights_t *const Bi_;
+    const weights_t *const Bi2_;
+
+    scratch_t *const C_gates_;
+    scratch_t *const C_cell_;
+    src_t *const Dl_;
+
+    const dim_t LDAl_;
+    const dim_t LDAi_p1_;
+    const dim_t LDAi_p2_;
+
+    const dim_t max_nthr_;
+    const dim_t n_blocking_;
+    const dim_t m_blocking_;
+    const int work_amount_;
+
+    const dim_t Bl_n_offset_;
+    const dim_t Bi_n_offset_;
+    const dim_t Bl_g_offset_;
+    const dim_t Bi_g_offset_;
+    const dim_t Al_k_tail_offset_;
+    const dim_t Ai_k_tail_offset_;
+    const dim_t Bl_kb_offset_;
+    const dim_t Bi_kb_offset_;
+    const dim_t Bl_k_tail_offset_;
+    const dim_t Bi_k_tail_offset_;
+
+    const dim_t n_gates_;
+
+    const brgemm_kernel_t *const brgemm_kernel_iter_p0_main_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_p0_n_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_p0_k_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_p0_nk_tail_;
+
+    const brgemm_kernel_t *const brgemm_kernel_iter_p1_main_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_p1_n_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_p1_k_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_iter_p1_nk_tail_;
+
+    const brgemm_kernel_t *const brgemm_kernel_layer_main_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_n_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_k_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_nk_tail_;
+
+    brgemm_batch_element_t *const addr_batch_global_;
+
+    const postgemm_fused_t fused_postgemm_part1_;
+    const postgemm_fused_t fused_postgemm_part2_;
+
+    const bool is_fused_layer_iter_brgemm_;
+};
+
+template <typename src_t, typename weights_t, typename scratch_t,
+        typename gemm_acc_t>
+class brgemm_merged_layer_t {
+public:
+    using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
+
+    brgemm_merged_layer_t(const ref_rnn_brgemm_t &rnn_brgemm_,
+            const rnn_utils::rnn_conf_t &rnn,
+            rnn_utils::cell_position_t cell_position, const src_t *src_layer,
+            weights_t *w_layer, scratch_t *scratch_gates,
+            aarch64::brgemm_batch_element_t *addr_batch_global);
+
+    void execute() const;
+
+private:
+    void kernel(const int ithr, const int nthr) const;
+
+    const ref_rnn_brgemm_t &rnn_brgemm_;
+    const rnn_utils::rnn_conf_t &rnn_;
+
+    const dim_t layer_desc_idx_;
+
+    const src_t *const Al_;
+    const weights_t *const Bl_;
+    scratch_t *const C_;
+
+    const dim_t LDAl_;
+    const dim_t max_nthr_;
+
+    const dim_t n_blocking_;
+    const dim_t m_blocking_;
+    const int work_amount_;
+
+    const dim_t Bl_n_offset_;
+    const dim_t Bl_g_offset_;
+    const dim_t Al_k_tail_offset_;
+    const dim_t Bl_kb_offset_;
+    const dim_t Bl_k_tail_offset_;
+
+    const brgemm_kernel_t *const brgemm_kernel_layer_main_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_n_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_k_tail_;
+    const brgemm_kernel_t *const brgemm_kernel_layer_nk_tail_;
+
+    brgemm_batch_element_t *const addr_batch_global_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_FWD_HPP

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp
@@ -42,7 +42,8 @@ public:
             rnn_utils::cell_position_t cell_position, const src_t *src_iter,
             const src_t *src_layer, weights_t *w_iter, weights_t *w_layer,
             scratch_t *scratch_gates, scratch_t *scratch_cell_,
-            aarch64::brgemm_batch_element_t *addr_batch_global,
+            gemm_acc_t *gemm_acc_scratchpad,
+            brgemm_batch_element_t *addr_batch_global,
             const postgemm_fused_t &fused_postgemm);
 
     void execute() const;
@@ -99,6 +100,7 @@ private:
     const brgemm_kernel_t *const brgemm_kernel_layer_k_tail_;
     const brgemm_kernel_t *const brgemm_kernel_layer_nk_tail_;
 
+    gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
     const postgemm_fused_t fused_postgemm_;
 
@@ -119,7 +121,8 @@ public:
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *proj_ht,
             const weights_t *w_projection, gemm_acc_t *output,
-            aarch64::brgemm_batch_element_t *addr_batch_global,
+            gemm_acc_t *gemm_acc_scratchpad,
+            brgemm_batch_element_t *addr_batch_global,
             const postgemm_fused_t &fused_postgemm);
 
     void execute() const;
@@ -143,6 +146,7 @@ private:
     const dim_t B_n_offset_;
     const dim_t Bp_kb_offset_;
 
+    gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
 
     const brgemm_kernel_t *const brgemm_kernel_main_;
@@ -164,8 +168,8 @@ public:
             rnn_utils::cell_position_t cell_position, const src_t *src_iter,
             const src_t *src_layer, weights_t *w_iter, weights_t *w_iter1,
             weights_t *w_layer, src_t *d_layer, scratch_t *scratch_gates,
-            scratch_t *scratch_cell,
-            aarch64::brgemm_batch_element_t *addr_batch_global,
+            scratch_t *scratch_cell, gemm_acc_t *gemm_acc_scratchpad,
+            brgemm_batch_element_t *addr_batch_global,
             const postgemm_fused_t &fused_postgemm_part1,
             const postgemm_fused_t &fused_postgemm_part2);
 
@@ -231,6 +235,7 @@ private:
     const brgemm_kernel_t *const brgemm_kernel_layer_k_tail_;
     const brgemm_kernel_t *const brgemm_kernel_layer_nk_tail_;
 
+    gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
 
     const postgemm_fused_t fused_postgemm_part1_;
@@ -249,7 +254,8 @@ public:
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *src_layer,
             weights_t *w_layer, scratch_t *scratch_gates,
-            aarch64::brgemm_batch_element_t *addr_batch_global);
+            gemm_acc_t *gemm_acc_scratchpad,
+            brgemm_batch_element_t *addr_batch_global);
 
     void execute() const;
 
@@ -283,6 +289,7 @@ private:
     const brgemm_kernel_t *const brgemm_kernel_layer_k_tail_;
     const brgemm_kernel_t *const brgemm_kernel_layer_nk_tail_;
 
+    gemm_acc_t *const gemm_acc_scratchpad_;
     brgemm_batch_element_t *const addr_batch_global_;
 };
 

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp
@@ -61,32 +61,32 @@ private:
     const dim_t layer_desc_idx_;
     const dim_t iter_desc_idx_;
 
-    const src_t *const Al_;
-    const src_t *const Ai_;
+    const src_t *const A_layer_;
+    const src_t *const A_iter_;
 
-    const weights_t *const Bl_;
-    const weights_t *const Bi_;
+    const weights_t *const B_layer_;
+    const weights_t *const B_iter_;
 
     scratch_t *const C_gates_;
     scratch_t *const C_cell_;
 
-    const dim_t LDAl_;
-    const dim_t LDAi_;
+    const dim_t LDA_layer_;
+    const dim_t LDA_iter_;
 
     const dim_t n_blocking_;
     const dim_t m_blocking_;
     const int work_amount_;
 
-    const dim_t Bl_n_offset_;
-    const dim_t Bi_n_offset_;
-    const dim_t Bl_g_offset_;
-    const dim_t Bi_g_offset_;
-    const dim_t Al_k_tail_offset_;
-    const dim_t Ai_k_tail_offset_;
-    const dim_t Bl_kb_offset_;
-    const dim_t Bi_kb_offset_;
-    const dim_t Bl_k_tail_offset_;
-    const dim_t Bi_k_tail_offset_;
+    const dim_t B_layer_n_offset_;
+    const dim_t B_iter_n_offset_;
+    const dim_t B_layer_g_offset_;
+    const dim_t B_iter_g_offset_;
+    const dim_t A_layer_k_tail_offset_;
+    const dim_t A_iter_k_tail_offset_;
+    const dim_t B_layer_kb_offset_;
+    const dim_t B_iter_kb_offset_;
+    const dim_t B_layer_k_tail_offset_;
+    const dim_t B_iter_k_tail_offset_;
 
     const dim_t n_gates_;
 
@@ -187,36 +187,36 @@ private:
     const dim_t iter_desc_idx_;
     const dim_t iter_part2_desc_idx_;
 
-    const src_t *const Al_;
-    const src_t *const Ai_;
+    const src_t *const A_layer_;
+    const src_t *const A_iter_;
 
-    const weights_t *const Bl_;
-    const weights_t *const Bi_;
-    const weights_t *const Bi2_;
+    const weights_t *const B_layer_;
+    const weights_t *const B_iter_;
+    const weights_t *const B_iter_part2_;
 
     scratch_t *const C_gates_;
     scratch_t *const C_cell_;
-    src_t *const Dl_;
+    src_t *const D_layer_;
 
-    const dim_t LDAl_;
-    const dim_t LDAi_p1_;
-    const dim_t LDAi_p2_;
+    const dim_t LDA_layer_;
+    const dim_t LDA_iter_part1_;
+    const dim_t LDA_iter_part2_;
 
     const dim_t max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
     const int work_amount_;
 
-    const dim_t Bl_n_offset_;
-    const dim_t Bi_n_offset_;
-    const dim_t Bl_g_offset_;
-    const dim_t Bi_g_offset_;
-    const dim_t Al_k_tail_offset_;
-    const dim_t Ai_k_tail_offset_;
-    const dim_t Bl_kb_offset_;
-    const dim_t Bi_kb_offset_;
-    const dim_t Bl_k_tail_offset_;
-    const dim_t Bi_k_tail_offset_;
+    const dim_t B_layer_n_offset_;
+    const dim_t B_iter_n_offset_;
+    const dim_t B_layer_g_offset_;
+    const dim_t B_iter_g_offset_;
+    const dim_t A_layer_k_tail_offset_;
+    const dim_t A_iter_k_tail_offset_;
+    const dim_t B_layer_kb_offset_;
+    const dim_t B_iter_kb_offset_;
+    const dim_t B_layer_k_tail_offset_;
+    const dim_t B_iter_k_tail_offset_;
 
     const dim_t n_gates_;
 
@@ -267,22 +267,22 @@ private:
 
     const dim_t layer_desc_idx_;
 
-    const src_t *const Al_;
-    const weights_t *const Bl_;
+    const src_t *const A_layer_;
+    const weights_t *const B_layer_;
     scratch_t *const C_;
 
-    const dim_t LDAl_;
+    const dim_t LDA_layer_;
     const dim_t max_nthr_;
 
     const dim_t n_blocking_;
     const dim_t m_blocking_;
     const int work_amount_;
 
-    const dim_t Bl_n_offset_;
-    const dim_t Bl_g_offset_;
-    const dim_t Al_k_tail_offset_;
-    const dim_t Bl_kb_offset_;
-    const dim_t Bl_k_tail_offset_;
+    const dim_t B_layer_n_offset_;
+    const dim_t B_layer_g_offset_;
+    const dim_t A_layer_k_tail_offset_;
+    const dim_t B_layer_kb_offset_;
+    const dim_t B_layer_k_tail_offset_;
 
     const brgemm_kernel_t *const brgemm_kernel_layer_main_;
     const brgemm_kernel_t *const brgemm_kernel_layer_n_tail_;

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_reorders.cpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_reorders.cpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+* Copyright 2021-2024 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp"
+
+#include <cstdlib>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "cpu/aarch64/jit_brgemm_transpose_utils.hpp"
+#include "cpu/rnn/rnn_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+src_layer_iter_transpose_t::src_layer_iter_transpose_t(const int src_ld,
+        const int dst_ld, const int rows, const int cols,
+        jit_brgemm_trans_src_t *const kernel_transpose)
+    : src_ld_(src_ld)
+    , dst_ld_(dst_ld)
+    , src_rows_(rows)
+    , src_cols_(cols)
+    , kernel_transpose_(kernel_transpose) {}
+
+namespace {
+
+template <typename Dt>
+void transpose_block_generic(const Dt *src, Dt *dst, const int src_ld,
+        const int dst_ld, const int rows, const int cols) {
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            dst[j * dst_ld + i] = src[i * src_ld + j];
+        }
+    }
+}
+
+} // namespace
+
+template <typename Dt>
+void src_layer_iter_transpose_t::execute(const Dt *src, Dt *dst) const {
+    static constexpr int block_size = 16;
+
+    const auto rows_div = std::div(src_rows_, block_size);
+    const auto rows_tail = rows_div.rem;
+    const auto rows_blks = rows_div.quot + (rows_tail > 0 ? 1 : 0);
+
+    const auto cols_div = std::div(src_cols_, block_size);
+    const auto cols_tail = cols_div.rem;
+    const auto cols_blks = cols_div.quot + (cols_tail > 0 ? 1 : 0);
+
+    // Use JIT kernel if provided, else fall back to generic transpose.
+    if (kernel_transpose_) {
+        parallel_nd(cols_blks, rows_blks, [&](dim_t c, dim_t r) {
+            const auto current_rows = (rows_tail && r == rows_blks - 1)
+                    ? rows_tail
+                    : block_size;
+            const auto current_cols = (cols_tail && c == cols_blks - 1)
+                    ? cols_tail
+                    : block_size;
+
+            jit_brgemm_trans_src_t::ctx_t ctx;
+            ctx.src = (const void *)(src + (r * src_ld_ + c) * block_size);
+            ctx.tr_src = (void *)(dst + (c * dst_ld_ + r) * block_size);
+            ctx.current_gemm_batch = 1;
+            ctx.current_M = current_cols;
+            ctx.current_K = current_rows;
+
+            (*kernel_transpose_)(&ctx);
+        });
+    } else {
+        parallel_nd(cols_blks, rows_blks, [&](dim_t c, dim_t r) {
+            const auto current_rows = (rows_tail && r == rows_blks - 1)
+                    ? rows_tail
+                    : block_size;
+            const auto current_cols = (cols_tail && c == cols_blks - 1)
+                    ? cols_tail
+                    : block_size;
+
+            const Dt *src_block = src + (r * src_ld_ + c) * block_size;
+            Dt *dst_block = dst + (c * dst_ld_ + r) * block_size;
+
+            transpose_block_generic(src_block, dst_block, src_ld_, dst_ld_,
+                    current_rows, current_cols);
+        });
+    }
+}
+
+template void src_layer_iter_transpose_t::execute<float>(
+        const float *, float *) const;
+template void src_layer_iter_transpose_t::execute<bfloat16_t>(
+        const bfloat16_t *, bfloat16_t *) const;
+template void src_layer_iter_transpose_t::execute<float16_t>(
+        const float16_t *, float16_t *) const;
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp
+++ b/src/cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+* Copyright 2021-2024 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_REORDERS_HPP
+#define CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_REORDERS_HPP
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+
+namespace rnn_utils {
+struct rnn_conf_t;
+} // namespace rnn_utils
+
+namespace aarch64 {
+
+struct jit_brgemm_trans_src_t;
+
+struct src_layer_iter_transpose_t {
+
+    src_layer_iter_transpose_t(const int src_ld, const int dst_ld,
+            const int rows, const int cols,
+            jit_brgemm_trans_src_t *const kernel_transpose);
+
+    template <typename Dt>
+    void execute(const Dt *src, Dt *dst) const;
+
+private:
+    const int src_ld_;
+    const int dst_ld_;
+    const int src_rows_;
+    const int src_cols_;
+    jit_brgemm_trans_src_t *const kernel_transpose_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_RNN_BRGEMM_CELL_COMMON_REORDERS_HPP

--- a/src/cpu/aarch64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/aarch64/rnn/rnn_brgemm_utils.cpp
@@ -1,0 +1,945 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <climits>
+#include <cmath>
+#include <tuple>
+#include <utility>
+
+#include "common/dnnl_thread.hpp"
+#include "cpu/aarch64/brgemm/brgemm.hpp"
+#include "cpu/aarch64/rnn/rnn_brgemm_utils.hpp"
+#include "cpu/rnn/rnn_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+namespace rnn_brgemm_utils {
+
+namespace {
+
+aarch64::cpu_isa_t brgemm_calc_isa(
+        const cpu::rnn_utils::rnn_conf_t &rnn, dim_t K1, dim_t K2);
+
+std::pair<dim_t, dim_t> brgemm_calc_k_block(
+        const cpu::rnn_utils::rnn_conf_t &rnn, dim_t K1, dim_t K2, dim_t M,
+        dim_t n_block, alg_kind_t cell_kind, dim_t src_layer_type_size,
+        dim_t As, dim_t Bs, dim_t Cs, dim_t l2_cache_size,
+        aarch64::cpu_isa_t isa);
+
+std::pair<dim_t, dim_t> brgemm_calc_k_block_vanilla_rnn(dim_t K1, dim_t K2,
+        dim_t M, dim_t n_block, dim_t src_layer_type_size, dim_t As, dim_t Bs,
+        dim_t Cs, dim_t l2_cache_size, bool is_xf16, aarch64::cpu_isa_t isa);
+
+dim_t brgemm_calc_m_block(alg_kind_t cell_kind, prop_kind_t aprop, dim_t nthr,
+        dim_t M, dim_t N_blocks, bool is_f32, float work_by_N, dim_t As,
+        dim_t Bs, dim_t Cs, dim_t l2_cache_size);
+
+dim_t brgemm_calc_m_block_vanilla_rnn(dim_t nthr, dim_t M, dim_t N_blocks,
+        float work_by_N, dim_t As, dim_t Bs, dim_t Cs, dim_t l2_cache_size);
+
+dim_t brgemm_calc_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks, bool is_f32,
+        float work_by_N, dim_t As, dim_t Cs, dim_t l2_cache_size);
+
+dim_t adjust_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks);
+
+dim_t brgemm_calc_n_block(
+        const cpu::rnn_utils::rnn_conf_t &rnn, alg_kind_t cell_kind);
+
+aarch64::cpu_isa_t brgemm_calc_isa(
+        const cpu::rnn_utils::rnn_conf_t &rnn, dim_t K1, dim_t K2) {
+
+    // Feature gating: reject early if HW lacks required dtype support
+    if (rnn.is_cell_dt_bf16() && !mayiuse_bf16()) return isa_undef;
+    // TODO: Add int8 dotprod / f16 gating if brgemm_desc_init
+    //       doesn't handle it robustly enough downstream.
+
+    if (mayiuse(sve_512)) return sve_512;
+    if (mayiuse(sve_256)) return sve_256;
+    if (mayiuse(sve_128)) return sve_128;
+    if (mayiuse(asimd)) return asimd;
+    return isa_undef;
+}
+
+std::pair<dim_t, dim_t> brgemm_calc_k_block(
+        const cpu::rnn_utils::rnn_conf_t &rnn, dim_t K1, dim_t K2, dim_t M,
+        dim_t n_block, alg_kind_t cell_kind, dim_t src_layer_type_size,
+        dim_t As, dim_t Bs, dim_t Cs, dim_t l2_cache_size,
+        aarch64::cpu_isa_t isa) {
+
+    if (cell_kind == alg_kind::vanilla_rnn)
+        return brgemm_calc_k_block_vanilla_rnn(K1, K2, M, n_block,
+                src_layer_type_size, As, Bs, Cs, l2_cache_size,
+                rnn.is_cell_dt_xf16(), isa);
+
+    return std::make_pair(K1, K2);
+}
+
+std::pair<dim_t, dim_t> brgemm_calc_k_block_vanilla_rnn(dim_t K1, dim_t K2,
+        dim_t M, dim_t n_block, dim_t src_layer_type_size, dim_t As, dim_t Bs,
+        dim_t Cs, dim_t l2_cache_size, bool is_xf16, aarch64::cpu_isa_t isa) {
+
+    const bool is_sve = is_superset(isa, aarch64::sve_128);
+    const float l2_occupancy = is_sve ? 0.35f : 0.70f;
+
+    const bool should_adjust_by_l2 = static_cast<float>(As + Bs + Cs)
+            >= l2_occupancy * static_cast<float>(l2_cache_size);
+
+    dim_t k1_block = K1;
+    dim_t k2_block = K2;
+
+    if (should_adjust_by_l2) {
+        int block_size = (l2_cache_size * l2_occupancy)
+                / ((M + n_block) * src_layer_type_size);
+
+        if (is_xf16) {
+            block_size -= (block_size % 2);
+            block_size = nstl::max(block_size, 0);
+        }
+
+        if (block_size) {
+            k1_block = nstl::min(K1, static_cast<dim_t>(block_size));
+            k2_block = nstl::min(K2, static_cast<dim_t>(block_size));
+        }
+    }
+
+    return std::make_pair(k1_block, k2_block);
+}
+
+dim_t brgemm_calc_m_block(alg_kind_t cell_kind, prop_kind_t aprop, dim_t nthr,
+        dim_t M, dim_t N_blocks, bool is_f32, float work_by_N, dim_t As,
+        dim_t Bs, dim_t Cs, dim_t l2_cache_size) {
+
+    if (cell_kind == alg_kind::vanilla_rnn
+            || (cell_kind == alg_kind::vanilla_lstm
+                    && aprop == prop_kind::backward))
+        return brgemm_calc_m_block_vanilla_rnn(
+                nthr, M, N_blocks, work_by_N, As, Bs, Cs, l2_cache_size);
+    else
+        return brgemm_calc_m_block_lstm(
+                nthr, M, N_blocks, is_f32, work_by_N, As, Cs, l2_cache_size);
+}
+
+dim_t brgemm_calc_m_block_vanilla_rnn(dim_t nthr, dim_t M, dim_t N_blocks,
+        float work_by_N, dim_t As, dim_t Bs, dim_t Cs, dim_t l2_cache_size) {
+
+    const float decimal_n_factor = work_by_N - std::floor(work_by_N);
+    static constexpr float thread_balance_threashold = 0.9f;
+
+    dim_t m_block = M;
+
+    if (work_by_N < 1.0f)
+        return adjust_m_block_lstm(nthr, M, N_blocks);
+    else if (decimal_n_factor < thread_balance_threashold
+            && decimal_n_factor != 0.0f) {
+
+        const dim_t m_block_start = M / 2;
+        const dim_t m_block_end = 8;
+        float max_decimal_mn = 0.0f;
+        dim_t best_candidate = m_block_start;
+        bool found_best_solution = false;
+
+        for (dim_t m_block_it = m_block_start; m_block_it >= m_block_end;
+                m_block_it--) {
+            if (M % m_block_it == 0) {
+                const auto m_blocks = M / m_block_it;
+                const auto work_by_MN
+                        = static_cast<float>(m_blocks * N_blocks) / nthr;
+                const float work_by_MN_decimal
+                        = work_by_MN - std::floor(work_by_MN);
+
+                static constexpr float tolerance = 0.01f;
+                if (work_by_MN_decimal > (max_decimal_mn + tolerance)) {
+                    best_candidate = m_block_it;
+                    max_decimal_mn = work_by_MN_decimal;
+                }
+
+                if (work_by_MN_decimal >= thread_balance_threashold
+                        || work_by_MN_decimal == 0.0f) {
+                    m_block = m_block_it;
+                    found_best_solution = true;
+                    break;
+                }
+            }
+        }
+
+        if (!found_best_solution) {
+            if ((decimal_n_factor < max_decimal_mn)
+                    || (static_cast<float>(As)
+                            > (0.5f * static_cast<float>(l2_cache_size)))) {
+                m_block = best_candidate;
+            }
+        }
+    }
+
+    return m_block;
+}
+
+dim_t brgemm_calc_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks, bool is_f32,
+        float work_by_N, dim_t As, dim_t Cs, dim_t l2_cache_size) {
+
+    const bool adj_by_l2 = is_f32
+            ? true
+            : (static_cast<float>(As + Cs)
+                      < 0.6f * static_cast<float>(l2_cache_size));
+
+    if (work_by_N > 2.0f || (work_by_N > 1.0f && adj_by_l2))
+        return M;
+    else
+        return adjust_m_block_lstm(nthr, M, N_blocks);
+}
+
+dim_t adjust_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks) {
+
+    const dim_t max_m_blocks = 4 * utils::div_up(nthr, N_blocks);
+    const dim_t max_m_value = 32;
+    const dim_t max_M
+            = nstl::min(max_m_value, nstl::max((dim_t)1, M / max_m_blocks));
+    const dim_t min_M = 4;
+
+    dim_t m_block = 1;
+    for (dim_t m = max_M; m >= min_M; m--)
+        if (M % m == 0) {
+            m_block = m;
+            break;
+        }
+
+    if (m_block == 1) m_block = M;
+    return m_block;
+}
+
+dim_t brgemm_calc_n_block(
+        const cpu::rnn_utils::rnn_conf_t &rnn, alg_kind_t cell_kind) {
+
+    const int simd_w = isa_max_vlen(rnn.brgemm_isa) / (int)sizeof(float);
+
+    if (rnn.brgemm_isa == asimd && rnn.M == 1
+            && utils::one_of(
+                    cell_kind, alg_kind::vanilla_lstm, alg_kind::lbr_gru))
+        return 4 * simd_w;
+    else
+        return 2 * simd_w;
+}
+
+} // namespace
+
+void rnn_brgemm_base_t::init_scratchpad(const cpu::rnn_utils::rnn_conf_t &rnn,
+        memory_tracking::registrar_t &scratchpad, dim_t gemm_acc_type_size,
+        dim_t gemm_acc_align) {
+
+    MAYBE_UNUSED(gemm_acc_type_size);
+    MAYBE_UNUSED(gemm_acc_align);
+
+    using namespace memory_tracking::names;
+    const int max_K_Block
+            = nstl::max(rnn.KB1_blocks + 1,
+                      nstl::max(rnn.KBproj_blocks + 1, rnn.KB2_blocks + 1))
+            * (rnn.brgemm_fwd_iter_layer_fuse_possible ? 2 : 1);
+
+    scratchpad.template book<aarch64::brgemm_batch_element_t>(
+            key_brgemm_primitive_batch, max_K_Block * rnn.nthr);
+}
+
+status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
+        cpu::rnn_utils::rnn_conf_t &rnn, alg_kind_t cell_kind,
+        dim_t src_layer_type_size, dim_t scratch_type_size) {
+
+    using namespace cpu::rnn_utils;
+
+    // no int8 brgemm RNN support for now
+    if (rnn.is_int8_conf() || rnn.is_cell_dt_int8())
+        return status::unimplemented;
+
+    // FOr now only support vanilla RNN/LSTM/GRU/AUGRU
+    if (!utils::one_of(cell_kind, alg_kind::vanilla_rnn, alg_kind::vanilla_lstm,
+                alg_kind::vanilla_gru, alg_kind::vanilla_augru))
+        return status::unimplemented;
+
+    rnn.M = rnn.mb;
+    rnn.N = rnn.dhc;
+    rnn.K1 = rnn.slc;
+    rnn.K2 = rnn.sic;
+
+    const auto is_int8 = rnn.is_cell_dt_int8();
+    const auto is_xf16 = rnn.is_cell_dt_xf16();
+
+    const dim_t padding = (is_int8 ? 4 : (is_xf16 ? 2 : 1));
+    rnn.K1padded = utils::rnd_up(rnn.K1, padding);
+    rnn.K2padded = utils::rnd_up(rnn.K2, padding);
+
+    rnn.brgemm_isa = brgemm_calc_isa(rnn, rnn.K1, rnn.K2);
+    if (rnn.brgemm_isa == isa_undef) return status::unimplemented;
+
+    if (rnn.brgemm_isa == asimd
+            && (rnn.is_lstm_peephole || rnn.is_lstm_projection))
+        return status::unimplemented;
+
+    if (!IMPLICATION(rnn.is_f32_conf(), rnn.is_cell_dt_f32()))
+        return status::unimplemented;
+
+    rnn.nthr = dnnl_get_max_threads();
+
+    rnn.n_block = brgemm_calc_n_block(rnn, cell_kind);
+    rnn.N_blocks = utils::div_up(rnn.N, rnn.n_block);
+    rnn.n_tail = rnn.N % rnn.n_block;
+
+    const float work_by_N
+            = static_cast<float>(rnn.N_blocks) / static_cast<float>(rnn.nthr);
+
+    const dim_t l2_cache_size = platform::get_per_core_cache_size(2);
+
+    const dim_t As = src_layer_type_size * rnn.M * (nstl::max(rnn.K1, rnn.K2));
+    const dim_t Bs
+            = src_layer_type_size * (nstl::max(rnn.K1, rnn.K2)) * rnn.n_block;
+    const dim_t Cs
+            = scratch_type_size * (rnn.n_gates + 1) * (rnn.M * rnn.n_block);
+
+    std::tie(rnn.k1_block, rnn.k2_block) = brgemm_calc_k_block(rnn, rnn.K1,
+            rnn.K2, rnn.M, rnn.n_block, cell_kind, src_layer_type_size, As, Bs,
+            Cs, l2_cache_size, rnn.brgemm_isa);
+
+    rnn.KB1_blocks = rnn.K1 / rnn.k1_block;
+    rnn.k1_tail = rnn.K1 % rnn.k1_block;
+    rnn.KB2_blocks = rnn.K2 / rnn.k2_block;
+    rnn.k2_tail = rnn.K2 % rnn.k2_block;
+
+    rnn.m_block = brgemm_calc_m_block(cell_kind, prop_kind::forward, rnn.nthr,
+            rnn.M, rnn.N_blocks, rnn.is_cell_dt_f32(), work_by_N, As, Bs, Cs,
+            l2_cache_size);
+    rnn.M_blocks = rnn.M / rnn.m_block;
+
+    rnn.unfused_post_gemm = false;
+
+    rnn.LDA1[0] = rnn.src_layer_ld_;
+    rnn.LDA1[1] = rnn.dst_iter_ld_;
+    rnn.LDA1[2] = rnn.ws_states_layer_ld;
+
+    rnn.LDA2[0] = rnn.src_iter_ld_;
+    rnn.LDA2[1] = rnn.dst_layer_ld_;
+    rnn.LDA2[2] = rnn.ws_states_iter_ld;
+
+    rnn.LDA2_2[0] = rnn.dst_layer_ld_;
+    rnn.LDA2_2[1] = rnn.dst_iter_ld_;
+    rnn.LDA2_2[2] = rnn.ws_states_layer_ld;
+    rnn.LDA2_2[3] = rnn.ws_states_iter_ld;
+
+    rnn.LDB1 = rnn.n_block;
+    rnn.LDB2 = rnn.n_block;
+    rnn.LDC = rnn.scratch_gates_ld;
+
+    auto get_dim = [&](dim_t block, dim_t tail) {
+        return (block == 0) ? tail : block;
+    };
+
+    dim_t n_block = nstl::min(rnn.N, rnn.n_block);
+    dim_t n_tail = nstl::min(rnn.N, rnn.n_tail);
+
+    if (rnn.LDA1[0] < rnn.k1_block || rnn.LDA1[1] < rnn.k1_block
+            || rnn.LDA1[2] < rnn.k1_block)
+        return status::unimplemented;
+
+    if (rnn.LDA2[0] < rnn.k2_block || rnn.LDA2[1] < rnn.k2_block
+            || rnn.LDA2[2] < rnn.k2_block)
+        return status::unimplemented;
+
+    if (rnn.LDB1 < get_dim(n_block, n_tail)
+            && rnn.LDB2 < get_dim(n_block, n_tail))
+        return status::unimplemented;
+
+    if (rnn.LDC < get_dim(n_block, n_tail)) return status::unimplemented;
+
+    rnn.KBproj_blocks = 0;
+    rnn.kproj_tail = 0;
+    rnn.kproj_block = 0;
+
+    if (rnn.is_lstm_projection) {
+        rnn.Nproj = rnn.dic;
+        rnn.Nproj_blocks = utils::div_up(rnn.Nproj, rnn.n_block);
+        rnn.nproj_tail = rnn.Nproj % rnn.n_block;
+
+        rnn.Kproj = rnn.dhc;
+        rnn.Kprojpadded = utils::rnd_up(rnn.Kproj, padding);
+
+        rnn.kproj_block = rnn.Kproj;
+        rnn.KBproj_blocks = rnn.Kproj / rnn.kproj_block;
+
+        rnn.LDAproj = rnn.proj_ht_ld;
+        rnn.LDBproj = rnn.n_block;
+
+        if (rnn.dt_conf != cpu::rnn_utils::all_f32) {
+            rnn.LDCproj[0] = rnn.scratch_gates_ld;
+        } else {
+            rnn.LDCproj[0] = rnn.scratch_ht_ld;
+            rnn.LDCproj[1] = rnn.dst_layer_ld_;
+            rnn.LDCproj[2] = rnn.dst_iter_ld_;
+            rnn.LDCproj[3] = rnn.ws_states_layer_ld;
+        }
+
+        dim_t n_block = nstl::min(rnn.Nproj, rnn.n_block);
+        dim_t n_tail = nstl::min(rnn.Nproj, rnn.nproj_tail);
+
+        bool check_LDC = false;
+        if (rnn.dt_conf != cpu::rnn_utils::all_f32) {
+            check_LDC = rnn.LDCproj[0] < get_dim(n_block, n_tail);
+        } else {
+            check_LDC = rnn.LDCproj[0] < get_dim(n_block, n_tail)
+                    && rnn.LDCproj[1] < get_dim(n_block, n_tail)
+                    && rnn.LDCproj[2] < get_dim(n_block, n_tail)
+                    && rnn.LDCproj[3] < get_dim(n_block, n_tail);
+        }
+
+        if (rnn.LDAproj < rnn.kproj_block
+                || rnn.LDBproj < get_dim(n_block, n_tail) || check_LDC)
+            return status::unimplemented;
+    }
+
+    const bool mlc_cell_type_ok
+            = (cell_kind == alg_kind::vanilla_lstm && !rnn.is_lstm_projection
+                      && !rnn.is_lstm_peephole)
+            || (cell_kind == alg_kind::lbr_gru && rnn.brgemm_isa == asimd);
+
+    const int mlc_mb_max_threshold = 1;
+    const int mlc_n_iter_min_threshold = 2;
+    const int mlc_n_layer_max_threshold = 1;
+
+    const bool mlc_problem_shape_ok = rnn.mb <= mlc_mb_max_threshold
+            && rnn.n_iter >= mlc_n_iter_min_threshold
+            && rnn.n_layer <= mlc_n_layer_max_threshold;
+
+    const bool mlc_m_dim_adjustment_not_required
+            = IMPLICATION(rnn.skip_dst_iter_copy(),
+                    rnn.skip_src_layer_copy() && rnn.n_layer == 1);
+
+    const bool merged_layer_compute_applicable = rnn.src_layer_is_trivial_stride
+            && mlc_cell_type_ok && mlc_problem_shape_ok
+            && mlc_m_dim_adjustment_not_required;
+
+    if (merged_layer_compute_applicable) {
+        rnn.merge_gemm_layer = true;
+        const int n_iters_to_merge = rnn.n_iter;
+        rnn.Mlayermerged = rnn.mb * n_iters_to_merge;
+        rnn.mlayermerged_block = brgemm_calc_m_block(cell_kind,
+                prop_kind::forward, rnn.nthr, rnn.Mlayermerged, rnn.N_blocks,
+                rnn.is_cell_dt_f32(), work_by_N, As, Bs, Cs, l2_cache_size);
+        rnn.Mlayermerged_blocks = rnn.Mlayermerged / rnn.mlayermerged_block;
+    }
+
+    rnn.brgemm_fwd_iter_layer_fuse_possible
+            = rnn.slc == rnn.sic && !rnn.merge_gemm_layer;
+
+    if (!rnn.is_orig_gru) {
+        rnn.loop_order = brgemm_rnn_execute_loop_order_t::nblk_mblk;
+    }
+
+    return status::success;
+}
+
+status_t init_brgemm_kernel(aarch64::brgemm_desc_t *desc,
+        aarch64::cpu_isa_t isa, impl::data_type_t src_type,
+        impl::data_type_t weights_type,
+        std::unique_ptr<aarch64::brgemm_kernel_t> &ker, dim_t M, dim_t N,
+        dim_t K, dim_t LDA, dim_t LDB, dim_t LDC, float beta, dim_t max_bs,
+        dim_t hint_expected_A_size = LLONG_MAX,
+        dim_t hint_expected_B_size = LLONG_MAX,
+        dim_t hint_expected_C_size = LLONG_MAX) {
+
+    bool transA = false;
+    bool transB = false;
+    aarch64::brgemm_layout_t layout = aarch64::brgemm_row_major;
+
+    CHECK(brgemm_desc_init(desc, isa, aarch64::brgemm_addr, src_type,
+            weights_type, transA, transB, layout, 1.0f, beta, LDA, LDB, LDC, M,
+            N, K));
+
+    aarch64::brgemm_attr_t brgattr {};
+    brgattr.hint_expected_A_size = hint_expected_A_size;
+    brgattr.hint_expected_B_size = hint_expected_B_size;
+    brgattr.hint_expected_C_size = hint_expected_C_size;
+    brgattr.max_bs = static_cast<int>(max_bs);
+    brgattr.max_top_vpad = 0;
+    brgattr.max_bottom_vpad = 0;
+    brgattr.use_uker = false;
+    brgattr.var_bs = true;
+
+    CHECK(brgemm_desc_set_attr(desc, brgattr));
+    CHECK(brgemm_desc_finalize(desc));
+
+    aarch64::brgemm_kernel_t *_t_ptr = nullptr;
+    CHECK(brgemm_kernel_create(&_t_ptr, *desc));
+    CHECK(safe_ptr_assign<aarch64::brgemm_kernel_t>(ker, _t_ptr));
+
+    return status::success;
+}
+
+status_t rnn_brgemm_t<prop_kind::forward>::init_kernels(
+        const cpu::rnn_utils::rnn_conf_t &rnn, data_type_t src_type,
+        data_type_t weights_type) {
+
+    const auto init_brgemm
+            = [&](aarch64::brgemm_desc_t *desc, aarch64::cpu_isa_t isa,
+                      std::unique_ptr<aarch64::brgemm_kernel_t> &ker, dim_t M,
+                      dim_t N, dim_t K, dim_t LDA, dim_t LDB, dim_t LDC,
+                      float beta, dim_t max_bs) {
+        return init_brgemm_kernel(desc, isa, src_type, weights_type, ker, M, N,
+                K, LDA, LDB, LDC, beta, max_bs);
+    };
+
+    const int brgemm_n = nstl::min(rnn.N, rnn.n_block);
+    const int brgemm_n_tail = nstl::min(rnn.N, rnn.n_tail);
+    const int max_bs_factor = rnn.brgemm_fwd_iter_layer_fuse_possible ? 2 : 1;
+
+    for (int i = 0; i < num_base_kernels_; i++) {
+        if (rnn.merge_gemm_layer) {
+            CHECK(init_brgemm(&desc_layermerged_b0_[i], rnn.brgemm_isa,
+                    kernel_layermerged_b0_[i], rnn.mlayermerged_block, brgemm_n,
+                    rnn.k1_block, rnn.LDA1[i], rnn.LDB1, rnn.LDC, 0.0f,
+                    rnn.KB1_blocks));
+        } else {
+            CHECK(init_brgemm(&desc_layer_b0_[i], rnn.brgemm_isa,
+                    kernel_layer_b0_[i], rnn.m_block, brgemm_n, rnn.k1_block,
+                    rnn.LDA1[i], rnn.LDB1, rnn.LDC, 0.0f,
+                    max_bs_factor * rnn.KB1_blocks));
+        }
+
+        CHECK(init_brgemm(&desc_iter_b0_[i], rnn.brgemm_isa, kernel_iter_b0_[i],
+                rnn.m_block, brgemm_n, rnn.k2_block, rnn.LDA2[i], rnn.LDB2,
+                rnn.LDC, 0.0f, rnn.KB2_blocks));
+
+        CHECK(init_brgemm(&desc_iter_b1_[i], rnn.brgemm_isa, kernel_iter_b1_[i],
+                rnn.m_block, brgemm_n, rnn.k2_block, rnn.LDA2[i], rnn.LDB2,
+                rnn.LDC, 1.0f, rnn.KB2_blocks));
+
+        if (rnn.n_tail) {
+            if (rnn.merge_gemm_layer) {
+                CHECK(init_brgemm(&desc_layermerged_N_tail_b0_[i],
+                        rnn.brgemm_isa, kernel_layermerged_N_tail_b0_[i],
+                        rnn.mlayermerged_block, brgemm_n_tail, rnn.k1_block,
+                        rnn.LDA1[i], rnn.LDB1, rnn.LDC, 0.0f, rnn.KB1_blocks));
+            } else {
+                CHECK(init_brgemm(&desc_layer_N_tail_b0_[i], rnn.brgemm_isa,
+                        kernel_layer_N_tail_b0_[i], rnn.m_block, brgemm_n_tail,
+                        rnn.k1_block, rnn.LDA1[i], rnn.LDB1, rnn.LDC, 0.0f,
+                        max_bs_factor * rnn.KB1_blocks));
+            }
+
+            CHECK(init_brgemm(&desc_iter_N_tail_b0_[i], rnn.brgemm_isa,
+                    kernel_iter_N_tail_b0_[i], rnn.m_block, brgemm_n_tail,
+                    rnn.k2_block, rnn.LDA2[i], rnn.LDB2, rnn.LDC, 0.0f,
+                    rnn.KB2_blocks));
+
+            CHECK(init_brgemm(&desc_iter_N_tail_b1_[i], rnn.brgemm_isa,
+                    kernel_iter_N_tail_b1_[i], rnn.m_block, brgemm_n_tail,
+                    rnn.k2_block, rnn.LDA2[i], rnn.LDB2, rnn.LDC, 1.0f,
+                    rnn.KB2_blocks));
+        }
+
+        if (rnn.k1_tail) {
+            if (rnn.merge_gemm_layer) {
+                CHECK(init_brgemm(&desc_layermerged_K1_tail_b1_[i],
+                        rnn.brgemm_isa, kernel_layermerged_K1_tail_b1_[i],
+                        rnn.mlayermerged_block, brgemm_n, rnn.k1_tail,
+                        rnn.LDA1[i], rnn.LDB1, rnn.LDC, 1.0f, 1));
+            } else {
+                CHECK(init_brgemm(&desc_layer_K1_tail_b1_[i], rnn.brgemm_isa,
+                        kernel_layer_K1_tail_b1_[i], rnn.m_block, brgemm_n,
+                        rnn.k1_tail, rnn.LDA1[i], rnn.LDB1, rnn.LDC, 1.0f,
+                        max_bs_factor * 1));
+            }
+        }
+
+        if (rnn.k2_tail) {
+            CHECK(init_brgemm(&desc_iter_K2_tail_b1_[i], rnn.brgemm_isa,
+                    kernel_iter_K2_tail_b1_[i], rnn.m_block, brgemm_n,
+                    rnn.k2_tail, rnn.LDA2[i], rnn.LDB2, rnn.LDC, 1.0f, 1));
+        }
+
+        if (rnn.k1_tail && rnn.n_tail) {
+            if (rnn.merge_gemm_layer) {
+                CHECK(init_brgemm(&desc_layermerged_NK1_tail_b1_[i],
+                        rnn.brgemm_isa, kernel_layermerged_NK1_tail_b1_[i],
+                        rnn.mlayermerged_block, brgemm_n_tail, rnn.k1_tail,
+                        rnn.LDA1[i], rnn.LDB1, rnn.LDC, 1.0f, 1));
+            } else {
+                CHECK(init_brgemm(&desc_layer_NK1_tail_b1_[i], rnn.brgemm_isa,
+                        kernel_layer_NK1_tail_b1_[i], rnn.m_block,
+                        brgemm_n_tail, rnn.k1_tail, rnn.LDA1[i], rnn.LDB1,
+                        rnn.LDC, 1.0f, max_bs_factor * 1));
+            }
+        }
+
+        if (rnn.k2_tail && rnn.n_tail) {
+            CHECK(init_brgemm(&desc_iter_NK2_tail_b1_[i], rnn.brgemm_isa,
+                    kernel_iter_NK2_tail_b1_[i], rnn.m_block, brgemm_n_tail,
+                    rnn.k2_tail, rnn.LDA2[i], rnn.LDB2, rnn.LDC, 1.0f, 1));
+        }
+    }
+
+    if (rnn.is_orig_gru) {
+        for (int i = 0; i < num_vanilla_gru_iter_part2_kernels_; i++) {
+            CHECK(init_brgemm(&desc_iter_p2_b1_[i], rnn.brgemm_isa,
+                    kernel_iter_p2_b1_[i], rnn.m_block, brgemm_n, rnn.k2_block,
+                    rnn.LDA2_2[i], rnn.LDB2, rnn.LDC, 1.0f, rnn.KB2_blocks));
+            if (rnn.n_tail) {
+                CHECK(init_brgemm(&desc_iter_p2_N_tail_b1_[i], rnn.brgemm_isa,
+                        kernel_iter_p2_N_tail_b1_[i], rnn.m_block,
+                        brgemm_n_tail, rnn.k2_block, rnn.LDA2_2[i], rnn.LDB2,
+                        rnn.LDC, 1.0f, rnn.KB2_blocks));
+            }
+            if (rnn.k2_tail) {
+                CHECK(init_brgemm(&desc_iter_p2_K2_tail_b1_[i], rnn.brgemm_isa,
+                        kernel_iter_p2_K2_tail_b1_[i], rnn.m_block, brgemm_n,
+                        rnn.k2_tail, rnn.LDA2_2[i], rnn.LDB2, rnn.LDC, 1.0f,
+                        1));
+            }
+            if (rnn.k2_tail && rnn.n_tail) {
+                CHECK(init_brgemm(&desc_iter_p2_NK2_tail_b1_[i], rnn.brgemm_isa,
+                        kernel_iter_p2_NK2_tail_b1_[i], rnn.m_block,
+                        brgemm_n_tail, rnn.k2_tail, rnn.LDA2_2[i], rnn.LDB2,
+                        rnn.LDC, 1.0f, 1));
+            }
+        }
+    }
+
+    if (rnn.is_lstm_projection) {
+        const dim_t brgemm_np = nstl::min(rnn.Nproj, rnn.n_block);
+        const dim_t brgemm_np_tail = nstl::min(rnn.Nproj, rnn.nproj_tail);
+        const int n_kernel = (rnn.dt_conf == cpu::rnn_utils::all_f32)
+                ? num_proj_kernels_
+                : 1;
+
+        for (int i = 0; i < n_kernel; i++) {
+            CHECK(init_brgemm(&desc_proj_b0_[i], rnn.brgemm_isa,
+                    kernel_proj_b0_[i], rnn.m_block, brgemm_np, rnn.kproj_block,
+                    rnn.LDAproj, rnn.LDBproj, rnn.LDCproj[i], 0.0f,
+                    rnn.KBproj_blocks));
+
+            if (rnn.nproj_tail) {
+                CHECK(init_brgemm(&desc_proj_N_tail_b0_[i], rnn.brgemm_isa,
+                        kernel_proj_N_tail_b0_[i], rnn.m_block, brgemm_np_tail,
+                        rnn.kproj_block, rnn.LDAproj, rnn.LDBproj,
+                        rnn.LDCproj[i], 0.0f, rnn.KBproj_blocks));
+
+                CHECK(init_brgemm(&desc_proj_N_tail_b1_[i], rnn.brgemm_isa,
+                        kernel_proj_N_tail_b1_[i], rnn.m_block, brgemm_np_tail,
+                        rnn.kproj_block, rnn.LDAproj, rnn.LDBproj,
+                        rnn.LDCproj[i], 1.0f, rnn.KBproj_blocks));
+            }
+        }
+    }
+
+    return status::success;
+}
+
+void rnn_brgemm_t<prop_kind::backward>::init_scratchpad(
+        const cpu::rnn_utils::rnn_conf_t &rnn,
+        memory_tracking::registrar_t &scratchpad, dim_t gemm_acc_type_size,
+        dim_t gemm_acc_align) {
+
+    rnn_brgemm_base_t::init_scratchpad(
+            rnn, scratchpad, gemm_acc_type_size, gemm_acc_align);
+
+    using namespace memory_tracking::names;
+
+    const auto data_size
+            = rnn.is_xf16_conf() ? sizeof(bfloat16_t) : sizeof(float);
+    const auto &d_wei = rnn.diff_wei_brgemm;
+
+    const auto scratch_gates_blocked_per_thr = d_wei.Kpadded * d_wei.n_block;
+    const auto scratch_gates_blocked_size
+            = rnn.nthr * scratch_gates_blocked_per_thr;
+    scratchpad.book(key_rnn_gates_blocked, scratch_gates_blocked_size,
+            data_size, gemm_acc_align);
+
+    const auto scratch_src_layer_size = d_wei.global_transpose
+            ? d_wei.M_layer * d_wei.Kpadded
+            : rnn.nthr * nstl::min(d_wei.m_block, d_wei.M_layer)
+                    * d_wei.Kpadded;
+    scratchpad.book(key_rnn_src_layer_trans, scratch_src_layer_size, data_size,
+            gemm_acc_align);
+
+    const auto scratch_src_iter_size = d_wei.global_transpose
+            ? d_wei.M_iter * d_wei.Kpadded
+            : rnn.nthr * nstl::min(d_wei.m_block, d_wei.M_iter) * d_wei.Kpadded;
+    scratchpad.book(key_rnn_src_iter_trans, scratch_src_iter_size, data_size,
+            gemm_acc_align);
+}
+
+status_t rnn_brgemm_t<prop_kind::backward>::configure_brgemm(
+        cpu::rnn_utils::rnn_conf_t &rnn, alg_kind_t cell_kind,
+        dim_t src_layer_type_size, dim_t scratch_type_size) {
+
+    using namespace cpu::rnn_utils;
+
+    if (rnn.is_cell_dt_xf16()) return status::unimplemented;
+
+    // no int8 brgemm RNN support for now
+    if (rnn.is_int8_conf() || rnn.is_cell_dt_int8())
+        return status::unimplemented;
+
+    // FOr now only support vanilla RNN/LSTM/GRU/AUGRU
+    if (!utils::one_of(cell_kind, alg_kind::vanilla_rnn, alg_kind::vanilla_lstm,
+                alg_kind::vanilla_gru, alg_kind::vanilla_augru))
+        return status::unimplemented;
+
+    auto &diff_src_conf = rnn.diff_src_brgemm;
+    diff_src_conf.M = rnn.mb;
+    diff_src_conf.N_iter = rnn.sic;
+    diff_src_conf.N_layer = rnn.slc;
+    diff_src_conf.N = nstl::max(diff_src_conf.N_iter, diff_src_conf.N_layer);
+    diff_src_conf.K = rnn.dhc;
+
+    rnn.nthr = dnnl_get_max_threads();
+
+    diff_src_conf.n_block = 32;
+    diff_src_conf.N_blocks
+            = utils::div_up(diff_src_conf.N, diff_src_conf.n_block);
+    diff_src_conf.n_tail = diff_src_conf.N % diff_src_conf.n_block;
+
+    diff_src_conf.N_layer_blocks
+            = utils::div_up(diff_src_conf.N_layer, diff_src_conf.n_block);
+    diff_src_conf.n_layer_tail = diff_src_conf.N_layer % diff_src_conf.n_block;
+
+    diff_src_conf.N_iter_blocks
+            = utils::div_up(diff_src_conf.N_iter, diff_src_conf.n_block);
+    diff_src_conf.n_iter_tail = diff_src_conf.N_iter % diff_src_conf.n_block;
+
+    const float work_by_N = static_cast<float>(diff_src_conf.N_blocks)
+            / static_cast<float>(rnn.nthr);
+
+    const dim_t l2_cache_size = platform::get_per_core_cache_size(2);
+
+    const dim_t As = src_layer_type_size * diff_src_conf.M * diff_src_conf.K;
+    const dim_t Bs
+            = src_layer_type_size * diff_src_conf.K * diff_src_conf.n_block;
+    const dim_t Cs = scratch_type_size * (rnn.n_gates + 1)
+            * (diff_src_conf.M * diff_src_conf.n_block);
+
+    const auto is_xf16 = rnn.is_cell_dt_xf16();
+    const dim_t padding = is_xf16 ? 2 : 1;
+
+    diff_src_conf.Kpadded = utils::rnd_up(diff_src_conf.K, padding);
+    diff_src_conf.isa = brgemm_calc_isa(rnn, diff_src_conf.K, diff_src_conf.K);
+    if (diff_src_conf.isa == isa_undef) return status::unimplemented;
+
+    diff_src_conf.gates_block = rnn.n_gates;
+
+    std::tie(diff_src_conf.k_block, std::ignore) = brgemm_calc_k_block(rnn,
+            diff_src_conf.K, diff_src_conf.K, diff_src_conf.M,
+            diff_src_conf.n_block, cell_kind, src_layer_type_size, As, Bs, Cs,
+            l2_cache_size, diff_src_conf.isa);
+
+    const dim_t K_blocks_per_gate = diff_src_conf.K / diff_src_conf.k_block;
+    diff_src_conf.K_blocks
+            = K_blocks_per_gate * rnn.n_gates; // total across gates
+    diff_src_conf.k_tail = diff_src_conf.K % diff_src_conf.k_block;
+
+    diff_src_conf.m_block = brgemm_calc_m_block(cell_kind, prop_kind::backward,
+            rnn.nthr, diff_src_conf.M, diff_src_conf.N_blocks,
+            rnn.is_cell_dt_f32(), work_by_N, As, Bs, Cs, l2_cache_size);
+    diff_src_conf.M_blocks = diff_src_conf.M / diff_src_conf.m_block;
+
+    diff_src_conf.LDA = rnn.scratch_gates_ld;
+    diff_src_conf.LDB = diff_src_conf.n_block;
+    diff_src_conf.LDC = rnn.ws_diff_states_iter_ld;
+
+    if (diff_src_conf.LDA < diff_src_conf.k_block) return status::unimplemented;
+    const dim_t n_block = nstl::min(diff_src_conf.N, diff_src_conf.n_block);
+    if (diff_src_conf.LDB < n_block) return status::unimplemented;
+    if (diff_src_conf.LDC < n_block) return status::unimplemented;
+
+    rnn.KBproj_blocks = 0;
+    rnn.kproj_tail = 0;
+    rnn.kproj_block = 0;
+
+    auto &diff_wei_conf = rnn.diff_wei_brgemm;
+    diff_wei_conf.global_transpose = rnn.mb > 1;
+    diff_wei_conf.M_iter = rnn.sic;
+    diff_wei_conf.M_layer = rnn.slc;
+    diff_wei_conf.M = nstl::max(rnn.sic, rnn.slc);
+    diff_wei_conf.N = rnn.dhc * rnn.n_gates;
+    diff_wei_conf.K = (scratch_type_size != (dim_t)sizeof(float))
+            ? utils::rnd_up(rnn.mb, 2)
+            : rnn.mb;
+    diff_wei_conf.Kpadded = utils::rnd_up(diff_wei_conf.K, padding);
+    diff_wei_conf.isa = brgemm_calc_isa(rnn, diff_wei_conf.K, diff_wei_conf.K);
+    if (diff_wei_conf.isa == isa_undef) return status::unimplemented;
+
+    diff_wei_conf.n_block = 32;
+    diff_wei_conf.N_blocks
+            = utils::div_up(diff_wei_conf.N, diff_wei_conf.n_block);
+    diff_wei_conf.n_tail = diff_wei_conf.N % diff_wei_conf.n_block;
+
+    const dim_t As_wei
+            = src_layer_type_size * diff_wei_conf.M * diff_wei_conf.K;
+    const dim_t Bs_wei
+            = src_layer_type_size * diff_wei_conf.K * diff_wei_conf.n_block;
+    const dim_t Cs_wei = scratch_type_size * (rnn.n_gates + 1)
+            * (diff_wei_conf.M * diff_wei_conf.n_block);
+
+    std::tie(diff_wei_conf.k_block, std::ignore) = brgemm_calc_k_block(rnn,
+            diff_wei_conf.K, diff_wei_conf.K, diff_wei_conf.M,
+            diff_wei_conf.n_block, cell_kind, src_layer_type_size, As_wei,
+            Bs_wei, Cs_wei, l2_cache_size, diff_wei_conf.isa);
+
+    diff_wei_conf.K_blocks = diff_wei_conf.K / diff_wei_conf.k_block;
+    diff_wei_conf.k_tail = diff_wei_conf.K % diff_wei_conf.k_block;
+
+    if (diff_wei_conf.M_iter != diff_wei_conf.M_layer) {
+        diff_wei_conf.m_block = diff_wei_conf.M;
+        diff_wei_conf.M_blocks = 1;
+    } else {
+        const float work_by_N_wei = static_cast<float>(diff_wei_conf.N_blocks)
+                / static_cast<float>(rnn.nthr);
+        diff_wei_conf.m_block = brgemm_calc_m_block(cell_kind,
+                prop_kind::backward, rnn.nthr, diff_wei_conf.M,
+                diff_wei_conf.N_blocks, rnn.is_cell_dt_f32(), work_by_N_wei,
+                As_wei, Bs_wei, Cs_wei, l2_cache_size);
+        diff_wei_conf.M_blocks = diff_wei_conf.M / diff_wei_conf.m_block;
+    }
+
+    diff_wei_conf.LDA_layer = diff_wei_conf.K;
+    diff_wei_conf.LDA_iter = diff_wei_conf.K;
+    diff_wei_conf.LDB = diff_wei_conf.n_block;
+    diff_wei_conf.LDC_iter = rnn.diff_weights_iter_ld;
+    diff_wei_conf.LDC_layer = rnn.diff_weights_layer_ld;
+
+    if (diff_wei_conf.LDA_layer < diff_wei_conf.k_block
+            || diff_wei_conf.LDA_iter < diff_wei_conf.k_block)
+        return status::unimplemented;
+
+    if (rnn.is_lstm_peephole) { configure_brgemm_peephole(rnn); }
+
+    rnn.M = nstl::max(diff_wei_conf.M, diff_src_conf.M);
+    rnn.N = nstl::max(diff_wei_conf.N, diff_src_conf.N);
+    rnn.K1 = nstl::max(diff_wei_conf.K, diff_src_conf.K);
+    rnn.K2 = rnn.K1;
+    rnn.m_block = nstl::max(diff_wei_conf.m_block, diff_src_conf.m_block);
+    rnn.M_blocks = nstl::max(diff_wei_conf.M_blocks, diff_src_conf.M_blocks);
+    rnn.n_block = nstl::max(diff_wei_conf.n_block, diff_src_conf.n_block);
+    rnn.N_blocks = nstl::max(diff_wei_conf.N_blocks, diff_src_conf.N_blocks);
+    rnn.n_tail = nstl::max(diff_wei_conf.n_tail, diff_src_conf.n_tail);
+    rnn.k1_block = nstl::max(diff_wei_conf.k_block, diff_src_conf.k_block);
+    rnn.k2_block = rnn.k1_block;
+    rnn.k1_tail = nstl::max(diff_wei_conf.k_tail, diff_src_conf.k_tail);
+    rnn.k2_tail = rnn.k1_tail;
+    rnn.KB1_blocks = nstl::max(diff_wei_conf.K_blocks, diff_src_conf.K_blocks);
+    rnn.KB2_blocks = rnn.KB1_blocks;
+    rnn.K1padded = nstl::max(diff_wei_conf.Kpadded, diff_src_conf.Kpadded);
+    rnn.K2padded = rnn.K1padded;
+    rnn.unfused_post_gemm = true;
+
+    rnn.brgemm_isa = is_superset(diff_wei_conf.isa, diff_src_conf.isa)
+            ? diff_wei_conf.isa
+            : diff_src_conf.isa;
+
+    if (!rnn.is_orig_gru) {
+        rnn.diff_src_brgemm.loop_order
+                = brgemm_rnn_execute_loop_order_t::nblk_mblk;
+        rnn.diff_wei_brgemm.loop_order
+                = brgemm_rnn_execute_loop_order_t::nblk_mblk;
+    }
+
+    return status::success;
+}
+
+static dim_t divide_block_to_improve_thread_balance(
+        const dim_t initial_work_amount, const dim_t division_block,
+        const dim_t nthr) {
+
+    const float nthr_f = static_cast<float>(nthr);
+    const float initial_work = static_cast<float>(initial_work_amount) / nthr_f;
+    const float decimal_initial_factor
+            = initial_work - std::floor(initial_work);
+
+    static constexpr float thread_balance_threashold = 0.8f;
+    static constexpr float tolerance = 0.01f;
+
+    float max_decimal_factor = -1.0f;
+    dim_t best_candidate = -1;
+    bool found_best_solution = false;
+
+    if (decimal_initial_factor < thread_balance_threashold
+            && decimal_initial_factor != 0.0f) {
+        for (const int block_size : {4096, 2048, 1024, 512, 256, 128, 64, 32}) {
+            if (division_block <= block_size) continue;
+            const auto blocks = utils::div_up(division_block, block_size);
+            const float work
+                    = static_cast<float>(initial_work_amount * blocks) / nthr_f;
+            const float work_decimal = work - std::floor(work);
+
+            if (work_decimal == 0.0f
+                    || (max_decimal_factor != 0.0f ? work_decimal
+                                            > (max_decimal_factor + tolerance)
+                                                   : work_decimal
+                                            >= thread_balance_threashold)) {
+                best_candidate = block_size;
+                max_decimal_factor = work_decimal;
+            }
+
+            if (work >= nthr_f
+                    && (work_decimal >= thread_balance_threashold
+                            || work_decimal == 0.0f)) {
+                found_best_solution = true;
+                break;
+            }
+        }
+    }
+
+    if (found_best_solution
+            || (!found_best_solution
+                    && max_decimal_factor
+                            > decimal_initial_factor + tolerance)) {
+        return best_candidate;
+    }
+
+    return division_block;
+}
+
+void rnn_brgemm_t<prop_kind::backward>::configure_brgemm_peephole(
+        cpu::rnn_utils::rnn_conf_t &rnn) {
+    static constexpr dim_t n_gates = 3;
+    rnn.dhc_block_peephole = divide_block_to_improve_thread_balance(
+            n_gates, rnn.dhc, rnn.nthr);
+    rnn.dhc_blocks_peephole = utils::div_up(rnn.dhc, rnn.dhc_block_peephole);
+    rnn.dhc_tail_peephole = rnn.dhc % rnn.dhc_block_peephole;
+}
+
+status_t rnn_brgemm_t<prop_kind::backward>::init_kernels(
+        const cpu::rnn_utils::rnn_conf_t &rnn, data_type_t src_type,
+        data_type_t weights_type) {
+    MAYBE_UNUSED(rnn);
+    MAYBE_UNUSED(src_type);
+    MAYBE_UNUSED(weights_type);
+
+    return status::unimplemented;
+}
+
+status_t rnn_brgemm_t<prop_kind::backward>::init_peephole_kernels(
+        const cpu::rnn_utils::rnn_conf_t &rnn) {
+
+    MAYBE_UNUSED(rnn);
+
+    return status::unimplemented;
+}
+
+} // namespace rnn_brgemm_utils
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/aarch64/rnn/rnn_brgemm_utils.cpp
@@ -96,7 +96,15 @@ std::pair<dim_t, dim_t> brgemm_calc_k_block_vanilla_rnn(dim_t K1, dim_t K2,
         dim_t Cs, dim_t l2_cache_size, bool is_xf16, aarch64::cpu_isa_t isa) {
 
     const bool is_sve = is_superset(isa, aarch64::sve_128);
-    const float l2_occupancy = is_sve ? 0.35f : 0.70f;
+    // Fraction of L2 that the A+B+C working set may occupy before we start
+    // K-blocking. This multiplies the runtime-queried L2 size, so it is a plain
+    // fraction and does not depend on vector length or ISA -- a single constant.
+    //
+    // The SVE value (0.50) was tuned on Graviton3 (Neoverse V1, sve_256, 1 MiB L2)
+    // with a benchdnn VANILLA_RNN sweep over 15 shapes. It cut worst-case
+    // per-shape regret from ~13% to ~4% (warm and cold).
+    // Similarly the NEON value is inherited from Graviton2 machine.
+    const float l2_occupancy = is_sve ? 0.50f : 0.70f;
 
     const bool should_adjust_by_l2 = static_cast<float>(As + Bs + Cs)
             >= l2_occupancy * static_cast<float>(l2_cache_size);
@@ -207,8 +215,17 @@ dim_t brgemm_calc_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks, bool is_f32,
 
 dim_t adjust_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks) {
 
+    // Target up to 4x the minimum number of M-blocks needed to cover all threads,
+    // giving the scheduler slack to balance load.
     const dim_t max_m_blocks = 4 * utils::div_up(nthr, N_blocks);
-    const dim_t max_m_value = 32;
+
+    // Upper bound on rows per M-block. This is thread-coupled, not vector-length
+    // coupled: it only takes effect through max_m_blocks (above), which scales with
+    // nthr. A benchdnn VANILLA_LSTM sweep on Graviton3 confirmed this -- the best
+    // value shifts with core count (the cap is near-inert at 64 threads but the
+    // inherited 32 degrades badly at 32). 40 is the most robust single value across
+    // the core counts tested.
+    const dim_t max_m_value = 40;
     const dim_t max_M
             = nstl::min(max_m_value, nstl::max((dim_t)1, M / max_m_blocks));
     const dim_t min_M = 4;
@@ -227,14 +244,14 @@ dim_t adjust_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks) {
 dim_t brgemm_calc_n_block(
         const cpu::rnn_utils::rnn_conf_t &rnn, alg_kind_t cell_kind) {
 
-    const int simd_w = isa_max_vlen(rnn.brgemm_isa) / (int)sizeof(float);
+    const int simd_elems = isa_max_vlen(rnn.brgemm_isa) / (int)sizeof(float);
 
     if (rnn.brgemm_isa == asimd && rnn.M == 1
             && utils::one_of(
                     cell_kind, alg_kind::vanilla_lstm, alg_kind::lbr_gru))
-        return 4 * simd_w;
+        return 4 * simd_elems;
     else
-        return 2 * simd_w;
+        return 2 * simd_elems;
 }
 
 } // namespace
@@ -266,7 +283,7 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
     if (rnn.is_int8_conf() || rnn.is_cell_dt_int8())
         return status::unimplemented;
 
-    // FOr now only support vanilla RNN/LSTM/GRU/AUGRU
+    // For now only support vanilla RNN/LSTM/GRU/AUGRU
     if (!utils::one_of(cell_kind, alg_kind::vanilla_rnn, alg_kind::vanilla_lstm,
                 alg_kind::vanilla_gru, alg_kind::vanilla_augru))
         return status::unimplemented;

--- a/src/cpu/aarch64/rnn/rnn_brgemm_utils.hpp
+++ b/src/cpu/aarch64/rnn/rnn_brgemm_utils.hpp
@@ -1,0 +1,207 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_RNN_RNN_BRGEMM_UTILS_HPP
+#define CPU_AARCH64_RNN_RNN_BRGEMM_UTILS_HPP
+
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+#include "cpu/aarch64/brgemm/brgemm.hpp"
+#include "cpu/aarch64/jit_brgemm_transpose_utils.hpp"
+#include "cpu/aarch64/matmul/brgemm_matmul_copy_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+
+namespace rnn_utils {
+struct rnn_conf_t;
+} // namespace rnn_utils
+
+namespace aarch64 {
+
+struct jit_brgemm_trans_src_t;
+
+namespace matmul {
+struct jit_brgemm_matmul_copy_b_t;
+} // namespace matmul
+
+namespace rnn_brgemm_utils {
+
+using brgemm_ker_ptr_t = std::unique_ptr<brgemm_kernel_t>;
+
+using scratch_gates_reorder_ker_ptr_t
+        = std::unique_ptr<matmul::jit_brgemm_matmul_copy_b_t>;
+
+struct rnn_brgemm_base_t {
+
+    static void init_scratchpad(const cpu::rnn_utils::rnn_conf_t &rnn,
+            memory_tracking::registrar_t &scratchpad, dim_t gemm_acc_type_size,
+            dim_t gemm_acc_align);
+
+    static constexpr dim_t num_base_kernels_ = 3;
+    static constexpr dim_t num_proj_kernels_ = 4;
+    static constexpr dim_t num_vanilla_gru_iter_part2_kernels_ = 4;
+};
+
+template <prop_kind_t aprop>
+struct rnn_brgemm_t;
+
+template <>
+struct rnn_brgemm_t<prop_kind::forward> : public rnn_brgemm_base_t {
+
+    using rnn_brgemm_base_t::init_scratchpad;
+
+    static status_t configure_brgemm(cpu::rnn_utils::rnn_conf_t &rnn,
+            alg_kind_t cell_kind, dim_t src_layer_type_size,
+            dim_t scratch_type_size);
+
+    status_t init_kernels(const cpu::rnn_utils::rnn_conf_t &rnn,
+            data_type_t src_type, data_type_t weights_type);
+
+    brgemm_desc_t desc_layer_b0_[num_base_kernels_];
+    brgemm_desc_t desc_iter_b0_[num_base_kernels_];
+    brgemm_desc_t desc_iter_b1_[num_base_kernels_];
+
+    brgemm_desc_t desc_layer_N_tail_b0_[num_base_kernels_];
+    brgemm_desc_t desc_iter_N_tail_b0_[num_base_kernels_];
+    brgemm_desc_t desc_iter_N_tail_b1_[num_base_kernels_];
+
+    brgemm_desc_t desc_layer_K1_tail_b1_[num_base_kernels_];
+    brgemm_desc_t desc_layer_NK1_tail_b1_[num_base_kernels_];
+    brgemm_desc_t desc_iter_K2_tail_b1_[num_base_kernels_];
+    brgemm_desc_t desc_iter_NK2_tail_b1_[num_base_kernels_];
+
+    brgemm_desc_t desc_layermerged_b0_[num_base_kernels_];
+    brgemm_desc_t desc_layermerged_N_tail_b0_[num_base_kernels_];
+    brgemm_desc_t desc_layermerged_K1_tail_b1_[num_base_kernels_];
+    brgemm_desc_t desc_layermerged_NK1_tail_b1_[num_base_kernels_];
+
+    brgemm_desc_t desc_proj_b0_[num_proj_kernels_];
+    brgemm_desc_t desc_proj_N_tail_b0_[num_proj_kernels_];
+    brgemm_desc_t desc_proj_N_tail_b1_[num_proj_kernels_];
+
+    brgemm_desc_t desc_iter_p2_b1_[num_vanilla_gru_iter_part2_kernels_];
+    brgemm_desc_t desc_iter_p2_N_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
+    brgemm_desc_t desc_iter_p2_K2_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
+    brgemm_desc_t
+            desc_iter_p2_NK2_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
+
+    brgemm_ker_ptr_t kernel_layer_b0_[num_base_kernels_];
+
+    brgemm_ker_ptr_t kernel_iter_b0_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_iter_b1_[num_base_kernels_];
+
+    brgemm_ker_ptr_t kernel_layer_N_tail_b0_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_iter_N_tail_b0_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_iter_N_tail_b1_[num_base_kernels_];
+
+    brgemm_ker_ptr_t kernel_layer_K1_tail_b1_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_layer_NK1_tail_b1_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_iter_K2_tail_b1_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_iter_NK2_tail_b1_[num_base_kernels_];
+
+    brgemm_ker_ptr_t kernel_layermerged_b0_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_layermerged_N_tail_b0_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_layermerged_K1_tail_b1_[num_base_kernels_];
+    brgemm_ker_ptr_t kernel_layermerged_NK1_tail_b1_[num_base_kernels_];
+
+    brgemm_ker_ptr_t kernel_proj_b0_[num_proj_kernels_];
+    brgemm_ker_ptr_t kernel_proj_N_tail_b0_[num_proj_kernels_];
+    brgemm_ker_ptr_t kernel_proj_N_tail_b1_[num_proj_kernels_];
+
+    brgemm_ker_ptr_t kernel_iter_p2_b1_[num_vanilla_gru_iter_part2_kernels_];
+    brgemm_ker_ptr_t
+            kernel_iter_p2_N_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
+    brgemm_ker_ptr_t
+            kernel_iter_p2_K2_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
+    brgemm_ker_ptr_t
+            kernel_iter_p2_NK2_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
+};
+
+struct rnn_diff_src_brgemm_t {
+    brgemm_desc_t desc_iter_layer_beta0_;
+    brgemm_desc_t desc_layer_N_tail_beta0_;
+    brgemm_desc_t desc_iter_N_tail_beta0_;
+    brgemm_desc_t desc_iter_layer_K_tail_beta1_;
+    brgemm_desc_t desc_layer_NK_tail_beta1_;
+    brgemm_desc_t desc_iter_NK_tail_beta1_;
+
+    brgemm_ker_ptr_t kernel_iter_layer_beta0_ = nullptr;
+    brgemm_ker_ptr_t kernel_layer_N_tail_beta0_ = nullptr;
+    brgemm_ker_ptr_t kernel_iter_N_tail_beta0_ = nullptr;
+    brgemm_ker_ptr_t kernel_iter_layer_K_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_layer_NK_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_iter_NK_tail_beta1_ = nullptr;
+};
+
+struct rnn_diff_wei_brgemm_t {
+    brgemm_desc_t desc_iter_beta1_;
+    brgemm_desc_t desc_layer_beta1_;
+
+    brgemm_desc_t desc_iter_N_tail_beta1_;
+    brgemm_desc_t desc_layer_N_tail_beta1_;
+
+    brgemm_desc_t desc_iter_NK_tail_beta1_;
+    brgemm_desc_t desc_layer_NK_tail_beta1_;
+
+    brgemm_desc_t desc_iter_K_tail_beta1_;
+    brgemm_desc_t desc_layer_K_tail_beta1_;
+
+    brgemm_ker_ptr_t kernel_iter_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_layer_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_iter_N_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_layer_N_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_iter_NK_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_layer_NK_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_iter_K_tail_beta1_ = nullptr;
+    brgemm_ker_ptr_t kernel_layer_K_tail_beta1_ = nullptr;
+
+    scratch_gates_reorder_ker_ptr_t scratch_gates_reorder_kernel_;
+};
+
+template <>
+struct rnn_brgemm_t<prop_kind::backward> : public rnn_brgemm_base_t {
+public:
+    static void init_scratchpad(const cpu::rnn_utils::rnn_conf_t &rnn,
+            memory_tracking::registrar_t &scratchpad, dim_t gemm_acc_type_size,
+            dim_t gemm_acc_align);
+
+    static status_t configure_brgemm(cpu::rnn_utils::rnn_conf_t &rnn,
+            alg_kind_t cell_kind, dim_t src_layer_type_size,
+            dim_t scratch_type_size);
+
+    status_t init_kernels(const cpu::rnn_utils::rnn_conf_t &rnn,
+            data_type_t src_type, data_type_t weights_type);
+
+    rnn_diff_src_brgemm_t diff_src_;
+    rnn_diff_wei_brgemm_t diff_wei_;
+
+private:
+    static void configure_brgemm_peephole(cpu::rnn_utils::rnn_conf_t &rnn);
+    status_t init_peephole_kernels(const cpu::rnn_utils::rnn_conf_t &rnn);
+};
+
+} // namespace rnn_brgemm_utils
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_RNN_RNN_BRGEMM_UTILS_HPP

--- a/src/cpu/aarch64/rnn/rnn_brgemm_utils.hpp
+++ b/src/cpu/aarch64/rnn/rnn_brgemm_utils.hpp
@@ -97,6 +97,7 @@ struct rnn_brgemm_t<prop_kind::forward> : public rnn_brgemm_base_t {
     brgemm_desc_t desc_proj_N_tail_b0_[num_proj_kernels_];
     brgemm_desc_t desc_proj_N_tail_b1_[num_proj_kernels_];
 
+    // Set of brgemm descriptor for 2nd part of iteration gemm in vanulla GRU cell
     brgemm_desc_t desc_iter_p2_b1_[num_vanilla_gru_iter_part2_kernels_];
     brgemm_desc_t desc_iter_p2_N_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
     brgemm_desc_t desc_iter_p2_K2_tail_b1_[num_vanilla_gru_iter_part2_kernels_];
@@ -126,6 +127,7 @@ struct rnn_brgemm_t<prop_kind::forward> : public rnn_brgemm_base_t {
     brgemm_ker_ptr_t kernel_proj_N_tail_b0_[num_proj_kernels_];
     brgemm_ker_ptr_t kernel_proj_N_tail_b1_[num_proj_kernels_];
 
+    // Set of brgemm kernels for 2nd part of iteration gemm in vanilla GRU cell
     brgemm_ker_ptr_t kernel_iter_p2_b1_[num_vanilla_gru_iter_part2_kernels_];
     brgemm_ker_ptr_t
             kernel_iter_p2_N_tail_b1_[num_vanilla_gru_iter_part2_kernels_];

--- a/src/cpu/rnn/brgemm_cell_common.cpp
+++ b/src/cpu/rnn/brgemm_cell_common.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -28,6 +29,12 @@
 #include "cpu/x64/rnn/brgemm_cell_common_fwd.hpp"
 #include "cpu/x64/rnn/brgemm_cell_common_reorders.hpp"
 #include "cpu/x64/rnn/brgemm_cell_common_utils.hpp"
+#elif DNNL_AARCH64
+#include <cassert>
+#include <functional>
+#include "cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp"
+#include "cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp"
+#include "cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp"
 #endif
 
 namespace dnnl {
@@ -38,6 +45,8 @@ using namespace rnn_utils;
 using namespace dnnl::impl::utils;
 #if DNNL_X64
 using namespace dnnl::impl::cpu::x64;
+#elif DNNL_AARCH64
+using namespace dnnl::impl::cpu::aarch64;
 #endif
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
@@ -50,6 +59,13 @@ rnn_merged_layer_execution_sig((
             cell_position, src_layer_, w_layer_[0], scratch_gates_,
             amx_scratchpad, addr_batch_global);
 
+    layer_calc.execute();
+#elif DNNL_AARCH64
+    using brgemm_merged_layer_t = aarch64::brgemm_merged_layer_t<src_iter_t,
+            weights_t, scratch_t, gemm_acc_t>;
+    const brgemm_merged_layer_t layer_calc(this->rnn_brgemm_, rnn,
+            cell_position, src_layer_, w_layer_[0], scratch_gates_,
+            addr_batch_global);
     layer_calc.execute();
 #endif
     return dnnl_success;
@@ -260,6 +276,188 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         }
     }
 
+#elif DNNL_AARCH64
+    const auto weights_scales = this->pd_->attr()->rnn_weights_qparams_.scales_;
+    const int mask = this->pd()->attr()->rnn_weights_qparams_.mask_;
+    const auto dst_postgemm = rnn.is_lstm_projection ? proj_ht_ : dst_layer_;
+    const auto dst_iter_postgemm = rnn.is_lstm_projection ? nullptr : dst_iter_;
+
+    const auto LDDl = rnn.dst_layer_ld(cell_position);
+    const auto LDDi = rnn.dst_iter_ld(cell_position);
+    const auto LDDic = rnn.dst_iter_c_ld(cell_position);
+    const auto LDAic = rnn.src_iter_c_ld(cell_position);
+
+    using brgemm_dst_layer_iter_t = aarch64::brgemm_dst_layer_iter_t<src_iter_t,
+            weights_t, scratch_t, gemm_acc_t>;
+
+    typename brgemm_dst_layer_iter_t::postgemm_fused_t fused_postgemm;
+    if (!rnn.unfused_post_gemm) {
+        fused_postgemm
+                = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
+                          scratch_t *C_n, scratch_t *C_cell_n, int block_step) {
+            const auto Dpg_n = (dst_postgemm != nullptr)
+                    ? dst_postgemm + m * LDDl + n
+                    : nullptr;
+            const auto Di_n = (dst_iter_postgemm != nullptr)
+                    ? dst_iter_postgemm + m * LDDi + n
+                    : nullptr;
+            const auto Dic_n = (dst_iter_c_ != nullptr)
+                    ? inc_ptr(dst_iter_c_, rnn.dst_iter_c_dt, m * LDDic + n)
+                    : nullptr;
+
+            const auto curr_ws_gates_
+                    = ws_gates_ + (m * rnn.ws_gates_ld) + nb_i * rnn.n_block;
+            const float *weights_peephole_n = weights_peephole_
+                    ? weights_peephole_ + n
+                    : weights_peephole_;
+            auto weights_scales_n = weights_scales + (mask ? n : 0);
+            const auto Aic_n
+                    = inc_ptr(src_iter_c_, rnn.src_iter_c_dt, m * LDAic + n);
+            const auto bias_n = inc_ptr(bias_[0], rnn.bias_dt, n);
+            this->rnn_postgemm_->execute(rnn, cell_position, curr_ws_gates_,
+                    C_n, augru_attention_, Dpg_n, Dic_n, Ai_m, Aic_n,
+                    diff_src_layer_, diff_augru_attention_, diff_src_iter_,
+                    diff_src_iter_c_, diff_dst_layer_, diff_dst_iter_,
+                    diff_dst_iter_c_, weights_peephole_n, bias_n, ws_grid_,
+                    C_cell_n, Di_n, weights_scales_n, block_step);
+        };
+    }
+
+    if (rnn.is_orig_gru) {
+        using brgemm_gru_t = aarch64::brgemm_gru_t<src_iter_t, weights_t,
+                scratch_t, gemm_acc_t>;
+        typename brgemm_gru_t::postgemm_fused_t fused_postgemm_gru_part1,
+                fused_postgemm_gru_part2;
+
+        if (!rnn.unfused_post_gemm) {
+            fused_postgemm_gru_part1
+                    = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
+                              scratch_t *C_gates_n, scratch_t *C_cell_n,
+                              int block_step) {
+                const auto Dpg_n = (dst_postgemm != nullptr)
+                        ? dst_postgemm + m * LDDl + n
+                        : nullptr;
+                const auto Di_n = (dst_iter_postgemm != nullptr)
+                        ? dst_iter_postgemm + m * LDDi + n
+                        : nullptr;
+                const auto Dic_n = (dst_iter_c_ != nullptr)
+                        ? inc_ptr(dst_iter_c_, rnn.dst_iter_c_dt, m * LDDic + n)
+                        : nullptr;
+                const auto curr_ws_gates_ = ws_gates_ + (m * rnn.ws_gates_ld)
+                        + nb_i * rnn.n_block;
+                const auto Aic_n = inc_ptr(
+                        src_iter_c_, rnn.src_iter_c_dt, m * LDAic + n);
+                const auto bias_n = inc_ptr(bias_[0], rnn.bias_dt, n);
+                auto weights_scales_n = weights_scales + (mask ? n : 0);
+                this->rnn_postgemm_->execute(rnn, cell_position, curr_ws_gates_,
+                        C_gates_n, augru_attention_, Dpg_n, Dic_n, Ai_m, Aic_n,
+                        diff_src_layer_, diff_augru_attention_, diff_src_iter_,
+                        diff_src_iter_c_, diff_dst_layer_, diff_dst_iter_,
+                        nullptr, nullptr, bias_n, ws_grid_, C_cell_n, Di_n,
+                        weights_scales_n, block_step);
+            };
+            fused_postgemm_gru_part2
+                    = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
+                              scratch_t *C_gates_n, scratch_t *C_cell_n,
+                              int block_step) {
+                const auto Dpg_n = (dst_postgemm != nullptr)
+                        ? dst_postgemm + m * LDDl + n
+                        : nullptr;
+                const auto Di_n = (dst_iter_postgemm != nullptr)
+                        ? dst_iter_postgemm + m * LDDi + n
+                        : nullptr;
+                const auto Dic_n = (dst_iter_c_ != nullptr)
+                        ? inc_ptr(dst_iter_c_, rnn.dst_iter_c_dt, m * LDDic + n)
+                        : nullptr;
+                const auto curr_ws_gates_ = ws_gates_ + (m * rnn.ws_gates_ld)
+                        + nb_i * rnn.n_block;
+                const auto Aic_n = inc_ptr(
+                        src_iter_c_, rnn.src_iter_c_dt, m * LDAic + n);
+                const auto bias_n = inc_ptr(bias_[0], rnn.bias_dt, n);
+                auto weights_scales_n = weights_scales + (mask ? n : 0);
+                this->rnn_postgemm_->execute_part2(rnn, cell_position,
+                        curr_ws_gates_, C_gates_n, augru_attention_, Dpg_n,
+                        Dic_n, Ai_m, Aic_n, diff_src_layer_,
+                        diff_augru_attention_, diff_src_iter_, diff_src_iter_c_,
+                        diff_dst_layer_, diff_dst_iter_, nullptr, nullptr,
+                        bias_n, ws_grid_, C_cell_n, Di_n, weights_scales_n,
+                        block_step);
+            };
+        }
+
+        const brgemm_gru_t dst_calc(this->rnn_brgemm_, rnn, cell_position,
+                src_iter_, src_layer_, w_iter_[0], w_iter_[1], w_layer_[0],
+                dst_postgemm, scratch_gates_, scratch_cell_, addr_batch_global,
+                fused_postgemm_gru_part1, fused_postgemm_gru_part2);
+        dst_calc.execute();
+    } else {
+        const brgemm_dst_layer_iter_t dst_calc(this->rnn_brgemm_, rnn,
+                cell_position, src_iter_, src_layer_, w_iter_[0], w_layer_[0],
+                scratch_gates_, scratch_cell_, addr_batch_global,
+                fused_postgemm);
+        dst_calc.execute();
+    }
+
+    if (rnn.unfused_post_gemm) {
+        const auto wscales_postgemm
+                = this->pd_->attr()->rnn_weights_qparams_.scales_;
+        this->rnn_postgemm_->execute(rnn, cell_position, ws_gates_,
+                scratch_gates_, augru_attention_, dst_postgemm, dst_iter_c_,
+                src_iter_, src_iter_c_, diff_src_layer_, diff_augru_attention_,
+                diff_src_iter_, diff_src_iter_c_, diff_dst_layer_,
+                diff_dst_iter_, diff_dst_iter_c_, weights_peephole_, bias_[0],
+                ws_grid_, scratch_cell_, dst_iter_postgemm, wscales_postgemm,
+                rnn.dhc * sizeof(scratch_t));
+    }
+
+    if (rnn.is_lstm_projection) {
+        const auto wscales_proj_postgemm
+                = this->pd_->attr()->rnn_weights_projection_qparams_.scales_;
+        gemm_acc_t *const Cp = (rnn.dt_conf == all_f32)
+                ? reinterpret_cast<gemm_acc_t *>(dst_layer_)
+                : scratch_gates_;
+        const int pLDDl = rnn.dst_layer_ld(cell_position, true);
+        const int pmask
+                = this->pd_->attr()->rnn_weights_projection_qparams_.mask_;
+
+        using brgemm_dst_proj_t
+                = aarch64::brgemm_dst_proj_t<ht_t, weights_t, gemm_acc_t>;
+        typename brgemm_dst_proj_t::postgemm_fused_t fused_postgemm_proj;
+
+        if (!rnn.unfused_post_gemm) {
+            fused_postgemm_proj
+                    = [&](dim_t m, dim_t n, gemm_acc_t *Cp_n, int block_step) {
+                const auto weights_scales_n
+                        = wscales_proj_postgemm + (pmask ? n : 0);
+                const auto Di_n = (dst_iter_ != nullptr)
+                        ? dst_iter_ + m * LDDi + n
+                        : nullptr;
+                const auto Dl_n = (dst_layer_ != nullptr)
+                        ? dst_layer_ + m * pLDDl + n
+                        : nullptr;
+                const auto Wp_comp_n = w_proj_comp + n;
+                this->rnn_postgemm_->execute_part2(rnn, cell_position, nullptr,
+                        Cp_n, nullptr, Dl_n, nullptr, nullptr, Wp_comp_n,
+                        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                        nullptr, nullptr, nullptr, nullptr, nullptr, Di_n,
+                        weights_scales_n, block_step);
+            };
+        }
+
+        const brgemm_dst_proj_t dst_proj_calc(this->rnn_brgemm_, rnn,
+                cell_position, proj_ht_, w_projection_[0], Cp,
+                addr_batch_global, fused_postgemm_proj);
+        dst_proj_calc.execute();
+
+        if (rnn.unfused_post_gemm) {
+            this->rnn_postgemm_->execute_part2(rnn, cell_position, nullptr, Cp,
+                    nullptr, dst_layer_, nullptr, nullptr, w_proj_comp, nullptr,
+                    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                    nullptr, nullptr, nullptr, nullptr, dst_iter_,
+                    wscales_proj_postgemm, rnn.dlc * sizeof(dst_layer_t));
+        }
+    }
+
 #endif
     return dnnl_success;
 }
@@ -333,6 +531,42 @@ rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
                 cell_position, scratch_gates_, src_iter_c_, dst_iter_c_,
                 diff_weights_peephole_);
 
+        diff_wei_peep_calc.execute();
+    }
+
+#elif DNNL_AARCH64
+    this->rnn_postgemm_->execute(rnn, cell_position, ws_gates_, scratch_gates_,
+            augru_attention_, dst_layer_, dst_iter_c_, src_iter_, src_iter_c_,
+            diff_src_layer_, diff_augru_attention_, diff_src_iter_,
+            diff_src_iter_c_, diff_dst_layer_, diff_dst_iter_, diff_dst_iter_c_,
+            weights_peephole_, bias_[0], ws_grid_, scratch_cell_, dst_iter_,
+            nullptr, 0);
+
+    using brgemm_diff_src_calc_t
+            = aarch64::brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
+                    gemm_acc_t>;
+    using brgemm_diff_weights_calc_t
+            = aarch64::brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t,
+                    scratch_t, gemm_acc_t>;
+
+    const brgemm_diff_src_calc_t diff_src_calc(this->rnn_brgemm_, rnn,
+            cell_position, scratch_gates_, w_iter_[0], w_layer_[0],
+            diff_src_iter_, diff_src_layer_, addr_batch_global);
+    const brgemm_diff_weights_calc_t diff_weights_calc(this->rnn_brgemm_, rnn,
+            cell_position, src_iter_, scratch_src_iter_, src_layer_,
+            scratch_src_layer_, scratch_gates_, scratch_gates_blocked_,
+            diff_w_iter_, diff_w_layer_, diff_bias_, addr_batch_global);
+
+    diff_src_calc.execute();
+
+    diff_weights_calc.execute();
+
+    if (rnn.is_lstm_peephole) {
+        using brgemm_diff_wei_peep_t
+                = aarch64::brgemm_diff_wei_peep_t<scratch_t>;
+        const brgemm_diff_wei_peep_t diff_wei_peep_calc(this->rnn_brgemm_, rnn,
+                cell_position, scratch_gates_, src_iter_c_, dst_iter_c_,
+                diff_weights_peephole_);
         diff_wei_peep_calc.execute();
     }
 

--- a/src/cpu/rnn/brgemm_cell_common.cpp
+++ b/src/cpu/rnn/brgemm_cell_common.cpp
@@ -22,16 +22,17 @@
 #include "common/bfloat16.hpp"
 #include "cpu/rnn/ref_rnn.hpp"
 
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
 #include <cassert>
 #include <functional>
+#endif
+
+#if DNNL_X64
 #include "cpu/x64/rnn/brgemm_cell_common_bwd.hpp"
 #include "cpu/x64/rnn/brgemm_cell_common_fwd.hpp"
 #include "cpu/x64/rnn/brgemm_cell_common_reorders.hpp"
 #include "cpu/x64/rnn/brgemm_cell_common_utils.hpp"
 #elif DNNL_AARCH64
-#include <cassert>
-#include <functional>
 #include "cpu/aarch64/rnn/brgemm_cell_common_bwd.hpp"
 #include "cpu/aarch64/rnn/brgemm_cell_common_fwd.hpp"
 #include "cpu/aarch64/rnn/brgemm_cell_common_reorders.hpp"
@@ -43,29 +44,18 @@ namespace cpu {
 
 using namespace rnn_utils;
 using namespace dnnl::impl::utils;
-#if DNNL_X64
-using namespace dnnl::impl::cpu::x64;
-#elif DNNL_AARCH64
-using namespace dnnl::impl::cpu::aarch64;
-#endif
 
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
 rnn_merged_layer_execution_sig((
         ref_rnn_fwd_t<src_type, weights_type, acc_type>::merged_layer_brgemm)) {
-#if DNNL_X64
-    using brgemm_merged_layer_t = x64::brgemm_merged_layer_t<src_iter_t,
-            weights_t, scratch_t, gemm_acc_t>;
+#if DNNL_X64 || DNNL_AARCH64
+    using brgemm_merged_layer_t
+            = rnn_brgemm_arch::brgemm_merged_layer_t<src_iter_t, weights_t,
+                    scratch_t, gemm_acc_t>;
     const brgemm_merged_layer_t layer_calc(this->rnn_brgemm_, rnn,
             cell_position, src_layer_, w_layer_[0], scratch_gates_,
-            amx_scratchpad, addr_batch_global);
+            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global);
 
-    layer_calc.execute();
-#elif DNNL_AARCH64
-    using brgemm_merged_layer_t = aarch64::brgemm_merged_layer_t<src_iter_t,
-            weights_t, scratch_t, gemm_acc_t>;
-    const brgemm_merged_layer_t layer_calc(this->rnn_brgemm_, rnn,
-            cell_position, src_layer_, w_layer_[0], scratch_gates_,
-            addr_batch_global);
     layer_calc.execute();
 #endif
     return dnnl_success;
@@ -83,7 +73,7 @@ template rnn_merged_layer_execution_sig(
 template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
 rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         acc_type>::cell_execution_brgemm)) {
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
 
     const auto weights_scales = this->pd_->attr()->rnn_weights_qparams_.scales_;
     const int mask = this->pd()->attr()->rnn_weights_qparams_.mask_;
@@ -95,8 +85,9 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     const auto LDDic = rnn.dst_iter_c_ld(cell_position);
     const auto LDAic = rnn.src_iter_c_ld(cell_position);
 
-    using brgemm_dst_layer_iter_t = x64::brgemm_dst_layer_iter_t<src_iter_t,
-            weights_t, scratch_t, gemm_acc_t>;
+    using brgemm_dst_layer_iter_t
+            = rnn_brgemm_arch::brgemm_dst_layer_iter_t<src_iter_t, weights_t,
+                    scratch_t, gemm_acc_t>;
 
     typename brgemm_dst_layer_iter_t::postgemm_fused_t fused_postgemm;
 
@@ -133,8 +124,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     }
 
     if (rnn.is_orig_gru) {
-        using brgemm_gru_t = x64::brgemm_gru_t<src_iter_t, weights_t, scratch_t,
-                gemm_acc_t>;
+        using brgemm_gru_t = rnn_brgemm_arch::brgemm_gru_t<src_iter_t,
+                weights_t, scratch_t, gemm_acc_t>;
         typename brgemm_gru_t::postgemm_fused_t fused_postgemm_gru_part1,
                 fused_postgemm_gru_part2;
         if (!rnn.unfused_post_gemm) {
@@ -197,17 +188,17 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
 
         const brgemm_gru_t dst_calc(this->rnn_brgemm_, rnn, cell_position,
                 src_iter_, src_layer_, w_iter_[0], w_iter_[1], w_layer_[0],
-                dst_postgemm, scratch_gates_, scratch_cell_, amx_scratchpad,
-                addr_batch_global, fused_postgemm_gru_part1,
-                fused_postgemm_gru_part2);
+                dst_postgemm, scratch_gates_, scratch_cell_,
+                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global,
+                fused_postgemm_gru_part1, fused_postgemm_gru_part2);
         dst_calc.execute();
     } else {
         // calculate
         // scratch_gates_ = src_layer_ * w_layer_ + src_iter_ * w_iter_
         const brgemm_dst_layer_iter_t dst_calc(this->rnn_brgemm_, rnn,
                 cell_position, src_iter_, src_layer_, w_iter_[0], w_layer_[0],
-                scratch_gates_, scratch_cell_, amx_scratchpad,
-                addr_batch_global, fused_postgemm);
+                scratch_gates_, scratch_cell_,
+                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global, fused_postgemm);
         dst_calc.execute();
     }
 
@@ -234,8 +225,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         const int pmask
                 = this->pd_->attr()->rnn_weights_projection_qparams_.mask_;
 
-        using brgemm_dst_proj_t
-                = x64::brgemm_dst_proj_t<ht_t, weights_t, gemm_acc_t>;
+        using brgemm_dst_proj_t = rnn_brgemm_arch::brgemm_dst_proj_t<ht_t,
+                weights_t, gemm_acc_t>;
         typename brgemm_dst_proj_t::postgemm_fused_t fused_postgemm_proj;
 
         if (!rnn.unfused_post_gemm) {
@@ -261,195 +252,14 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         // calculate
         // output = proj_ht_ * w_projection_
         const brgemm_dst_proj_t dst_proj_calc(this->rnn_brgemm_, rnn,
-                cell_position, proj_ht_, w_projection_[0], Cp, amx_scratchpad,
-                addr_batch_global, fused_postgemm_proj);
+                cell_position, proj_ht_, w_projection_[0], Cp,
+                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global,
+                fused_postgemm_proj);
         dst_proj_calc.execute();
 
         if (rnn.unfused_post_gemm) {
             // we have to downconvert the output to dst_layer_t and copy to
             // dst_iter if needed
-            this->rnn_postgemm_->execute_part2(rnn, cell_position, nullptr, Cp,
-                    nullptr, dst_layer_, nullptr, nullptr, w_proj_comp, nullptr,
-                    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                    nullptr, nullptr, nullptr, nullptr, dst_iter_,
-                    wscales_proj_postgemm, rnn.dlc * sizeof(dst_layer_t));
-        }
-    }
-
-#elif DNNL_AARCH64
-    const auto weights_scales = this->pd_->attr()->rnn_weights_qparams_.scales_;
-    const int mask = this->pd()->attr()->rnn_weights_qparams_.mask_;
-    const auto dst_postgemm = rnn.is_lstm_projection ? proj_ht_ : dst_layer_;
-    const auto dst_iter_postgemm = rnn.is_lstm_projection ? nullptr : dst_iter_;
-
-    const auto LDDl = rnn.dst_layer_ld(cell_position);
-    const auto LDDi = rnn.dst_iter_ld(cell_position);
-    const auto LDDic = rnn.dst_iter_c_ld(cell_position);
-    const auto LDAic = rnn.src_iter_c_ld(cell_position);
-
-    using brgemm_dst_layer_iter_t = aarch64::brgemm_dst_layer_iter_t<src_iter_t,
-            weights_t, scratch_t, gemm_acc_t>;
-
-    typename brgemm_dst_layer_iter_t::postgemm_fused_t fused_postgemm;
-    if (!rnn.unfused_post_gemm) {
-        fused_postgemm
-                = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
-                          scratch_t *C_n, scratch_t *C_cell_n, int block_step) {
-            const auto Dpg_n = (dst_postgemm != nullptr)
-                    ? dst_postgemm + m * LDDl + n
-                    : nullptr;
-            const auto Di_n = (dst_iter_postgemm != nullptr)
-                    ? dst_iter_postgemm + m * LDDi + n
-                    : nullptr;
-            const auto Dic_n = (dst_iter_c_ != nullptr)
-                    ? inc_ptr(dst_iter_c_, rnn.dst_iter_c_dt, m * LDDic + n)
-                    : nullptr;
-
-            const auto curr_ws_gates_
-                    = ws_gates_ + (m * rnn.ws_gates_ld) + nb_i * rnn.n_block;
-            const float *weights_peephole_n = weights_peephole_
-                    ? weights_peephole_ + n
-                    : weights_peephole_;
-            auto weights_scales_n = weights_scales + (mask ? n : 0);
-            const auto Aic_n
-                    = inc_ptr(src_iter_c_, rnn.src_iter_c_dt, m * LDAic + n);
-            const auto bias_n = inc_ptr(bias_[0], rnn.bias_dt, n);
-            this->rnn_postgemm_->execute(rnn, cell_position, curr_ws_gates_,
-                    C_n, augru_attention_, Dpg_n, Dic_n, Ai_m, Aic_n,
-                    diff_src_layer_, diff_augru_attention_, diff_src_iter_,
-                    diff_src_iter_c_, diff_dst_layer_, diff_dst_iter_,
-                    diff_dst_iter_c_, weights_peephole_n, bias_n, ws_grid_,
-                    C_cell_n, Di_n, weights_scales_n, block_step);
-        };
-    }
-
-    if (rnn.is_orig_gru) {
-        using brgemm_gru_t = aarch64::brgemm_gru_t<src_iter_t, weights_t,
-                scratch_t, gemm_acc_t>;
-        typename brgemm_gru_t::postgemm_fused_t fused_postgemm_gru_part1,
-                fused_postgemm_gru_part2;
-
-        if (!rnn.unfused_post_gemm) {
-            fused_postgemm_gru_part1
-                    = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
-                              scratch_t *C_gates_n, scratch_t *C_cell_n,
-                              int block_step) {
-                const auto Dpg_n = (dst_postgemm != nullptr)
-                        ? dst_postgemm + m * LDDl + n
-                        : nullptr;
-                const auto Di_n = (dst_iter_postgemm != nullptr)
-                        ? dst_iter_postgemm + m * LDDi + n
-                        : nullptr;
-                const auto Dic_n = (dst_iter_c_ != nullptr)
-                        ? inc_ptr(dst_iter_c_, rnn.dst_iter_c_dt, m * LDDic + n)
-                        : nullptr;
-                const auto curr_ws_gates_ = ws_gates_ + (m * rnn.ws_gates_ld)
-                        + nb_i * rnn.n_block;
-                const auto Aic_n = inc_ptr(
-                        src_iter_c_, rnn.src_iter_c_dt, m * LDAic + n);
-                const auto bias_n = inc_ptr(bias_[0], rnn.bias_dt, n);
-                auto weights_scales_n = weights_scales + (mask ? n : 0);
-                this->rnn_postgemm_->execute(rnn, cell_position, curr_ws_gates_,
-                        C_gates_n, augru_attention_, Dpg_n, Dic_n, Ai_m, Aic_n,
-                        diff_src_layer_, diff_augru_attention_, diff_src_iter_,
-                        diff_src_iter_c_, diff_dst_layer_, diff_dst_iter_,
-                        nullptr, nullptr, bias_n, ws_grid_, C_cell_n, Di_n,
-                        weights_scales_n, block_step);
-            };
-            fused_postgemm_gru_part2
-                    = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
-                              scratch_t *C_gates_n, scratch_t *C_cell_n,
-                              int block_step) {
-                const auto Dpg_n = (dst_postgemm != nullptr)
-                        ? dst_postgemm + m * LDDl + n
-                        : nullptr;
-                const auto Di_n = (dst_iter_postgemm != nullptr)
-                        ? dst_iter_postgemm + m * LDDi + n
-                        : nullptr;
-                const auto Dic_n = (dst_iter_c_ != nullptr)
-                        ? inc_ptr(dst_iter_c_, rnn.dst_iter_c_dt, m * LDDic + n)
-                        : nullptr;
-                const auto curr_ws_gates_ = ws_gates_ + (m * rnn.ws_gates_ld)
-                        + nb_i * rnn.n_block;
-                const auto Aic_n = inc_ptr(
-                        src_iter_c_, rnn.src_iter_c_dt, m * LDAic + n);
-                const auto bias_n = inc_ptr(bias_[0], rnn.bias_dt, n);
-                auto weights_scales_n = weights_scales + (mask ? n : 0);
-                this->rnn_postgemm_->execute_part2(rnn, cell_position,
-                        curr_ws_gates_, C_gates_n, augru_attention_, Dpg_n,
-                        Dic_n, Ai_m, Aic_n, diff_src_layer_,
-                        diff_augru_attention_, diff_src_iter_, diff_src_iter_c_,
-                        diff_dst_layer_, diff_dst_iter_, nullptr, nullptr,
-                        bias_n, ws_grid_, C_cell_n, Di_n, weights_scales_n,
-                        block_step);
-            };
-        }
-
-        const brgemm_gru_t dst_calc(this->rnn_brgemm_, rnn, cell_position,
-                src_iter_, src_layer_, w_iter_[0], w_iter_[1], w_layer_[0],
-                dst_postgemm, scratch_gates_, scratch_cell_, addr_batch_global,
-                fused_postgemm_gru_part1, fused_postgemm_gru_part2);
-        dst_calc.execute();
-    } else {
-        const brgemm_dst_layer_iter_t dst_calc(this->rnn_brgemm_, rnn,
-                cell_position, src_iter_, src_layer_, w_iter_[0], w_layer_[0],
-                scratch_gates_, scratch_cell_, addr_batch_global,
-                fused_postgemm);
-        dst_calc.execute();
-    }
-
-    if (rnn.unfused_post_gemm) {
-        const auto wscales_postgemm
-                = this->pd_->attr()->rnn_weights_qparams_.scales_;
-        this->rnn_postgemm_->execute(rnn, cell_position, ws_gates_,
-                scratch_gates_, augru_attention_, dst_postgemm, dst_iter_c_,
-                src_iter_, src_iter_c_, diff_src_layer_, diff_augru_attention_,
-                diff_src_iter_, diff_src_iter_c_, diff_dst_layer_,
-                diff_dst_iter_, diff_dst_iter_c_, weights_peephole_, bias_[0],
-                ws_grid_, scratch_cell_, dst_iter_postgemm, wscales_postgemm,
-                rnn.dhc * sizeof(scratch_t));
-    }
-
-    if (rnn.is_lstm_projection) {
-        const auto wscales_proj_postgemm
-                = this->pd_->attr()->rnn_weights_projection_qparams_.scales_;
-        gemm_acc_t *const Cp = (rnn.dt_conf == all_f32)
-                ? reinterpret_cast<gemm_acc_t *>(dst_layer_)
-                : scratch_gates_;
-        const int pLDDl = rnn.dst_layer_ld(cell_position, true);
-        const int pmask
-                = this->pd_->attr()->rnn_weights_projection_qparams_.mask_;
-
-        using brgemm_dst_proj_t
-                = aarch64::brgemm_dst_proj_t<ht_t, weights_t, gemm_acc_t>;
-        typename brgemm_dst_proj_t::postgemm_fused_t fused_postgemm_proj;
-
-        if (!rnn.unfused_post_gemm) {
-            fused_postgemm_proj
-                    = [&](dim_t m, dim_t n, gemm_acc_t *Cp_n, int block_step) {
-                const auto weights_scales_n
-                        = wscales_proj_postgemm + (pmask ? n : 0);
-                const auto Di_n = (dst_iter_ != nullptr)
-                        ? dst_iter_ + m * LDDi + n
-                        : nullptr;
-                const auto Dl_n = (dst_layer_ != nullptr)
-                        ? dst_layer_ + m * pLDDl + n
-                        : nullptr;
-                const auto Wp_comp_n = w_proj_comp + n;
-                this->rnn_postgemm_->execute_part2(rnn, cell_position, nullptr,
-                        Cp_n, nullptr, Dl_n, nullptr, nullptr, Wp_comp_n,
-                        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                        nullptr, nullptr, nullptr, nullptr, nullptr, Di_n,
-                        weights_scales_n, block_step);
-            };
-        }
-
-        const brgemm_dst_proj_t dst_proj_calc(this->rnn_brgemm_, rnn,
-                cell_position, proj_ht_, w_projection_[0], Cp,
-                addr_batch_global, fused_postgemm_proj);
-        dst_proj_calc.execute();
-
-        if (rnn.unfused_post_gemm) {
             this->rnn_postgemm_->execute_part2(rnn, cell_position, nullptr, Cp,
                     nullptr, dst_layer_, nullptr, nullptr, w_proj_comp, nullptr,
                     nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
@@ -472,69 +282,7 @@ template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
 rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
         acc_type>::cell_execution_brgemm)) {
 
-#if DNNL_X64
-    this->rnn_postgemm_->execute(rnn, cell_position, ws_gates_, scratch_gates_,
-            augru_attention_, dst_layer_, dst_iter_c_, src_iter_, src_iter_c_,
-            diff_src_layer_, diff_augru_attention_, diff_src_iter_,
-            diff_src_iter_c_, diff_dst_layer_, diff_dst_iter_, diff_dst_iter_c_,
-            weights_peephole_, bias_[0], ws_grid_, scratch_cell_, dst_iter_,
-            nullptr, 0);
-
-    using brgemm_diff_src_calc_t = x64::brgemm_diff_src_layer_iter_t<weights_t,
-            scratch_t, gemm_acc_t>;
-    using brgemm_diff_weights_calc_t
-            = x64::brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t,
-                    scratch_t, gemm_acc_t>;
-
-    const brgemm_diff_src_calc_t diff_src_calc(this->rnn_brgemm_, rnn,
-            cell_position, scratch_gates_, w_iter_[0], w_layer_[0],
-            diff_src_iter_, diff_src_layer_, amx_scratchpad, addr_batch_global);
-    const brgemm_diff_weights_calc_t diff_weights_calc(this->rnn_brgemm_, rnn,
-            cell_position, src_iter_, scratch_src_iter_, src_layer_,
-            scratch_src_layer_, scratch_gates_, scratch_gates_blocked_,
-            diff_w_iter_, diff_w_layer_, diff_bias_, amx_scratchpad,
-            addr_batch_global);
-
-    // calculate
-    // dff_src_iter = scratch * w_iter
-    // dff_src_layer = scratch * w_layer
-    diff_src_calc.execute();
-
-    if (rnn.diff_wei_brgemm.global_transpose) {
-        const auto src_layer_ld = rnn.src_layer_ld(cell_position);
-        const auto src_iter_ld = rnn.src_iter_ld(cell_position);
-        const auto src_layer_ld_nb = rnn.layer_brgemm_desc(cell_position);
-        const auto src_iter_ld_nb = rnn.iter_brgemm_desc(cell_position);
-        const auto rnd_up_size = data_type_vnni_granularity(src_type);
-        const auto dst_ld = utils::rnd_up(rnn.mb, rnd_up_size);
-
-        const auto layer_transpose = src_layer_iter_transpose_t(src_layer_ld,
-                dst_ld, rnn.mb, rnn.slc,
-                this->rnn_brgemm_.kernel_transpose_layer_[src_layer_ld_nb]
-                        .get());
-        const auto iter_transpose = src_layer_iter_transpose_t(src_iter_ld,
-                dst_ld, rnn.mb, rnn.sic,
-                this->rnn_brgemm_.kernel_transpose_iter_[src_iter_ld_nb].get());
-        layer_transpose.execute(src_layer_, scratch_src_layer_);
-        iter_transpose.execute(src_iter_, scratch_src_iter_);
-    }
-    // calculate
-    // dff_weights_layer = src_layer^T * scratch
-    // dff_weights_iter = src_iter^T * scratch
-    // performs gates reductions
-    // diff_bias = scratch reduction over mb
-    diff_weights_calc.execute();
-
-    if (rnn.is_lstm_peephole) {
-        using brgemm_diff_wei_peep_t = x64::brgemm_diff_wei_peep_t<scratch_t>;
-        const brgemm_diff_wei_peep_t diff_wei_peep_calc(this->rnn_brgemm_, rnn,
-                cell_position, scratch_gates_, src_iter_c_, dst_iter_c_,
-                diff_weights_peephole_);
-
-        diff_wei_peep_calc.execute();
-    }
-
-#elif DNNL_AARCH64
+#if DNNL_X64 || DNNL_AARCH64
     this->rnn_postgemm_->execute(rnn, cell_position, ws_gates_, scratch_gates_,
             augru_attention_, dst_layer_, dst_iter_c_, src_iter_, src_iter_c_,
             diff_src_layer_, diff_augru_attention_, diff_src_iter_,
@@ -543,30 +291,60 @@ rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
             nullptr, 0);
 
     using brgemm_diff_src_calc_t
-            = aarch64::brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
-                    gemm_acc_t>;
-    using brgemm_diff_weights_calc_t
-            = aarch64::brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t,
+            = rnn_brgemm_arch::brgemm_diff_src_layer_iter_t<weights_t,
                     scratch_t, gemm_acc_t>;
+    using brgemm_diff_weights_calc_t
+            = rnn_brgemm_arch::brgemm_diff_weights_layer_iter_t<src_layer_t,
+                    src_iter_t, scratch_t, gemm_acc_t>;
 
     const brgemm_diff_src_calc_t diff_src_calc(this->rnn_brgemm_, rnn,
             cell_position, scratch_gates_, w_iter_[0], w_layer_[0],
-            diff_src_iter_, diff_src_layer_, addr_batch_global);
+            diff_src_iter_, diff_src_layer_,
+            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global);
     const brgemm_diff_weights_calc_t diff_weights_calc(this->rnn_brgemm_, rnn,
             cell_position, src_iter_, scratch_src_iter_, src_layer_,
             scratch_src_layer_, scratch_gates_, scratch_gates_blocked_,
-            diff_w_iter_, diff_w_layer_, diff_bias_, addr_batch_global);
+            diff_w_iter_, diff_w_layer_, diff_bias_,
+            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global);
 
+    // calculate
+    // dff_src_iter = scratch * w_iter
+    // dff_src_layer = scratch * w_layer
     diff_src_calc.execute();
+#if DNNL_X64
+    if (rnn.diff_wei_brgemm.global_transpose) {
+        const auto src_layer_ld = rnn.src_layer_ld(cell_position);
+        const auto src_iter_ld = rnn.src_iter_ld(cell_position);
+        const auto src_layer_ld_nb = rnn.layer_brgemm_desc(cell_position);
+        const auto src_iter_ld_nb = rnn.iter_brgemm_desc(cell_position);
+        const auto rnd_up_size = x64::data_type_vnni_granularity(src_type);
+        const auto dst_ld = utils::rnd_up(rnn.mb, rnd_up_size);
 
+        const auto layer_transpose = x64::src_layer_iter_transpose_t(
+                src_layer_ld, dst_ld, rnn.mb, rnn.slc,
+                this->rnn_brgemm_.kernel_transpose_layer_[src_layer_ld_nb]
+                        .get());
+        const auto iter_transpose = x64::src_layer_iter_transpose_t(src_iter_ld,
+                dst_ld, rnn.mb, rnn.sic,
+                this->rnn_brgemm_.kernel_transpose_iter_[src_iter_ld_nb].get());
+        layer_transpose.execute(src_layer_, scratch_src_layer_);
+        iter_transpose.execute(src_iter_, scratch_src_iter_);
+    }
+#endif
+    // calculate
+    // dff_weights_layer = src_layer^T * scratch
+    // dff_weights_iter = src_iter^T * scratch
+    // performs gates reductions
+    // diff_bias = scratch reduction over mb
     diff_weights_calc.execute();
 
     if (rnn.is_lstm_peephole) {
         using brgemm_diff_wei_peep_t
-                = aarch64::brgemm_diff_wei_peep_t<scratch_t>;
+                = rnn_brgemm_arch::brgemm_diff_wei_peep_t<scratch_t>;
         const brgemm_diff_wei_peep_t diff_wei_peep_calc(this->rnn_brgemm_, rnn,
                 cell_position, scratch_gates_, src_iter_c_, dst_iter_c_,
                 diff_weights_peephole_);
+
         diff_wei_peep_calc.execute();
     }
 

--- a/src/cpu/rnn/brgemm_cell_common.cpp
+++ b/src/cpu/rnn/brgemm_cell_common.cpp
@@ -49,12 +49,11 @@ template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
 rnn_merged_layer_execution_sig((
         ref_rnn_fwd_t<src_type, weights_type, acc_type>::merged_layer_brgemm)) {
 #if DNNL_X64 || DNNL_AARCH64
-    using brgemm_merged_layer_t
-            = rnn_brgemm_arch::brgemm_merged_layer_t<src_iter_t, weights_t,
-                    scratch_t, gemm_acc_t>;
+    using brgemm_merged_layer_t = brgemm_merged_layer_t<src_iter_t, weights_t,
+            scratch_t, gemm_acc_t>;
     const brgemm_merged_layer_t layer_calc(this->rnn_brgemm_, rnn,
             cell_position, src_layer_, w_layer_[0], scratch_gates_,
-            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global);
+            gemm_acc_scratchpad, addr_batch_global);
 
     layer_calc.execute();
 #endif
@@ -85,9 +84,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     const auto LDDic = rnn.dst_iter_c_ld(cell_position);
     const auto LDAic = rnn.src_iter_c_ld(cell_position);
 
-    using brgemm_dst_layer_iter_t
-            = rnn_brgemm_arch::brgemm_dst_layer_iter_t<src_iter_t, weights_t,
-                    scratch_t, gemm_acc_t>;
+    using brgemm_dst_layer_iter_t = brgemm_dst_layer_iter_t<src_iter_t,
+            weights_t, scratch_t, gemm_acc_t>;
 
     typename brgemm_dst_layer_iter_t::postgemm_fused_t fused_postgemm;
 
@@ -124,8 +122,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     }
 
     if (rnn.is_orig_gru) {
-        using brgemm_gru_t = rnn_brgemm_arch::brgemm_gru_t<src_iter_t,
-                weights_t, scratch_t, gemm_acc_t>;
+        using brgemm_gru_t
+                = brgemm_gru_t<src_iter_t, weights_t, scratch_t, gemm_acc_t>;
         typename brgemm_gru_t::postgemm_fused_t fused_postgemm_gru_part1,
                 fused_postgemm_gru_part2;
         if (!rnn.unfused_post_gemm) {
@@ -189,7 +187,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         const brgemm_gru_t dst_calc(this->rnn_brgemm_, rnn, cell_position,
                 src_iter_, src_layer_, w_iter_[0], w_iter_[1], w_layer_[0],
                 dst_postgemm, scratch_gates_, scratch_cell_,
-                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global,
+                gemm_acc_scratchpad, addr_batch_global,
                 fused_postgemm_gru_part1, fused_postgemm_gru_part2);
         dst_calc.execute();
     } else {
@@ -197,8 +195,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         // scratch_gates_ = src_layer_ * w_layer_ + src_iter_ * w_iter_
         const brgemm_dst_layer_iter_t dst_calc(this->rnn_brgemm_, rnn,
                 cell_position, src_iter_, src_layer_, w_iter_[0], w_layer_[0],
-                scratch_gates_, scratch_cell_,
-                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global, fused_postgemm);
+                scratch_gates_, scratch_cell_, gemm_acc_scratchpad,
+                addr_batch_global, fused_postgemm);
         dst_calc.execute();
     }
 
@@ -225,8 +223,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         const int pmask
                 = this->pd_->attr()->rnn_weights_projection_qparams_.mask_;
 
-        using brgemm_dst_proj_t = rnn_brgemm_arch::brgemm_dst_proj_t<ht_t,
-                weights_t, gemm_acc_t>;
+        using brgemm_dst_proj_t
+                = brgemm_dst_proj_t<ht_t, weights_t, gemm_acc_t>;
         typename brgemm_dst_proj_t::postgemm_fused_t fused_postgemm_proj;
 
         if (!rnn.unfused_post_gemm) {
@@ -253,8 +251,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         // output = proj_ht_ * w_projection_
         const brgemm_dst_proj_t dst_proj_calc(this->rnn_brgemm_, rnn,
                 cell_position, proj_ht_, w_projection_[0], Cp,
-                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global,
-                fused_postgemm_proj);
+                gemm_acc_scratchpad, addr_batch_global, fused_postgemm_proj);
         dst_proj_calc.execute();
 
         if (rnn.unfused_post_gemm) {
@@ -291,21 +288,20 @@ rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
             nullptr, 0);
 
     using brgemm_diff_src_calc_t
-            = rnn_brgemm_arch::brgemm_diff_src_layer_iter_t<weights_t,
-                    scratch_t, gemm_acc_t>;
+            = brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>;
     using brgemm_diff_weights_calc_t
-            = rnn_brgemm_arch::brgemm_diff_weights_layer_iter_t<src_layer_t,
-                    src_iter_t, scratch_t, gemm_acc_t>;
+            = brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t,
+                    scratch_t, gemm_acc_t>;
 
     const brgemm_diff_src_calc_t diff_src_calc(this->rnn_brgemm_, rnn,
             cell_position, scratch_gates_, w_iter_[0], w_layer_[0],
-            diff_src_iter_, diff_src_layer_,
-            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global);
+            diff_src_iter_, diff_src_layer_, gemm_acc_scratchpad,
+            addr_batch_global);
     const brgemm_diff_weights_calc_t diff_weights_calc(this->rnn_brgemm_, rnn,
             cell_position, src_iter_, scratch_src_iter_, src_layer_,
             scratch_src_layer_, scratch_gates_, scratch_gates_blocked_,
-            diff_w_iter_, diff_w_layer_, diff_bias_,
-            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global);
+            diff_w_iter_, diff_w_layer_, diff_bias_, gemm_acc_scratchpad,
+            addr_batch_global);
 
     // calculate
     // dff_src_iter = scratch * w_iter
@@ -339,8 +335,7 @@ rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
     diff_weights_calc.execute();
 
     if (rnn.is_lstm_peephole) {
-        using brgemm_diff_wei_peep_t
-                = rnn_brgemm_arch::brgemm_diff_wei_peep_t<scratch_t>;
+        using brgemm_diff_wei_peep_t = brgemm_diff_wei_peep_t<scratch_t>;
         const brgemm_diff_wei_peep_t diff_wei_peep_calc(this->rnn_brgemm_, rnn,
                 cell_position, scratch_gates_, src_iter_c_, dst_iter_c_,
                 diff_weights_peephole_);

--- a/src/cpu/rnn/postgemm_dispatcher.hpp
+++ b/src/cpu/rnn/postgemm_dispatcher.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -105,7 +106,9 @@ struct rnn_postgemm_dispatcher_t {
     virtual ~rnn_postgemm_dispatcher_t() = default;
 
     status_t init(const rnn_utils::rnn_conf_t &rnn) {
-        DNNL_X64_ONLY(CHECK(initialize_jit(rnn)));
+#if DNNL_X64
+        CHECK(initialize_jit(rnn));
+#endif
         return status::success;
     }
 

--- a/src/cpu/rnn/postgemm_dispatcher.hpp
+++ b/src/cpu/rnn/postgemm_dispatcher.hpp
@@ -1,6 +1,5 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
-* Copyright 2026 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -106,9 +105,7 @@ struct rnn_postgemm_dispatcher_t {
     virtual ~rnn_postgemm_dispatcher_t() = default;
 
     status_t init(const rnn_utils::rnn_conf_t &rnn) {
-#if DNNL_X64
-        CHECK(initialize_jit(rnn));
-#endif
+        DNNL_X64_ONLY(CHECK(initialize_jit(rnn)));
         return status::success;
     }
 

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -533,6 +534,194 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
     }
 
     return status::success;
+
+#elif DNNL_AARCH64
+    using namespace aarch64;
+
+    const alg_kind_t cell_kind = this->desc()->cell_kind;
+    const data_type_t src_layer_dt = this->desc()->src_layer_desc.data_type;
+    const data_type_t weights_iter_dt
+            = this->desc()->weights_iter_desc.data_type;
+    const data_type_t weights_layer_dt
+            = this->desc()->weights_layer_desc.data_type;
+
+    rnn_ = zero<decltype(rnn_)>();
+    rnn_.is_brgemm = true;
+
+    VDISPATCH_RNN(
+            one_of(cell_kind, alg_kind::vanilla_rnn, alg_kind::vanilla_lstm,
+                    alg_kind::vanilla_gru, alg_kind::lbr_gru,
+                    alg_kind::vanilla_augru, alg_kind::lbr_augru),
+            VERBOSE_BAD_ALGORITHM);
+    VDISPATCH_RNN(IMPLICATION(aprop == prop_kind::forward,
+                          one_of(this->desc()->prop_kind, forward_training,
+                                  forward_inference)),
+            VERBOSE_BAD_PROPKIND);
+    VDISPATCH_RNN(IMPLICATION(one_of(cell_kind, alg_kind::lbr_gru,
+                                      alg_kind::lbr_augru),
+                          this->desc()->prop_kind == forward_inference),
+            VERBOSE_BAD_ALGORITHM);
+    VDISPATCH_RNN(IMPLICATION(aprop == backward,
+                          one_of(this->desc()->prop_kind, backward)),
+            VERBOSE_BAD_PROPKIND);
+    VDISPATCH_RNN(IMPLICATION(aprop == backward,
+                          this->diff_weights_overwrite() == false),
+            VERBOSE_BAD_PROPKIND);
+
+    /* No bf32 down-conversion on aarch64 — require exact type match. */
+    VDISPATCH_RNN(src_layer_dt == src_type
+                    && everyone_is(
+                            weights_type, weights_iter_dt, weights_layer_dt),
+            VERBOSE_UNSUPPORTED_DT);
+
+    VDISPATCH_RNN(this->set_default_params() == status::success,
+            VERBOSE_UNSUPPORTED_ATTR);
+    VDISPATCH_RNN(this->with_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
+
+    VDISPATCH_RNN(init_conf<class_name>(rnn_, *this->desc(), *this->attr(),
+                          this->src_md(0), this->src_md(1), this->src_md(2),
+                          this->weights_md(0), this->weights_md(1),
+                          this->arg_md(DNNL_ARG_WEIGHTS_PROJECTION),
+                          this->dst_md(0), this->dst_md(1), this->dst_md(2),
+                          this->arg_md(DNNL_ARG_BIAS)),
+            VERBOSE_PRIMITIVE_CREATION_FAIL, "rnn");
+
+    VDISPATCH_RNN(IMPLICATION(one_of(this->desc()->prop_kind, forward_training,
+                                      backward),
+                          (rnn_.is_xf16_conf() || rnn_.is_f32_conf())),
+            VERBOSE_PROPKIND_DT_MISMATCH);
+
+    VDISPATCH_RNN(IMPLICATION(rnn_.is_orig_gru,
+                          this->desc()->prop_kind == forward_inference
+                                  && !rnn_.is_cell_dt_f32()),
+            VERBOSE_UNSUPPORTED_FEATURE,
+            "gru/augru cell in brgemm-based forward inference");
+
+    VDISPATCH_RNN(!(rnn_.is_cell_dt_f32()
+                          && utils::one_of(this->desc()->prop_kind, backward,
+                                  forward_training)),
+            VERBOSE_UNSUPPORTED_FEATURE,
+            "f32 datatype in brgemm-based implementation");
+
+    VDISPATCH_RNN((IMPLICATION((cell_kind == alg_kind::vanilla_lstm
+                                       && rnn_.is_lstm_projection),
+                          this->desc()->prop_kind == forward_inference)),
+            "bad algorithm for lstm projection for forward inference");
+
+    //    const auto isa = get_max_cpu_isa();
+    VDISPATCH_RNN(mayiuse(asimd), VERBOSE_ISA_DT_MISMATCH);
+
+    if (rnn_.is_bf16_conf()) {
+        const bool isa_dt_not_ok = (!mayiuse_bf16()
+                || !utils::one_of(rnn_.bias_dt, data_type::bf16, data_type::f32)
+                || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt
+                || !utils::one_of(rnn_.src_iter_c_dt, data_type::undef,
+                        data_type::bf16, data_type::f32));
+        VDISPATCH_RNN(!isa_dt_not_ok, VERBOSE_ISA_DT_MISMATCH);
+    } else if (rnn_.is_f16_conf()) {
+        const bool isa_dt_not_ok
+                = (!utils::one_of(rnn_.bias_dt, data_type::f16, data_type::f32)
+                        || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt
+                        || !utils::one_of(rnn_.src_iter_c_dt, data_type::undef,
+                                data_type::f16, data_type::f32));
+        VDISPATCH_RNN(!isa_dt_not_ok, VERBOSE_ISA_DT_MISMATCH);
+    } else {
+        const bool dt_not_ok = (rnn_.bias_dt != data_type::f32
+                || !utils::one_of(
+                        rnn_.src_iter_c_dt, data_type::undef, data_type::f32)
+                || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt);
+        VDISPATCH_RNN(!dt_not_ok, VERBOSE_UNSUPPORTED_DT_CFG);
+    }
+
+    VDISPATCH_RNN(!(rnn_.is_int8_conf()
+                          && !(rnn_.src_layer_is_trivial_stride
+                                  && rnn_.dst_layer_is_trivial_stride)),
+            VERBOSE_NONTRIVIAL_STRIDE);
+
+    primitive_attr_t::skip_mask_t attr_mask
+            = primitive_attr_t::skip_mask_t::rnn_tparams;
+    if (weights_layer_dt == data_type::s8)
+        attr_mask = attr_mask | primitive_attr_t::skip_mask_t::rnn_data_qparams
+                | primitive_attr_t::skip_mask_t::rnn_weights_qparams
+                | primitive_attr_t::skip_mask_t::rnn_weights_projection_qparams;
+    VDISPATCH_RNN(this->attr()->has_default_values(attr_mask),
+            VERBOSE_UNSUPPORTED_ATTR);
+
+    set_conf<class_name>(rnn_, *this->desc(), this->weights_md(0),
+            this->weights_md(1), this->arg_md(DNNL_ARG_WEIGHTS_PROJECTION),
+            this->diff_weights_md(0), this->diff_weights_md(1),
+            this->arg_md(DNNL_ARG_DIFF_WEIGHTS_PROJECTION));
+
+    CHECK(ref_rnn_brgemm_t::configure_brgemm(rnn_, this->desc()->cell_kind,
+            sizeof(src_layer_t), sizeof(scratch_t)));
+
+    set_workspace_sizes<class_name>(rnn_, *this->desc());
+
+    memory_desc_t new_weights_layer_md = *this->weights_md(0);
+    CHECK(set_expected_desc(
+            rnn_, new_weights_layer_md, rnn_utils::weights_type_t::layer));
+    if (this->weights_layer_md_.format_kind == format_kind::any) {
+        this->weights_layer_md_ = new_weights_layer_md;
+    } else {
+        VDISPATCH_RNN(this->weights_layer_md_ == new_weights_layer_md,
+                VERBOSE_INCONSISTENT_MDS, "weights_layer", "new_weights_layer");
+    }
+
+    memory_desc_t new_weights_iter_md = *this->weights_md(1);
+    CHECK(set_expected_desc(
+            rnn_, new_weights_iter_md, rnn_utils::weights_type_t::iter));
+    if (this->weights_iter_md_.format_kind == format_kind::any) {
+        this->weights_iter_md_ = new_weights_iter_md;
+    } else {
+        VDISPATCH_RNN(this->weights_iter_md_ == new_weights_iter_md,
+                VERBOSE_INCONSISTENT_MDS, "weights_iter", "new_weights_iter");
+    }
+
+    if (rnn_.is_lstm_projection) {
+        memory_desc_t new_weights_projection_md
+                = *this->arg_md(DNNL_ARG_WEIGHTS_PROJECTION);
+        CHECK(set_expected_desc(rnn_, new_weights_projection_md,
+                rnn_utils::weights_type_t::projection));
+        if (this->weights_projection_md_.format_kind == format_kind::any) {
+            this->weights_projection_md_ = new_weights_projection_md;
+        } else {
+            VDISPATCH_RNN(
+                    this->weights_projection_md_ == new_weights_projection_md,
+                    VERBOSE_INCONSISTENT_MDS, "weights_projection",
+                    "new_weights_projection");
+        }
+    }
+
+    if (rnn_.is_unsigned_int8_conf()) {
+        const memory_desc_wrapper &weights_layer_d(this->weights_layer_md_);
+        const memory_desc_wrapper &weights_iter_d(this->weights_iter_md_);
+        const auto &pdims_l = weights_layer_d.padded_dims();
+        const auto &pdims_i = weights_iter_d.padded_dims();
+        rnn_.weights_layer_comp_offset = rnn_.n_layer * rnn_.n_dir
+                * rnn_.n_gates * pdims_l[2] * pdims_l[4];
+        rnn_.weights_iter_comp_offset = rnn_.n_layer * rnn_.n_dir * rnn_.n_gates
+                * pdims_i[2] * pdims_i[4];
+        if (rnn_.is_lstm_projection) {
+            const memory_desc_wrapper &weights_proj_d(
+                    this->weights_projection_md_);
+            const auto &pdims_p = weights_proj_d.padded_dims();
+            rnn_.weights_projection_comp_offset
+                    = rnn_.n_layer * rnn_.n_dir * pdims_p[2] * pdims_p[3];
+        } else {
+            rnn_.weights_projection_comp_offset = 0;
+        }
+    }
+
+    VDISPATCH_RNN(this->check_layout_consistency(true /*is_brgemm*/)
+                    == status::success,
+            "layout consistency check failed");
+
+    VDISPATCH_RNN(!rnn_.is_bf32(), VERBOSE_UNSUPPORTED_FEATURE,
+            "bf32 is not supported in aarch64 brgemm rnn as No bf32 reorder on "
+            "aarch64.");
+
+    return status::success;
+
 #else
     return status::unimplemented;
 #endif
@@ -595,7 +784,7 @@ void ref_rnn_common_t<aprop, src_type, weights_type,
     scratchpad.template book<void *>(
             key_rnn_ptrs_bia, ptr_wei_sz * bias_dt_size);
 
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
     if (rnn_.is_brgemm)
         ref_rnn_brgemm_t::init_scratchpad(
                 rnn_, scratchpad, sizeof(gemm_acc_t), alignof(gemm_acc_t));
@@ -725,6 +914,11 @@ status_t dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
             CHECK(pd()->bf32_wei_iter_reorder_pd_->create_primitive(
                     bf32_wei_iter_reorder_, engine));
         }
+        return rnn_brgemm_.init_kernels(rnn, src_type, weights_type);
+    }
+#elif DNNL_AARCH64
+    const auto rnn = pd()->rnn_;
+    if (rnn.is_brgemm) {
         return rnn_brgemm_.init_kernels(rnn, src_type, weights_type);
     }
 #endif
@@ -1030,6 +1224,11 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
                 SAFE_PTR(ws_diff_states_layer, lay, dir, 0, 0),
                 SAFE_PTR(diff_weights_layer, lay, dir, 0), amx_scratchpad,
                 addr_batch_global));
+#elif DNNL_AARCH64
+        CHECK((this->*merged_layer_func)(ctx, rnn, cell_position,
+                SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
+                SAFE_PTR(ws_diff_states_layer, lay, dir, 0, 0),
+                SAFE_PTR(diff_weights_layer, lay, dir, 0), addr_batch_global));
 #else
         CHECK((this->*merged_layer_func)(rnn, cell_position,
                 SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
@@ -1168,6 +1367,35 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
                     scratch_gates_blocked_, scratch_src_layer_,
                     scratch_src_iter_, cell_dst_iter, amx_scratchpad,
                     addr_batch_global));
+#elif DNNL_AARCH64
+            CHECK((this->*cell_func)(ctx, rnn, cell_position, cell_dst_layer,
+                    cell_dst_iter_c,
+                    SAFE_PTR(ws_diff_states_layer, lay, dir, iter, 0),
+                    SAFE_PTR(diff_augru_attention, iter, 0, 0),
+                    SAFE_PTR(ws_diff_states_iter, lay, dir, iter, 0),
+                    SAFE_PTR(ws_diff_states_iter_c, lay, dir, iter, 0),
+                    SAFE_PTR(weights_layer, lay, dir, 0),
+                    SAFE_PTR(weights_iter, lay, dir, 0),
+                    SAFE_PTR(weights_projection, lay, dir),
+                    SAFE_PTR(weights_peephole, lay, dir, 0),
+                    w_proj_comp ? w_proj_comp + (j * rnn.n_dir + dir) * rnn.dic
+                                : nullptr,
+                    bias(lay, dir), cell_src_layer,
+                    SAFE_PTR(augru_attention, iter, 0, 0), cell_src_iter,
+                    cell_src_iter_c,
+                    SAFE_PTR(ws_diff_states_layer, lay + 1, dir, iter, 0),
+                    SAFE_PTR(ws_diff_states_iter, lay, dir, iter + 1, 0),
+                    SAFE_PTR(ws_diff_states_iter_c, lay, dir, iter + 1, 0),
+                    SAFE_PTR(diff_weights_layer, lay, dir, 0),
+                    SAFE_PTR(diff_weights_iter, lay, dir, 0),
+                    SAFE_PTR(diff_weights_projection, lay, dir, 0),
+                    SAFE_PTR(diff_weights_peephole, lay, dir, 0),
+                    SAFE_PTR(diff_bias, lay, dir, 0),
+                    SAFE_PTR(ws_gates, lay, dir, iter, 0), cell_scratch_gates,
+                    proj_ht, scratch_diff_ht_,
+                    SAFE_PTR(ws_grid, lay, dir, iter, 0), scratch_cell_,
+                    scratch_gates_blocked_, scratch_src_layer_,
+                    scratch_src_iter_, cell_dst_iter, addr_batch_global));
 #else
             CHECK((this->*cell_func)(ctx, rnn, cell_position, cell_dst_layer,
                     cell_dst_iter_c,
@@ -2052,9 +2280,18 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             = scratchpad.template get<scratch_t>(key_rnn_src_layer_trans);
     const auto scratch_src_iter
             = scratchpad.template get<scratch_t>(key_rnn_src_iter_trans);
+#elif DNNL_AARCH64
+    const auto scratch_gates_blocked
+            = scratchpad.template get<scratch_t>(key_rnn_gates_blocked);
+    const auto scratch_src_layer
+            = scratchpad.template get<scratch_t>(key_rnn_src_layer_trans);
+    const auto scratch_src_iter
+            = scratchpad.template get<scratch_t>(key_rnn_src_iter_trans);
 #endif
 
     gemm_acc_t *amx_scratchpad = nullptr;
+    MAYBE_UNUSED(amx_scratchpad);
+
 #if DNNL_X64
     x64::brgemm_batch_element_t *addr_batch_global = nullptr;
     if (rnn.is_brgemm && rnn.is_cell_amx()) {
@@ -2063,6 +2300,14 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     }
     addr_batch_global = scratchpad.template get<x64::brgemm_batch_element_t>(
             key_brgemm_primitive_batch);
+#elif DNNL_AARCH64
+    aarch64::brgemm_batch_element_t *addr_batch_global = nullptr;
+    if (rnn.is_brgemm) {
+        addr_batch_global
+                = scratchpad.template get<aarch64::brgemm_batch_element_t>(
+                        key_brgemm_primitive_batch);
+    }
+
 #endif
     // Fetching buffers from the workspace
     // if no workspace was provided we use the scratchpad
@@ -2249,6 +2494,19 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             diff_weights_layer, diff_weights_iter, diff_weights_projection,
             diff_weights_peephole, diff_bias, amx_scratchpad,
             addr_batch_global));
+
+#elif DNNL_AARCH64
+    CHECK((this->*grid_computation)(ctx, rnn, ptr_wei_layer, ptr_wei_iter,
+            ptr_wei_projection, weights_peephole, w_projection_comp, ptr_bias,
+            src_layer, augru_attention, (const src_iter_t *)src_iter,
+            src_iter_c, (dst_layer_t *)dst_layer, (dst_iter_t *)dst_iter,
+            dst_iter_c, ws_states_layer, ws_states_iter, ws_states_iter_c,
+            ws_diff_states_layer, ws_diff_states_iter, ws_diff_states_iter_c,
+            ws_gates, ws_ht, ws_grid, scratch_gates, scratch_ht,
+            scratch_diff_ht, scratch_cell, scratch_gates_blocked,
+            scratch_src_layer, scratch_src_iter, diff_augru_attention,
+            diff_weights_layer, diff_weights_iter, diff_weights_projection,
+            diff_weights_peephole, diff_bias, addr_batch_global));
 #else
     CHECK((this->*grid_computation)(ctx, rnn, ptr_wei_layer, ptr_wei_iter,
             ptr_wei_projection, weights_peephole, w_projection_comp, ptr_bias,

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -303,8 +303,8 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
     using namespace utils;
     using namespace format_tag;
     using namespace rnn_utils;
-#if DNNL_X64
-    using namespace x64;
+#if DNNL_X64 || DNNL_AARCH64
+    using namespace rnn_brgemm_arch;
     const alg_kind_t cell_kind = this->desc()->cell_kind;
 
     const data_type_t src_layer_dt = this->desc()->src_layer_desc.data_type;
@@ -312,6 +312,7 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
             = this->desc()->weights_iter_desc.data_type;
     const data_type_t weights_layer_dt
             = this->desc()->weights_layer_desc.data_type;
+#if DNNL_X64
     bool is_f32 = everyone_is(
             data_type::f32, src_layer_dt, weights_iter_dt, weights_layer_dt);
     bool is_impl_bf16 = everyone_is(data_type::bf16, src_type, weights_type);
@@ -319,6 +320,7 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
             this->attr()->fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any);
     bool allow_down_conversion_to_bf16
             = is_f32 && is_fpmath_bf16 && is_impl_bf16;
+#endif
 
     // Initialized rnn_ early to get correct verbose output
     rnn_ = zero<decltype(rnn_)>();
@@ -346,11 +348,18 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
             VERBOSE_BAD_PROPKIND);
     // cell_type (or src_type) and primitive data type should
     // match, except for the bf32 case.
+#if DNNL_X64
     VDISPATCH_RNN(IMPLICATION(!allow_down_conversion_to_bf16,
                           src_layer_dt == src_type
                                   && everyone_is(weights_type, weights_iter_dt,
                                           weights_layer_dt)),
             VERBOSE_UNSUPPORTED_DT);
+#else
+    VDISPATCH_RNN(src_layer_dt == src_type
+                    && everyone_is(
+                            weights_type, weights_iter_dt, weights_layer_dt),
+            VERBOSE_UNSUPPORTED_DT);
+#endif
     VDISPATCH_RNN(this->set_default_params() == status::success,
             VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_RNN(this->with_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
@@ -389,16 +398,28 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
                           this->desc()->prop_kind == forward_inference)),
             "bad algorithm for lstm projection for forward inference");
 
+#if DNNL_AARCH64
+    VDISPATCH_RNN(mayiuse(asimd), VERBOSE_ISA_DT_MISMATCH);
+#endif
+
     if (rnn_.is_bf16_conf()) {
-        const bool isa_dt_not_ok = (!mayiuse(avx512_core_bf16)
-                || !utils::one_of(rnn_.bias_dt, data_type::bf16, data_type::f32)
+        const bool isa_dt_not_ok = (
+#if DNNL_X64
+                !mayiuse(avx512_core_bf16) ||
+#else
+                !mayiuse_bf16() ||
+#endif
+                !utils::one_of(rnn_.bias_dt, data_type::bf16, data_type::f32)
                 || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt
                 || !utils::one_of(rnn_.src_iter_c_dt, data_type::undef,
                         data_type::bf16, data_type::f32));
         VDISPATCH_RNN(!isa_dt_not_ok, VERBOSE_ISA_DT_MISMATCH);
     } else if (rnn_.is_f16_conf()) {
-        const bool isa_dt_not_ok = (!mayiuse(avx512_core_amx_fp16)
-                || !utils::one_of(rnn_.bias_dt, data_type::f16, data_type::f32)
+        const bool isa_dt_not_ok = (
+#if DNNL_X64
+                !mayiuse(avx512_core_amx_fp16) ||
+#endif
+                !utils::one_of(rnn_.bias_dt, data_type::f16, data_type::f32)
                 || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt
                 || !utils::one_of(rnn_.src_iter_c_dt, data_type::undef,
                         data_type::f16, data_type::f32));
@@ -410,6 +431,7 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
                 || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt);
         VDISPATCH_RNN(!dt_not_ok, VERBOSE_UNSUPPORTED_DT_CFG);
     }
+#if DNNL_X64
     const auto isa = get_max_cpu_isa();
     VDISPATCH_RNN(
             !(rnn_.is_signed_int8_conf() && !is_superset(isa, avx512_core_amx)),
@@ -424,6 +446,7 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
                           this->attr()->rnn_data_qparams_.shift_ == 0),
             VERBOSE_UNSUPPORTED_FEATURE,
             "s8s8 amx lstm does not support shift");
+#endif
 
     /* INT8 cases with non-trivial strides are not supported */
     VDISPATCH_RNN(!(rnn_.is_int8_conf()
@@ -438,7 +461,10 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
         attr_mask = attr_mask | primitive_attr_t::skip_mask_t::rnn_data_qparams
                 | primitive_attr_t::skip_mask_t::rnn_weights_qparams
                 | primitive_attr_t::skip_mask_t::rnn_weights_projection_qparams
-                | primitive_attr_t::skip_mask_t::fpmath_mode;
+#if DNNL_X64
+                | primitive_attr_t::skip_mask_t::fpmath_mode
+#endif
+                ;
     VDISPATCH_RNN(this->attr()->has_default_values(attr_mask),
             VERBOSE_UNSUPPORTED_ATTR);
 
@@ -454,8 +480,10 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
     set_workspace_sizes<class_name>(rnn_, *this->desc());
 
     // Only AMX LSTM supports s8s8 now
+#if DNNL_X64
     VDISPATCH_RNN(!(rnn_.is_signed_int8_conf() && !rnn_.is_cell_int8_amx()),
             VERBOSE_UNSUPPORTED_DT);
+#endif
 
     // Set weights descriptors to desired format
     memory_desc_t new_weights_layer_md = *this->weights_md(0);
@@ -513,7 +541,7 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
     VDISPATCH_RNN(this->check_layout_consistency(true /*is_brgemm*/)
                     == status::success,
             "layout consistency check failed");
-
+#if DNNL_X64
     if (rnn_.is_bf32()) {
         const memory_desc_wrapper weights_layer_d(this->weights_layer_md_);
         memory_desc_t weights_layer_md;
@@ -532,196 +560,13 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
         CHECK(reorder_primitive_desc_create(bf32_wei_iter_reorder_pd_, engine,
                 weights_iter_d.md_, &weights_iter_md, nullptr));
     }
-
-    return status::success;
-
-#elif DNNL_AARCH64
-    using namespace aarch64;
-
-    const alg_kind_t cell_kind = this->desc()->cell_kind;
-    const data_type_t src_layer_dt = this->desc()->src_layer_desc.data_type;
-    const data_type_t weights_iter_dt
-            = this->desc()->weights_iter_desc.data_type;
-    const data_type_t weights_layer_dt
-            = this->desc()->weights_layer_desc.data_type;
-
-    rnn_ = zero<decltype(rnn_)>();
-    rnn_.is_brgemm = true;
-
-    VDISPATCH_RNN(
-            one_of(cell_kind, alg_kind::vanilla_rnn, alg_kind::vanilla_lstm,
-                    alg_kind::vanilla_gru, alg_kind::lbr_gru,
-                    alg_kind::vanilla_augru, alg_kind::lbr_augru),
-            VERBOSE_BAD_ALGORITHM);
-    VDISPATCH_RNN(IMPLICATION(aprop == prop_kind::forward,
-                          one_of(this->desc()->prop_kind, forward_training,
-                                  forward_inference)),
-            VERBOSE_BAD_PROPKIND);
-    VDISPATCH_RNN(IMPLICATION(one_of(cell_kind, alg_kind::lbr_gru,
-                                      alg_kind::lbr_augru),
-                          this->desc()->prop_kind == forward_inference),
-            VERBOSE_BAD_ALGORITHM);
-    VDISPATCH_RNN(IMPLICATION(aprop == backward,
-                          one_of(this->desc()->prop_kind, backward)),
-            VERBOSE_BAD_PROPKIND);
-    VDISPATCH_RNN(IMPLICATION(aprop == backward,
-                          this->diff_weights_overwrite() == false),
-            VERBOSE_BAD_PROPKIND);
-
-    /* No bf32 down-conversion on aarch64 — require exact type match. */
-    VDISPATCH_RNN(src_layer_dt == src_type
-                    && everyone_is(
-                            weights_type, weights_iter_dt, weights_layer_dt),
-            VERBOSE_UNSUPPORTED_DT);
-
-    VDISPATCH_RNN(this->set_default_params() == status::success,
-            VERBOSE_UNSUPPORTED_ATTR);
-    VDISPATCH_RNN(this->with_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
-
-    VDISPATCH_RNN(init_conf<class_name>(rnn_, *this->desc(), *this->attr(),
-                          this->src_md(0), this->src_md(1), this->src_md(2),
-                          this->weights_md(0), this->weights_md(1),
-                          this->arg_md(DNNL_ARG_WEIGHTS_PROJECTION),
-                          this->dst_md(0), this->dst_md(1), this->dst_md(2),
-                          this->arg_md(DNNL_ARG_BIAS)),
-            VERBOSE_PRIMITIVE_CREATION_FAIL, "rnn");
-
-    VDISPATCH_RNN(IMPLICATION(one_of(this->desc()->prop_kind, forward_training,
-                                      backward),
-                          (rnn_.is_xf16_conf() || rnn_.is_f32_conf())),
-            VERBOSE_PROPKIND_DT_MISMATCH);
-
-    VDISPATCH_RNN(IMPLICATION(rnn_.is_orig_gru,
-                          this->desc()->prop_kind == forward_inference
-                                  && !rnn_.is_cell_dt_f32()),
-            VERBOSE_UNSUPPORTED_FEATURE,
-            "gru/augru cell in brgemm-based forward inference");
-
-    VDISPATCH_RNN(!(rnn_.is_cell_dt_f32()
-                          && utils::one_of(this->desc()->prop_kind, backward,
-                                  forward_training)),
-            VERBOSE_UNSUPPORTED_FEATURE,
-            "f32 datatype in brgemm-based implementation");
-
-    VDISPATCH_RNN((IMPLICATION((cell_kind == alg_kind::vanilla_lstm
-                                       && rnn_.is_lstm_projection),
-                          this->desc()->prop_kind == forward_inference)),
-            "bad algorithm for lstm projection for forward inference");
-
-    //    const auto isa = get_max_cpu_isa();
-    VDISPATCH_RNN(mayiuse(asimd), VERBOSE_ISA_DT_MISMATCH);
-
-    if (rnn_.is_bf16_conf()) {
-        const bool isa_dt_not_ok = (!mayiuse_bf16()
-                || !utils::one_of(rnn_.bias_dt, data_type::bf16, data_type::f32)
-                || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt
-                || !utils::one_of(rnn_.src_iter_c_dt, data_type::undef,
-                        data_type::bf16, data_type::f32));
-        VDISPATCH_RNN(!isa_dt_not_ok, VERBOSE_ISA_DT_MISMATCH);
-    } else if (rnn_.is_f16_conf()) {
-        const bool isa_dt_not_ok
-                = (!utils::one_of(rnn_.bias_dt, data_type::f16, data_type::f32)
-                        || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt
-                        || !utils::one_of(rnn_.src_iter_c_dt, data_type::undef,
-                                data_type::f16, data_type::f32));
-        VDISPATCH_RNN(!isa_dt_not_ok, VERBOSE_ISA_DT_MISMATCH);
-    } else {
-        const bool dt_not_ok = (rnn_.bias_dt != data_type::f32
-                || !utils::one_of(
-                        rnn_.src_iter_c_dt, data_type::undef, data_type::f32)
-                || rnn_.src_iter_c_dt != rnn_.dst_iter_c_dt);
-        VDISPATCH_RNN(!dt_not_ok, VERBOSE_UNSUPPORTED_DT_CFG);
-    }
-
-    VDISPATCH_RNN(!(rnn_.is_int8_conf()
-                          && !(rnn_.src_layer_is_trivial_stride
-                                  && rnn_.dst_layer_is_trivial_stride)),
-            VERBOSE_NONTRIVIAL_STRIDE);
-
-    primitive_attr_t::skip_mask_t attr_mask
-            = primitive_attr_t::skip_mask_t::rnn_tparams;
-    if (weights_layer_dt == data_type::s8)
-        attr_mask = attr_mask | primitive_attr_t::skip_mask_t::rnn_data_qparams
-                | primitive_attr_t::skip_mask_t::rnn_weights_qparams
-                | primitive_attr_t::skip_mask_t::rnn_weights_projection_qparams;
-    VDISPATCH_RNN(this->attr()->has_default_values(attr_mask),
-            VERBOSE_UNSUPPORTED_ATTR);
-
-    set_conf<class_name>(rnn_, *this->desc(), this->weights_md(0),
-            this->weights_md(1), this->arg_md(DNNL_ARG_WEIGHTS_PROJECTION),
-            this->diff_weights_md(0), this->diff_weights_md(1),
-            this->arg_md(DNNL_ARG_DIFF_WEIGHTS_PROJECTION));
-
-    CHECK(ref_rnn_brgemm_t::configure_brgemm(rnn_, this->desc()->cell_kind,
-            sizeof(src_layer_t), sizeof(scratch_t)));
-
-    set_workspace_sizes<class_name>(rnn_, *this->desc());
-
-    memory_desc_t new_weights_layer_md = *this->weights_md(0);
-    CHECK(set_expected_desc(
-            rnn_, new_weights_layer_md, rnn_utils::weights_type_t::layer));
-    if (this->weights_layer_md_.format_kind == format_kind::any) {
-        this->weights_layer_md_ = new_weights_layer_md;
-    } else {
-        VDISPATCH_RNN(this->weights_layer_md_ == new_weights_layer_md,
-                VERBOSE_INCONSISTENT_MDS, "weights_layer", "new_weights_layer");
-    }
-
-    memory_desc_t new_weights_iter_md = *this->weights_md(1);
-    CHECK(set_expected_desc(
-            rnn_, new_weights_iter_md, rnn_utils::weights_type_t::iter));
-    if (this->weights_iter_md_.format_kind == format_kind::any) {
-        this->weights_iter_md_ = new_weights_iter_md;
-    } else {
-        VDISPATCH_RNN(this->weights_iter_md_ == new_weights_iter_md,
-                VERBOSE_INCONSISTENT_MDS, "weights_iter", "new_weights_iter");
-    }
-
-    if (rnn_.is_lstm_projection) {
-        memory_desc_t new_weights_projection_md
-                = *this->arg_md(DNNL_ARG_WEIGHTS_PROJECTION);
-        CHECK(set_expected_desc(rnn_, new_weights_projection_md,
-                rnn_utils::weights_type_t::projection));
-        if (this->weights_projection_md_.format_kind == format_kind::any) {
-            this->weights_projection_md_ = new_weights_projection_md;
-        } else {
-            VDISPATCH_RNN(
-                    this->weights_projection_md_ == new_weights_projection_md,
-                    VERBOSE_INCONSISTENT_MDS, "weights_projection",
-                    "new_weights_projection");
-        }
-    }
-
-    if (rnn_.is_unsigned_int8_conf()) {
-        const memory_desc_wrapper &weights_layer_d(this->weights_layer_md_);
-        const memory_desc_wrapper &weights_iter_d(this->weights_iter_md_);
-        const auto &pdims_l = weights_layer_d.padded_dims();
-        const auto &pdims_i = weights_iter_d.padded_dims();
-        rnn_.weights_layer_comp_offset = rnn_.n_layer * rnn_.n_dir
-                * rnn_.n_gates * pdims_l[2] * pdims_l[4];
-        rnn_.weights_iter_comp_offset = rnn_.n_layer * rnn_.n_dir * rnn_.n_gates
-                * pdims_i[2] * pdims_i[4];
-        if (rnn_.is_lstm_projection) {
-            const memory_desc_wrapper &weights_proj_d(
-                    this->weights_projection_md_);
-            const auto &pdims_p = weights_proj_d.padded_dims();
-            rnn_.weights_projection_comp_offset
-                    = rnn_.n_layer * rnn_.n_dir * pdims_p[2] * pdims_p[3];
-        } else {
-            rnn_.weights_projection_comp_offset = 0;
-        }
-    }
-
-    VDISPATCH_RNN(this->check_layout_consistency(true /*is_brgemm*/)
-                    == status::success,
-            "layout consistency check failed");
-
+#else
     VDISPATCH_RNN(!rnn_.is_bf32(), VERBOSE_UNSUPPORTED_FEATURE,
             "bf32 is not supported in aarch64 brgemm rnn as No bf32 reorder on "
             "aarch64.");
+#endif
 
     return status::success;
-
 #else
     return status::unimplemented;
 #endif
@@ -903,25 +748,21 @@ status_t dnnl::impl::cpu::ref_rnn_common_t<aprop, src_type, weights_type,
     CREATE_MATMUL(matmul_part2_4_);
 #undef CREATE_MATMUL
 
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
     const auto rnn = pd()->rnn_;
     if (rnn.is_brgemm) {
+#if DNNL_X64
         if (rnn.is_bf32()) {
-
             CHECK(pd()->bf32_wei_layer_reorder_pd_->create_primitive(
                     bf32_wei_layer_reorder_, engine));
-
             CHECK(pd()->bf32_wei_iter_reorder_pd_->create_primitive(
                     bf32_wei_iter_reorder_, engine));
         }
-        return rnn_brgemm_.init_kernels(rnn, src_type, weights_type);
-    }
-#elif DNNL_AARCH64
-    const auto rnn = pd()->rnn_;
-    if (rnn.is_brgemm) {
+#endif
         return rnn_brgemm_.init_kernels(rnn, src_type, weights_type);
     }
 #endif
+
     return status::success;
 }
 
@@ -1218,17 +1059,12 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         const src_layer_t *src_layer = lay == 0 && rnn.skip_src_layer_copy()
                 ? src_layer_
                 : SAFE_PTR(ws_states_layer, lay, dir, 1, 0);
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
         CHECK((this->*merged_layer_func)(ctx, rnn, cell_position,
                 SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
                 SAFE_PTR(ws_diff_states_layer, lay, dir, 0, 0),
-                SAFE_PTR(diff_weights_layer, lay, dir, 0), amx_scratchpad,
-                addr_batch_global));
-#elif DNNL_AARCH64
-        CHECK((this->*merged_layer_func)(ctx, rnn, cell_position,
-                SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
-                SAFE_PTR(ws_diff_states_layer, lay, dir, 0, 0),
-                SAFE_PTR(diff_weights_layer, lay, dir, 0), addr_batch_global));
+                SAFE_PTR(diff_weights_layer, lay, dir, 0),
+                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global));
 #else
         CHECK((this->*merged_layer_func)(rnn, cell_position,
                 SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
@@ -1337,7 +1173,7 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
                     proj_ht = scratch_ht_;
             }
 
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
             CHECK((this->*cell_func)(ctx, rnn, cell_position, cell_dst_layer,
                     cell_dst_iter_c,
                     SAFE_PTR(ws_diff_states_layer, lay, dir, iter, 0),
@@ -1365,37 +1201,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
                     proj_ht, scratch_diff_ht_,
                     SAFE_PTR(ws_grid, lay, dir, iter, 0), scratch_cell_,
                     scratch_gates_blocked_, scratch_src_layer_,
-                    scratch_src_iter_, cell_dst_iter, amx_scratchpad,
-                    addr_batch_global));
-#elif DNNL_AARCH64
-            CHECK((this->*cell_func)(ctx, rnn, cell_position, cell_dst_layer,
-                    cell_dst_iter_c,
-                    SAFE_PTR(ws_diff_states_layer, lay, dir, iter, 0),
-                    SAFE_PTR(diff_augru_attention, iter, 0, 0),
-                    SAFE_PTR(ws_diff_states_iter, lay, dir, iter, 0),
-                    SAFE_PTR(ws_diff_states_iter_c, lay, dir, iter, 0),
-                    SAFE_PTR(weights_layer, lay, dir, 0),
-                    SAFE_PTR(weights_iter, lay, dir, 0),
-                    SAFE_PTR(weights_projection, lay, dir),
-                    SAFE_PTR(weights_peephole, lay, dir, 0),
-                    w_proj_comp ? w_proj_comp + (j * rnn.n_dir + dir) * rnn.dic
-                                : nullptr,
-                    bias(lay, dir), cell_src_layer,
-                    SAFE_PTR(augru_attention, iter, 0, 0), cell_src_iter,
-                    cell_src_iter_c,
-                    SAFE_PTR(ws_diff_states_layer, lay + 1, dir, iter, 0),
-                    SAFE_PTR(ws_diff_states_iter, lay, dir, iter + 1, 0),
-                    SAFE_PTR(ws_diff_states_iter_c, lay, dir, iter + 1, 0),
-                    SAFE_PTR(diff_weights_layer, lay, dir, 0),
-                    SAFE_PTR(diff_weights_iter, lay, dir, 0),
-                    SAFE_PTR(diff_weights_projection, lay, dir, 0),
-                    SAFE_PTR(diff_weights_peephole, lay, dir, 0),
-                    SAFE_PTR(diff_bias, lay, dir, 0),
-                    SAFE_PTR(ws_gates, lay, dir, iter, 0), cell_scratch_gates,
-                    proj_ht, scratch_diff_ht_,
-                    SAFE_PTR(ws_grid, lay, dir, iter, 0), scratch_cell_,
-                    scratch_gates_blocked_, scratch_src_layer_,
-                    scratch_src_iter_, cell_dst_iter, addr_batch_global));
+                    scratch_src_iter_, cell_dst_iter,
+                    RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global));
 #else
             CHECK((this->*cell_func)(ctx, rnn, cell_position, cell_dst_layer,
                     cell_dst_iter_c,
@@ -2273,14 +2080,7 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     auto ptr_wei_projection
             = scratchpad.template get<weights_t *>(key_rnn_ptrs_wei_projection);
     auto ptr_bias = scratchpad.template get<void *>(key_rnn_ptrs_bia);
-#if DNNL_X64
-    const auto scratch_gates_blocked
-            = scratchpad.template get<scratch_t>(key_rnn_gates_blocked);
-    const auto scratch_src_layer
-            = scratchpad.template get<scratch_t>(key_rnn_src_layer_trans);
-    const auto scratch_src_iter
-            = scratchpad.template get<scratch_t>(key_rnn_src_iter_trans);
-#elif DNNL_AARCH64
+#if DNNL_X64 || DNNL_AARCH64
     const auto scratch_gates_blocked
             = scratchpad.template get<scratch_t>(key_rnn_gates_blocked);
     const auto scratch_src_layer
@@ -2289,25 +2089,20 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             = scratchpad.template get<scratch_t>(key_rnn_src_iter_trans);
 #endif
 
-    gemm_acc_t *amx_scratchpad = nullptr;
-    MAYBE_UNUSED(amx_scratchpad);
-
 #if DNNL_X64
-    x64::brgemm_batch_element_t *addr_batch_global = nullptr;
+    gemm_acc_t *amx_scratchpad = nullptr;
     if (rnn.is_brgemm && rnn.is_cell_amx()) {
         amx_scratchpad = scratchpad.template get<gemm_acc_t>(
                 key_brgemm_primitive_buffer);
     }
-    addr_batch_global = scratchpad.template get<x64::brgemm_batch_element_t>(
-            key_brgemm_primitive_batch);
-#elif DNNL_AARCH64
-    aarch64::brgemm_batch_element_t *addr_batch_global = nullptr;
+#endif
+#if DNNL_X64 || DNNL_AARCH64
+    rnn_brgemm_arch::brgemm_batch_element_t *addr_batch_global = nullptr;
     if (rnn.is_brgemm) {
-        addr_batch_global
-                = scratchpad.template get<aarch64::brgemm_batch_element_t>(
-                        key_brgemm_primitive_batch);
+        addr_batch_global = scratchpad.template get<
+                rnn_brgemm_arch::brgemm_batch_element_t>(
+                key_brgemm_primitive_batch);
     }
-
 #endif
     // Fetching buffers from the workspace
     // if no workspace was provided we use the scratchpad
@@ -2481,7 +2276,7 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
     }
 
     // run the execution on the grid
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
     CHECK((this->*grid_computation)(ctx, rnn, ptr_wei_layer, ptr_wei_iter,
             ptr_wei_projection, weights_peephole, w_projection_comp, ptr_bias,
             src_layer, augru_attention, (const src_iter_t *)src_iter,
@@ -2492,21 +2287,8 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             scratch_diff_ht, scratch_cell, scratch_gates_blocked,
             scratch_src_layer, scratch_src_iter, diff_augru_attention,
             diff_weights_layer, diff_weights_iter, diff_weights_projection,
-            diff_weights_peephole, diff_bias, amx_scratchpad,
-            addr_batch_global));
-
-#elif DNNL_AARCH64
-    CHECK((this->*grid_computation)(ctx, rnn, ptr_wei_layer, ptr_wei_iter,
-            ptr_wei_projection, weights_peephole, w_projection_comp, ptr_bias,
-            src_layer, augru_attention, (const src_iter_t *)src_iter,
-            src_iter_c, (dst_layer_t *)dst_layer, (dst_iter_t *)dst_iter,
-            dst_iter_c, ws_states_layer, ws_states_iter, ws_states_iter_c,
-            ws_diff_states_layer, ws_diff_states_iter, ws_diff_states_iter_c,
-            ws_gates, ws_ht, ws_grid, scratch_gates, scratch_ht,
-            scratch_diff_ht, scratch_cell, scratch_gates_blocked,
-            scratch_src_layer, scratch_src_iter, diff_augru_attention,
-            diff_weights_layer, diff_weights_iter, diff_weights_projection,
-            diff_weights_peephole, diff_bias, addr_batch_global));
+            diff_weights_peephole, diff_bias,
+            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global));
 #else
     CHECK((this->*grid_computation)(ctx, rnn, ptr_wei_layer, ptr_wei_iter,
             ptr_wei_projection, weights_peephole, w_projection_comp, ptr_bias,

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -304,7 +304,6 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
     using namespace format_tag;
     using namespace rnn_utils;
 #if DNNL_X64 || DNNL_AARCH64
-    using namespace rnn_brgemm_arch;
     const alg_kind_t cell_kind = this->desc()->cell_kind;
 
     const data_type_t src_layer_dt = this->desc()->src_layer_desc.data_type;
@@ -479,8 +478,8 @@ ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::pd_t::init_brgemm(
     // must be called after configure_brgemm()
     set_workspace_sizes<class_name>(rnn_, *this->desc());
 
-    // Only AMX LSTM supports s8s8 now
 #if DNNL_X64
+    // Only AMX LSTM supports s8s8 now
     VDISPATCH_RNN(!(rnn_.is_signed_int8_conf() && !rnn_.is_cell_int8_amx()),
             VERBOSE_UNSUPPORTED_DT);
 #endif
@@ -1063,8 +1062,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         CHECK((this->*merged_layer_func)(ctx, rnn, cell_position,
                 SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
                 SAFE_PTR(ws_diff_states_layer, lay, dir, 0, 0),
-                SAFE_PTR(diff_weights_layer, lay, dir, 0),
-                RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global));
+                SAFE_PTR(diff_weights_layer, lay, dir, 0), gemm_acc_scratchpad,
+                addr_batch_global));
 #else
         CHECK((this->*merged_layer_func)(rnn, cell_position,
                 SAFE_PTR(weights_layer, lay, dir, 0), src_layer, scratch_gates_,
@@ -1201,8 +1200,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
                     proj_ht, scratch_diff_ht_,
                     SAFE_PTR(ws_grid, lay, dir, iter, 0), scratch_cell_,
                     scratch_gates_blocked_, scratch_src_layer_,
-                    scratch_src_iter_, cell_dst_iter,
-                    RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global));
+                    scratch_src_iter_, cell_dst_iter, gemm_acc_scratchpad,
+                    addr_batch_global));
 #else
             CHECK((this->*cell_func)(ctx, rnn, cell_position, cell_dst_layer,
                     cell_dst_iter_c,
@@ -1230,7 +1229,7 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
                     SAFE_PTR(ws_gates, lay, dir, iter, 0), cell_scratch_gates,
                     proj_ht, scratch_diff_ht_,
                     SAFE_PTR(ws_grid, lay, dir, iter, 0), scratch_cell_,
-                    cell_dst_iter, amx_scratchpad));
+                    cell_dst_iter, gemm_acc_scratchpad));
 #endif
         }
 
@@ -2089,21 +2088,22 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             = scratchpad.template get<scratch_t>(key_rnn_src_iter_trans);
 #endif
 
-#if DNNL_X64
-    gemm_acc_t *amx_scratchpad = nullptr;
-    if (rnn.is_brgemm && rnn.is_cell_amx()) {
-        amx_scratchpad = scratchpad.template get<gemm_acc_t>(
-                key_brgemm_primitive_buffer);
-    }
-#endif
+    gemm_acc_t *gemm_acc_scratchpad = nullptr;
 #if DNNL_X64 || DNNL_AARCH64
-    rnn_brgemm_arch::brgemm_batch_element_t *addr_batch_global = nullptr;
+    brgemm_batch_element_t *addr_batch_global = nullptr;
+
     if (rnn.is_brgemm) {
-        addr_batch_global = scratchpad.template get<
-                rnn_brgemm_arch::brgemm_batch_element_t>(
+#if DNNL_X64
+        if (rnn.is_cell_amx()) {
+            gemm_acc_scratchpad = scratchpad.template get<gemm_acc_t>(
+                    key_brgemm_primitive_buffer);
+        }
+#endif
+        addr_batch_global = scratchpad.template get<brgemm_batch_element_t>(
                 key_brgemm_primitive_batch);
     }
 #endif
+
     // Fetching buffers from the workspace
     // if no workspace was provided we use the scratchpad
     char *scratch_ptr = scratchpad.template get<char>(key_rnn_space);
@@ -2287,8 +2287,8 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             scratch_diff_ht, scratch_cell, scratch_gates_blocked,
             scratch_src_layer, scratch_src_iter, diff_augru_attention,
             diff_weights_layer, diff_weights_iter, diff_weights_projection,
-            diff_weights_peephole, diff_bias,
-            RNN_AMX_SCRATCHPAD_ACTUAL addr_batch_global));
+            diff_weights_peephole, diff_bias, gemm_acc_scratchpad,
+            addr_batch_global));
 #else
     CHECK((this->*grid_computation)(ctx, rnn, ptr_wei_layer, ptr_wei_iter,
             ptr_wei_projection, weights_peephole, w_projection_comp, ptr_bias,
@@ -2299,7 +2299,7 @@ status_t ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute(
             ws_gates, ws_ht, ws_grid, scratch_gates, scratch_ht,
             scratch_diff_ht, scratch_cell, diff_augru_attention,
             diff_weights_layer, diff_weights_iter, diff_weights_projection,
-            diff_weights_peephole, diff_bias, amx_scratchpad));
+            diff_weights_peephole, diff_bias, gemm_acc_scratchpad));
 #endif
 
     // Finally we copy the results to the result buffers

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -32,6 +33,8 @@
 #include "cpu/rnn/postgemm_dispatcher.hpp"
 #if DNNL_X64
 #include "cpu/x64/rnn/rnn_brgemm_utils.hpp"
+#elif DNNL_AARCH64
+#include "cpu/aarch64/rnn/rnn_brgemm_utils.hpp"
 #endif
 #include "cpu/rnn/rnn_utils.hpp"
 namespace dnnl {
@@ -114,6 +117,8 @@ struct ref_rnn_common_t : public primitive_t {
             = ref_rnn_common_t<aprop, src_type, weights_type, acc_type>;
 #if DNNL_X64
     using ref_rnn_brgemm_t = x64::rnn_brgemm_utils::rnn_brgemm_t<aprop>;
+#elif DNNL_AARCH64
+    using ref_rnn_brgemm_t = aarch64::rnn_brgemm_utils::rnn_brgemm_t<aprop>;
 #endif
 
     using cell_execution_f
@@ -141,6 +146,12 @@ struct ref_rnn_common_t : public primitive_t {
         const char *impl_name() const {
 #if DNNL_X64
             using namespace dnnl::impl::cpu::x64;
+            return rnn_.is_brgemm
+                    ? JIT_IMPL_NAME_HELPER("brgemm:", rnn_.brgemm_isa, "")
+                    : rnn_.use_matmul ? "ref+matmul"
+                                      : "ref";
+#elif DNNL_AARCH64
+            using namespace dnnl::impl::cpu::aarch64;
             return rnn_.is_brgemm
                     ? JIT_IMPL_NAME_HELPER("brgemm:", rnn_.brgemm_isa, "")
                     : rnn_.use_matmul ? "ref+matmul"
@@ -187,6 +198,8 @@ protected:
     ref_rnn_brgemm_t rnn_brgemm_;
     std::shared_ptr<primitive_t> bf32_wei_layer_reorder_;
     std::shared_ptr<primitive_t> bf32_wei_iter_reorder_;
+#elif DNNL_AARCH64
+    ref_rnn_brgemm_t rnn_brgemm_;
 #endif
 
     template <typename input_t>

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -37,9 +37,22 @@
 #include "cpu/aarch64/rnn/rnn_brgemm_utils.hpp"
 #endif
 #include "cpu/rnn/rnn_utils.hpp"
+
+#if DNNL_X64
+#define RNN_AMX_SCRATCHPAD_ACTUAL amx_scratchpad,
+#else
+#define RNN_AMX_SCRATCHPAD_ACTUAL
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
+
+#if DNNL_X64
+namespace rnn_brgemm_arch = x64;
+#elif DNNL_AARCH64
+namespace rnn_brgemm_arch = aarch64;
+#endif
 
 namespace {
 template <typename gates_t, typename acc_t>
@@ -115,10 +128,9 @@ struct ref_rnn_common_t : public primitive_t {
 
     using class_name
             = ref_rnn_common_t<aprop, src_type, weights_type, acc_type>;
-#if DNNL_X64
-    using ref_rnn_brgemm_t = x64::rnn_brgemm_utils::rnn_brgemm_t<aprop>;
-#elif DNNL_AARCH64
-    using ref_rnn_brgemm_t = aarch64::rnn_brgemm_utils::rnn_brgemm_t<aprop>;
+#if DNNL_X64 || DNNL_AARCH64
+    using ref_rnn_brgemm_t
+            = rnn_brgemm_arch::rnn_brgemm_utils::rnn_brgemm_t<aprop>;
 #endif
 
     using cell_execution_f
@@ -144,14 +156,8 @@ struct ref_rnn_common_t : public primitive_t {
         using base_pd_t::base_pd_t;
 
         const char *impl_name() const {
-#if DNNL_X64
-            using namespace dnnl::impl::cpu::x64;
-            return rnn_.is_brgemm
-                    ? JIT_IMPL_NAME_HELPER("brgemm:", rnn_.brgemm_isa, "")
-                    : rnn_.use_matmul ? "ref+matmul"
-                                      : "ref";
-#elif DNNL_AARCH64
-            using namespace dnnl::impl::cpu::aarch64;
+#if DNNL_X64 || DNNL_AARCH64
+            using namespace rnn_brgemm_arch;
             return rnn_.is_brgemm
                     ? JIT_IMPL_NAME_HELPER("brgemm:", rnn_.brgemm_isa, "")
                     : rnn_.use_matmul ? "ref+matmul"
@@ -194,12 +200,12 @@ struct ref_rnn_common_t : public primitive_t {
     status_t execute(const exec_ctx_t &ctx) const override;
 
 protected:
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
     ref_rnn_brgemm_t rnn_brgemm_;
+#endif
+#if DNNL_X64
     std::shared_ptr<primitive_t> bf32_wei_layer_reorder_;
     std::shared_ptr<primitive_t> bf32_wei_iter_reorder_;
-#elif DNNL_AARCH64
-    ref_rnn_brgemm_t rnn_brgemm_;
 #endif
 
     template <typename input_t>

--- a/src/cpu/rnn/ref_rnn.hpp
+++ b/src/cpu/rnn/ref_rnn.hpp
@@ -38,21 +38,9 @@
 #endif
 #include "cpu/rnn/rnn_utils.hpp"
 
-#if DNNL_X64
-#define RNN_AMX_SCRATCHPAD_ACTUAL amx_scratchpad,
-#else
-#define RNN_AMX_SCRATCHPAD_ACTUAL
-#endif
-
 namespace dnnl {
 namespace impl {
 namespace cpu {
-
-#if DNNL_X64
-namespace rnn_brgemm_arch = x64;
-#elif DNNL_AARCH64
-namespace rnn_brgemm_arch = aarch64;
-#endif
 
 namespace {
 template <typename gates_t, typename acc_t>
@@ -129,8 +117,7 @@ struct ref_rnn_common_t : public primitive_t {
     using class_name
             = ref_rnn_common_t<aprop, src_type, weights_type, acc_type>;
 #if DNNL_X64 || DNNL_AARCH64
-    using ref_rnn_brgemm_t
-            = rnn_brgemm_arch::rnn_brgemm_utils::rnn_brgemm_t<aprop>;
+    using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<aprop>;
 #endif
 
     using cell_execution_f
@@ -157,7 +144,6 @@ struct ref_rnn_common_t : public primitive_t {
 
         const char *impl_name() const {
 #if DNNL_X64 || DNNL_AARCH64
-            using namespace rnn_brgemm_arch;
             return rnn_.is_brgemm
                     ? JIT_IMPL_NAME_HELPER("brgemm:", rnn_.brgemm_isa, "")
                     : rnn_.use_matmul ? "ref+matmul"

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
+* Copyright 2026 FUJITSU LIMITED
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -31,6 +32,8 @@
 
 #if DNNL_X64
 #include "cpu/x64/cpu_isa_traits.hpp"
+#elif DNNL_AARCH64
+#include "cpu/aarch64/cpu_isa_traits.hpp"
 #endif
 
 #define rnn_postgemm_sig_args \
@@ -100,6 +103,59 @@
             float *diff_weights_projection_, float *diff_weights_peephole_, \
             float *diff_bias_, gemm_acc_t *amx_scratchpad, \
             x64::brgemm_batch_element_t *addr_batch_global
+
+#elif DNNL_AARCH64
+
+#define rnn_merged_layer_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+            rnn_utils::cell_position_t cell_position, weights_t **w_layer_, \
+            const src_layer_t *src_layer_, scratch_t *scratch_gates_, \
+            gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_, \
+            aarch64::brgemm_batch_element_t *addr_batch_global
+
+#define rnn_cell_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+            rnn_utils::cell_position_t cell_position, dst_layer_t *dst_layer_, \
+            void *dst_iter_c_, gemm_acc_t *diff_src_layer_, \
+            gemm_acc_t *diff_augru_attention_, gemm_acc_t *diff_src_iter_, \
+            gemm_acc_t *diff_src_iter_c_, weights_t **w_layer_, \
+            weights_t **w_iter_, weights_t **w_projection_, \
+            const float *weights_peephole_, const float *w_proj_comp, \
+            void **bias_, const src_layer_t *src_layer_, \
+            const src_layer_t *augru_attention_, const src_iter_t *src_iter_, \
+            const void *src_iter_c_, gemm_acc_t *diff_dst_layer_, \
+            gemm_acc_t *diff_dst_iter_, gemm_acc_t *diff_dst_iter_c_, \
+            gemm_acc_t *diff_w_layer_, gemm_acc_t *diff_w_iter_, \
+            float *diff_weights_projection_, float *diff_weights_peephole_, \
+            float *diff_bias_, gates_t *ws_gates_, scratch_t *scratch_gates_, \
+            ht_t *proj_ht_, gemm_acc_t *scratch_diff_ht_, gates_t *ws_grid_, \
+            scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
+            scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
+            dst_iter_t *dst_iter_, \
+            aarch64::brgemm_batch_element_t *addr_batch_global
+
+#define rnn_grid_execution_sig_args \
+    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
+            weights_t **weights_layer_, weights_t **weights_iter_, \
+            weights_t **weights_projection_, const float *weights_peephole_, \
+            const float *w_proj_comp, void **bias_, \
+            const src_layer_t *src_layer_, \
+            const src_layer_t *augru_attention_, const src_iter_t *src_iter_, \
+            const void *src_iter_c_, dst_layer_t *dst_layer_, \
+            dst_iter_t *dst_iter_, void *dst_iter_c_, \
+            src_layer_t *ws_states_layer_, src_iter_t *ws_states_iter_, \
+            void *ws_states_iter_c_, gemm_acc_t *ws_diff_states_layer_, \
+            gemm_acc_t *ws_diff_states_iter_, \
+            gemm_acc_t *ws_diff_states_iter_c_, gates_t *ws_gates_, \
+            ht_t *ws_ht_, gates_t *ws_grid_, scratch_t *scratch_gates_, \
+            ht_t *scratch_ht_, gemm_acc_t *scratch_diff_ht_, \
+            scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
+            scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
+            gemm_acc_t *diff_augru_attention_, \
+            gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
+            float *diff_weights_projection_, float *diff_weights_peephole_, \
+            float *diff_bias_, \
+            aarch64::brgemm_batch_element_t *addr_batch_global
 
 #else
 
@@ -278,6 +334,8 @@ struct diff_src_brgemm_conf_t {
 
 #if DNNL_X64
     x64::cpu_isa_t isa = x64::isa_undef;
+#elif DNNL_AARCH64
+    aarch64::cpu_isa_t isa = aarch64::isa_undef;
 #endif
 
     brgemm_rnn_execute_loop_order_t loop_order
@@ -299,6 +357,8 @@ struct diff_wei_brgemm_conf_t {
 
 #if DNNL_X64
     x64::cpu_isa_t isa = x64::isa_undef;
+#elif DNNL_AARCH64
+    aarch64::cpu_isa_t isa = aarch64::isa_undef;
 #endif
 
     brgemm_rnn_execute_loop_order_t loop_order
@@ -656,6 +716,8 @@ struct rnn_conf_t {
     int nthr;
 #if DNNL_X64
     x64::cpu_isa_t brgemm_isa;
+#elif DNNL_AARCH64
+    aarch64::cpu_isa_t brgemm_isa;
 #endif
     bool unfused_post_gemm;
     brgemm_rnn_execute_loop_order_t loop_order
@@ -726,6 +788,8 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
 #if DNNL_X64
         if (!(x64::mayiuse(x64::avx512_core) || x64::mayiuse(x64::avx2_vnni_2)))
             return false;
+#elif DNNL_AARCH64
+        if (!aarch64::mayiuse_bf16()) return false;
 #endif
         rnn.dt_conf = all_bf16;
     } else if (utils::everyone_is(data_type::f16, src_layer_d.data_type(),

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -29,17 +29,12 @@
 #include "cpu/platform.hpp"
 
 #include "cpu/gemm/gemm_pack.hpp"
+#include "cpu/simple_q10n.hpp"
 
 #if DNNL_X64
 #include "cpu/x64/cpu_isa_traits.hpp"
 #elif DNNL_AARCH64
 #include "cpu/aarch64/cpu_isa_traits.hpp"
-#endif
-
-#if DNNL_X64
-#define RNN_AMX_SCRATCHPAD_ARG gemm_acc_t *amx_scratchpad,
-#else
-#define RNN_AMX_SCRATCHPAD_ARG
 #endif
 
 #define rnn_postgemm_sig_args \
@@ -57,14 +52,18 @@
 
 #define rnn_postgemm_sig(f) void f(rnn_postgemm_sig_args) const
 
+// gemm_acc_scratchpad is a GEMM accumulation scratchpad used by tile-based
+// brgemm kernels (AMX on x64, MMLA/SME on aarch64). It can be nullptr on
+// implementations that don't need it (e.g. current AArch64 SVE kernels).
+
 #if DNNL_X64 || DNNL_AARCH64
 #define rnn_merged_layer_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, weights_t **w_layer_, \
             const src_layer_t *src_layer_, scratch_t *scratch_gates_, \
             gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_, \
-            RNN_AMX_SCRATCHPAD_ARG rnn_brgemm_arch::brgemm_batch_element_t \
-                    *addr_batch_global
+            gemm_acc_t *gemm_acc_scratchpad, \
+            brgemm_batch_element_t *addr_batch_global
 
 #define rnn_cell_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
@@ -84,9 +83,8 @@
             ht_t *proj_ht_, gemm_acc_t *scratch_diff_ht_, gates_t *ws_grid_, \
             scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
             scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
-            dst_iter_t *dst_iter_, \
-            RNN_AMX_SCRATCHPAD_ARG rnn_brgemm_arch::brgemm_batch_element_t \
-                    *addr_batch_global
+            dst_iter_t *dst_iter_, gemm_acc_t *gemm_acc_scratchpad, \
+            brgemm_batch_element_t *addr_batch_global
 
 #define rnn_grid_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
@@ -108,9 +106,8 @@
             gemm_acc_t *diff_augru_attention_, \
             gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
             float *diff_weights_projection_, float *diff_weights_peephole_, \
-            float *diff_bias_, \
-            RNN_AMX_SCRATCHPAD_ARG rnn_brgemm_arch::brgemm_batch_element_t \
-                    *addr_batch_global
+            float *diff_bias_, gemm_acc_t *gemm_acc_scratchpad, \
+            brgemm_batch_element_t *addr_batch_global
 
 #else
 
@@ -137,7 +134,7 @@
             float *diff_bias_, gates_t *ws_gates_, scratch_t *scratch_gates_, \
             ht_t *proj_ht_, gemm_acc_t *scratch_diff_ht_, gates_t *ws_grid_, \
             scratch_t *scratch_cell_, dst_iter_t *dst_iter_, \
-            gemm_acc_t *amx_scratchpad
+            gemm_acc_t *gemm_acc_scratchpad
 
 #define rnn_grid_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
@@ -157,7 +154,7 @@
             scratch_t *scratch_cell_, gemm_acc_t *diff_augru_attention_, \
             gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
             float *diff_weights_projection_, float *diff_weights_peephole_, \
-            float *diff_bias_, gemm_acc_t *amx_scratchpad
+            float *diff_bias_, gemm_acc_t *gemm_acc_scratchpad
 
 #endif
 
@@ -212,9 +209,9 @@ namespace impl {
 namespace cpu {
 
 #if DNNL_X64
-namespace rnn_brgemm_arch = x64;
+using namespace x64;
 #elif DNNL_AARCH64
-namespace rnn_brgemm_arch = aarch64;
+using namespace aarch64;
 #endif
 
 namespace rnn_utils {
@@ -294,7 +291,7 @@ struct diff_src_brgemm_conf_t {
     dim_t LDA = 0, LDB = 0, LDC = 0;
 
 #if DNNL_X64 || DNNL_AARCH64
-    rnn_brgemm_arch::cpu_isa_t isa = rnn_brgemm_arch::isa_undef;
+    cpu_isa_t isa = isa_undef;
 #endif
 
     brgemm_rnn_execute_loop_order_t loop_order
@@ -315,7 +312,7 @@ struct diff_wei_brgemm_conf_t {
     bool global_transpose = false;
 
 #if DNNL_X64 || DNNL_AARCH64
-    rnn_brgemm_arch::cpu_isa_t isa = rnn_brgemm_arch::isa_undef;
+    cpu_isa_t isa = isa_undef;
 #endif
 
     brgemm_rnn_execute_loop_order_t loop_order
@@ -672,7 +669,7 @@ struct rnn_conf_t {
 
     int nthr;
 #if DNNL_X64 || DNNL_AARCH64
-    rnn_brgemm_arch::cpu_isa_t brgemm_isa;
+    cpu_isa_t brgemm_isa = isa_undef;
 #endif
     bool unfused_post_gemm;
     brgemm_rnn_execute_loop_order_t loop_order

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -36,6 +36,12 @@
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #endif
 
+#if DNNL_X64
+#define RNN_AMX_SCRATCHPAD_ARG gemm_acc_t *amx_scratchpad,
+#else
+#define RNN_AMX_SCRATCHPAD_ARG
+#endif
+
 #define rnn_postgemm_sig_args \
     const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, gates_t *ws_gates_, \
@@ -51,67 +57,14 @@
 
 #define rnn_postgemm_sig(f) void f(rnn_postgemm_sig_args) const
 
-#if DNNL_X64
+#if DNNL_X64 || DNNL_AARCH64
 #define rnn_merged_layer_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
             rnn_utils::cell_position_t cell_position, weights_t **w_layer_, \
             const src_layer_t *src_layer_, scratch_t *scratch_gates_, \
             gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_, \
-            gemm_acc_t *amx_scratchpad, \
-            x64::brgemm_batch_element_t *addr_batch_global
-
-#define rnn_cell_execution_sig_args \
-    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
-            rnn_utils::cell_position_t cell_position, dst_layer_t *dst_layer_, \
-            void *dst_iter_c_, gemm_acc_t *diff_src_layer_, \
-            gemm_acc_t *diff_augru_attention_, gemm_acc_t *diff_src_iter_, \
-            gemm_acc_t *diff_src_iter_c_, weights_t **w_layer_, \
-            weights_t **w_iter_, weights_t **w_projection_, \
-            const float *weights_peephole_, const float *w_proj_comp, \
-            void **bias_, const src_layer_t *src_layer_, \
-            const src_layer_t *augru_attention_, const src_iter_t *src_iter_, \
-            const void *src_iter_c_, gemm_acc_t *diff_dst_layer_, \
-            gemm_acc_t *diff_dst_iter_, gemm_acc_t *diff_dst_iter_c_, \
-            gemm_acc_t *diff_w_layer_, gemm_acc_t *diff_w_iter_, \
-            float *diff_weights_projection_, float *diff_weights_peephole_, \
-            float *diff_bias_, gates_t *ws_gates_, scratch_t *scratch_gates_, \
-            ht_t *proj_ht_, gemm_acc_t *scratch_diff_ht_, gates_t *ws_grid_, \
-            scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
-            scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
-            dst_iter_t *dst_iter_, gemm_acc_t *amx_scratchpad, \
-            x64::brgemm_batch_element_t *addr_batch_global
-
-#define rnn_grid_execution_sig_args \
-    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
-            weights_t **weights_layer_, weights_t **weights_iter_, \
-            weights_t **weights_projection_, const float *weights_peephole_, \
-            const float *w_proj_comp, void **bias_, \
-            const src_layer_t *src_layer_, \
-            const src_layer_t *augru_attention_, const src_iter_t *src_iter_, \
-            const void *src_iter_c_, dst_layer_t *dst_layer_, \
-            dst_iter_t *dst_iter_, void *dst_iter_c_, \
-            src_layer_t *ws_states_layer_, src_iter_t *ws_states_iter_, \
-            void *ws_states_iter_c_, gemm_acc_t *ws_diff_states_layer_, \
-            gemm_acc_t *ws_diff_states_iter_, \
-            gemm_acc_t *ws_diff_states_iter_c_, gates_t *ws_gates_, \
-            ht_t *ws_ht_, gates_t *ws_grid_, scratch_t *scratch_gates_, \
-            ht_t *scratch_ht_, gemm_acc_t *scratch_diff_ht_, \
-            scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
-            scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
-            gemm_acc_t *diff_augru_attention_, \
-            gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
-            float *diff_weights_projection_, float *diff_weights_peephole_, \
-            float *diff_bias_, gemm_acc_t *amx_scratchpad, \
-            x64::brgemm_batch_element_t *addr_batch_global
-
-#elif DNNL_AARCH64
-
-#define rnn_merged_layer_execution_sig_args \
-    const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
-            rnn_utils::cell_position_t cell_position, weights_t **w_layer_, \
-            const src_layer_t *src_layer_, scratch_t *scratch_gates_, \
-            gemm_acc_t *diff_src_layer_, gemm_acc_t *diff_w_layer_, \
-            aarch64::brgemm_batch_element_t *addr_batch_global
+            RNN_AMX_SCRATCHPAD_ARG rnn_brgemm_arch::brgemm_batch_element_t \
+                    *addr_batch_global
 
 #define rnn_cell_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
@@ -132,7 +85,8 @@
             scratch_t *scratch_cell_, scratch_t *scratch_gates_blocked_, \
             scratch_t *scratch_src_layer_, scratch_t *scratch_src_iter_, \
             dst_iter_t *dst_iter_, \
-            aarch64::brgemm_batch_element_t *addr_batch_global
+            RNN_AMX_SCRATCHPAD_ARG rnn_brgemm_arch::brgemm_batch_element_t \
+                    *addr_batch_global
 
 #define rnn_grid_execution_sig_args \
     const exec_ctx_t &ctx, const rnn_utils::rnn_conf_t &rnn, \
@@ -155,7 +109,8 @@
             gemm_acc_t *diff_weights_layer_, gemm_acc_t *diff_weights_iter_, \
             float *diff_weights_projection_, float *diff_weights_peephole_, \
             float *diff_bias_, \
-            aarch64::brgemm_batch_element_t *addr_batch_global
+            RNN_AMX_SCRATCHPAD_ARG rnn_brgemm_arch::brgemm_batch_element_t \
+                    *addr_batch_global
 
 #else
 
@@ -256,6 +211,12 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 
+#if DNNL_X64
+namespace rnn_brgemm_arch = x64;
+#elif DNNL_AARCH64
+namespace rnn_brgemm_arch = aarch64;
+#endif
+
 namespace rnn_utils {
 
 enum execution_direction_t {
@@ -332,10 +293,8 @@ struct diff_src_brgemm_conf_t {
     dim_t N_iter_blocks = 0, n_iter_tail = 0;
     dim_t LDA = 0, LDB = 0, LDC = 0;
 
-#if DNNL_X64
-    x64::cpu_isa_t isa = x64::isa_undef;
-#elif DNNL_AARCH64
-    aarch64::cpu_isa_t isa = aarch64::isa_undef;
+#if DNNL_X64 || DNNL_AARCH64
+    rnn_brgemm_arch::cpu_isa_t isa = rnn_brgemm_arch::isa_undef;
 #endif
 
     brgemm_rnn_execute_loop_order_t loop_order
@@ -355,10 +314,8 @@ struct diff_wei_brgemm_conf_t {
 
     bool global_transpose = false;
 
-#if DNNL_X64
-    x64::cpu_isa_t isa = x64::isa_undef;
-#elif DNNL_AARCH64
-    aarch64::cpu_isa_t isa = aarch64::isa_undef;
+#if DNNL_X64 || DNNL_AARCH64
+    rnn_brgemm_arch::cpu_isa_t isa = rnn_brgemm_arch::isa_undef;
 #endif
 
     brgemm_rnn_execute_loop_order_t loop_order
@@ -714,10 +671,8 @@ struct rnn_conf_t {
     bool brgemm_fwd_iter_layer_fuse_possible = false;
 
     int nthr;
-#if DNNL_X64
-    x64::cpu_isa_t brgemm_isa;
-#elif DNNL_AARCH64
-    aarch64::cpu_isa_t brgemm_isa;
+#if DNNL_X64 || DNNL_AARCH64
+    rnn_brgemm_arch::cpu_isa_t brgemm_isa;
 #endif
     bool unfused_post_gemm;
     brgemm_rnn_execute_loop_order_t loop_order


### PR DESCRIPTION
# Description

This PR introduces the core BRGEMM-based RNN infrastructure for AArch64 as a first “Phase A” step, focusing on shared utilities and common cell (non-JIT). JIT related broader tuning will be follow in subsequent PRs.

### What’s included
- BRGEMM RNN foundational helpers:
    -     rnn_brgemm_utils.hpp/.cpp
- BRGEMM forward cell:
    -     brgemm_cell_common_fwd.hpp/.cpp
- BRGEMM backward cell:
    -     brgemm_cell_common_bwd.hpp/.cpp
- BRGEMM reorders support:
    -      brgemm_cell_common_reorders.hpp/.cpp

> Plan to bring optimized RNN for aarch64

This is Phase A of a 7-phase effort to bring full optimize RNN support to AArch64. Structured whole RNN development as each phase is a self-contained, reviewable unit with a clear scope which make it easier on my end to develop/tested and also for community end to review easily. 

**Phase A (this PR)**: BRGEMM core — the non-JIT compute path, end-to-end fwd + bwd
**Phase B**: JIT helper kernels — bf16 emulation and fp32 add-to-bf16 convert for bf16 training path
**Phase C**: JIT helper kernels — transpose, gates reduction, peephole, BF16 conversion
**Phase D**: Post-GEMM infrastructure — shared abstractions and vanilla RNN cell post-GEMM
**Phase E**: LSTM optimization
**Phase F**: GRU optimization
**Phase G**: LBR-GRU optimization


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

| **RNN Benchmarking Name** | **Before (total perf (ms))** | **This Patch (total perf (ms))** |
|----------|----------|----------|
| **_shapes_deepspeech_2_**  | 89.7729  | 6.9917  |
| **_shapes_inference_**  | 42.4207  | 15.1135  |
| **_shapes_training_**  | 289.159 | 113.703 |
| **_perf_rnn_inference_sb_**  | 159.371 | 97.6782 |
| **_perf_rnn_inference_lb_**  | 1068.06 | 875.916 |
| **_perf_rnn_training_**  | 4803.65 | 3554.14 |

AWS instance used for benchamrking is [c7g.metal](https://instances.vantage.sh/aws/ec2/c7g.metal?currency=USD)