### PR TITLE
cpu: fix coverity major issues

### DIFF
--- a/src/cpu/cpu_batch_normalization_utils.cpp
+++ b/src/cpu/cpu_batch_normalization_utils.cpp
@@ -32,6 +32,11 @@ using namespace dnnl::impl::utils;
 
 void cache_balance(size_t working_set_size, dim_t C_blks, dim_t N, int nthr,
         dim_t &C_blks_per_iter, int64_t &iters) {
+    if (working_set_size == 0 || C_blks <= 0) {
+        C_blks_per_iter = 1;
+        iters = nstl::max<int64_t>(C_blks, 1);
+        return;
+    }
     int l3_size = platform::get_per_core_cache_size(3) * nthr / 2;
     C_blks_per_iter = saturate<dim_t>(1, C_blks, l3_size / working_set_size);
 
@@ -42,15 +47,18 @@ void cache_balance(size_t working_set_size, dim_t C_blks, dim_t N, int nthr,
     // place
     int C_nthr = nthr;
     if (C_blks_per_iter < nthr) {
-        const int N_nthr = (int)nstl::min<dim_t>(N, nthr);
+        const int N_nthr = (int)nstl::max<dim_t>(1, nstl::min<dim_t>(N, nthr));
         C_nthr = (int)nstl::min<dim_t>(C_blks, nthr / N_nthr);
     }
+
+    if (C_nthr <= 0) C_nthr = 1;
 
     if (C_blks_per_iter > C_nthr)
         C_blks_per_iter = rnd_dn(C_blks_per_iter, C_nthr);
     else
         C_blks_per_iter = div_up(C_nthr, div_up(C_nthr, C_blks_per_iter));
 
+    if (C_blks_per_iter <= 0) C_blks_per_iter = 1;
     iters = div_up(C_blks, C_blks_per_iter);
 }
 

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -95,8 +95,8 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                     && jcp.ic_block == jcp.ic));
     assert(IMPLICATION(jcp.ow_block != jcp.ow, jcp.oh_block == 1));
 
-    const dim_t nb_oh = div_up(jcp.oh, jcp.oh_block);
-    const dim_t nb_ow = div_up(jcp.ow, jcp.ow_block);
+    const dim_t nb_oh = div_up(jcp.oh, nstl::max<dim_t>(jcp.oh_block, 1));
+    const dim_t nb_ow = div_up(jcp.ow, nstl::max<dim_t>(jcp.ow_block, 1));
     // threads share work across mini-batch, groups, and blocked width/height
     const dim_t work_amount = jcp.mb * jcp.ngroups * nb_oh * nb_ow;
     balance211(work_amount, nthr, ithr, start, end);

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -1000,6 +1000,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
     jcp.prop_kind = cd.prop_kind;
 
     jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    if (jcp.ngroups <= 0) return status::invalid_arguments;
     jcp.mb = src_d.dims()[0];
 
     jcp.oc = dst_d.dims()[1] / jcp.ngroups;
@@ -1346,18 +1347,21 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const dim_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / nstl::max<dim_t>(rnd_up(outer_work, max_threads), 1);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / nstl::max<size_t>(rnd_up(inner_work, max_threads), 1);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
-                        && (outer_thr_eff / inner_thr_eff >= 1.f
-                                || (jcp.os * jcp.ic * jcp.oc) / max_threads
-                                        < gemm_thrld);
+                        && (inner_thr_eff > 0.f
+                                        ? outer_thr_eff / inner_thr_eff >= 1.f
+                                        : true
+                                                || (jcp.os * jcp.ic * jcp.oc)
+                                                                / max_threads
+                                                        < gemm_thrld);
             }
             jcp.nthr = jcp.outer_threading ? max_threads : 1;
             scratchpad.book<int8_t>(

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -217,8 +217,8 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
             jcp.oh_block == jcp.oh && jcp.ow_block == jcp.ow
                     && jcp.ic_block == jcp.ic));
 
-    const dim_t nb_oh = div_up(jcp.oh, jcp.oh_block);
-    const dim_t nb_ow = div_up(jcp.ow, jcp.ow_block);
+    const dim_t nb_oh = div_up(jcp.oh, nstl::max<dim_t>(jcp.oh_block, 1));
+    const dim_t nb_ow = div_up(jcp.ow, nstl::max<dim_t>(jcp.ow_block, 1));
     const dim_t work_amount = jcp.ngroups * jcp.mb * nb_oh * nb_ow;
     balance211(work_amount, nthr, ithr, start, end);
     nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ohb, nb_oh, owb, nb_ow);

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -509,13 +509,16 @@ void cpu_reducer_2d_t<data_type>::reduce_nolock(int ithr, data_t *dst,
 
     const int id_in_grp = balancer().id_in_group(ithr);
     const int njobs_in_grp = balancer().ithr_njobs(ithr);
-    const int njobs_x = utils::div_up(conf_.dst_x_, conf_.job_size_x_);
+    const int njobs_x
+            = utils::div_up(conf_.dst_x_, nstl::max(conf_.job_size_x_, 1));
     const int global_job_start = balancer().ithr_job_off(ithr);
 
     const data_t *space_base = get_local_ptr(ithr - id_in_grp, scratchpad);
 
     const int pr_grps = nstl::min(njobs_in_grp, balancer().nthr_per_group_);
+    if (pr_grps <= 0) return;
     const int pr_nthr_per_grp = balancer().nthr_per_group_ / pr_grps;
+    if (pr_nthr_per_grp <= 0) return;
 
     if (id_in_grp >= pr_grps * pr_nthr_per_grp) return; /* idle */
 
@@ -534,6 +537,8 @@ void cpu_reducer_2d_t<data_type>::reduce_nolock(int ithr, data_t *dst,
         const int ny = nstl::min(conf_.dst_y_ - start_y, conf_.job_size_y_);
         const int nx = nstl::min(conf_.dst_x_ - start_x, conf_.job_size_x_);
         int x_blocking = choose_x_blocking(nx, ny, pr_nthr_per_grp);
+        if (x_blocking <= 0) x_blocking = 1;
+        if (nx <= 0) continue;
 
         int nxy_start {0}, nxy_end {0};
         balance211(ny * nx / x_blocking, pr_nthr_per_grp, pr_my_id, nxy_start,

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -424,8 +424,8 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
             jcp.oh_block == jcp.oh && jcp.ow_block == jcp.ow
                     && jcp.ic_block == jcp.ic));
 
-    const dim_t nb_oh = div_up(jcp.oh, jcp.oh_block);
-    const dim_t nb_ow = div_up(jcp.ow, jcp.ow_block);
+    const dim_t nb_oh = div_up(jcp.oh, nstl::max<dim_t>(jcp.oh_block, 1));
+    const dim_t nb_ow = div_up(jcp.ow, nstl::max<dim_t>(jcp.ow_block, 1));
     const dim_t work_amount = jcp.ngroups * jcp.mb * nb_oh * nb_ow;
     balance211(work_amount, nthr, ithr, start, end);
     nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ohb, nb_oh, owb, nb_ow);

--- a/src/cpu/x64/gemm_bf16_inner_product.hpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.hpp
@@ -280,11 +280,13 @@ struct gemm_bf16_inner_product_bwd_weights_t : public primitive_t {
         void get_bias_partitioning(
                 dim_t &OC_per_thread, int &nthr_OCB, int &nthr_MB) const {
             dim_t OCB = utils::div_up(OC(), bias_blksize);
-            dim_t OCB_per_thread = utils::div_up(OCB, bias_reduction_nthr_);
+            dim_t OCB_per_thread = utils::div_up(
+                    OCB, nstl::max<int>(bias_reduction_nthr_, 1));
 
             OC_per_thread = OCB_per_thread * bias_blksize;
-            nthr_OCB = utils::div_up(OCB, OCB_per_thread);
-            nthr_MB = bias_reduction_nthr_ / nthr_OCB;
+            nthr_OCB = OCB_per_thread > 0 ? utils::div_up(OCB, OCB_per_thread)
+                                          : 1;
+            nthr_MB = nthr_OCB > 0 ? bias_reduction_nthr_ / nthr_OCB : 1;
 
             assert(nthr_OCB * nthr_MB <= bias_reduction_nthr_);
         }

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -577,6 +577,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     jcp.prop_kind = cd.prop_kind;
 
     jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    if (jcp.ngroups <= 0) return status::invalid_arguments;
     jcp.mb = src_d.dims()[0];
 
     jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -2061,8 +2061,11 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     } else {
         assert(jcp.oh_per_tile == 1);
         Label label_done;
-        int ow_blocks_per_call = utils::div_up(jcp.ow_block, jcp.tile_width);
-        int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call;
+        int ow_blocks_per_call
+                = utils::div_up(jcp.ow_block, nstl::max(jcp.tile_width, 1));
+        int last_owb_tile_blocks = ow_blocks_per_call > 0
+                ? jcp.ow_blocks % ow_blocks_per_call
+                : 0;
         if (last_owb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_owb_tile_blocks = ow_blocks_per_call;
         if (last_owb_tile_blocks > 0) {
@@ -3631,8 +3634,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_iw_loop() {
         compute_iw_loop_body(true, jcp.iw_blocks);
     } else {
         Label label_done;
-        int iw_blocks_per_call = div_up(jcp.iw_block, jcp.tile_width);
-        int last_iwb_tile_blocks = jcp.iw_blocks % iw_blocks_per_call;
+        int iw_blocks_per_call
+                = div_up(jcp.iw_block, nstl::max(jcp.tile_width, 1));
+        int last_iwb_tile_blocks = iw_blocks_per_call > 0
+                ? jcp.iw_blocks % iw_blocks_per_call
+                : 0;
         if (last_iwb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_iwb_tile_blocks = iw_blocks_per_call;
         if (last_iwb_tile_blocks > 0) {

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -1211,6 +1211,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
     jcp.prop_kind = cd.prop_kind;
 
     jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    if (jcp.ngroups <= 0) return status::invalid_arguments;
     jcp.mb = src_d.dims()[0];
 
     jcp.oc = dst_d.dims()[1] / jcp.ngroups;
@@ -1813,8 +1814,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_scratchpad(
 
     // TODO: Check - do we need this buffer for ALL cases?
     if (jcp.prop_kind != backward_weights) {
-        const size_t grp_count = utils::div_up(
-                jcp.nthr, utils::div_up(jcp.nthr, jcp.load_grp_count));
+        const size_t grp_count = utils::div_up(jcp.nthr,
+                utils::div_up(jcp.nthr, nstl::max(jcp.load_grp_count, 1)));
         const bool is_out_layout_nxc
                 = (utils::one_of(jcp.prop_kind, prop_kind::forward_training,
                            prop_kind::forward_inference)

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -45,6 +45,10 @@ namespace {
 template <typename T, typename U>
 void balance2D(U nthr, U ithr, T ny, T &ny_start, T &ny_end, T nx, T &nx_start,
         T &nx_end, T nx_divider) {
+    if (nx_divider <= 0 || nthr <= 0) {
+        ny_start = ny_end = nx_start = nx_end = 0;
+        return;
+    }
     const T grp_size = utils::div_up(nthr, nx_divider);
     const T grp_count = utils::div_up(nthr, grp_size);
 
@@ -55,8 +59,10 @@ void balance2D(U nthr, U ithr, T ny, T &ny_start, T &ny_end, T nx, T &nx_start,
     if (first_grps > 0 && grp >= first_grps) {
         ithr -= first_grps * grp_size;
         grp_nthr--;
-        grp = ithr / grp_nthr + first_grps;
-        grp_ithr = ithr % grp_nthr;
+        if (grp_nthr > 0) {
+            grp = ithr / grp_nthr + first_grps;
+            grp_ithr = ithr % grp_nthr;
+        }
     }
     balance211(nx, grp_count, grp, nx_start, nx_end);
     balance211(ny, grp_nthr, grp_ithr, ny_start, ny_end);
@@ -760,10 +766,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
     auto ker = [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         assert(nthr == jcp.nthr);
 
-        const int ithr_ic_b = ithr % jcp.nthr_ic_b;
-        const int ithr_oc_b = ithr / jcp.nthr_ic_b % jcp.nthr_oc_b;
-        const int ithr_g = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b % jcp.nthr_g;
-        const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
+        const int safe_nthr_ic_b = nstl::max(jcp.nthr_ic_b, 1);
+        const int safe_nthr_oc_b = nstl::max(jcp.nthr_oc_b, 1);
+        const int safe_nthr_g = nstl::max(jcp.nthr_g, 1);
+        const int ithr_ic_b = ithr % safe_nthr_ic_b;
+        const int ithr_oc_b = ithr / safe_nthr_ic_b % safe_nthr_oc_b;
+        const int ithr_g = ithr / safe_nthr_ic_b / safe_nthr_oc_b % safe_nthr_g;
+        const int ithr_mb
+                = ithr / safe_nthr_ic_b / safe_nthr_oc_b / safe_nthr_g;
 
         /* reduction dimension */
         int mb_sp_b_start {0}, mb_sp_b_end {0};
@@ -977,10 +987,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             = [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         assert(nthr == jcp.nthr);
 
-        const int ithr_ic_b = ithr % jcp.nthr_ic_b;
-        const int ithr_oc_b = ithr / jcp.nthr_ic_b % jcp.nthr_oc_b;
-        const int ithr_g = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b % jcp.nthr_g;
-        const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
+        const int safe_nthr_ic_b = nstl::max(jcp.nthr_ic_b, 1);
+        const int safe_nthr_oc_b = nstl::max(jcp.nthr_oc_b, 1);
+        const int safe_nthr_g = nstl::max(jcp.nthr_g, 1);
+        const int ithr_ic_b = ithr % safe_nthr_ic_b;
+        const int ithr_oc_b = ithr / safe_nthr_ic_b % safe_nthr_oc_b;
+        const int ithr_g = ithr / safe_nthr_ic_b / safe_nthr_oc_b % safe_nthr_g;
+        const int ithr_mb
+                = ithr / safe_nthr_ic_b / safe_nthr_oc_b / safe_nthr_g;
 
         /* independent dimensions */
         int g_start {0}, oc_b_start {0}, ic_b_start {0};

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -494,6 +494,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
 
     static int get_inp_block_size(
             int out_size, int stride, int ext_k, int padding) {
+        if (stride <= 0) return out_size;
         const auto res = div_up(out_size + padding % stride, stride)
                 + (ext_k - 1 - padding % stride) / stride;
         return res;
@@ -728,25 +729,40 @@ bool brg_blocking_t::fast_check_ic_block() const {
 
 float brg_blocking_t::est_eff() {
     if (is_1x1) return est_eff_1x1();
-    const auto icblock = ic_block / acc_simd_w;
+    const auto safe_acc_simd_w = nstl::max(acc_simd_w, 1);
+    const auto icblock = ic_block / safe_acc_simd_w;
 
-    const auto brgemm_microkernel_eff
-            = (static_cast<float>(icblock) * ur) / ((ur + icblock) * max_regs);
+    const auto ur_icblock_regs = (ur + icblock) * max_regs;
+    const auto brgemm_microkernel_eff = ur_icblock_regs > 0
+            ? (static_cast<float>(icblock) * ur) / ur_icblock_regs
+            : 0.f;
 
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
+    const auto rnd_sp_ur = rnd_up(sp_block, nstl::max(ur, 1));
+    const auto ur_eff
+            = rnd_sp_ur > 0 ? static_cast<float>(sp_block) / rnd_sp_ur : 0.f;
     const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    sp_block > 0
+                                            ? static_cast<float>(ur) / sp_block
+                                            : 0.f))
                     / 64,
             0.5f);
 
     const auto sp_amount = nb_id * nb_ih * nb_sp;
     const auto work_amount = mb * ngroups * nb_ic * sp_amount;
-    const auto sp_eff = (static_cast<float>(sp) / rnd_up(sp, sp_block));
+    const auto rnd_sp_spb = rnd_up(sp, nstl::max(sp_block, 1));
+    const auto sp_eff
+            = rnd_sp_spb > 0 ? (static_cast<float>(sp) / rnd_sp_spb) : 0.f;
 
-    const auto thr_eff = static_cast<float>(work_amount)
-            / utils::rnd_up(work_amount, nthr);
+    const auto rnd_wa_nthr = utils::rnd_up(work_amount, nstl::max(nthr, 1));
+    const auto thr_eff = rnd_wa_nthr > 0
+            ? static_cast<float>(work_amount) / rnd_wa_nthr
+            : 0.f;
 
-    const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+    const auto rnd_ic_icb = rnd_up(ic, nstl::max(ic_block, 1));
+    const auto ic_block_eff
+            = rnd_ic_icb > 0 ? static_cast<float>(ic) / rnd_ic_icb : 0.f;
 
     const auto job = div_up(work_amount, nthr);
 
@@ -794,8 +810,9 @@ float brg_blocking_t::est_eff() {
             if (thr_jobs[ithr] > max_job) max_job = thr_jobs[ithr];
             sum_job += thr_jobs[ithr];
         }
-        job_eff = max_job == 0 ? 1
-                               : static_cast<float>(sum_job) / (max_job * nthr);
+        job_eff = (max_job == 0 || nthr == 0)
+                ? 1
+                : static_cast<float>(sum_job) / (max_job * nthr);
 
     } else {
         job_eff = thr_eff;
@@ -979,11 +996,12 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
     const auto L2_available = nstl::min(static_cast<size_t>(div_up(L2, 2)),
             other_size > L2 ? 0 : L2 - other_size);
     if (odp * ohp * w_block_size > L2_available) {
+        const auto ohp_w_block = ohp * w_block_size;
         id_block = utils::saturate(
-                1, id, int(L2_available / (ohp * w_block_size)));
+                1, id, int(ohp_w_block > 0 ? L2_available / ohp_w_block : 1));
         if (id_block == 1)
-            ih_block = utils::saturate(
-                    1, ih, int(L2_available / (w_block_size)));
+            ih_block = utils::saturate(1, ih,
+                    int(w_block_size > 0 ? L2_available / w_block_size : 1));
         else
             ih_block = ih;
     } else {
@@ -998,11 +1016,12 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         const auto src_w_block_size
                 = src_dsz * oc * owp + dst_dsz * iw * ic_block;
         if (src_w_block_size < L1) {
+            const auto ohp_src_w = ohp * src_w_block_size;
             cur_id_block = utils::saturate(
-                    1, id, int(L1 / (ohp * src_w_block_size)));
+                    1, id, int(ohp_src_w > 0 ? L1 / ohp_src_w : 1));
             if (cur_id_block == 1)
-                cur_ih_block
-                        = utils::saturate(1, ih, int(L1 / (src_w_block_size)));
+                cur_ih_block = utils::saturate(1, ih,
+                        int(src_w_block_size > 0 ? L1 / src_w_block_size : 1));
         }
         for (; cur_id_block > 1; cur_id_block--) {
             const auto sp_size = cur_id_block * cur_ih_block * owp;
@@ -1036,32 +1055,35 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
             = div_up(ih, thr_ic_block * div_up(id, thr_id_block));
     id_block = nstl::min(id_block, thr_id_block);
     ih_block = nstl::min(ih_block, thr_ih_block);
-    while ((id_block % stride_d != 0
-                   || (id % stride_d == 0
-                           && id % id_block
-                                   != 0) // TODO: remove this once perf is validated for all shapes
-                   )
+    while (stride_d > 0
+            && (id_block % stride_d != 0
+                    || (id % stride_d == 0
+                            && id % id_block
+                                    != 0) // TODO: remove this once perf is validated for all shapes
+                    )
             && id_block < id)
         id_block++;
-    while ((ih_block % stride_h != 0
-                   || (ih % stride_h == 0
-                           && ih % ih_block
-                                   != 0) // TODO: remove this once perf is validated for all shapes
-                   )
+    while (stride_h > 0
+            && (ih_block % stride_h != 0
+                    || (ih % stride_h == 0
+                            && ih % ih_block
+                                    != 0) // TODO: remove this once perf is validated for all shapes
+                    )
             && ih_block < ih)
         ih_block++;
 
     // --- Select iw_block ----
     const auto max_iw_block_L2 = iw;
     auto start_iw_block = nstl::min(max_iw_block_thr, max_iw_block_L2);
-    sp = has_uneven_iw ? rnd_up(iw, stride_w) : iw;
-    const auto start_sp_block
-            = has_uneven_iw ? rnd_up(start_iw_block, stride_w) : start_iw_block;
+    sp = has_uneven_iw ? rnd_up(iw, nstl::max(stride_w, 1)) : iw;
+    const auto start_sp_block = has_uneven_iw
+            ? rnd_up(start_iw_block, nstl::max(stride_w, 1))
+            : start_iw_block;
     auto prev_spb = 0;
     for (auto ns = 1; ns <= sp; ns++) {
         const auto spb = div_up(sp, ns);
         if (spb == prev_spb || spb > start_sp_block) continue;
-        if (spb % stride_w != 0) continue;
+        if (stride_w > 0 && spb % stride_w != 0) continue;
         if (!has_uneven_iw && iw % spb != 0) continue;
 
         prev_spb = spb;
@@ -1090,7 +1112,7 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
 }
 
 status_t brg_blocking_t::calc_blocks() {
-    sp = has_uneven_iw ? rnd_up(iw, stride_w) : iw;
+    sp = has_uneven_iw ? rnd_up(iw, nstl::max(stride_w, 1)) : iw;
 
     nb_oc_blocking = 1;
     // --- Select kernel blocking ---
@@ -1156,16 +1178,20 @@ bool brg_blocking_t::fast_check_ic_block_1x1() const {
 }
 
 float brg_blocking_t::est_eff_1x1() {
-    const auto icblock = ic_block / acc_simd_w;
+    const auto safe_acc_simd_w = nstl::max(acc_simd_w, 1);
+    const auto icblock = ic_block / safe_acc_simd_w;
 
     auto calc_ave_blk = [&](int dim, int block, bool use_ave) -> float {
+        if (block <= 0) return 0.f;
         const int nb = dim / block;
         constexpr int max_nb = 2; // only consider 2x2 tile blocking
         const int block2 = nstl::min(max_nb, nb);
+        if (block2 <= 0) return 0.f;
         const int nb2 = nb / block2;
         const int nb2_tail = nb % block2;
         if (!use_ave) return block2;
-        return (float(nb2) * block2 + nb2_tail) / div_up(nb, block2);
+        const auto div_nb = div_up(nb, block2);
+        return div_nb > 0 ? (float(nb2) * block2 + nb2_tail) / div_nb : 0.f;
     };
     const bool use_ocb_ave = true;
     const auto icb_ave = calc_ave_blk(ic_block, acc_simd_w, use_ocb_ave);
@@ -1180,28 +1206,49 @@ float brg_blocking_t::est_eff_1x1() {
     const bool maskrcnn_cond = (ic == 1024 && oc == 2048)
             || (ic == 1024 && oc == 512) || (ic == 256 && oc == 1024)
             || (ic == 512 && oc == 1024) || (ic == 512 && oc == 2048);
-    const auto amx_fac = maskrcnn_cond
-            ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
-            : (static_cast<float>(div_up(M + M_tail, 16))
-                      / (M_n_sp_blks + M_tail_n_sp_blks));
+    const auto mn_sp_blks_sum = M_n_sp_blks + M_tail_n_sp_blks;
+    const auto amx_fac = mn_sp_blks_sum > 0
+            ? (maskrcnn_cond ? (div_up(M + M_tail, 16) / mn_sp_blks_sum)
+                             : (static_cast<float>(div_up(M + M_tail, 16))
+                                       / mn_sp_blks_sum))
+            : 0.f;
 
+    const auto icb_spb_sum = icb_ave + spb_ave;
+    const auto ur_icblock_regs = (ur + icblock) * max_regs;
     const auto brgemm_microkernel_eff = is_amx(isa)
-            ? amx_fac * (static_cast<float>(icb_ave) * spb_ave)
-                    / (icb_ave + spb_ave)
-            : (static_cast<float>(icblock) * ur) / ((ur + icblock) * max_regs);
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
+            ? amx_fac
+                    * (icb_spb_sum > 0.f
+                                    ? (static_cast<float>(icb_ave) * spb_ave)
+                                            / icb_spb_sum
+                                    : 0.f)
+            : (ur_icblock_regs > 0 ? (static_cast<float>(icblock) * ur)
+                                      / ur_icblock_regs
+                                   : 0.f);
+    const auto rnd_sp_ur = rnd_up(sp_block, nstl::max(ur, 1));
+    const auto ur_eff
+            = rnd_sp_ur > 0 ? static_cast<float>(sp_block) / rnd_sp_ur : 0.f;
     const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    sp_block > 0
+                                            ? static_cast<float>(ur) / sp_block
+                                            : 0.f))
                     / 64,
             0.5f);
 
     const auto sp_amount = nb_id * nb_ih * nb_sp;
     const auto work_amount = mb * ngroups * nb_ic * sp_amount;
 
-    const auto sp_eff = static_cast<float>(sp) / rnd_up(sp, sp_block);
-    const auto thr_eff = static_cast<float>(work_amount)
-            / utils::rnd_up(work_amount, nthr);
-    const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+    const auto rnd_sp_spb = rnd_up(sp, nstl::max(sp_block, 1));
+    const auto sp_eff
+            = rnd_sp_spb > 0 ? static_cast<float>(sp) / rnd_sp_spb : 0.f;
+    const auto rnd_wa_nthr = utils::rnd_up(work_amount, nstl::max(nthr, 1));
+    const auto thr_eff = rnd_wa_nthr > 0
+            ? static_cast<float>(work_amount) / rnd_wa_nthr
+            : 0.f;
+    const auto rnd_ic_icb = rnd_up(ic, nstl::max(ic_block, 1));
+    const auto ic_block_eff
+            = rnd_ic_icb > 0 ? static_cast<float>(ic) / rnd_ic_icb : 0.f;
 
     const auto job = div_up(work_amount, nthr);
 
@@ -1270,8 +1317,9 @@ float brg_blocking_t::est_eff_1x1() {
             sum_job += thr_jobs[ithr];
         }
 
-        job_eff = max_job == 0 ? 1
-                               : static_cast<float>(sum_job) / (max_job * nthr);
+        job_eff = (max_job == 0 || nthr == 0)
+                ? 1
+                : static_cast<float>(sum_job) / (max_job * nthr);
     } else {
         job_eff = thr_eff;
     }
@@ -1291,8 +1339,9 @@ float brg_blocking_t::est_eff_1x1() {
     const auto nb_ur = div_up(sp_block, ur);
     const auto nb_sp_no_tail = sp / sp_block;
     const auto sp_block_tail = sp % sp_block;
-    const auto nb_ur_average
-            = (nb_sp_no_tail * nb_ur + div_up(sp_block_tail, ur)) / nb_sp;
+    const auto nb_ur_average = nb_sp > 0
+            ? (nb_sp_no_tail * nb_ur + div_up(sp_block_tail, ur)) / nb_sp
+            : nb_ur;
     loop[l].src.set(ur * rnd_simd(oc_blocking_size), 1);
     loop[l].dst.set(ur * ic_block, 1);
     loop[l].wei.set(ic_blocking_size, is_amx(isa) ? nb_ur_average : nb_ur);
@@ -1501,8 +1550,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.acc_dsz = types::data_type_size(jcp.acc_dt);
     jcp.bia_dsz = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
 
-    jcp.simd_w = isa_max_vlen(isa) / jcp.src_dsz;
-    jcp.acc_simd_w = isa_max_vlen(isa) / jcp.acc_dsz;
+    jcp.simd_w = jcp.src_dsz > 0 ? isa_max_vlen(isa) / jcp.src_dsz : 1;
+    jcp.acc_simd_w = jcp.acc_dsz > 0 ? isa_max_vlen(isa) / jcp.acc_dsz : 1;
     jcp.is_bf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
             && one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any)
             && isa == avx512_core_amx;

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -841,6 +841,7 @@ dim_t brg_blocking_t::grid_coverage(
 * Returns:
 * The total area covered by the rectangles formed by the blocks.
 */
+    if (xb <= 0 || yb <= 0 || nx <= 0) return 0;
     const auto nb_x = div_up(x, xb);
     const auto nb_y = div_up(y, yb);
     // Compute how many full y blocks and x blocks are covered
@@ -1177,11 +1178,14 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         }
 
         // limit oh_block to have good threading
-        const auto thr_oc_block = div_up(
-                nthr, mb * div_up((oc > 32 ? ngroups : 1) * oc, oc_block));
+        const auto thr_oc_block = nstl::max<dim_t>(1,
+                div_up(nthr,
+                        mb
+                                * div_up((oc > 32 ? ngroups : 1) * oc,
+                                        nstl::max<dim_t>(oc_block, 1))));
         const auto thr_od_block = div_up(od, thr_oc_block);
-        const auto thr_oh_block
-                = div_up(oh, thr_oc_block * div_up(od, thr_od_block));
+        const auto thr_oh_block = div_up(oh,
+                nstl::max<dim_t>(1, thr_oc_block * div_up(od, thr_od_block)));
         od_block = nstl::min(od_block, thr_od_block);
         oh_block = nstl::min(oh_block, thr_oh_block);
     } else {
@@ -1567,9 +1571,19 @@ void brg_blocking_t::calc_blocks_1x1() {
         const auto max_os_block_thr
                 = (src_dsz * ic >= 1024 && src_dsz * ic < 4096)
                 ? nstl::max(nstl::min(16, os),
-                          div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
-                : nstl::max(div_up(2048, oc_block),
-                          static_cast<int>(div_up(mb * ngroups * os, nthr)));
+                          div_up(os,
+                                  nstl::max<dim_t>(1,
+                                          div_up(nthr,
+                                                  nstl::max<dim_t>(1,
+                                                          mb
+                                                                  * div_up(oc,
+                                                                          nstl::max<
+                                                                                  dim_t>(
+                                                                                  oc_block,
+                                                                                  1)))))))
+                : nstl::max(div_up(2048, nstl::max<dim_t>(oc_block, 1)),
+                          static_cast<int>(div_up(mb * ngroups * os,
+                                  nstl::max<dim_t>(nthr, 1))));
         const auto max_os_block_L2 = max_sp_block_L2;
 
         auto max_os_block_aliasing = 1000000 / nthr;
@@ -2798,9 +2812,9 @@ status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
 
 void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
 
-    const auto os_chunks = jcp.nthr_mb_work;
-    const auto oc_chunks = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
-    const auto ic_chunks = div_up(jcp.nb_ic, jcp.nb_ic_blocking);
+    const auto os_chunks = nstl::max<dim_t>(jcp.nthr_mb_work, 1);
+    const auto oc_chunks = div_up(jcp.nb_oc, nstl::max(jcp.nb_oc_blocking, 1));
+    const auto ic_chunks = div_up(jcp.nb_ic, nstl::max(jcp.nb_ic_blocking, 1));
 
     auto calc_mem_cost = [&jcp, os_chunks, oc_chunks, ic_chunks](int nthr_mb,
                                  int nthr_g, int nthr_oc_b, int nthr_ic_b) {
@@ -2830,7 +2844,8 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         dim_t wei_size = (dim_t)jcp.oc * jcp.ic * wei_ks * wei_type_size;
 
         float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
-        float oi_channels_ratio = (float)(oc_chunks) / ic_chunks;
+        float oi_channels_ratio
+                = ic_chunks > 0 ? (float)(oc_chunks) / ic_chunks : 1.0f;
 
         auto get_src_coef = [=]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
@@ -2857,8 +2872,10 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
 
         const auto thr_g = div_up(jcp.ngroups, nthr_g);
         const auto thr_ic_b = div_up(ic_chunks, nthr_ic_b);
-        const auto thr_src_sp = thr_mb * src_chunk / jcp.stride_d / jcp.stride_h
-                / jcp.stride_w;
+        const auto thr_src_sp = thr_mb * src_chunk
+                / nstl::max<dim_t>(jcp.stride_d, 1)
+                / nstl::max<dim_t>(jcp.stride_h, 1)
+                / nstl::max<dim_t>(jcp.stride_w, 1);
         const auto thr_dst_sp = thr_mb * dst_chunk;
         const auto thr_ic_amount = thr_ic_b * nb_ic_job;
 

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -359,7 +359,7 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
             = [=](const int ithr, const int nthr, int &nthr_ic, int &nthr_oc_mb,
                       int &ithr_ic, int &ithr_oc_mb) {
         nthr_ic = jbgp.nthr_ic_b <= nthr ? jbgp.nthr_ic_b : 1;
-        nthr_oc_mb = nthr / nthr_ic;
+        nthr_oc_mb = nstl::max(nthr / nthr_ic, 1);
         ithr_ic = ithr / nthr_oc_mb;
         ithr_oc_mb = ithr % nthr_oc_mb;
         if (ithr_oc_mb >= work_amount || ithr_ic >= ic_chunks
@@ -948,7 +948,7 @@ void brgemm_inner_product_bwd_data_t<isa>::execute_backward_data(
 
     parallel(num_threads, [=](const int ithr, const int nthr) {
         const int nthr_oc = jbgp.nthr_oc_b <= nthr ? jbgp.nthr_oc_b : 1;
-        const int nthr_ic_mb = nthr / nthr_oc;
+        const int nthr_ic_mb = nstl::max(nthr / nthr_oc, 1);
         const int ithr_ic_mb = ithr % nthr_ic_mb;
         const int ithr_oc = ithr / nthr_ic_mb;
         if (ithr_ic_mb >= work_amount || ithr_oc >= oc_chunks

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -318,6 +318,7 @@ int jit_brgemm_ip_conf_t::get_nb_oc_blocking(bool is_adjustment) const {
 
 // Check if work amount is balanced between threads.
 static bool is_balanced(int work, int min_work, int nthrs, int goal_nthrs = 0) {
+    if (nthrs <= 0) return true;
     if (goal_nthrs <= 0) goal_nthrs = nthrs;
     int eff_nthrs = work % nthrs;
     if (!eff_nthrs) return true;
@@ -975,16 +976,17 @@ void jit_brgemm_ip_bwd_w_conf_t::thread_balance(int &nb_os_blocking_,
         int ic_chunks = div_up(j.nb_ic, nb_ic_blocking);
         int sp_ic_chunks = j.ks() * ic_chunks;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
+        float wei_compensation_scale
+                = wei_size > 0 ? 0.5f * (dst_size + src_size) / wei_size : 1.0f;
 
         float oi_channels_ratio = 0;
         if (is_xf16) {
             oi_channels_ratio = ((j.oc > (dim_t)3 * j.ic && os_chunks > 1)
                                         || (os_chunks == 1 && j.ic > j.oc))
-                    ? src_size / dst_size
-                    : dst_size / src_size;
+                    ? (dst_size > 0 ? src_size / dst_size : 1.0f)
+                    : (src_size > 0 ? dst_size / src_size : 1.0f);
         } else {
-            oi_channels_ratio = src_size / dst_size;
+            oi_channels_ratio = dst_size > 0 ? src_size / dst_size : 1.0f;
         }
 
         auto get_src_coef = [&]() {

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -779,7 +779,8 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
 
                 // calculate thread use efficiency
                 int total_nthr = cur_nthr_g * cur_nthr_mb * cur_nthr_oh;
-                float thr_eff = ((float)total_nthr) / nthreads;
+                float thr_eff
+                        = nthreads > 0 ? ((float)total_nthr) / nthreads : 0.f;
                 assert(total_nthr <= nthreads);
 
                 // efficiency can only worsen, skip
@@ -788,16 +789,20 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
                 }
 
                 // calculate imbalance
-                float imbalance_g = ((float)std::abs(approx_g_block * cur_nthr_g
-                                            - ch_outer_blocks))
-                        / ch_outer_blocks;
-                float imbalance_mb
-                        = ((float)std::abs(
+                float imbalance_g = ch_outer_blocks > 0
+                        ? ((float)std::abs(approx_g_block * cur_nthr_g
+                                  - ch_outer_blocks))
+                                / ch_outer_blocks
+                        : 0.f;
+                float imbalance_mb = jcp.mb > 0
+                        ? ((float)std::abs(
                                   approx_mb_block * cur_nthr_mb - jcp.mb))
-                        / jcp.mb;
-                float imbalance_oh
-                        = ((float)std::abs(oh_block * cur_nthr_oh - jcp.oh))
-                        / jcp.oh;
+                                / jcp.mb
+                        : 0.f;
+                float imbalance_oh = jcp.oh > 0
+                        ? ((float)std::abs(oh_block * cur_nthr_oh - jcp.oh))
+                                / jcp.oh
+                        : 0.f;
                 float total_imbalance = imbalance_g * (jcp.mb * jcp.oh)
                         + imbalance_mb * (ch_outer_blocks * jcp.oh)
                         + imbalance_oh * (ch_outer_blocks * jcp.mb);

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -720,6 +720,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     const int ndims = src_d.ndims();
     jcp.nthr = nthreads;
     jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    if (jcp.ngroups <= 0) return status::invalid_arguments;
     jcp.mb = src_d.dims()[0];
     jcp.oc = dst_d.dims()[1] / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -63,11 +63,13 @@ void matmul_amx_blocking_params_t::update_configuration(
 }
 
 dim_t matmul_amx_blocking_params_t::get_actual_lda() const {
+    const auto safe_a_dt_sz = nstl::max<dim_t>(a_dt_sz, 1);
     if (!need_buf_a_)
-        return treat_A_as_plain ? K : A_strides[1 - transposed_A] / a_dt_sz;
+        return treat_A_as_plain ? K
+                                : A_strides[1 - transposed_A] / safe_a_dt_sz;
 
     constexpr int bytes_in_cacheline = 64;
-    const int elems_in_cacheline = bytes_in_cacheline / a_dt_sz;
+    const int elems_in_cacheline = bytes_in_cacheline / safe_a_dt_sz;
     dim_t lda = rnd_up(k_blk_, elems_in_cacheline);
     const bool is_big_2_pow = lda >= 512 && math::is_pow2(lda);
     if (is_big_2_pow) lda += elems_in_cacheline;
@@ -143,7 +145,9 @@ bool matmul_amx_blocking_params_macro_t::divs_are_acceptable() const {
 }
 
 size_t determine_tmul_size(size_t num_elements, int full_tile_size) {
+    if (full_tile_size <= 0) return num_elements;
     size_t tmul_tiles = div_up(num_elements, full_tile_size);
+    if (tmul_tiles == 0) return num_elements;
     size_t tmul_size = div_up(num_elements, tmul_tiles);
     return tmul_size;
 }
@@ -200,7 +204,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         best_blocking.n_decomposition
                 = nstl::min(bgmmc.N, (dim_t)bgmmc.wei_n_blk);
         best_blocking.m_decomposition = bgmmc.M;
-        uint32_t n_per_core = div_up(bgmmc.N, bgmmc.nthr);
+        uint32_t n_per_core = div_up(bgmmc.N, nstl::max(bgmmc.nthr, 1));
         n_per_core = rnd_up(n_per_core, best_blocking.n_decomposition);
         best_blocking.set_core_divs(1, 1, 1, div_up(bgmmc.N, n_per_core));
 
@@ -233,7 +237,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.K <= best_blocking.wei_k_blk && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        const uint32_t m_per_core = div_up(bgmmc.M, nstl::max(bgmmc.nthr, 1));
         best_blocking.set_core_divs(1, div_up(bgmmc.M, m_per_core), 1, 1);
         best_blocking.set_tmul_sizes();
         best_blocking.set_decomposition();
@@ -268,7 +272,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.N <= 32 && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        const uint32_t m_per_core = div_up(bgmmc.M, nstl::max(bgmmc.nthr, 1));
 
         best_blocking.m_per_thread = m_per_core;
         // in this case 2 full are preferable
@@ -406,14 +410,16 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
         size_t strip_dst_size = m_decomposition * n_per_thread
                 * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
         // Amount of compute
-        num_tmuls_per_strip = m_decomposition * k_per_thread * n_per_thread
-                / (m_tmul * k_tmul * n_tmul);
+        num_tmuls_per_strip = (m_tmul * k_tmul * n_tmul) > 0
+                ? m_decomposition * k_per_thread * n_per_thread
+                        / (m_tmul * k_tmul * n_tmul)
+                : 0;
         // Amount of strips in the execution
-        num_strip = div_up(m_per_thread, m_decomposition);
+        num_strip = div_up(m_per_thread, nstl::max<dim_t>(m_decomposition, 1));
         // B is blocked to the L2 in horizontal traversal, its loads are NT
         nt_mat_l1_miss = b_size;
         // Number of times A is reused from L1 in a strip
-        l1_reuse = div_up(n_blk_, n_decomposition);
+        l1_reuse = div_up(n_blk_, nstl::max<dim_t>(n_decomposition, 1));
 
         // In horizontal multiple cores load the same B to L2
         strip_1_size_shared = b_size;
@@ -441,14 +447,16 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
         size_t strip_dst_size = n_decomposition * m_per_thread
                 * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
         // Amount of compute
-        num_tmuls_per_strip = n_decomposition * k_per_thread * m_per_thread
-                / (m_tmul * k_tmul * n_tmul);
+        num_tmuls_per_strip = (m_tmul * k_tmul * n_tmul) > 0
+                ? n_decomposition * k_per_thread * m_per_thread
+                        / (m_tmul * k_tmul * n_tmul)
+                : 0;
         // Amount of strips in the execution
-        num_strip = div_up(n_per_thread, n_decomposition);
+        num_strip = div_up(n_per_thread, nstl::max<dim_t>(n_decomposition, 1));
         // A is blocked to the L2 in vertical traversal, its loads are NT
         nt_mat_l1_miss = a_size;
         // Number of times B is reused from L1 in a strip
-        l1_reuse = div_up(m_blk_, m_decomposition);
+        l1_reuse = div_up(m_blk_, nstl::max<dim_t>(m_decomposition, 1));
 
         // In vertical multiple cores load the same A to L2
         strip_1_size_shared = a_size;
@@ -557,8 +565,10 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
 
     if (nthr_k_ != 1) {
         if (c_size_per_core * 2 < L2_threshold() && batch == 1) {
-            float reduction_read_bytes = (M * rnd_up(N, 16) * acc_dt_sz)
-                    * ((nthr_k_ - 1)) / (nthr_m_ * nthr_n_);
+            float reduction_read_bytes = (nthr_m_ * nthr_n_) > 0
+                    ? (M * rnd_up(N, 16) * acc_dt_sz) * ((nthr_k_ - 1))
+                            / (nthr_m_ * nthr_n_)
+                    : 0;
             float reduction_read_cycles;
             if (a_size + b_size + d_size < L2_threshold()) {
                 reduction_read_cycles
@@ -568,8 +578,9 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
                         = reduction_read_bytes / bw_interpulator.llc_bw;
             }
 
-            float reduction_write_bytes
-                    = (M * N * c_dt_sz) / (nthr_m_ * nthr_n_);
+            float reduction_write_bytes = (nthr_m_ * nthr_n_) > 0
+                    ? (M * N * c_dt_sz) / (nthr_m_ * nthr_n_)
+                    : 0;
             float reduction_write_cycles
                     = reduction_write_bytes / bw_interpulator.get_bw(1);
             // Add reduction const overhead - measured
@@ -586,7 +597,11 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
 
     float total_macs = M * K * N * batch;
     float total_cycles = (gemm_cycles + reduction_cycles) * b_per_thread;
-    float peak_macs_per_cycle = (macs_per_cycle_base / gemm_dt_sz) * nthr;
+    float peak_macs_per_cycle
+            = (gemm_dt_sz > 0 ? macs_per_cycle_base / gemm_dt_sz
+                              : macs_per_cycle_base)
+            * nthr;
+    if (peak_macs_per_cycle == 0.f || total_cycles == 0.f) return 0;
     float peak_cycles = total_macs / peak_macs_per_cycle;
     return peak_cycles / total_cycles;
 }

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -791,20 +791,24 @@ struct matmul_avx512_blocking_params_t {
     }
 
     float get_imbalance() const {
-        const size_t cur_nthr = nthr / nthr_k;
+        const size_t cur_nthr = nthr / nstl::max(nthr_k, 1);
 
         size_t parallel_work = get_parallel_work();
         const float parallel_work_disb
                 = calculate_spatial_disbalance(parallel_work, cur_nthr);
 
-        const auto m_work = (m_blk * div_up(mp.M, m_blk)) % mp.M;
-        const float m_blk_disbalance = static_cast<float>(m_work) / mp.M;
+        const auto m_work = (m_blk * div_up(mp.M, nstl::max<dim_t>(m_blk, 1)))
+                % nstl::max<dim_t>(mp.M, 1);
+        const float m_blk_disbalance
+                = mp.M > 0 ? static_cast<float>(m_work) / mp.M : 0.f;
 
-        const auto num_n_blk = div_up(mp.N, n_blk);
-        const auto par_n_chunks = div_up(num_n_blk, n_chunks);
-        const float n_chunk_disbalance
-                = (static_cast<float>(par_n_chunks) * n_chunks - num_n_blk)
-                / num_n_blk;
+        const auto num_n_blk = div_up(mp.N, nstl::max<dim_t>(n_blk, 1));
+        const auto par_n_chunks
+                = div_up(num_n_blk, nstl::max<dim_t>(n_chunks, 1));
+        const float n_chunk_disbalance = num_n_blk > 0
+                ? (static_cast<float>(par_n_chunks) * n_chunks - num_n_blk)
+                        / num_n_blk
+                : 0.f;
 
         const float disbalance_nthr_k
                 = calculate_spatial_disbalance(mp.K, nthr_k * k_blk);
@@ -2050,10 +2054,10 @@ status_t init_conf(brgemm_matmul_conf_t &conf, dim_t batch, dim_t M, dim_t K,
 void init_aux_values(brgemm_matmul_conf_t &bgmmc,
         const memory_desc_wrapper &src_d, const memory_desc_wrapper &wei_d,
         const memory_desc_wrapper &dst_d) {
-    bgmmc.M_chunk_elems = bgmmc.M_blk * bgmmc.M_chunk_size;
-    bgmmc.N_chunk_elems = bgmmc.N_blk * bgmmc.N_chunk_size;
-    bgmmc.K_chunk_elems
-            = bgmmc.K_blk * bgmmc.K_chunk_size * bgmmc.brgemm_batch_size;
+    bgmmc.M_chunk_elems = nstl::max<dim_t>(bgmmc.M_blk * bgmmc.M_chunk_size, 1);
+    bgmmc.N_chunk_elems = nstl::max<dim_t>(bgmmc.N_blk * bgmmc.N_chunk_size, 1);
+    bgmmc.K_chunk_elems = nstl::max<dim_t>(
+            bgmmc.K_blk * bgmmc.K_chunk_size * bgmmc.brgemm_batch_size, 1);
     bgmmc.M_chunks = bgmmc.is_runtime_M ? runtime_value_for(bgmmc.M_chunks)
                                         : div_up(bgmmc.M, bgmmc.M_chunk_elems);
     bgmmc.N_chunks = bgmmc.is_runtime_N ? runtime_value_for(bgmmc.N_chunks)

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -260,6 +260,8 @@ dim_t brgemm_calc_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks, bool is_f32,
 dim_t adjust_m_block_lstm(dim_t nthr, dim_t M, dim_t N_blocks, bool is_int8_amx,
         bool is_xf16_amx) {
 
+    if (N_blocks <= 0 || M <= 0) return M > 0 ? M : 1;
+
     const bool is_amx = is_int8_amx || is_xf16_amx;
 
     const dim_t max_m_blocks = (is_amx ? 1 : 4) * utils::div_up(nthr, N_blocks);
@@ -398,11 +400,12 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
 
     rnn.nthr = dnnl_get_max_threads();
     rnn.n_block = brgemm_calc_n_block(rnn, cell_kind);
+    if (rnn.n_block <= 0) return status::unimplemented;
     rnn.N_blocks = utils::div_up(rnn.N, rnn.n_block);
     rnn.n_tail = rnn.N % rnn.n_block;
 
-    const float work_by_N
-            = static_cast<float>(rnn.N_blocks) / static_cast<float>(rnn.nthr);
+    const float work_by_N = static_cast<float>(rnn.N_blocks)
+            / static_cast<float>(nstl::max(rnn.nthr, 1));
 
     const dim_t l2_cache_size = platform::get_per_core_cache_size(2);
     const dim_t As = src_layer_type_size * rnn.M * (nstl::max(rnn.K1, rnn.K2));
@@ -414,6 +417,7 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
     std::tie(rnn.k1_block, rnn.k2_block) = brgemm_calc_k_block(rnn, rnn.K1,
             rnn.K2, rnn.M, rnn.n_block, cell_kind, src_layer_type_size, As, Bs,
             Cs, l2_cache_size, rnn.brgemm_isa);
+    if (rnn.k1_block <= 0 || rnn.k2_block <= 0) return status::unimplemented;
     rnn.KB1_blocks = rnn.K1 / rnn.k1_block;
     rnn.k1_tail = rnn.K1 % rnn.k1_block;
     rnn.KB2_blocks = rnn.K2 / rnn.k2_block;
@@ -421,6 +425,7 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
     rnn.m_block = brgemm_calc_m_block(cell_kind, prop_kind::forward, rnn.nthr,
             rnn.M, rnn.N_blocks, rnn.is_cell_dt_f32(), rnn.is_cell_int8_amx(),
             rnn.is_cell_xf16_amx(), work_by_N, As, Bs, Cs, l2_cache_size);
+    if (rnn.m_block <= 0) return status::unimplemented;
 
     rnn.M_blocks = rnn.M / rnn.m_block;
 


### PR DESCRIPTION
| File | CIDs | Severity | Issue Type | Fix |
|------|------|----------|------------|-----|
| `cpu/x64/jit_brgemm_conv_utils.cpp` | 8207614, 8207617, 8207622, 8207634, 8207641, 8207652, 8207656, 8207726 | Major | Div/mod by zero, float div by zero | Added zero-divisor guards in `grid_coverage`, `iterate_ker_block`, `calc_blocks_1x1`, `balance_bwd_w`, and `operator()` |
| `cpu/x64/rnn/rnn_brgemm_utils.cpp` | 8207650, 8207701, 8207735, 8207740, 8207742, 8207755 | Major | Div/mod by zero | Early return guards for `N_blocks<=0`, `n_block<=0`, `k1/k2_block<=0`, `m_block<=0`; `nstl::max` for `nthr` |
| `cpu/x64/matmul/amx_blocking_heuristics.cpp` | 8207612, 8207616, 8207670, 8207690, 8207753 | Major | Div/mod by zero | Guards for `a_dt_sz`, `full_tile_size`, `bgmmc.nthr`, `m_tmul*k_tmul*n_tmul`, `nthr_m_*nthr_n_`, `gemm_dt_sz`, `total_cycles` |
| `cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp` | 8207615, 8207637, 8207643, 8207721, 8207728 | Major | Div/mod by zero | `nthr`/work guards in `balance2D` and `operator()`; `safe_nthr` pattern for thread decomposition |
| `cpu/x64/jit_brgemm_conv_bwd_utils.cpp` | 8207618, 8207642, 8207675, 8207715 | Major | Div/mod by zero, float div by zero | Guarded `ohp*w_block_size`, `stride_d/h/w` divisions, float divisions in `est_eff`/`est_eff_1x1`, `get_inp_block_size` |
| `cpu/x64/gemm_bf16_convolution.cpp` | 8207625, 8207641, 8207655, 8207671 | Major | Div/mod by zero | `nstl::max<dim_t>(oh_block, 1)` and `nstl::max<dim_t>(ow_block, 1)` |
| `cpu/gemm_convolution_utils.cpp` | 8207657, 8207686, 8207743, 8207746 | Major | Div/mod by zero, float div by zero | `ngroups<=0` validation, guarded `rnd_up` and float divisions |
| `cpu/x64/jit_brgemm_inner_product_utils.cpp` | 8207658, 8207659, 8207681, 8207697 | Major | Div/mod by zero, float div by zero | `nthrs<=0` guard in `is_balanced`, ternary fallbacks for float divisions |
| `cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp` | 8207623, 8207678, 8207683 | Major | Div/mod by zero | `ngroups<=0` validation, guarded `load_grp_count` division |
| `cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp` | 8207648, 8207665, 8207685 | Major | Div/mod by zero, float div by zero | `ngroups<=0` validation returning `status::invalid_arguments` |
| `cpu/x64/matmul/brgemm_matmul_utils.cpp` | 8207624, 8207706 | Major | Float div by zero, overflowed constant | `nstl::max(..., 1)` for chunk element divisors and threading params in `get_imbalance` |
| `cpu/x64/jit_brgemm_inner_product.cpp` | 8207653, 8207710 | Major | Div/mod by zero | `nstl::max(nthr/..., 1)` for `nthr_oc_mb` and `nthr_ic_mb` |
| `cpu/x64/gemm_bf16_inner_product.hpp` | 8207676, 8207745 | Major | Div/mod by zero | Guarded `bias_reduction_nthr_` and OC divisions with `nstl::max` and ternary checks |
| `cpu/x64/jit_avx512_core_amx_conv_kernel.cpp` | 8207682, 8207720 | Major | Div/mod by zero | `nstl::max(jcp.tile_width, 1)` and conditional modulo in `compute_ow_loop`/`compute_iw_loop` |
| `cpu/cpu_batch_normalization_utils.cpp` | 8207688, 8207738 | Major | Div/mod by zero | `working_set_size==0` and `C_blks<=0` early returns, guarded `N_nthr`/`C_nthr`/`C_blks_per_iter` |
| `cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp` | 8207716, 8207717 | Major | Div/mod by zero | `ngroups<=0` validation returning `status::invalid_arguments` |
| `cpu/x64/cpu_reducer.cpp` | 8207649, 8207667 | Major | Div/mod by zero | `pr_grps`/`pr_nthr_per_grp` early returns, guarded `job_size_x` and `x_blocking` |
| `cpu/gemm_convolution.cpp` | 8207613, 8207684 | Major | Div/mod by zero | `nstl::max<dim_t>(jcp.oh_block, 1)` and `nstl::max<dim_t>(jcp.ow_block, 1)` |
| `cpu/gemm_x8s8s32x_convolution.cpp` | 8207723, 8207733 | Major | Div/mod by zero | `nstl::max<dim_t>(oh_block, 1)` and `nstl::max<dim_t>(ow_block, 1)` |
| `cpu/x64/jit_uni_dw_conv_kernel_utils.cpp` | 8207660 | Major | Float div by zero | Guarded float divisions by `ch_outer_blocks`, `jcp.mb`, `jcp.oh`, `nthreads` with `>0` checks |