### PR TITLE
common: add create/exec verbose on entry

### DIFF
--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -73,6 +73,11 @@ status_t primitive_create(primitive_iface_t **primitive_iface,
     }
 #endif
 
+    if (get_verbose(verbose_t::debuginfo) >= 1) {
+        VFORMAT(get_msec(), verbose_t::debuginfo, primitive, create, ":start",
+                "%s", primitive_desc_iface->info());
+    }
+
     if (get_verbose(verbose_t::create_profile,
                 prim_kind2_comp_kind(primitive_desc_iface->impl()->kind()))) {
         double start_ms = get_msec();
@@ -144,6 +149,11 @@ status_t primitive_execute(
         }
     }
 #endif
+
+    if (get_verbose(verbose_t::debuginfo) >= 1) {
+        VFORMAT(get_msec(), verbose_t::debuginfo, primitive, exec, ":start",
+                "%s", pd->info());
+    }
 
     if (get_verbose(verbose_t::exec_profile,
                 prim_kind2_comp_kind(pd->impl()->kind()))) {


### PR DESCRIPTION
This to improve diagnostics when debugging exceptions, segfaults or hangs inside primitive creation and execution.