### PR TITLE
xpu: use regular host memory for map_data staging buffer

### DIFF
--- a/src/gpu/intel/utils.cpp
+++ b/src/gpu/intel/utils.cpp
@@ -17,6 +17,7 @@
 #include "gpu/intel/utils.hpp"
 
 #include "common/utils.hpp"
+#include "gpu/intel/engine.hpp"
 
 #include <cstdio>
 #include <mutex>
@@ -59,6 +60,15 @@ status_t dump_kernel_binary(
 
     counter++;
     return status::success;
+}
+
+bool use_usm_host_for_memory_map(const impl::engine_t *engine) {
+    auto *intel_engine = dynamic_cast<const intel::engine_t *>(engine);
+    if (!intel_engine) return false;
+    if (intel_engine->device_info()->is_integrated()) return false;
+    // XXX: Use USM host memory for discrete XeHPC/XeHPG where there are
+    // stability issues with mixing USM and system memory in memcpy().
+    return intel_engine->is_xe_hpc() || intel_engine->is_xe_hpg();
 }
 
 } // namespace gpu_utils

--- a/src/gpu/intel/utils.hpp
+++ b/src/gpu/intel/utils.hpp
@@ -197,6 +197,10 @@ bool is_jit_dump_enabled();
 status_t dump_kernel_binary(
         const std::vector<uint8_t> &binary, const std::string &name);
 
+// Whether map_data should stage through a USM host allocation rather than
+// regular system memory.
+bool use_usm_host_for_memory_map(const impl::engine_t *engine);
+
 // -------------------------------------------------------------
 //  Backend      | Compound ID
 // -------------------------------------------------------------

--- a/src/xpu/ocl/usm_memory_storage.cpp
+++ b/src/xpu/ocl/usm_memory_storage.cpp
@@ -17,6 +17,11 @@
 #include <CL/cl.h>
 
 #include "common/memory_map_manager.hpp"
+#include "common/utils.hpp"
+
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+#include "gpu/intel/utils.hpp"
+#endif
 
 #include "xpu/ocl/usm_memory_storage.hpp"
 #include "xpu/ocl/usm_utils.hpp"
@@ -43,22 +48,35 @@ status_t usm_memory_storage_t::map_data(
 
     if (!stream) CHECK(engine()->get_service_stream(stream));
 
-    void *host_ptr = usm::malloc_host(stream->engine(), size);
+    bool use_usm_host = false;
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+    use_usm_host = gpu::intel::gpu_utils::use_usm_host_for_memory_map(engine());
+#endif
+    void *host_ptr = use_usm_host ? usm::malloc_host(stream->engine(), size)
+                                  : impl::malloc(size, 64);
     if (!host_ptr) return status::out_of_memory;
 
-    auto leak_guard = decltype(usm_ptr_)(
-            host_ptr, [this](void *p) { usm::free(engine(), p); });
+    auto leak_guard
+            = decltype(usm_ptr_)(host_ptr, [use_usm_host, this](void *p) {
+        if (use_usm_host)
+            usm::free(engine(), p);
+        else
+            impl::free(p);
+    });
     CHECK(usm::memcpy(stream, host_ptr, usm_ptr(), size, 0, nullptr, nullptr));
     CHECK(stream->wait());
     leak_guard.release();
 
     auto *usm_ptr_for_unmap = usm_ptr();
-    auto unmap_callback = [size, usm_ptr_for_unmap](
+    auto unmap_callback = [size, usm_ptr_for_unmap, use_usm_host](
                                   impl::stream_t *stream, void *mapped_ptr) {
         CHECK(usm::memcpy(stream, usm_ptr_for_unmap, mapped_ptr, size, 0,
                 nullptr, nullptr));
         CHECK(stream->wait());
-        usm::free(stream->engine(), mapped_ptr);
+        if (use_usm_host)
+            usm::free(stream->engine(), mapped_ptr);
+        else
+            impl::free(mapped_ptr);
         return status::success;
     };
 

--- a/src/xpu/sycl/usm_memory_storage.cpp
+++ b/src/xpu/sycl/usm_memory_storage.cpp
@@ -21,6 +21,10 @@
 #include "common/stream.hpp"
 #include "common/utils.hpp"
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+#include "gpu/intel/utils.hpp"
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace xpu {
@@ -60,20 +64,30 @@ status_t usm_memory_storage_t::map_data(
             = *utils::downcast<xpu::sycl::stream_impl_t *>(stream->impl())
                        ->queue();
 
-    void *host_ptr = ::sycl::malloc_host(size, sycl_queue.get_context());
+    bool use_usm_host = false;
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+    use_usm_host = gpu::intel::gpu_utils::use_usm_host_for_memory_map(engine());
+#endif
+    void *host_ptr = use_usm_host
+            ? ::sycl::malloc_host(size, sycl_queue.get_context())
+            : impl::malloc(size, 64);
     if (!host_ptr) return status::out_of_memory;
 
     sycl_queue.wait_and_throw();
     sycl_queue.memcpy(host_ptr, usm_ptr, size).wait();
 
     *mapped_ptr = host_ptr;
-    auto unmap_callback = [usm_ptr, size](stream_t *stream, void *mapped_ptr) {
+    auto unmap_callback = [usm_ptr, size, use_usm_host](
+                                  stream_t *stream, void *mapped_ptr) {
         ::sycl::queue sycl_queue
                 = *utils::downcast<xpu::sycl::stream_impl_t *>(stream->impl())
                            ->queue();
         sycl_queue.wait_and_throw();
         sycl_queue.memcpy(usm_ptr, mapped_ptr, size).wait();
-        ::sycl::free(mapped_ptr, sycl_queue.get_context());
+        if (use_usm_host)
+            ::sycl::free(mapped_ptr, sycl_queue.get_context());
+        else
+            impl::free(mapped_ptr);
         return status::success;
     };
 

--- a/src/xpu/ze/memory_storage.cpp
+++ b/src/xpu/ze/memory_storage.cpp
@@ -19,6 +19,10 @@
 #include "common/stream.hpp"
 #include "common/utils.hpp"
 
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+#include "gpu/intel/utils.hpp"
+#endif
+
 #include "xpu/ze/engine_impl.hpp"
 #include "xpu/ze/memory_storage.hpp"
 #include "xpu/ze/stream_impl.hpp"
@@ -65,20 +69,32 @@ status_t memory_storage_t::map_data(
 
     if (!stream) CHECK(engine()->get_service_stream(stream));
 
-    void *host_ptr = malloc_host(size);
+    bool use_usm_host = false;
+#if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
+    use_usm_host = gpu::intel::gpu_utils::use_usm_host_for_memory_map(engine());
+#endif
+    void *host_ptr = use_usm_host ? malloc_host(size) : impl::malloc(size, 64);
     if (!host_ptr) return status::out_of_memory;
 
-    auto leak_guard = decltype(ptr_)(host_ptr, [this](void *p) { free(p); });
+    auto leak_guard = decltype(ptr_)(host_ptr, [use_usm_host, this](void *p) {
+        if (use_usm_host)
+            free(p);
+        else
+            impl::free(p);
+    });
     CHECK(memcpy(stream, host_ptr, ptr(), size));
     CHECK(stream->wait());
     leak_guard.release();
 
     auto *usm_ptr_for_unmap = ptr();
-    auto unmap_callback = [size, usm_ptr_for_unmap, this](
+    auto unmap_callback = [size, usm_ptr_for_unmap, use_usm_host, this](
                                   impl::stream_t *stream, void *mapped_ptr) {
         CHECK(memcpy(stream, usm_ptr_for_unmap, mapped_ptr, size));
         CHECK(stream->wait());
-        free(mapped_ptr);
+        if (use_usm_host)
+            free(mapped_ptr);
+        else
+            impl::free(mapped_ptr);
 
         return status::success;
     };


### PR DESCRIPTION
This PR fixes [MFDNN-15173](https://jira.devtools.intel.com/browse/MFDNN-15173) by dropping host USM usage for map/unmap.

I initially tried to drop host USM usage across all platforms, but testing revealed numerous segfaults and correctness issues on PVC and ATS-M. This is likely a bug specific to i915 and/or ATS-M/PVC. I attempted to narrow down these issues, but after spending some time on it, I decided not to invest further resources as they required long batch runs and are slow to triage.

Hence, the changes in this PR represent a middle ground: keeping host USM for legacy discrete ATS-M/DG2/PVC, and using system memory for all other platforms. My experiments didn't show host USM usage and GPU memory interaction so I assume the effect observed on NVL-P for the original Jira is irrelevant for these platforms.

Alternatively, we could merge the fix/workaround from the rls-v3.13 PR: https://github.com/uxlfoundation/oneDNN/pull/5444. I don't have a strong preference - both options work for me.