### PR TITLE
cpu: x64: pool: enable different dt on src and dst in jit

### DIFF
--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -548,6 +548,7 @@ struct jit_pool_conf_t {
     data_type_t dst_dt;
 
     int dt_size;
+    int dst_dt_size;
     bool is_bf16;
     bool is_f16;
     bool is_fp8;

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -210,13 +210,13 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
 
     void load_src_max_op(
             int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void load_src_avg_op(
+    void load_src_s32_op(
             int jj, int ll, size_t offset, bool masked, uint64_t msk);
     void load_src(int jj, int ll, int c_tail);
 
     void store_dst_max_op(
             int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void store_dst_avg_op(
+    void store_dst_s32_op(
             int jj, int ll, size_t offset, bool masked, uint64_t msk);
     void store_dst(int jj, int ll, int c_tail);
 
@@ -374,7 +374,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
+void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_s32_op(
         int jj, int ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
@@ -409,7 +409,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
+void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_s32_op(
         int jj, int ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
@@ -499,7 +499,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_avg_op(
+void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_s32_op(
         int jj, int ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
@@ -533,7 +533,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
             auto offset = (ll * (c_block / max_num_ll) + jj * c_block)
                     * sizeof_src_dt();
             bool masked = jj == ur_c - 1 && c_tail;
-            load_src_avg_op(jj, ll, offset, masked, jpp.tail[ll]);
+            load_src_s32_op(jj, ll, offset, masked, jpp.tail[ll]);
             break;
         }
         default: assert(!"unsupported algorithm");
@@ -652,7 +652,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
+void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_s32_op(
         int jj, int ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
@@ -699,7 +699,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
+void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_s32_op(
         int jj, int ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
@@ -842,7 +842,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
+void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_s32_op(
         int jj, int ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
@@ -912,7 +912,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::store_dst(
             auto offset = (ll * (c_block / max_num_ll) + jj * c_block)
                     * sizeof_dst_dt();
             bool masked = jj == ur_c - 1 && c_tail;
-            store_dst_avg_op(jj, ll, offset, masked, jpp.tail[ll]);
+            store_dst_s32_op(jj, ll, offset, masked, jpp.tail[ll]);
             break;
         }
         default: assert(!"unsupported pooling algorithm");
@@ -1020,7 +1020,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
                                 auto offset = (ll * (jpp.c_block / max_num_ll)
                                                       + jj * jpp.c_block)
                                         * sizeof_src_dt();
-                                load_src_avg_op(jj, ll, offset, masked, msk);
+                                load_src_s32_op(jj, ll, offset, masked, msk);
 
                                 if (utils::one_of(isa, sse41)) {
                                     pmaxsd(vreg_dst_s32(jj, ll),
@@ -1064,7 +1064,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
                                 jpp.dst_dt, data_type::f32, data_type::f16))
                         uni_vcvtdq2ps(
                                 vreg_dst_f32(jj, ll), vreg_dst_s32(jj, ll));
-                    store_dst_avg_op(jj, ll,
+                    store_dst_s32_op(jj, ll,
                             (ll * (jpp.c_block / max_num_ll) + jj * jpp.c_block)
                                     * sizeof_dst_dt(),
                             masked, msk);

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -661,16 +661,30 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
 
     const Vmm &vr_dst = vreg_dst_s32(jj, ll);
 
-    if (jpp.src_dt == s32) {
+    if (jpp.dst_dt == f32) {
+        const Xmm &xmm_dst = Xmm(vreg_dst_f32(jj, ll).getIdx());
+        if (!masked) {
+            movups(ptr[reg_ptr_dst_i8 + offset], xmm_dst);
+        } else {
+            const int msk_gran
+                    = cpu_isa_traits_t<sse41>::vlen / data_type_size(f32);
+            for (int i = 0; i < msk_gran; i++) {
+                if (msk & (1ULL << i))
+                    vextractps(ptr[reg_ptr_dst_i8 + offset
+                                       + i * data_type_size(f32)],
+                            xmm_dst, i);
+            }
+        }
+    } else if (jpp.dst_dt == s32) {
         if (masked)
             for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
                         vr_dst, i);
         else
             movups(ptr[reg_ptr_dst_i8 + offset], vr_dst);
-    } else if (utils::one_of(jpp.src_dt, s8, u8)) {
+    } else if (utils::one_of(jpp.dst_dt, s8, u8)) {
         packssdw(vr_dst, vr_dst);
-        if (jpp.src_dt == s8)
+        if (jpp.dst_dt == s8)
             packsswb(vr_dst, vr_dst);
         else
             packuswb(vr_dst, vr_dst);
@@ -771,6 +785,49 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
     };
 
     switch (jpp.dst_dt) {
+        case f32: {
+            const Vmm &vr_dst = vreg_dst_f32(jj, ll);
+            if (!masked) {
+                vmovups(ptr[reg_ptr_dst_i8 + offset], vr_dst);
+            } else {
+                const int msk_gran
+                        = cpu_isa_traits_t<avx2>::vlen / sizeof(float);
+                Xmm xmm_hi = xreg_mask_hi;
+                for (int i = 0; i < msk_gran; i++) {
+                    if (msk & (1ULL << i)) {
+                        if (i < 4) {
+                            vextractps(ptr[reg_ptr_dst_i8 + offset
+                                               + i * sizeof(float)],
+                                    Xmm(vr_dst.getIdx()), i);
+                        } else {
+                            vextractf128(xmm_hi, vr_dst, 1);
+                            vextractps(ptr[reg_ptr_dst_i8 + offset
+                                               + i * sizeof(float)],
+                                    xmm_hi, i - 4);
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        case f16: {
+            const Vmm &vr_dst = vreg_dst_f32(jj, ll);
+            const Xmm xmm_dst(vr_dst.getIdx());
+            uni_vcvtps2phx(xmm_dst, vr_dst);
+            if (!masked) {
+                movups(ptr[reg_ptr_dst_i8 + offset], xmm_dst);
+            } else {
+                const int msk_gran
+                        = cpu_isa_traits_t<avx2>::vlen / sizeof(float);
+                for (int i = 0; i < msk_gran; i++) {
+                    if (msk & (1ULL << i))
+                        pextrw(ptr[reg_ptr_dst_i8 + offset
+                                       + i * data_type_size(f16)],
+                                xmm_dst, i);
+                }
+            }
+            break;
+        }
         case s32:
             if (masked) {
                 vpmaskmovd(ptr[reg_ptr_dst_i8 + offset], vreg_mask,
@@ -796,6 +853,38 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
             = masked ? vreg_dst_s32(jj, ll) | mask(ll) : vreg_dst_s32(jj, ll);
 
     switch (jpp.dst_dt) {
+        case f32:
+            vmovups(ptr[reg_ptr_dst_i8 + offset],
+                    masked ? vreg_dst_f32(jj, ll) | mask(ll)
+                           : vreg_dst_f32(jj, ll));
+            break;
+        case f16: {
+            const Vmm &vr_dst = vreg_dst_f32(jj, ll);
+            const Ymm ymm_dst(vr_dst.getIdx());
+            const Xmm xmm_lo(ymm_dst.getIdx());
+            const Xmm xmm_hi = xreg_mask_hi;
+            uni_vcvtps2phx(ymm_dst, vr_dst);
+            if (!masked) {
+                vmovups(ptr[reg_ptr_dst_i8 + offset], ymm_dst);
+            } else {
+                vextracti128(xmm_hi, ymm_dst, 1);
+                const int msk_gran
+                        = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
+                for (int i = 0; i < msk_gran; i++) {
+                    if (msk & (1ULL << i)) {
+                        if (i < 8)
+                            pextrw(ptr[reg_ptr_dst_i8 + offset
+                                           + i * data_type_size(f16)],
+                                    xmm_lo, i);
+                        else
+                            pextrw(ptr[reg_ptr_dst_i8 + offset
+                                           + i * data_type_size(f16)],
+                                    xmm_hi, i - 8);
+                    }
+                }
+            }
+            break;
+        }
         case s32: vmovups(ptr[reg_ptr_dst_i8 + offset], vr_dst); break;
         case s8: vpmovsdb(ptr[reg_ptr_dst_i8 + offset], vr_dst); break;
         case u8: vpmovusdb(ptr[reg_ptr_dst_i8 + offset], vr_dst); break;
@@ -1015,13 +1104,17 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
                             reg_dst_f32.getIdx(), rhs_arg_params);
                 }
 
-                uni_vcvtps2dq(reg_dst_s32, reg_dst_f32);
+                if (jpp.dst_dt == f32 || jpp.dst_dt == f16) {
+                    store_dst(jj, ll, c_tail);
+                } else {
+                    uni_vcvtps2dq(reg_dst_s32, reg_dst_f32);
 
-                if (jpp.with_postops)
-                    if (jpp.dst_dt == u8) {
-                        uni_vpmaxsd(reg_dst_s32, reg_dst_s32, vreg_zeros);
-                    }
-                store_dst(jj, ll, c_tail);
+                    if (jpp.with_postops)
+                        if (jpp.dst_dt == u8) {
+                            uni_vpmaxsd(reg_dst_s32, reg_dst_s32, vreg_zeros);
+                        }
+                    store_dst(jj, ll, c_tail);
+                }
             }
         }
     }

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -975,6 +975,105 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
     int iw = jpp.iw;
     int c = jpp.c;
 
+    if (utils::one_of(jpp.src_dt, data_type::s8, data_type::u8)
+            && jpp.dst_dt != jpp.src_dt) {
+        const int num_ll
+                = data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt);
+
+        if (jpp.dst_dt == data_type::u8)
+            mov(reg_tmp, static_cast<int32_t>(0));
+        else if (jpp.src_dt == data_type::s8)
+            mov(reg_tmp,
+                    static_cast<int32_t>(
+                            nstl::numeric_limits<int8_t>::lowest()));
+        else
+            mov(reg_tmp, static_cast<int32_t>(0));
+        uni_vmovq(xmm_tmp, reg_tmp);
+        uni_vpbroadcastd(vreg_tmp, xmm_tmp);
+
+        for (int jj = 0; jj < ur_c; jj++) {
+            for (int ll = 0; ll < num_ll; ll++) {
+                bool masked = jj == ur_c - 1 && c_tail;
+                size_t msk = jpp.tail[ll];
+                if (!(masked && !msk))
+                    uni_vmovups(vreg_dst_s32(jj, ll), vreg_tmp);
+            }
+        }
+
+        mov(aux_reg_src_d, reg_ptr_src_i8);
+        xor_(reg_kd_index, reg_kd_index);
+        L(l_kd);
+        {
+            mov(aux_reg_src_h, aux_reg_src_d);
+            xor_(reg_kh_index, reg_kh_index);
+            L(l_kh);
+            {
+                mov(aux_reg_src_w, aux_reg_src_h);
+                xor_(reg_kw_index, reg_kw_index);
+                L(l_kw);
+                {
+                    for (int jj = 0; jj < ur_c; jj++) {
+                        for (int ll = 0; ll < num_ll; ll++) {
+                            bool masked = jj == ur_c - 1 && c_tail;
+                            size_t msk = jpp.tail[ll];
+                            if (!(masked && !msk)) {
+                                auto offset = (ll * (jpp.c_block / max_num_ll)
+                                                      + jj * jpp.c_block)
+                                        * sizeof_src_dt();
+                                load_src_avg_op(jj, ll, offset, masked, msk);
+
+                                if (utils::one_of(isa, sse41)) {
+                                    pmaxsd(vreg_dst_s32(jj, ll),
+                                            vreg_src_s32(jj, ll));
+                                } else if (utils::one_of(isa, avx2)) {
+                                    vpmaxsd(vreg_dst_s32(jj, ll),
+                                            vreg_dst_s32(jj, ll),
+                                            vreg_src_s32(jj, ll));
+                                } else {
+                                    vpcmpd(k_cmp_mask, vreg_dst_s32(jj, ll),
+                                            vreg_src_s32(jj, ll), _cmp_lt_os);
+                                    vpblendmd(vreg_dst_s32(jj, ll) | k_cmp_mask,
+                                            vreg_dst_s32(jj, ll),
+                                            vreg_src_s32(jj, ll));
+                                }
+                            }
+                        }
+                    }
+                    add(aux_reg_src_w, c * sizeof_src_dt());
+                    inc(reg_kw_index);
+                    cmp(reg_kw_index, reg_kw);
+                    jl(l_kw, T_NEAR);
+                }
+                add(aux_reg_src_h, iw * c * sizeof_src_dt());
+                inc(reg_kh_index);
+                cmp(reg_kh_index, reg_kh);
+                jl(l_kh, T_NEAR);
+            }
+            add(aux_reg_src_d, ih * iw * c * sizeof_src_dt());
+            inc(reg_kd_index);
+            cmp(reg_kd_index, reg_kd);
+            jl(l_kd, T_NEAR);
+        }
+
+        for (int jj = 0; jj < ur_c; jj++) {
+            for (int ll = 0; ll < num_ll; ll++) {
+                const bool masked = jj == ur_c - 1 && c_tail;
+                const size_t msk = jpp.tail[ll];
+                if (!(masked && !msk)) {
+                    if (utils::one_of(
+                                jpp.dst_dt, data_type::f32, data_type::f16))
+                        uni_vcvtdq2ps(
+                                vreg_dst_f32(jj, ll), vreg_dst_s32(jj, ll));
+                    store_dst_avg_op(jj, ll,
+                            (ll * (jpp.c_block / max_num_ll) + jj * jpp.c_block)
+                                    * sizeof_dst_dt(),
+                            masked, msk);
+                }
+            }
+        }
+        return;
+    }
+
     for (int jj = 0; jj < ur_c; jj++)
         uni_vmovups(vreg_dst(jj), vreg_tmp);
 
@@ -1246,10 +1345,19 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
     };
 
     uint64_t tail_mask = (1ULL << jpp.c_tail) - 1;
+    const bool max_mixed_dt = jpp.alg == pooling_max
+            && utils::one_of(jpp.src_dt, s8, u8) && jpp.dst_dt != jpp.src_dt;
     switch (jpp.alg) {
         case pooling_max:
-            // For "max" we need mask only in case of non-zero tail
-            if (tail_mask) init(tail_mask);
+            if (max_mixed_dt) {
+                if (utils::one_of(jpp.dst_dt, s8, u8)) {
+                    init(tail_mask ? tail_mask : ~0ULL, tail_mask != 0, true);
+                } else {
+                    if (tail_mask) init(tail_mask);
+                }
+            } else {
+                if (tail_mask) init(tail_mask);
+            }
             break;
         case pooling_avg_include_padding:
         case pooling_avg_exclude_padding:
@@ -1436,6 +1544,9 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
     jpp.ur_c_tail = jpp.c_tail != 0;
 
     size_t tail_mask = (1ULL << jpp.c_tail) - 1;
+    const bool max_mixed_dt = jpp.alg == pooling_max
+            && utils::one_of(jpp.src_dt, data_type::s8, data_type::u8)
+            && jpp.dst_dt != jpp.src_dt;
 
     /* If channel_size is bigger than vlen, we can safely assume there is no
      * underflow of memory boundary, so always perform c_tail and save
@@ -1444,10 +1555,21 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
 
     switch (jpp.alg) {
         case pooling_max:
-            jpp.tail[0] = tail_mask;
-            jpp.tail[1] = 0;
-            jpp.tail[2] = 0;
-            jpp.tail[3] = 0;
+            if (max_mixed_dt) {
+                const size_t msk_gran = cpu_isa_traits_t<isa>::vlen
+                        / data_type_size(avg_proc_dt);
+                const size_t msk_msk = (1ULL << msk_gran) - 1;
+                size_t m = tail_mask;
+                for (size_t ll = 0; ll < max_num_ll; ll++) {
+                    jpp.tail[ll] = m & msk_msk;
+                    m = m >> msk_gran;
+                }
+            } else {
+                jpp.tail[0] = tail_mask;
+                jpp.tail[1] = 0;
+                jpp.tail[2] = 0;
+                jpp.tail[3] = 0;
+            }
             break;
         case pooling_avg_include_padding:
         case pooling_avg_exclude_padding: {

--- a/src/cpu/x64/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.hpp
@@ -59,8 +59,8 @@ struct jit_uni_i8i8_pooling_fwd_t : public primitive_t {
             VDISPATCH_POOLING(utils::one_of(src_md()->data_type, data_type::s32,
                                       data_type::s8, data_type::u8),
                     VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_POOLING(src_md()->data_type == dst_md()->data_type,
-                    VERBOSE_INCONSISTENT_DT, "src", "dst");
+            //     VDISPATCH_POOLING(src_md()->data_type == dst_md()->data_type,
+            //             VERBOSE_INCONSISTENT_DT, "src", "dst");
             VDISPATCH_POOLING(!is_dilated(), VERBOSE_UNSUPPORTED_FEATURE,
                     "does not support dilations");
             VDISPATCH_POOLING(attr()->has_default_values(

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -106,6 +106,7 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
                 = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
                         this, jpp.post_ops, bsp);
     }
+    io::io_conf_t io_conf;
 
     io::io_tail_conf_t io_tail_conf(jpp.c_block, tail_size,
             k_c_tail_mask.getIdx(), vmm_c_tail_mask.getIdx(), tmp_gpr);
@@ -132,8 +133,15 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
     if (jpp.ind_dt == data_type::s32) dtypes.insert(data_type::f32);
     if (jpp.needs_f32_accum_for_bf16) dtypes.insert(data_type::f32);
 
-    io_ = io_mdt_helper(this, jpp.isa, dtypes, {}, io_tail_conf, io_bf16_conf,
-            {}, utils::nullopt, io_fp8_conf);
+    typename io_mdt_helper::saturation_map_t saturation_confs;
+    if (jpp.dst_dt == data_type::u8 || jpp.dst_dt == data_type::s8) {
+        io::io_saturation_conf_t io_saturation_conf(
+                vmm_zero.getIdx(), vmm_saturation_ubound.getIdx(), tmp_gpr);
+        saturation_confs.insert({jpp.dst_dt, io_saturation_conf});
+    }
+
+    io_ = io_mdt_helper(this, jpp.isa, dtypes, io_conf, io_tail_conf,
+            io_bf16_conf, saturation_confs, utils::nullopt, io_fp8_conf);
 }
 
 static status_t set_binary_postops_formats(
@@ -460,6 +468,29 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         jpp.ur_bc_tail = 0;
     }
 
+    const int service_reg_border = is_superset(jpp.isa, avx512_core) ? 9 : 5;
+    const int max_data_vregs = (is_superset(jpp.isa, avx512_core) ? 31 : 15)
+            - service_reg_border;
+    const bool is_max_alg = jpp.alg == pooling_max;
+    int reg_blocks = 2;
+    if (is_max_alg) {
+        if (utils::one_of(jpp.isa, avx, avx2, avx2_vnni_2)) {
+            reg_blocks = 4;
+        } else {
+            reg_blocks = (jpp.is_training || jpp.is_backward) ? 3 : 2;
+        }
+    }
+
+    const int max_ur_bc = nstl::max(1, max_data_vregs / reg_blocks);
+    if (jpp.ur_bc > max_ur_bc) {
+        jpp.ur_bc = max_ur_bc;
+        jpp.ur_bc_tail = jpp.nb_c % jpp.ur_bc;
+    }
+
+    const int max_ur_w_by_regs
+            = nstl::max(1, max_data_vregs / (reg_blocks * jpp.ur_bc));
+    jpp.ur = nstl::max(1, nstl::min(jpp.ur, max_ur_w_by_regs * jpp.ur_bc));
+
     jpp.f32_accum_block_size = jpp.ur_bc * jpp.c_block;
     if (jpp.needs_f32_accum_for_bf16) {
         assert(memory_desc_wrapper(jpp.tmp_md).is_zero()
@@ -551,6 +582,7 @@ inline void jit_uni_pool_kernel_t<isa>::store(const data_type_t dt,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing && jpp.is_c_padded && jpp.with_postops)
         pad_with_zeros(idx);
+    io_.init_saturate_f32({dt});
     io_[dt]->store(Vmm(idx), vmmword[reg_ptr + offset],
             is_c_tail_proccessing && !jpp.is_c_padded);
 }
@@ -749,11 +781,10 @@ template <cpu_isa_t isa>
 void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
         const std::function<bool(int, bool)> &is_tail_predicate) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
-    const int end_idx = vmm_idx_upper_bound() + 1;
-    const int start_idx = end_idx - (ur_bc * ur_w);
+    injector_utils::vmm_index_set_t vmm_idxs;
     const bool sse41_postops_disabled
             = isa == sse41 && disable_postops_when_sse_high_half_processed_;
-    if (end_idx - start_idx == 0) return;
+    if (ur_bc <= 0 || ur_w <= 0) return;
     if (jpp.with_binary && !sse41_postops_disabled) {
 
         const int c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
@@ -768,8 +799,8 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
 
         for (int jj = 0; jj < ur_w; jj++) {
             for (int bci = 0; bci < ur_bc; bci++) {
-                const auto vmm_idx
-                        = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).getIdx();
+                const auto vmm_idx = static_cast<size_t>(
+                        vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).getIdx());
 
                 const size_t output_offset
                         = jpp.dt_size * (jj * c_off + bci * c_block);
@@ -785,10 +816,22 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
                                 bci, true /*process_with_postops*/)) {
                     rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
                 }
+
+                vmm_idxs.emplace(vmm_idx);
             }
         }
     }
-    postops_injector_->compute_vector_range(start_idx, end_idx, rhs_arg_params);
+
+    if (vmm_idxs.empty()) {
+        for (int jj = 0; jj < ur_w; jj++) {
+            for (int bci = 0; bci < ur_bc; bci++) {
+                vmm_idxs.emplace(static_cast<size_t>(
+                        vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).getIdx()));
+            }
+        }
+    }
+
+    postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
 }
 
 template <cpu_isa_t isa>
@@ -887,13 +930,14 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
             for_(int jj = jj_start; jj < jj_end; jj++)
             for (int bci = 0; bci < ur_bc; bci++) {
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
-                const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
-                auto inpvr = vreg(inpr_i);
                 int aux_input_offset
                         = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
                 if (aux_input_offset >= iw * c_off) continue;
                 int input_offset = dt_size * aux_input_offset;
                 if (jpp.is_backward) {
+                    const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
+                    auto inpvr = vreg(inpr_i);
+
                     load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
                             input_offset, is_tail_processing(bci));
                     uni_vaddps(inpvr, inpvr, accvr);
@@ -1008,8 +1052,6 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
-                const auto indvr = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
-                const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
                 int aux_input_offset
                         = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
                 if (aux_input_offset >= iw * c_off) continue;
@@ -1020,17 +1062,28 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
                     movups(vmm_mask, accvr);
                     cmpps(vmm_mask, inpvr, _cmp_lt_os);
                     blendvps(accvr, inpvr);
-                    if (jpp.is_training) blendvps(indvr, vmm_k_offset);
+                    if (jpp.is_training) {
+                        const auto indvr
+                                = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
+                        blendvps(indvr, vmm_k_offset);
+                    }
                 } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
+                    const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
                     vcmpps(cvtvr, accvr, inpvr, _cmp_lt_os);
                     vblendvps(accvr, accvr, inpvr, cvtvr);
-                    if (jpp.is_training)
+                    if (jpp.is_training) {
+                        const auto indvr
+                                = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
                         vblendvps(indvr, indvr, vmm_k_offset, cvtvr);
+                    }
                 } else {
                     vcmpps(k_store_mask, accvr, inpvr, _cmp_lt_os);
                     vblendmps(accvr | k_store_mask, accvr, inpvr);
-                    if (jpp.is_training)
+                    if (jpp.is_training) {
+                        const auto indvr
+                                = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
                         vblendmps(indvr | k_store_mask, indvr, vmm_k_offset);
+                    }
                 }
             }
             if (jpp.is_training) {
@@ -1178,7 +1231,6 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
                 const auto indvr = vreg(reg_ind(1, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
-                const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
                 int aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
                         + bci * c_block;
                 if (aux_inp_offset >= iw * input_c_off) continue;
@@ -1186,6 +1238,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
                 load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
+                    const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
                     movups(cvtvr, indvr);
                     pcmpeqd(cvtvr, vmm_k_offset);
                     andps(cvtvr, outvr);
@@ -1193,6 +1246,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
                     store(input_dt, inpvr.getIdx(), aux_reg_input, inp_offset,
                             is_tail_processing(bci));
                 } else if (isa == avx || isa == avx2) {
+                    const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
                     if (mayiuse(avx2)) {
                         vpcmpeqd(cvtvr, indvr, vmm_k_offset);
                     } else {

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -293,6 +293,7 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         jpp.is_fp8 = false;
         jpp.src_dt = jpp.dst_dt = data_type::f32;
         jpp.dt_size = types::data_type_size(jpp.src_dt);
+        jpp.dst_dt_size = types::data_type_size(jpp.dst_dt);
         jpp.tag_kind = jit_memory_tag_kind_t::ncsp;
 
         // used to initialize binary post-ops
@@ -302,6 +303,7 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         }
     } else {
         jpp.dt_size = types::data_type_size(src_d.data_type());
+        jpp.dst_dt_size = types::data_type_size(dst_d.data_type());
         jpp.tag_kind = (fmt_tag == nspc_fmt_tag)
                 ? jit_memory_tag_kind_t::nspc
                 : jit_memory_tag_kind_t::blocked;
@@ -983,7 +985,7 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
             for (int bci = 0; bci < ur_bc; bci++) {
                 const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
                 const auto output_offset
-                        = dt_size * (jj * c_off + bci * c_block);
+                        = jpp.dst_dt_size * (jj * c_off + bci * c_block);
                 store(jpp.dst_dt, reg_idx(accr_i), reg_output, output_offset,
                         is_tail_processing(bci));
             }
@@ -1139,7 +1141,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     for_(int jj = 0; jj < ur_w; jj++)
     for (int bci = 0; bci < ur_bc; bci++) {
         const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
-        const auto output_offset = jpp.dt_size * (jj * c_off + bci * c_block);
+        const auto output_offset
+                = jpp.dst_dt_size * (jj * c_off + bci * c_block);
         const bool is_c_tail_processing = is_tail_processing(bci);
         store(jpp.dst_dt, reg_idx(accr_i), reg_output, output_offset,
                 is_c_tail_processing);
@@ -1451,7 +1454,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
 
         if (!inc_reg) return;
 
-        auto output_dt_size = jpp.dt_size;
+        auto output_dt_size = jpp.dst_dt_size;
         auto shift = (isa == sse41) ? vlen : 0;
         add(reg_input,
                 input_dt_size * nstl::max(0, ur_w * stride_w - lpad)

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -65,7 +65,12 @@ private:
         return is_superset(isa, avx512_core) ? 31 : 15;
     }
 
-    int reg_idx(int idx) const noexcept { return vmm_idx_upper_bound() - idx; }
+    int reg_idx(int idx) const noexcept {
+        const int reg = vmm_idx_upper_bound() - idx;
+        assert(reg > (is_superset(isa, avx512_core) ? 9 : 5)
+                && "Insufficient VMM space for service registers");
+        return reg;
+    }
 
     Xmm xreg(int idx) const noexcept { return Xmm(reg_idx(idx)); }
     Ymm yreg(int idx) const noexcept { return Ymm(reg_idx(idx)); }
@@ -90,6 +95,9 @@ private:
     Xmm xmm_tmp = Xmm(3);
 
     Vmm vmm_k_offset = Vmm(1);
+
+    Vmm vmm_zero = Vmm(4);
+    Vmm vmm_saturation_ubound = Vmm(5);
 
     Zmm bf16_emu_reserv_1 = Zmm(5);
     Zmm bf16_emu_reserv_2 = Zmm(6);

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -752,7 +752,9 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
             }
         } else {
             args.dst = static_cast<const void *>(
-                    &dst[dst_d.blk_off(n, c_off, oh)]);
+                    reinterpret_cast<const uint8_t *>(dst)
+                    + dst_d.blk_off(n, c_off, oh)
+                            * types::data_type_size(dst_d.data_type()));
         }
 
         if (indices) {
@@ -882,7 +884,9 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
                 args.dst_po_helper = static_cast<const void *>(&dst[blk_off]);
             }
         } else {
-            args.dst = &dst[dst_d.blk_off(n, c_off, od, oh)];
+            args.dst = static_cast<const void *>(
+                    reinterpret_cast<const uint8_t *>(dst)
+                    + dst_d.blk_off(n, c_off, od, oh) * dst_d.data_type_size());
         }
 
         if (indices) {

--- a/src/cpu/x64/jit_uni_pooling.hpp
+++ b/src/cpu/x64/jit_uni_pooling.hpp
@@ -58,8 +58,7 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
             // Disabling verbose dispatch messages for unsupported dt for better
             // readability.
             // TODO: restore once `d_type` template argument is removed.
-            if (!everyone_is(
-                        d_type, src_md()->data_type, dst_md()->data_type)) {
+            if (!everyone_is(d_type, src_md()->data_type)) {
                 return status::unimplemented;
             }
 


### PR DESCRIPTION
Addresses MFDNN-14412.

This PR adds support for different data types on source and destination in jit pooling.
Depending on the direction:
- int8 -> fp and int8 -> int8 are handled by `jit_int`
- fp -> int8 is handled by `jit_uni`

This branch includes squashed commit of changes from [#3440](https://github.com/uxlfoundation/oneDNN/pull/3440) These changes enable correct saturation logic for int8, needed in `jit_uni` while destination is of int8 type.