### PR TITLE
benchdnn: add GatedMLP driver

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -15,6 +15,7 @@
 ################################################################################
 
 import logging
+import re
 from collections import defaultdict
 from typing import Dict, List, Mapping, Optional, Set, cast
 
@@ -943,6 +944,48 @@ class SDPAConverter(Converter):
         return " ".join(parts)
 
 
+class GatedMLPConverter(Converter):
+    driver: str = "gated_mlp"
+
+    @property
+    def aux(self):
+        alg = self._get_alg()
+        if alg is not None:
+            activation = alg[len("eltwise_") :]
+            return f"--activation={activation}"
+        return ""
+
+    @property
+    def dts(self):
+        dt_map = {md.arg: md.data_type for md in self.entry.mds}
+        dts = [
+            dt_map.get("src", ""),
+            dt_map.get("wei_gate", ""),
+            dt_map.get("wei_up", ""),
+            dt_map.get("wei_down", ""),
+            dt_map.get("dst", ""),
+        ]
+        return "--dt=" + ":".join(dt for dt in dts if dt)
+
+    @property
+    def tags(self):
+        md_map = {md.arg: md for md in self.entry.mds}
+        tags = []
+        if "src" in md_map:
+            tags.append(f"--stag={maybe_make_any_tag(md_map['src'])}")
+        if "wei_gate" in md_map:
+            tags.append(f"--wtag={maybe_make_any_tag(md_map['wei_gate'])}")
+        if "dst" in md_map:
+            tags.append(f"--dtag={maybe_make_any_tag(md_map['dst'])}")
+        return " ".join(tags)
+
+    @property
+    def shapes(self):
+        # Convert verbose format "mb64ic896oc4864" to "64x896x4864"
+        nums = re.findall(r"\d+", self.entry.shapes)
+        return "x".join(nums)
+
+
 def get_converter(primitive: str) -> ConverterMeta:
     converters: Dict[str, ConverterMeta] = {
         "batch_normalization": BatchNormalizationConverter,
@@ -952,6 +995,7 @@ def get_converter(primitive: str) -> ConverterMeta:
         "convolution": ConvolutionConverter,
         "deconvolution": DeconvolutionConverter,
         "eltwise": EltwiseConverter,
+        "gated_mlp": GatedMLPConverter,
         "group_normalization": GroupNormalizationConverter,
         "inner_product": InnerProductConverter,
         "layer_normalization": LayerNormalizationConverter,

--- a/scripts/verbose_converter/tests/dataset_ci
+++ b/scripts/verbose_converter/tests/dataset_ci
@@ -22,6 +22,7 @@ conv,test_conv_ci
 conv,harness_conv_fused_depthwise
 deconv,test_deconv_ci
 eltwise,test_eltwise_ci
+gated_mlp,test_gated_mlp_smoke
 ip,test_ip_ci
 gnorm,test_gnorm_ci
 lnorm,test_lnorm_ci

--- a/scripts/verbose_converter/tests/dataset_simple
+++ b/scripts/verbose_converter/tests/dataset_simple
@@ -22,6 +22,7 @@ conv,shapes_auto
 conv,shapes_regression_small_spatial
 deconv,shapes_ci
 eltwise,shapes_eltwise
+gated_mlp,test_gated_mlp_smoke
 gnorm,shapes_ci
 ip,shapes_ci
 lnorm,shapes_ci

--- a/tests/benchdnn/README.md
+++ b/tests/benchdnn/README.md
@@ -20,6 +20,7 @@ where `DRIVER` is one of:
 * [conv](doc/driver_conv.md)
 * [deconv](doc/driver_conv.md)
 * [eltwise](doc/driver_eltwise.md)
+* [gated_mlp](doc/driver_gated_mlp.md)
 * [gnorm](doc/driver_gnorm.md)
 * [graph](doc/driver_graph.md)
 * [ip](doc/driver_ip.md)

--- a/tests/benchdnn/benchdnn.cpp
+++ b/tests/benchdnn/benchdnn.cpp
@@ -33,6 +33,7 @@
 #include "conv/conv.hpp"
 #include "deconv/deconv.hpp"
 #include "eltwise/eltwise.hpp"
+#include "gated_mlp/gated_mlp.hpp"
 #include "gnorm/gnorm.hpp"
 #include "ip/ip.hpp"
 #include "lnorm/lnorm.hpp"
@@ -128,6 +129,8 @@ int main(int argc, char **argv) {
         sum::bench(--argc, ++argv);
     } else if (!strcmp("--eltwise", argv[0])) {
         eltwise::bench(--argc, ++argv);
+    } else if (!strcmp("--gated_mlp", argv[0])) {
+        gated_mlp::bench(--argc, ++argv);
     } else if (!strcmp("--concat", argv[0])) {
         concat::bench(--argc, ++argv);
     } else if (!strcmp("--lrn", argv[0])) {

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -96,6 +96,8 @@ static const std::map<int, std::vector<const char *>> supported_args {
         {DNNL_ARG_SRC, {"src", "src0"}},
         {DNNL_ARG_SRC_1, {"src1"}},
         {DNNL_ARG_WEIGHTS, {"wei"}},
+        {DNNL_ARG_WEIGHTS_1, {"wei_up"}},
+        {DNNL_ARG_WEIGHTS_2, {"wei_down"}},
         {DNNL_ARG_DST, {"dst"}},
         {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_DST, {"attr_post_op_dw_dst"}},
         {DNNL_ARG_ATTR_POST_OP_DW | DNNL_ARG_WEIGHTS, {"attr_post_op_dw_wei"}},

--- a/tests/benchdnn/doc/driver_gated_mlp.md
+++ b/tests/benchdnn/doc/driver_gated_mlp.md
@@ -1,0 +1,128 @@
+# GatedMLP Driver
+
+## Usage
+``` sh
+    ./benchdnn --gated_mlp [benchdnn-knobs] [gated_mlp-knobs] [gated_mlp-desc] ...
+```
+
+where *gated_mlp-knobs* are:
+
+ - `--dt={f32 [default], ...}` -- source, weight, and destination data types.
+            Interface supports broadcasting, when a single input is provided,
+            e.g., `--dt=f32`, the value is applied for all tensors. Five
+            individual values can be specified in SRC, W_GATE, W_UP, W_DOWN,
+            DST order.
+            Refer to [data types](knobs_dt.md) for details.
+ - `--stag={abx [default], ...}` -- memory format of the source tensor.
+            Refer to [tags](knobs_tag.md) for details.
+ - `--wtag={abx [default], ...}` -- memory format of the weight tensors
+            (applied to all three: gate, up, down).
+            Refer to [tags](knobs_tag.md) for details.
+ - `--dtag={abx [default], ...}` -- memory format of the destination tensor.
+            Refer to [tags](knobs_tag.md) for details.
+ - `--activation={swish [default], gelu_erf, gelu_tanh}` -- specifies the
+            gated activation function applied after the gate matmul.
+ - `--match=REGEX` -- skip problems not matching the regular expression in
+            `REGEX`. By default no pattern is applied (run everything).
+            Note: Windows may interpret only string arguments surrounded by
+            double quotation marks.
+
+and *gated_mlp-desc* is a problem descriptor. The canonical form is:
+```
+    MBxICxOC
+```
+Here `x` is the delimiter for the three dimensions: `MB` (batch size), `IC`
+(input channels / model dimension), and `OC` (intermediate dimension). All
+tensor shapes are derived from these three values:
+- Source: `[MB, IC]`
+- Gate weights: `[IC, OC]`
+- Up weights: `[IC, OC]`
+- Down weights: `[OC, IC]`
+- Destination: `[MB, IC]`
+
+When a 3D tag is specified (e.g. `--stag=abc --wtag=cab --dtag=abc`), the
+driver creates "fake 3D" tensors with a unit dimension matching the layout used
+by OpenVINO networks:
+- Source: `[MB, 1, IC]`
+- Gate/Up weights: `[1, IC, OC]`
+- Down weights: `[1, OC, IC]`
+- Destination: `[MB, 1, IC]`
+
+## Quantization Attributes
+
+The driver supports `--attr-scales` and `--attr-zero-points` for input and
+weight dequantization. Supported argument names are `src` (for quantized
+activations), `wei`, `wei_up`, and `wei_down` (corresponding to the gate, up,
+and down projection weights).
+
+Supported policies:
+- `common` -- single scale/zero-point shared across the entire tensor.
+- `per_dim_1` -- one value per output channel (dimension 1 of the weight tensor).
+- `per_dim_01` -- grouped quantization along both dimensions (group size
+            specified inline, e.g., `per_dim_01:f16:32x1`).
+
+Example: run u4 quantized weights with per-channel f32 scales:
+``` sh
+    ./benchdnn --gated_mlp --dt=f32:u4:u4:u4:f32 \
+               --attr-scales=wei:per_dim_1:f32+wei_up:per_dim_1:f32+wei_down:per_dim_1:f32 \
+               64x128x256
+```
+
+Example: grouped quantization with groups along the K-dimension:
+``` sh
+    ./benchdnn --gated_mlp --dt=f32:u4:u4:u4:f32 \
+               --attr-scales=wei:per_dim_01:f32:32x1+wei_up:per_dim_01:f32:32x1+wei_down:per_dim_01:f32:32x1 \
+               --attr-zero-points=wei:per_dim_01:s4:32x1+wei_up:per_dim_01:s4:32x1+wei_down:per_dim_01:s4:32x1 \
+               64x128x256
+```
+
+Example: INT8 SRC with per-tensor SRC scale and quantized weights:
+``` sh
+    ./benchdnn --gated_mlp --dt=s8:u4:u4:u4:f16 \
+               --attr-scales=src:common:f16+wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1 \
+               64x256x4864
+```
+
+## Post-ops
+
+The driver supports post-ops applied to the final (down) matmul output.
+Supported kinds include `sum`, `eltwise`, and `binary`.
+
+Example: binary add post-op:
+``` sh
+    ./benchdnn --gated_mlp --dt=f16:u4:u4:u4:f16 \
+               --attr-scales=wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1 \
+               --attr-post-ops=binary_add:f16:2:ab \
+               64x128x4864
+```
+
+## Essence of Testing
+
+The GatedMLP operation computes
+`DST = (activation(SRC • W_gate) ⊙ (SRC • W_up)) • W_down`,
+where `•` denotes matrix multiplication and `⊙` denotes element-wise
+(Hadamard) product. The reference executes each step independently using f32
+matmul and element-wise primitives on the CPU. The driver compares the fused
+primitive output against this stepwise reference.
+
+## Examples
+
+Run the default validation set of GatedMLP using `inputs/gated_mlp/shapes_basic`
+file:
+``` sh
+    ./benchdnn --gated_mlp --batch=inputs/gated_mlp/shapes_basic
+```
+
+Run f16 GatedMLP with gelu_erf activation on a small shape:
+``` sh
+    ./benchdnn --gated_mlp --dt=f16 --activation=gelu_erf 64x128x256
+```
+
+Run GatedMLP performance benchmark on GPU with an LLM shape:
+``` sh
+    ./benchdnn --mode=f --gated_mlp --engine=gpu --dt=f16 \
+               --activation=swish 1024x896x4864
+```
+
+More examples with different driver options can be found at
+inputs/gated_mlp/test_\*.

--- a/tests/benchdnn/gated_mlp/bench_gated_mlp.cpp
+++ b/tests/benchdnn/gated_mlp/bench_gated_mlp.cpp
@@ -1,0 +1,111 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "dnnl_common.hpp"
+#include "utils/parser.hpp"
+#include "utils/task_executor.hpp"
+
+#include "gated_mlp/gated_mlp.hpp"
+
+namespace gated_mlp {
+
+TASK_EXECUTOR_DECL_TYPES;
+
+void check_correctness(
+        const settings_t &s, driver_task_executor_t &task_executor) {
+    for_(const auto &i_dt : s.dt)
+    for_(const auto &i_stag : s.stag)
+    for_(const auto &i_wtag : s.wtag)
+    for_(const auto &i_dtag : s.dtag)
+    for_(const auto &i_activation : s.activation)
+    for_(const auto &i_attr : s.attributes)
+    for_(const auto &i_ctx_init : s.ctx_init)
+    for (const auto &i_ctx_exe : s.ctx_exe) {
+        auto prb = std::make_shared<prb_t>(s.prb_dims, i_dt, i_stag, i_wtag,
+                i_dtag, i_activation, i_attr, i_ctx_init, i_ctx_exe,
+                s.impl_filter);
+        if (s.pattern && !match_regex(prb->str(), s.pattern)) return;
+
+        task_executor.submit(prb, s.perf_template, createit, checkit, doit);
+    }
+}
+
+int verify_input(const settings_t &s) {
+    static constexpr int n_inputs = 5; // src, w_gate, w_up, w_down, dst dt
+
+    for (const auto &i_dt : s.dt) {
+        if (i_dt.size() != 1 && i_dt.size() != n_inputs) {
+            BENCHDNN_PRINT(0,
+                    "ERROR: gated_mlp driver: `dt` option expects either a "
+                    "single input or five inputs in SRC, W_GATE, W_UP, "
+                    "W_DOWN, DST order. Current size is: \"%ld\"\n",
+                    (long)i_dt.size());
+            SAFE_V(FAIL);
+        }
+    }
+
+    static constexpr int n_dims = 3; // MB, IC, OC
+    if (s.prb_dims.ndims != n_dims) {
+        BENCHDNN_PRINT(0,
+                "ERROR: Expected number of dims is `%d` (MBxICxOC), "
+                "provided `%d`.\n",
+                n_dims, s.prb_dims.ndims);
+        SAFE_V(FAIL);
+    }
+    return OK;
+}
+
+static const std::string help_activation
+        = "ACTIVATION    (Default: `swish`)\n    Specifies the gated "
+          "activation function.\n    `swish`, `gelu_erf`, `gelu_tanh`.\n";
+
+int bench(int argc, char **argv) {
+    driver_name = "gated_mlp";
+    using namespace parser;
+    static settings_t s;
+    static const settings_t def {};
+    static driver_task_executor_t task_executor;
+    for (; argc > 0; --argc, ++argv) {
+        const bool parsed_options = parse_bench_settings(argv[0])
+                || parse_batch(bench, argv[0])
+                || parse_multi_dt(s.dt, def.dt, argv[0], "dt")
+                || parse_tag(s.stag, def.stag, argv[0], "stag")
+                || parse_tag(s.wtag, def.wtag, argv[0], "wtag")
+                || parse_tag(s.dtag, def.dtag, argv[0], "dtag")
+                || parse_vector_option(s.activation, def.activation,
+                        str2activation, argv[0], "activation", help_activation)
+                || parse_driver_shared_settings(s, def, argv[0]);
+        if (!parsed_options) {
+            catch_unknown_options(argv[0]);
+
+            parse_prb_dims(s.prb_dims, argv[0]);
+
+            SAFE(verify_input(s), WARN);
+
+            s.finalize();
+            check_correctness(s, task_executor);
+        }
+    }
+
+    task_executor.flush();
+
+    return parse_last_argument();
+}
+
+} // namespace gated_mlp

--- a/tests/benchdnn/gated_mlp/cfg.cpp
+++ b/tests/benchdnn/gated_mlp/cfg.cpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gated_mlp/gated_mlp.hpp"
+
+namespace gated_mlp {
+
+cfg_t::cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds)
+    : base_cfg_t {prb->attr.acc_mode} {
+    for (const auto kind : kinds) {
+        auto orig_data_type = prb->get_dt(kind);
+        auto data_type = deduce_cfg_data_type(orig_data_type, prb->attr, kind);
+        cfg_entry_.emplace(kind,
+                cfg_entry_t {
+                        kind, orig_data_type, data_type, get_cfg_map(kind)});
+    }
+
+    adjust_ranges();
+    print_fill_cfg_verbose();
+}
+
+// Adjust density based on accumulation chain length.
+float cfg_t::get_density(const cfg_t::density_args_t &density_args) const {
+    float density = 1.f;
+    if (density_args.data_kind != SRC) return density;
+
+    const int64_t safe_n_acc = get_safe_n_acc();
+    float safe_density = (float)safe_n_acc / density_args.n_acc;
+    density = MIN2(density, safe_density);
+
+    BENCHDNN_PRINT(6, "%s safe_n_acc=%d density=%f\n", "[FILL_CFG]",
+            (int)safe_n_acc, density);
+
+    return density;
+}
+
+cfg_t::cfg_entry_t::cfg_map_t cfg_t::get_cfg_map(data_kind_t kind) const {
+    // Tight ranges for chained pipeline. SRC is further scaled in fill.
+    static const cfg_t::cfg_entry_t::cfg_map_t src_cfg_map = {
+            {{dnnl_f32}, {-1, 1}},
+            {{dnnl_bf16}, {-1, 1}},
+            {{dnnl_f16}, {-1, 1}},
+            {{dnnl_s8}, {-1, 1}},
+            {{dnnl_u8}, {0, 2}},
+            {{dnnl_s4}, {-1, 1}},
+            {{dnnl_u4}, {0, 2}},
+    };
+
+    // Weight tensor ranges, small to control accumulation magnitude.
+    static const cfg_t::cfg_entry_t::cfg_map_t wei_cfg_map = {
+            {{dnnl_f32}, {-1, 1}},
+            {{dnnl_bf16}, {-1, 1}},
+            {{dnnl_f16}, {-1, 1}},
+            {{dnnl_s8}, {-1, 1}},
+            {{dnnl_u8}, {0, 2}},
+            {{dnnl_s4}, {-1, 1}},
+            {{dnnl_u4}, {0, 2}},
+    };
+
+    // Destination tensor ranges.
+    static const cfg_t::cfg_entry_t::cfg_map_t dst_cfg_map = {
+            {{dnnl_f32}, {-8, 8}},
+            {{dnnl_bf16}, {-4, 4}},
+            {{dnnl_f16}, {-4, 4}},
+            {{dnnl_s32}, {-8, 8}},
+            {{dnnl_s8}, {-4, 4}},
+            {{dnnl_u8}, {0, 8}},
+            {{dnnl_s4}, {-2, 2}},
+            {{dnnl_u4}, {0, 4}},
+    };
+
+    switch (kind) {
+        case SRC: return src_cfg_map;
+        case WEI: return wei_cfg_map;
+        case DST: return dst_cfg_map;
+        default: assert(!"unsupported data kind"); break;
+    }
+    static cfg_t::cfg_entry_t::cfg_map_t dummy;
+    return dummy;
+}
+
+} // namespace gated_mlp

--- a/tests/benchdnn/gated_mlp/gated_mlp.cpp
+++ b/tests/benchdnn/gated_mlp/gated_mlp.cpp
@@ -1,0 +1,349 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <math.h>
+#include <random>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "oneapi/dnnl/dnnl.h"
+
+#include "utils/fill.hpp"
+#include "utils/memory.hpp"
+#include "utils/numeric.hpp"
+#include "utils/parallel.hpp"
+
+#include "dnnl_common.hpp"
+#include "dnnl_memory.hpp"
+
+#include "gated_mlp/gated_mlp.hpp"
+
+namespace gated_mlp {
+
+benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> create_md(
+        const dims_t &dims, dnnl_data_type_t dt, const std::string &tag) {
+    return dnn_mem_t::init_md(
+            static_cast<int>(dims.size()), dims.data(), dt, tag);
+}
+
+dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
+    const prb_t *prb = prb_t::from(init_pd_args.base_prb);
+    res_t *res = init_pd_args.res;
+    bool force_f32_dt = init_pd_args.force_f32_dt;
+
+    auto src_dt = force_f32_dt ? dnnl_f32 : prb->src_dt();
+    auto w_gate_dt = force_f32_dt ? dnnl_f32 : prb->w_gate_dt();
+    auto w_up_dt = force_f32_dt ? dnnl_f32 : prb->w_up_dt();
+    auto w_down_dt = force_f32_dt ? dnnl_f32 : prb->w_down_dt();
+    auto dst_dt = force_f32_dt ? dnnl_f32 : prb->dst_dt();
+
+    auto src_d = create_md(prb->src_dims, src_dt, prb->stag);
+    auto w_gate_d = create_md(prb->w_gate_dims, w_gate_dt, prb->wtag);
+    auto w_up_d = create_md(prb->w_up_dims, w_up_dt, prb->wtag);
+    auto w_down_d = create_md(prb->w_down_dims, w_down_dt, prb->wtag);
+    auto dst_d = create_md(prb->dst_dims, dst_dt, prb->dtag);
+
+    attr_args_t attr_args;
+    attr_args.prepare_post_ops_mds(prb->attr,
+            static_cast<int>(prb->dst_dims.size()), prb->dst_dims.data(),
+            dnnl_matmul);
+    auto dnnl_attr = make_benchdnn_dnnl_wrapper(
+            create_dnnl_attr(prb->attr, attr_args, prb->ndims));
+
+    TIME_C_PD(DNN_SAFE_STATUS(dnnl_gated_mlp_primitive_desc_create(
+            &init_pd_args.pd, init_pd_args.engine, src_d, w_gate_d, w_up_d,
+            w_down_d, dst_d, prb->activation, dnnl_attr)));
+
+    return dnnl_success;
+}
+
+int fill_data(int exec_arg, data_kind_t kind, const prb_t *prb,
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
+    const auto nelems = mem_fp.nelems();
+    if (nelems == 0) return OK;
+    if (fill_from_file(exec_arg, mem_dt, mem_fp)) return OK;
+
+    // Refer to modes documentation for filling principles.
+    if (has_bench_mode_bit(mode_bit_t::bitwise)) {
+        return fill_random_real(mem_dt, mem_fp, res);
+    }
+    if (has_bench_mode_bit(mode_bit_t::perf)) {
+        return fill_random_real(
+                mem_dt, mem_fp, res, get_perf_fill_cfg(mem_dt.dt()));
+    }
+
+    cfg_t::density_args_t density_args;
+    density_args.data_kind = kind;
+    // Chained matmul pipeline amplifies magnitudes quadratically (up*gate).
+    // ZP adds per-group bias on top. Inflate n_acc to reduce density.
+    const bool has_zp = !prb->attr.zero_points.is_def();
+    density_args.n_acc = std::max(prb->ic, prb->oc) * (has_zp ? 64 : 4);
+    const auto density = cfg.get_density(density_args);
+
+    /* Do fixed partitioning to have same filling for any number of threads */
+    const int64_t chunk_size = 64;
+    const int64_t n_chunks = div_up(nelems, chunk_size);
+
+    benchdnn_parallel_nd(n_chunks, [&](int64_t idx_chunk) {
+        int64_t idx_start = idx_chunk * chunk_size;
+        int64_t idx_end = MIN2(idx_start + chunk_size, nelems);
+        std::minstd_rand int_seed(kind * nelems + idx_start + 1);
+        int_seed.discard(1);
+        std::bernoulli_distribution b_dist(density);
+        std::minstd_rand b_seed(kind * nelems + idx_start + 1);
+        b_seed.discard(10);
+
+        std::uniform_int_distribution<> gen(
+                cfg.get_range_min(kind), cfg.get_range_max(kind));
+
+        // Make sure the first element is positive.
+        if (idx_start == 0) {
+            float val = 0;
+            while (val <= 0)
+                val = gen(int_seed);
+            mem_fp.set_f32_elem(
+                    0, round_to_nearest_representable(cfg.get_dt(kind), val));
+            idx_start += 1;
+        }
+
+        for (int64_t idx = idx_start; idx < idx_end; ++idx) {
+            bool is_one = density == 1.f ? true : b_dist(b_seed);
+            if (!is_one) {
+                mem_fp.set_f32_elem(idx, 0.f);
+                continue;
+            }
+            float val = gen(int_seed);
+            mem_fp.set_f32_elem(
+                    idx, round_to_nearest_representable(cfg.get_dt(kind), val));
+        }
+    });
+
+    // Scale SRC to tame quadratic amplification in the chained pipeline.
+    // For int types this is done through scales instead (see below).
+    if (kind == SRC && !is_integral_dt(cfg.get_dt(kind))) {
+        const float coeff = 0.125f;
+        for (int64_t idx = 0; idx < nelems; ++idx) {
+            mem_fp.set_f32_elem(idx, mem_fp.get_f32_elem(idx) * coeff);
+        }
+    }
+
+    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    return OK;
+}
+
+void prb_t::skip_unimplemented(res_t *res) const {
+    const prb_t *prb = this;
+    skip_unimplemented_data_type(
+            {prb->src_dt(), prb->w_gate_dt(), prb->w_up_dt(), prb->w_down_dt(),
+                    prb->dst_dt()},
+            prb->dir, res);
+
+    // GatedMLP is currently only implemented for GPU.
+    if (is_cpu()) {
+        res->state = SKIPPED;
+        res->reason = reason_t::skip_not_supported;
+        return;
+    }
+}
+
+void prb_t::skip_invalid(res_t *res) const {
+    const prb_t *prb = this;
+    // Validate dimensions are positive.
+    if (prb->mb <= 0 || prb->ic <= 0 || prb->oc <= 0) {
+        res->state = SKIPPED;
+        res->reason = reason_t::invalid;
+        return;
+    }
+}
+
+void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
+        data_kind_t kind, const args_t &ref_args) {
+    const prb_t *prb = prb_t::from(base_prb);
+    const int64_t max_acc = std::max(prb->ic, prb->oc);
+    const auto dst_dt = prb->dst_dt();
+
+    // Relaxed fpmath may accumulate in f16 precision; error ~ sqrt(K)*eps.
+    const bool relaxed_acc = prb->attr.acc_mode != dnnl_accumulation_mode_strict
+            && prb->attr.acc_mode != dnnl_accumulation_mode_f32;
+    const float eps_acc
+            = relaxed_acc ? epsilon_dt(dnnl_f16) : epsilon_dt(dst_dt);
+    const float rel_trh = std::max(5e-2f, 3.f * sqrtf(max_acc) * eps_acc);
+    cmp.set_threshold(rel_trh);
+
+    // Absolute threshold for near-zero outputs where relative check is
+    // too strict. Floor at rel_trh covers GPU-vs-CPU reduction order diffs.
+    const float abs_trh = std::max(rel_trh, 20.f * sqrtf(max_acc) * eps_acc);
+    const float dst_max = max_dt(dst_dt);
+    cmp.set_driver_check_function(
+            [abs_trh, dst_max](
+                    const compare::compare_t::driver_check_func_args_t &a)
+                    -> bool {
+        if (a.diff <= abs_trh) return true;
+        // Accept overflow saturation in either direction:
+        // ref→±inf with GPU→±max, or GPU→±inf with ref→±max.
+        if (std::isinf(a.exp) && fabsf(a.got) == dst_max) return true;
+        if (std::isinf(a.got) && fabsf(a.exp) == dst_max) return true;
+        return false;
+    });
+
+    cmp.set_zero_trust_percent(90.f);
+}
+
+std::vector<int> prb_t::supported_exec_args(bool override_dir_with_fwd) const {
+    static const std::vector<int> exec_args = {
+            DNNL_ARG_SRC,
+            DNNL_ARG_WEIGHTS_GATE,
+            DNNL_ARG_WEIGHTS_UP,
+            DNNL_ARG_WEIGHTS_DOWN,
+            DNNL_ARG_DST,
+    };
+    return exec_args;
+}
+
+int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
+        dnnl_primitive_t prim, const prb_t *prb, res_t *res,
+        dnnl_primitive_t prim_ref = nullptr) {
+    if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) return OK;
+
+    const auto &ref_engine = get_cpu_engine();
+
+    // Move cfg out of filling since its creation is not free.
+    cfg_t cfg(prb, {SRC, WEI, DST});
+
+    for (auto &entry : mem_map) {
+        const int exec_arg = entry.first;
+        // The function targets regular exec_args that are positive.
+        if (exec_arg <= 0) continue;
+
+        auto &mem = entry.second; // `mem` is modified by filler (reorder).
+
+        // Scratchpad memory relates to a primitive.
+        if (exec_arg == DNNL_ARG_SCRATCHPAD) continue;
+
+        ref_mem_map.emplace(exec_arg,
+                dnn_mem_t(mem.md_, dnnl_f32, tag::abx, ref_engine,
+                        /* prefill = */ false));
+        auto &ref_mem = ref_mem_map[exec_arg];
+
+        switch (exec_arg) {
+            case DNNL_ARG_SRC:
+                SAFE(fill_data(exec_arg, SRC, prb, cfg, mem, ref_mem, res),
+                        WARN);
+                break;
+            case DNNL_ARG_WEIGHTS_GATE:
+            case DNNL_ARG_WEIGHTS_UP:
+            case DNNL_ARG_WEIGHTS_DOWN:
+                SAFE(fill_data(exec_arg, WEI, prb, cfg, mem, ref_mem, res),
+                        WARN);
+                break;
+            case DNNL_ARG_DST:
+                if (prb->attr.post_ops.find(attr_t::post_ops_t::SUM) >= 0) {
+                    SAFE(fill_data(exec_arg, DST, prb, cfg, mem, ref_mem, res),
+                            WARN);
+                }
+                break;
+            default:
+                // Apply coeff to scales to prevent overflow. For int SRC
+                // without own scales, go through WEI gate/up scales instead.
+                if (exec_arg & DNNL_ARG_ATTR_SCALES) {
+                    const int true_arg = exec_arg ^ DNNL_ARG_ATTR_SCALES;
+                    const bool is_src_scale = (true_arg == DNNL_ARG_SRC);
+                    const bool int_src_no_scale = is_integral_dt(prb->src_dt())
+                            && prb->attr.scales.get(DNNL_ARG_SRC).is_def();
+                    const bool is_gate_up_scale
+                            = (true_arg == DNNL_ARG_WEIGHTS_GATE
+                                    || true_arg == DNNL_ARG_WEIGHTS_UP);
+                    if (is_src_scale
+                            || (int_src_no_scale && is_gate_up_scale)) {
+                        const float coeff = 0.125f;
+                        dnn_mem_t null;
+                        SAFE(fill_scales(
+                                     prb->attr, true_arg, null, ref_mem, res),
+                                WARN);
+                        for (int64_t i = 0; i < ref_mem.nelems(); i++)
+                            ref_mem.set_f32_elem(
+                                    i, ref_mem.get_f32_elem(i) * coeff);
+                        SAFE(mem.reorder(ref_mem), WARN);
+                        break;
+                    }
+                }
+                SAFE(init_ref_memory_args_default_case(
+                             exec_arg, mem, ref_mem, prb->attr, res),
+                        WARN);
+                break;
+        }
+
+        // Don't keep reference memory if it is not used further.
+        if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
+    }
+
+    return OK;
+}
+
+int createit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const base_prb_t *base_prb, res_t *res) {
+    const prb_t *prb = prb_t::from(base_prb);
+    v_prim.resize(1);
+    SAFE(init_prim(prb->ctx_init, v_prim[0], init_pd, prb, res), WARN);
+    return OK;
+}
+
+int checkit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const base_prb_t *base_prb, res_t *res) {
+    const prb_t *prb = prb_t::from(base_prb);
+    if (has_bench_mode_bit(mode_bit_t::exec)) {
+        SAFE(check_total_size(res), WARN);
+    }
+    if (has_bench_mode_bit(mode_bit_t::corr)) {
+        SAFE(check_caches(v_prim[0], prb->ctx_init, res), WARN);
+    }
+    return OK;
+}
+
+std::vector<data_kind_t> get_kinds_to_check(const prb_t *prb) {
+    std::vector<data_kind_t> check_kinds = {DST};
+    get_kinds_to_check_shared(check_kinds, prb->attr);
+    return check_kinds;
+}
+
+int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const base_prb_t *base_prb, res_t *res) {
+    const prb_t *prb = prb_t::from(base_prb);
+    set_zmalloc_max_expected_size(res->mem_size_args.zmalloc_expected_size);
+
+    const auto &prim = v_prim[0];
+
+    dnn_mem_map_t mem_map, ref_mem_map;
+
+    init_memory_args(mem_map, prb, prim);
+
+    TIME_FILL(SAFE(
+            init_ref_memory_args(ref_mem_map, mem_map, prim, prb, res), WARN));
+
+    args_t args(mem_map), ref_args(ref_mem_map);
+
+    SAFE(run_execution(prim, args, res), WARN);
+
+    check_correctness(prb, get_kinds_to_check(prb), args, ref_args, compute_ref,
+            setup_cmp, res, prb->dir);
+    SAFE(check_bitwise(prim, get_kinds_to_check(prb), args, prb->attr,
+                 prb->inplace, res),
+            WARN);
+
+    return measure_perf(prb->ctx_exe, res, prim, args);
+}
+
+} // namespace gated_mlp

--- a/tests/benchdnn/gated_mlp/gated_mlp.hpp
+++ b/tests/benchdnn/gated_mlp/gated_mlp.hpp
@@ -1,0 +1,228 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GATED_MLP_HPP
+#define GATED_MLP_HPP
+
+#include <iostream>
+
+#include "oneapi/dnnl/dnnl.h"
+
+#include "common.hpp"
+#include "dnnl_common.hpp"
+#include "utils/cfg.hpp"
+#include "utils/perf_report.hpp"
+#include "utils/settings.hpp"
+
+// GatedMLP primitive C API.
+#include "src/common/gated_mlp_iface.hpp"
+
+namespace gated_mlp {
+
+// Argument aliases for gated MLP weight tensors.
+#define DNNL_ARG_WEIGHTS_GATE DNNL_ARG_WEIGHTS_0
+#define DNNL_ARG_WEIGHTS_UP DNNL_ARG_WEIGHTS_1
+#define DNNL_ARG_WEIGHTS_DOWN DNNL_ARG_WEIGHTS_2
+
+dnnl_alg_kind_t str2activation(const char *str);
+const char *activation2str(dnnl_alg_kind_t act);
+
+struct settings_t : public base_settings_t {
+    using base_settings_t::base_settings_t;
+
+    prb_dims_t prb_dims;
+
+    std::vector<std::vector<dnnl_data_type_t>> dt {{dnnl_f32}};
+    std::vector<std::string> stag {tag::abx}, wtag {tag::abx}, dtag {tag::abx};
+    std::vector<dnnl_alg_kind_t> activation {dnnl_eltwise_swish};
+
+    const char *perf_template_csv() const {
+        static const std::string args = "%sdt%,%stag%,%wtag%,%dtag%";
+        return perf_template_csv_base(args);
+    }
+
+    void reset() { *this = settings_t(perf_template); }
+
+    bool has_single_setup() const override {
+        return dt.size() == 1 && stag.size() == 1 && wtag.size() == 1
+                && dtag.size() == 1 && activation.size() == 1
+                && base_settings_t::has_single_setup();
+    }
+};
+
+struct prb_t : public prb_dims_t, public base_prb_t {
+    // A ctor with common interface across all drivers.
+    prb_t(const settings_t &s)
+        : prb_t(s.prb_dims, s.dt[0], s.stag[0], s.wtag[0], s.dtag[0],
+                  s.activation[0], s.attributes.front(), s.ctx_init[0],
+                  s.ctx_exe[0], s.impl_filter) {
+        SAFE_V(s.has_single_setup() ? OK : FAIL);
+    }
+
+    prb_t(const prb_dims_t &prb_dims, const std::vector<dnnl_data_type_t> &dt,
+            const std::string &stag, const std::string &wtag,
+            const std::string &dtag, dnnl_alg_kind_t activation,
+            const attr_t &attr, const thr_ctx_t &ctx_init,
+            const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
+        : prb_dims_t(prb_dims)
+        , base_prb_t(FLAG_FWD, false, attr, impl_filter)
+        , dt(dt)
+        , stag(stag)
+        , wtag(wtag)
+        , dtag(dtag)
+        , activation(activation)
+        , ctx_init(ctx_init)
+        , ctx_exe(ctx_exe) {
+
+        // Broadcast data types if needed: src, w_gate, w_up, w_down, dst.
+        if (this->dt.size() == 1) {
+            const auto val = this->dt[0];
+            this->dt.assign(5, val);
+        }
+
+        // dims is [MB, IC, OC].
+        mb = dims[0];
+        ic = dims[1];
+        oc = dims[2];
+
+        // Determine ndims from tags. Explicit tags (e.g. "abc", "cab")
+        // imply 3D; generic tags ("abx") default to 2D.
+        auto tag_ndims = [](const std::string &t) -> int {
+            if (t == tag::abx || t == tag::axb || t == tag::any
+                    || t == tag::undef)
+                return 0;
+            int n = 0;
+            for (char c : t)
+                if (c >= 'a' && c <= 'l') n = std::max(n, c - 'a' + 1);
+            return n;
+        };
+        ndims = std::max({2, tag_ndims(this->stag), tag_ndims(this->wtag),
+                tag_ndims(this->dtag)});
+
+        // Derive tensor shapes. For 3D ("fake batch"), prepend/insert a
+        // unit dimension to match OV's layout: SRC/DST=[MB,1,IC],
+        // W_GATE/W_UP=[1,IC,OC], W_DOWN=[1,OC,IC].
+        if (ndims == 3) {
+            src_dims = {mb, 1, ic};
+            w_gate_dims = {1, ic, oc};
+            w_up_dims = {1, ic, oc};
+            w_down_dims = {1, oc, ic};
+            dst_dims = {mb, 1, ic};
+        } else {
+            src_dims = {mb, ic};
+            w_gate_dims = {ic, oc};
+            w_up_dims = {ic, oc};
+            w_down_dims = {oc, ic};
+            dst_dims = {mb, ic};
+        }
+
+        // FLOPs: 3 matmuls + element-wise ops.
+        // matmul(src, W_gate): 2*MB*IC*OC
+        // matmul(src, W_up):   2*MB*IC*OC
+        // matmul(gate, W_down): 2*MB*OC*IC
+        ops = 6.0 * mb * ic * oc;
+
+        repro = set_repro_line(); // must be last in ctor to collect right info
+    }
+
+    int64_t mb, ic, oc;
+    int ndims;
+    std::vector<dnnl_data_type_t> dt;
+    std::string stag, wtag, dtag;
+    dnnl_alg_kind_t activation;
+
+    thr_ctx_t ctx_init, ctx_exe;
+
+    double ops;
+    dims_t src_dims, w_gate_dims, w_up_dims, w_down_dims, dst_dims;
+
+    dnnl_data_type_t src_dt() const { return dt[0]; }
+    dnnl_data_type_t w_gate_dt() const { return dt[1]; }
+    dnnl_data_type_t w_up_dt() const { return dt[2]; }
+    dnnl_data_type_t w_down_dt() const { return dt[3]; }
+    dnnl_data_type_t dst_dt() const { return dt[4]; }
+    dnnl_data_type_t get_dt(data_kind_t data_kind) const;
+
+    // Required by init_memory_args (for runtime dims support).
+    benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> get_md(int arg) const override;
+
+    static const prb_t *from(const base_prb_t *base_prb) {
+        return downcast<const prb_t *>(base_prb);
+    }
+
+    void skip_unimplemented(res_t *res) const override;
+    void skip_invalid(res_t *res) const override;
+    std::vector<int> supported_exec_args(
+            bool override_dir_with_fwd) const override;
+
+private:
+    std::string set_repro_line() override;
+};
+
+struct perf_report_t : public base_perf_report_t {
+    perf_report_t(const base_prb_t *base_prb, const char *perf_template)
+        : base_perf_report_t(perf_template)
+        , p_(prb_t::from(base_prb))
+        , stag_({normalize_tag(p_->stag, p_->ndims)})
+        , wtag_(normalize_tag(p_->wtag, p_->ndims))
+        , dtag_(normalize_tag(p_->dtag, p_->ndims)) {}
+
+    void dump_desc(std::ostream &s) const override {
+        s << static_cast<const prb_dims_t &>(*p_);
+    }
+
+    double ops() const override { return p_->ops; }
+    const std::vector<dnnl_data_type_t> *sdt() const override {
+        return &p_->dt;
+    }
+    const attr_t *attr() const override { return &p_->attr; }
+    const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
+    const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }
+    const std::string *name() const override { return &p_->name; }
+    const std::vector<std::string> *stag() const override { return &stag_; }
+    const std::string *wtag() const override { return &wtag_; }
+    const std::string *dtag() const override { return &dtag_; }
+
+private:
+    const prb_t *p_;
+    std::vector<std::string> stag_;
+    std::string wtag_, dtag_;
+};
+
+int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const base_prb_t *base_prb, res_t *res);
+int createit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const base_prb_t *base_prb, res_t *res);
+int checkit(std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
+        const base_prb_t *base_prb, res_t *res);
+void compute_ref(const base_prb_t *base_prb, dir_t dir, const args_t &args,
+        dnnl_primitive_t);
+void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
+        data_kind_t kind, const args_t &ref_args);
+
+struct cfg_t : public base_cfg_t {
+    cfg_t(const prb_t *prb, const std::vector<data_kind_t> &kinds);
+
+    cfg_entry_t::cfg_map_t get_cfg_map(data_kind_t kind) const override;
+
+    float get_density(const density_args_t &density_args) const override;
+};
+
+int bench(int argc, char **argv);
+
+} // namespace gated_mlp
+
+#endif

--- a/tests/benchdnn/gated_mlp/gated_mlp_aux.cpp
+++ b/tests/benchdnn/gated_mlp/gated_mlp_aux.cpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <sstream>
+#include <string.h>
+
+#include "dnnl_common.hpp"
+#include "dnnl_memory.hpp"
+
+#include "gated_mlp/gated_mlp.hpp"
+
+namespace gated_mlp {
+
+dnnl_alg_kind_t str2activation(const char *str) {
+    if (!strcmp(str, "swish")) return dnnl_eltwise_swish;
+    if (!strcmp(str, "gelu_erf")) return dnnl_eltwise_gelu_erf;
+    if (!strcmp(str, "gelu_tanh")) return dnnl_eltwise_gelu_tanh;
+    assert(!"unknown activation");
+    return dnnl_eltwise_swish;
+}
+
+const char *activation2str(dnnl_alg_kind_t act) {
+    switch (act) {
+        case dnnl_eltwise_swish: return "swish";
+        case dnnl_eltwise_gelu_erf: return "gelu_erf";
+        case dnnl_eltwise_gelu_tanh: return "gelu_tanh";
+        default: assert(!"unknown activation"); return "unknown";
+    }
+}
+
+dnnl_data_type_t prb_t::get_dt(data_kind_t data_kind) const {
+    switch (data_kind) {
+        case SRC: return src_dt();
+        case WEI: return w_gate_dt(); // All weights share WEI kind.
+        case DST: return dst_dt();
+        default: assert(!"unexpected"); return dnnl_data_type_undef;
+    }
+}
+
+benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
+    switch (arg) {
+        case DNNL_ARG_SRC:
+            return dnn_mem_t::init_md(ndims, src_dims.data(), src_dt(), stag);
+        case DNNL_ARG_WEIGHTS_GATE:
+            return dnn_mem_t::init_md(
+                    ndims, w_gate_dims.data(), w_gate_dt(), wtag);
+        case DNNL_ARG_WEIGHTS_UP:
+            return dnn_mem_t::init_md(ndims, w_up_dims.data(), w_up_dt(), wtag);
+        case DNNL_ARG_WEIGHTS_DOWN:
+            return dnn_mem_t::init_md(
+                    ndims, w_down_dims.data(), w_down_dt(), wtag);
+        case DNNL_ARG_DST:
+            return dnn_mem_t::init_md(ndims, dst_dims.data(), dst_dt(), dtag);
+        default:
+            assert(!"unsupported arg");
+            return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
+    }
+}
+
+std::string prb_t::set_repro_line() {
+    dnnl::impl::stringstream_t s;
+    dump_global_params(s);
+    settings_t def;
+
+    bool has_default_dts = true;
+    for (const auto &i_dt : dt)
+        has_default_dts = has_default_dts && i_dt == dnnl_f32;
+
+    if (canonical || !has_default_dts) s << "--dt=" << dt << " ";
+    if (canonical || stag != def.stag[0]) s << "--stag=" << stag << " ";
+    if (canonical || wtag != def.wtag[0]) s << "--wtag=" << wtag << " ";
+    if (canonical || dtag != def.dtag[0]) s << "--dtag=" << dtag << " ";
+    if (canonical || activation != def.activation[0])
+        s << "--activation=" << activation2str(activation) << " ";
+
+    s << attr;
+    if (canonical || ctx_init != def.ctx_init[0])
+        s << "--ctx-init=" << ctx_init << " ";
+    if (canonical || ctx_exe != def.ctx_exe[0])
+        s << "--ctx-exe=" << ctx_exe << " ";
+    if (canonical || !impl_filter.is_def() || !global_impl_filter.is_def())
+        s << impl_filter;
+
+    s << static_cast<const prb_dims_t &>(*this);
+
+    return s.str();
+}
+
+} // namespace gated_mlp

--- a/tests/benchdnn/gated_mlp/ref_gated_mlp.cpp
+++ b/tests/benchdnn/gated_mlp/ref_gated_mlp.cpp
@@ -1,0 +1,276 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstring>
+#include <vector>
+
+#include "oneapi/dnnl/dnnl.h"
+
+#include "dnnl_common.hpp"
+#include "dnnl_memory.hpp"
+
+#include "gated_mlp/gated_mlp.hpp"
+
+namespace gated_mlp {
+
+// Reference GatedMLP: generates gold data by composing existing oneDNN
+// primitives (matmul, eltwise) instead of reimplementing from scratch.
+//
+// Pipeline:
+//   up     = matmul(src, W_up)            -> [MB, OC]
+//   gate   = matmul(src, W_gate)          -> [MB, OC]
+//   gate   = eltwise(gate, activation)    -> [MB, OC]
+//   up     = up * gate                    -> [MB, OC]  (elementwise)
+//   dst    = matmul(up, W_down)           -> [MB, IC]
+//
+// All intermediate computation is done in f32 on the CPU engine.
+
+namespace {
+
+// Execute a matmul primitive on CPU: dst = src x wei.
+void exec_matmul(dnnl_engine_t eng, dnnl_stream_t strm, const dnn_mem_t &src,
+        const dnn_mem_t &wei, const dnn_mem_t &dst, const args_t &all_args,
+        const_dnnl_primitive_attr_t attr = nullptr) {
+    dnnl_primitive_desc_t pd {};
+    DNN_SAFE_V(dnnl_matmul_primitive_desc_create(
+            &pd, eng, src.md_, wei.md_, nullptr, dst.md_, attr));
+    auto pd_w = make_benchdnn_dnnl_wrapper(pd);
+
+    dnnl_primitive_t prim {};
+    DNN_SAFE_V(dnnl_primitive_create(&prim, pd));
+    auto prim_w = make_benchdnn_dnnl_wrapper(prim);
+
+    std::vector<dnnl_exec_arg_t> args = {
+            {DNNL_ARG_SRC, src.m_},
+            {DNNL_ARG_WEIGHTS, wei.m_},
+            {DNNL_ARG_DST, dst.m_},
+    };
+    for (int p = 0, pl = 32 * !!attr; p < pl; p++) {
+        auto idx = DNNL_ARG_ATTR_MULTIPLE_POST_OP(p) | DNNL_ARG_SRC_1;
+        auto &maybe_buf = all_args.find(idx);
+        if (maybe_buf) args.emplace_back(dnnl_exec_arg_t {idx, maybe_buf.m_});
+    }
+    DNN_SAFE_V(dnnl_primitive_execute(
+            prim, strm, static_cast<int>(args.size()), args.data()));
+    DNN_SAFE_V(dnnl_stream_wait(strm));
+}
+
+// Execute in-place eltwise forward on CPU.
+void exec_eltwise(dnnl_engine_t eng, dnnl_stream_t strm, dnn_mem_t &mem,
+        dnnl_alg_kind_t alg) {
+    // Swish uses alpha=1.0 by default. GELU variants ignore alpha/beta.
+    float alpha = (alg == dnnl_eltwise_swish) ? 1.0f : 0.0f;
+    float beta = 0.0f;
+
+    dnnl_primitive_desc_t pd {};
+    DNN_SAFE_V(dnnl_eltwise_forward_primitive_desc_create(&pd, eng,
+            dnnl_forward_inference, alg, mem.md_, mem.md_, alpha, beta,
+            nullptr));
+    auto pd_w = make_benchdnn_dnnl_wrapper(pd);
+
+    dnnl_primitive_t prim {};
+    DNN_SAFE_V(dnnl_primitive_create(&prim, pd));
+    auto prim_w = make_benchdnn_dnnl_wrapper(prim);
+
+    dnnl_exec_arg_t args[] = {
+            {DNNL_ARG_SRC, mem.m_},
+            {DNNL_ARG_DST, mem.m_},
+    };
+    DNN_SAFE_V(dnnl_primitive_execute(prim, strm, 2, args));
+    DNN_SAFE_V(dnnl_stream_wait(strm));
+}
+
+// Execute in-place binary operation on CPU: lhs = lhs <alg> rhs.
+void exec_binary(dnnl_engine_t eng, dnnl_stream_t strm, dnn_mem_t &lhs,
+        const dnn_mem_t &rhs, dnnl_alg_kind_t alg) {
+    dnnl_primitive_desc_t pd {};
+    DNN_SAFE_V(dnnl_binary_primitive_desc_create(
+            &pd, eng, alg, lhs.md_, rhs.md_, lhs.md_, nullptr));
+    auto pd_w = make_benchdnn_dnnl_wrapper(pd);
+
+    dnnl_primitive_t prim {};
+    DNN_SAFE_V(dnnl_primitive_create(&prim, pd));
+    auto prim_w = make_benchdnn_dnnl_wrapper(prim);
+
+    dnnl_exec_arg_t args[] = {
+            {DNNL_ARG_SRC_0, lhs.m_},
+            {DNNL_ARG_SRC_1, rhs.m_},
+            {DNNL_ARG_DST, lhs.m_},
+    };
+    DNN_SAFE_V(dnnl_primitive_execute(prim, strm, 3, args));
+    DNN_SAFE_V(dnnl_stream_wait(strm));
+}
+
+// Create an f32 plain memory on `eng` with the given dims.
+dnn_mem_t make_mem(dnnl_engine_t eng, const dims_t &d) {
+    auto md = dnn_mem_t::init_md(
+            static_cast<int>(d.size()), d.data(), dnnl_f32, tag::abx);
+    return dnn_mem_t(md, eng, /* prefill = */ false);
+}
+
+// Dequantize a tensor in-place:
+//   t[k][n] = scale[idx] * (t[k][n] - zp[idx]).
+// For weights shaped [K, N]:
+//   mask=2: scale/zp indexed by n only.
+//   mask=3: scale/zp indexed by (k / group_k) and n.
+void dequantize_buf(const dnn_mem_t &buf, int64_t K, int64_t N, bool has_scale,
+        int scale_mask, const std::vector<dnnl_dim_t> &scale_grp,
+        const dnn_mem_t &scales_m, bool has_zp, int zp_mask,
+        const std::vector<dnnl_dim_t> &zp_grp, const dnn_mem_t &zps_m, bool T) {
+    if (!has_scale && !has_zp) return;
+
+    int kmask = 1 << (int)T;
+    int nmask = 1 << (int)!T;
+    if ((buf.ndims() == 3) && (buf.dims()[0] >= 2) && (buf.dims()[1] == 1)) {
+        kmask <<= (int)T;
+        nmask <<= (int)!T;
+    }
+    if ((buf.ndims() == 3) && (buf.dims()[0] == 1) && (buf.dims()[1] >= 2)) {
+        kmask <<= 1;
+        nmask <<= 1;
+    }
+
+    // Determine K-group size for scales and zero-points;
+    // mask bit 1 (1<<0) set means per-K; k*_group subdivides K dimension
+    int64_t kz_grp = (zp_mask & kmask) ? (zp_grp.empty()) ? 1 : zp_grp[T] : K;
+    int64_t ks_grp
+            = (scale_mask & kmask) ? (scale_grp.empty()) ? 1 : scale_grp[T] : K;
+
+    bool nz_inc = zp_mask & nmask;
+    bool ns_inc = scale_mask & nmask;
+
+    auto t = (float *)buf;
+    if (T) { // if transposed
+        int64_t nz_mult = (nz_inc) ? K / kz_grp : 1;
+        int64_t ns_mult = (ns_inc) ? K / ks_grp : 1;
+        for (int64_t n = 0, nz = 0, ns = 0; n < N;
+                ++n, nz += nz_inc, ns += ns_inc)
+            for (int64_t k = 0, kz = 0, ks = 0; k < K; ++k,
+                         kz = (k >= (kz + 1) * kz_grp) ? kz + 1 : kz,
+                         ks = (k >= (ks + 1) * ks_grp) ? ks + 1 : ks) {
+                auto z = (has_zp) ? zps_m.get_f32_elem(nz * nz_mult + kz) : 0.f;
+                auto s = (has_scale) ? scales_m.get_f32_elem(ns * ns_mult + ks)
+                                     : 1.f;
+                t[n * K + k] = s * (t[n * K + k] - z);
+            }
+    } else { // if not transposed
+        int64_t kz_mult = (nz_inc) ? N : 1;
+        int64_t ks_mult = (ns_inc) ? N : 1;
+        for (int64_t k = 0, kz = 0, ks = 0; k < K; ++k,
+                     kz = (k >= (kz + 1) * kz_grp) ? kz + 1 : kz,
+                     ks = (k >= (ks + 1) * ks_grp) ? ks + 1 : ks)
+            for (int64_t n = 0, nz = 0, ns = 0; n < N;
+                    ++n, nz += nz_inc, ns += ns_inc) {
+                auto z = (has_zp) ? zps_m.get_f32_elem(nz + kz * kz_mult) : 0.f;
+                auto s = (has_scale) ? scales_m.get_f32_elem(ns + ks * ks_mult)
+                                     : 1.f;
+                t[k * N + n] = s * (t[k * N + n] - z);
+            }
+    }
+}
+
+} // anonymous namespace
+
+void compute_ref(const base_prb_t *base_prb, dir_t dir, const args_t &args,
+        dnnl_primitive_t) {
+    const prb_t *prb = prb_t::from(base_prb);
+    const auto &eng = get_cpu_engine();
+    dnnl_stream_t strm {};
+    DNN_SAFE_V(dnnl_stream_create(&strm, eng, dnnl_stream_default_flags));
+
+    const dnn_mem_t &src_m = args.find(DNNL_ARG_SRC);
+    const dnn_mem_t &w_gate_m = args.find(DNNL_ARG_WEIGHTS_GATE);
+    const dnn_mem_t &w_up_m = args.find(DNNL_ARG_WEIGHTS_UP);
+    const dnn_mem_t &w_down_m = args.find(DNNL_ARG_WEIGHTS_DOWN);
+    const dnn_mem_t &dst_m = args.find(DNNL_ARG_DST);
+
+    const int64_t MB = prb->mb;
+    const int64_t IC = prb->ic;
+    const int64_t OC = prb->oc;
+
+    // f32 memories for intermediate results.
+    auto dims = (src_m.ndims() == 2) ? dims_t {MB, OC} : dims_t {MB, 1, OC};
+    auto up_result = make_mem(eng, dims);
+    auto gate_result = make_mem(eng, dims);
+
+    // Dequantize if quantization attributes are set.
+    const auto &attr = prb->attr;
+    auto dequant = [&](const dnn_mem_t &buf, int64_t K, int64_t N, int arg) {
+        const bool has_scale = !attr.scales.get(arg).is_def();
+        const bool has_zp = !attr.zero_points.get(arg).is_def();
+        if (!has_scale && !has_zp) return dnn_mem_t();
+
+        const auto &sc_groups = (has_scale) ? attr.scales.get(arg).groups
+                                            : std::vector<dnnl_dim_t> {};
+        const auto &zp_groups = (has_zp) ? attr.zero_points.get(arg).groups
+                                         : std::vector<dnnl_dim_t> {};
+
+        const auto md_dims = args.find(arg).dims();
+        const dims_t dims(md_dims, md_dims + args.find(arg).ndims());
+
+        const auto undef = dnnl_undefined_primitive;
+        const int sc_mask = (has_scale) ? attr.scales.get_mask(arg, undef,
+                                                  static_cast<int>(dims.size()))
+                                        : 0;
+        const int zp_mask = (has_zp) ? attr.zero_points.get_mask(arg, undef,
+                                               static_cast<int>(dims.size()))
+                                     : 0;
+
+        auto retn = make_mem(eng, dims);
+        std::memcpy((float *)retn, (float *)buf, K * N * sizeof(float));
+        dequantize_buf(retn, K, N, has_scale, sc_mask, sc_groups,
+                args.find(DNNL_ARG_ATTR_SCALES | arg), has_zp, zp_mask,
+                zp_groups, args.find(DNNL_ARG_ATTR_ZERO_POINTS | arg),
+                arg == DNNL_ARG_SRC);
+        return retn;
+    };
+
+    auto src_ref = dequant(src_m, IC, MB, DNNL_ARG_SRC);
+    auto w_gate_ref = dequant(w_gate_m, IC, OC, DNNL_ARG_WEIGHTS_GATE);
+    auto w_up_ref = dequant(w_up_m, IC, OC, DNNL_ARG_WEIGHTS_UP);
+    auto w_down_ref = dequant(w_down_m, OC, IC, DNNL_ARG_WEIGHTS_DOWN);
+
+    // Step 1: up_result = matmul(src, W_up).
+    exec_matmul(eng, strm, (src_ref) ? src_ref : src_m,
+            (w_up_ref) ? w_up_ref : w_up_m, up_result, args);
+
+    // Step 2: gate_result = matmul(src, W_gate).
+    exec_matmul(eng, strm, (src_ref) ? src_ref : src_m,
+            (w_gate_ref) ? w_gate_ref : w_gate_m, gate_result, args);
+
+    // Step 3: gate_result = activation(gate_result).
+    exec_eltwise(eng, strm, gate_result, prb->activation);
+
+    // Step 4: up_result = up_result * gate_result (element-wise).
+    exec_binary(eng, strm, up_result, gate_result, dnnl_binary_mul);
+
+    // Step 5: dst = matmul(up_result, W_down).
+    attr_t down_attr;
+    down_attr.post_ops = prb->attr.post_ops;
+    for (auto &po : down_attr.post_ops.entry)
+        if (po.is_binary_kind()) po.binary.src1_dt = dnnl_f32;
+    attr_args_t attr_args;
+    attr_args.prepare_post_ops_mds(
+            down_attr, dst_m.ndims(), dst_m.dims(), dnnl_matmul);
+    auto dnnl_attr = make_benchdnn_dnnl_wrapper(
+            create_dnnl_attr(down_attr, attr_args, prb->ndims));
+    exec_matmul(eng, strm, up_result, (w_down_ref) ? w_down_ref : w_down_m,
+            dst_m, args, dnnl_attr);
+
+    DNN_SAFE_V(dnnl_stream_destroy(strm));
+}
+
+} // namespace gated_mlp

--- a/tests/benchdnn/inputs/gated_mlp/shapes_basic
+++ b/tests/benchdnn/inputs/gated_mlp/shapes_basic
@@ -1,0 +1,14 @@
+# Basic GatedMLP shapes for smoke and CI testing.
+# Format: MBxICxOC
+
+# Small
+32x32x32
+64x64x128
+
+# Medium
+128x256x512
+256x512x1024
+
+# LLM-like (from internal test suite)
+32x128x32
+64x896x4864

--- a/tests/benchdnn/inputs/gated_mlp/shapes_llm
+++ b/tests/benchdnn/inputs/gated_mlp/shapes_llm
@@ -1,0 +1,8 @@
+# LLM GatedMLP shapes for GPU testing.
+# Format: MBxICxOC
+
+# Exemplary LLM shapes
+1024x3584x18944
+1024x896x4864
+1024x4096x14336
+1024x4096x27392

--- a/tests/benchdnn/inputs/gated_mlp/test_gated_mlp_ci
+++ b/tests/benchdnn/inputs/gated_mlp/test_gated_mlp_ci
@@ -1,0 +1,4 @@
+--reset
+--dt=f32,f16,bf16
+--activation=swish,gelu_erf,gelu_tanh
+--batch=shapes_basic

--- a/tests/benchdnn/inputs/gated_mlp/test_gated_mlp_gpu
+++ b/tests/benchdnn/inputs/gated_mlp/test_gated_mlp_gpu
@@ -1,0 +1,73 @@
+--reset
+--dt=f16,bf16
+--activation=swish,gelu_erf,gelu_tanh
+--batch=shapes_basic
+
+--reset
+--dt=f16,bf16
+--batch=shapes_llm
+
+# Quantized weights: u4 with grouped scales (group_size=128)
+--reset
+--dt=f16:u4:u4:u4:f16
+--stag=ab
+--wtag=ba
+--dtag=ab
+--attr-fpmath=any:true
+--attr-scales=wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1
+64x128x4864
+64x896x4864
+
+# Quantized weights: u4 with grouped scales and zero-points (group_size=128)
+--reset
+--dt=f16:u4:u4:u4:f16
+--stag=ab
+--wtag=ba
+--dtag=ab
+--attr-fpmath=any:true
+--attr-scales=wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1
+--attr-zero-points=wei:per_dim_01:s4:128x1+wei_up:per_dim_01:s4:128x1+wei_down:per_dim_01:s4:128x1
+64x128x4864
+64x896x4864
+
+# Quantized bf16 weights: exercises abs_trh with bf16 epsilon (larger tolerance)
+--reset
+--dt=bf16:u4:u4:u4:bf16
+--stag=ab
+--wtag=ba
+--dtag=ab
+--attr-fpmath=any:true
+--attr-scales=wei:per_dim_01:bf16:128x1+wei_up:per_dim_01:bf16:128x1+wei_down:per_dim_01:bf16:128x1
+64x128x4864
+
+# INT8 SRC with per-tensor SRC scale and quantized weights
+--reset
+--dt=s8:u4:u4:u4:f16
+--stag=ab
+--wtag=ba
+--dtag=ab
+--attr-fpmath=any:true
+--attr-scales=src:common:0.125+wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1
+64x128x4864
+64x256x4864
+
+# INT8 SRC without SRC scale (coeff applied through WEI gate/up scales)
+--reset
+--dt=s8:u4:u4:u4:f16
+--stag=ab
+--wtag=ba
+--dtag=ab
+--attr-fpmath=any:true
+--attr-scales=wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1
+64x128x4864
+
+# Binary post-ops on the down matmul
+--reset
+--dt=f16:u4:u4:u4:f16
+--stag=ab
+--wtag=ba
+--dtag=ab
+--attr-fpmath=any:true
+--attr-scales=wei:per_dim_01:f16:128x1+wei_up:per_dim_01:f16:128x1+wei_down:per_dim_01:f16:128x1
+--attr-post-ops=binary_add:f16:2:ab
+64x128x4864

--- a/tests/benchdnn/inputs/gated_mlp/test_gated_mlp_smoke
+++ b/tests/benchdnn/inputs/gated_mlp/test_gated_mlp_smoke
@@ -1,0 +1,8 @@
+--reset
+--dt=f32,f16,bf16
+--batch=shapes_basic
+
+--reset
+--dt=f32
+--activation=gelu_erf,gelu_tanh
+--batch=shapes_basic

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1274,17 +1274,40 @@ bool parse_main_help(
     std::string pattern = utils::get_pattern(option_name, false);
     if (!utils::option_matched(pattern, str)) return false;
 
+    static constexpr const char supported_drivers[]
+            = "    * binary\n"
+              "    * bnorm\n"
+              "    * concat\n"
+              "    * conv\n"
+              "    * deconv\n"
+              "    * eltwise\n"
+              "    * gated_mlp\n"
+              "    * ip\n"
+              "    * lnorm\n"
+              "    * lrn\n"
+              "    * matmul\n"
+              "    * pool\n"
+              "    * prelu\n"
+              "    * reduction\n"
+              "    * reorder\n"
+              "    * resampling\n"
+              "    * rnn\n"
+              "    * sdpa\n"
+              "    * shuffle\n"
+              "    * softmax\n"
+              "    * sum\n"
+              "    * zeropad\n\n";
+
     static const std::string main_help
-            = "Usage:\n    benchdnn --<driver> [global_options] "
-              "[driver_options] problem_description\n\nList of supported "
-              "<drivers> (lower case accepted only):\n    * binary\n    * "
-              "bnorm\n    * concat\n    * conv\n    * deconv\n    * eltwise\n  "
-              "  * ip\n    * lnorm\n    * lrn\n    * matmul\n    * pool\n    * "
-              "prelu\n    * reduction\n    * reorder\n    * resampling\n    * "
-              "rnn\n    * sdpa\n    * shuffle\n    * softmax\n    * sum\n    * "
-              "zeropad\n\nFor global and specific driver options, use:\n    "
-              "benchdnn --<driver> --help\n\nMore details at "
-            + benchdnn_url + "\n";
+        = "Usage:\n"
+          "    benchdnn --<driver> [global_options] [driver_options] "
+          "problem_description\n\n"
+          "List of supported <drivers> (lower case accepted only):\n"
+        + std::string(supported_drivers)
+        + "For global and specific driver options, use:\n"
+          "    benchdnn --<driver> --help\n\n"
+          "More details at "
+        + benchdnn_url + "\n";
 
     BENCHDNN_PRINT(0, "%s\n", main_help.c_str());
     exit(0);


### PR DESCRIPTION
### This PR adds a new benchdnn driver for the **Gated MLP** primitive, enabling correctness validation and performance benchmarking of the fused GatedMLP GPU kernel directly from the benchdnn application.

**JIRA:** [MFDNN-14716](https://jira.devtools.intel.com/browse/MFDNN-14716)

---

Adds a `--gated_mlp` benchdnn driver for correctness validation and performance benchmarking of the fused GatedMLP GPU kernel.

**Scope:** `tests/benchdnn/` and `scripts/verbose_converter/` only. Zero changes to `src/`.

#### Features

- Data types: f32, bf16, f16, s8, u8, s4, u4 (SRC/weights/DST independently)
- Activations: swish (default), gelu_erf, gelu_tanh
- Quantization: `--attr-scales` / `--attr-zero-points` for `wei`, `wei_up`, `wei_down`, `src` with `per_dim_1` and `per_dim_01` policies (grouped quantization)
- 2D (`--stag=ab --wtag=ba`) and fake-3D (`--stag=abc --wtag=cab`) tensor layouts
- Problem descriptor: `MBxICxOC`
- Verbose converter support (`GatedMLPConverter`)

#### Reference implementation

Composes existing oneDNN primitives on CPU (matmul + eltwise + binary) with explicit weight/src dequantization when quantization attributes are set.

#### Test suites

```
test_gated_mlp_smoke  - f32/f16/bf16, basic shapes, all activations
test_gated_mlp_ci     - f32/f16/bf16, basic shapes
test_gated_mlp_gpu    - f16/bf16, LLM shapes + u4 quantized (scales, scales+ZPs)
```

---

### Pull Request Checklist

#### General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

#### New features

- [ ] ~~Have you published an RFC for the new feature?~~ (N/A — benchdnn driver only)
- [ ] ~~Was the RFC approved?~~ (N/A)
- [x] Have you added relevant tests?
- [x] Have you added relevant documentation? (`doc/driver_gated_mlp.md`)