### PR TITLE
[GPU] JIT GEMM: support robust jit gemm kernel override via primitive attribute

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -287,6 +287,8 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
 
     // Matmul supports fpmath mode and accumulation mode
     attr_mask |= smask_t::fpmath_mode | smask_t::accumulation_mode;
+    // GPU attribute (GRF/threads-per-EU and the dev-only GEMM kernel override).
+    attr_mask |= smask_t::gpu_attr;
 
     VCHECK_MATMUL_UNIMPL(attr->has_default_values(attr_mask, dst_dt),
             VERBOSE_UNSUPPORTED_ATTR);

--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -300,6 +300,8 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
 
     // Matmul supports fpmath mode and accumulation mode
     attr_mask |= smask_t::fpmath_mode | smask_t::accumulation_mode;
+    // GPU attribute (GRF/threads-per-EU and the dev-only GEMM kernel override).
+    attr_mask |= smask_t::gpu_attr;
 
     VCHECK_MATMUL_UNIMPL(attr->has_default_values(attr_mask, dst_dt),
             VERBOSE_UNSUPPORTED_ATTR);

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -32,6 +32,7 @@
 #include "gpu/intel/gemm/jit/pd.hpp"
 #include "gpu/intel/gemm/primitive.hpp"
 #include "gpu/intel/gemm/utils.hpp"
+#include "gpu/intel/primitive_attr.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -112,7 +113,7 @@ struct gen_t : public primitive_t {
                     | smask_t::scales | smask_t::scales_data_type
                     | smask_t::scales_groups | smask_t::precomputed_reductions
                     | smask_t::zero_points | smask_t::zero_points_data_type
-                    | smask_t::zero_points_groups;
+                    | smask_t::zero_points_groups | smask_t::gpu_attr;
             VDISPATCH_GEMM(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_GEMM(
@@ -301,6 +302,11 @@ struct gen_t : public primitive_t {
 
             bool print_verbose = get_verbose(verbose_t::debuginfo) >= 5;
             bool kernel_success = false;
+            if (attr()->gpu_attr_) {
+                auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
+                        attr()->gpu_attr_.get());
+                kernel_desc_.set_kernel_override(gpu_attr->kernel_override());
+            }
             auto lda = ld(DNNL_ARG_A);
             auto ldb = ld(DNNL_ARG_B);
             if (swap_ab_) std::swap(lda, ldb);

--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -34,6 +34,7 @@
 #include "gpu/intel/gemm/primitive.hpp"
 #include "gpu/intel/gemm/utils.hpp"
 #include "gpu/intel/logging.hpp"
+#include "gpu/intel/primitive_attr.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -115,7 +116,7 @@ struct gen_t : public primitive_t {
                     | smask_t::scales | smask_t::scales_data_type
                     | smask_t::scales_groups | smask_t::precomputed_reductions
                     | smask_t::zero_points | smask_t::zero_points_data_type
-                    | smask_t::zero_points_groups;
+                    | smask_t::zero_points_groups | smask_t::gpu_attr;
             VDISPATCH_GEMM(attr()->has_default_values(attr_skip_mask),
                     VERBOSE_UNSUPPORTED_ATTR);
             VDISPATCH_GEMM(
@@ -302,6 +303,11 @@ struct gen_t : public primitive_t {
                 kernel_desc_.set_efficient_64b(dev_info_->is_efficient_64bit());
 
             bool kernel_success = false;
+            if (attr()->gpu_attr_) {
+                auto *gpu_attr = utils::downcast<gpu_primitive_attr_t *>(
+                        attr()->gpu_attr_.get());
+                kernel_desc_.set_kernel_override(gpu_attr->kernel_override());
+            }
             auto lda = ld(DNNL_ARG_A);
             auto ldb = ld(DNNL_ARG_B);
             if (swap_ab_) std::swap(lda, ldb);
@@ -570,6 +576,15 @@ struct gen_t : public primitive_t {
             return &kernel_desc_;
         }
 
+        // Deployed (post-finalize) strategy string; lazily dumped and cached.
+        const std::string &gemm_kernel_str() const {
+            if (kernel_str_.empty())
+                kernel_str_ = jit::dump_kernel(kernel_desc_.hw(),
+                        *kernel_desc_.problem(), *kernel_desc_.strategy(),
+                        kernel_desc_.aux_params());
+            return kernel_str_;
+        }
+
         int max_k_sliced_groups() const {
             const auto *info = kernel_desc()->driver_info();
 
@@ -589,6 +604,7 @@ struct gen_t : public primitive_t {
         compute::gpu_arch_t arch_ = compute::gpu_arch_t::unknown;
 
         kernel_desc_t kernel_desc_;
+        mutable std::string kernel_str_; // lazy dump for dnnl_impl_gpu_intel_get_gemm_kernel
     };
 
     gen_t(const pd_t *apd) : primitive_t(apd) {}

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -53,6 +53,33 @@ void entryObserver(
                 entry->str().c_str(), score);
     }
 }
+
+// Trailing " | dispatch k0=.. wgK=.." section with evaluator-derived geometry
+// the strategy string can't encode; '|' is unused by the strategy grammar.
+constexpr char dispatch_divider = '|';
+
+std::string serialize_dispatch(const EvaluateAuxOutput &aux) {
+    return std::string(" ") + dispatch_divider + " dispatch k0="
+            + std::to_string(aux.k0) + " wgK=" + std::to_string(aux.wgK);
+}
+
+#ifdef DNNL_DEV_MODE
+// Parses and trims the dispatch section off `str`; returns whether present.
+bool parse_dispatch(std::string &str, int64_t &k0, int &wgK) {
+    auto pos = str.find(dispatch_divider);
+    if (pos == std::string::npos) return false;
+    std::stringstream ss(str.substr(pos + 1));
+    std::string tok;
+    while (ss >> tok) {
+        if (tok.rfind("k0=", 0) == 0)
+            k0 = std::stoll(tok.substr(3));
+        else if (tok.rfind("wgK=", 0) == 0)
+            wgK = std::stoi(tok.substr(4));
+    }
+    str.resize(pos);
+    return true;
+}
+#endif
 } // anonymous namespace
 
 bool enable_generator_dsl() {
@@ -99,42 +126,17 @@ static gemmstone::Scalar stringToScalar(std::string val) {
         default: return Scalar(std::stoi(val));
     }
 }
-#endif
 
-status_t gen_desc_t::finalize(const char *tags) {
-    // Update problem alignments to match catalog entry.
-    if (!isPacked(problem_.A.layout)
-            && problem_.Ta_ext.paddedSize() >= problem_.Ta.paddedSize()) {
-        problem_.A.setAlignment(std::max(
-                problem_.Ta_ext.paddedSize(), entry_->driverInfo.alignment[0]));
-    }
-
-    if (!isPacked(problem_.B.layout)
-            && problem_.Tb_ext.paddedSize() >= problem_.Tb.paddedSize()) {
-        problem_.B.setAlignment(std::max(
-                problem_.Tb_ext.paddedSize(), entry_->driverInfo.alignment[1]));
-    }
-
-    if (!isPacked(problem_.C.layout)) {
-        problem_.C.setAlignment(std::max(problem_.Tc_ext.paddedSize(),
-                entry_->restrictions.alignment[2]));
-    }
-
-    problem_.CO.setAlignment(problem_.Tco.paddedSize());
-
-    // Parse strategy string.
-    strategy_ = GEMMStrategy(hw_, stepping_);
-#ifdef DNNL_DEV_MODE
-    std::string ovr_strategy;
-    ovr_strategy = gpu_utils::dev_getenv("GEMM_KERNEL", ovr_strategy);
-    if (!ovr_strategy.empty()) {
+status_t gen_desc_t::apply_kernel_override(std::string ovr_strategy) {
+    using namespace gemmstone;
+    try {
         // Warning: will override problem data types (including up/down
         // conversions) - this will cause inaccuracies if precisions/layouts
         // are chosen that are incompatible with the given problem
         std::stringstream ss(ovr_strategy);
         std::string val;
         ss >> val;
-        gpu_assert(val == "gemm");
+        if (val != "gemm") throw std::runtime_error("expected 'gemm' prefix");
         ss >> val;
         const char *pstr = val.c_str();
         pstr = parsePrecisions(pstr, problem_.Ta_ext, problem_.Ta);
@@ -166,13 +168,21 @@ status_t gen_desc_t::finalize(const char *tags) {
         problem_.beta = stringToScalar(val);
 
         ovr_strategy = ss.str().substr(ss.tellg()); // remaining string
+
+        // Strip dispatch section before parseStrategy.
+        int64_t disp_k0 = 0;
+        int disp_wgK = 1;
+        bool have_disp = parse_dispatch(ovr_strategy, disp_k0, disp_wgK);
+
         parseStrategy(ovr_strategy, hw_, problem_, strategy_);
 
-        // TODO: override derived values in aux_params_ in a way that's
-        // consistent with the kernel evaluator (typically requires extra
-        // benchmarking data not supplied with the kernel override string)
-        // Currently: assume the W model because it's simple
-        if (strategy_.kParallelLocal) {
+        // Honor carried dispatch values; else re-derive from the strategy.
+        if (have_disp) {
+            aux_params_.k0 = disp_k0;
+            aux_params_.wgK = disp_wgK;
+        } else if (strategy_.kParallelLocal) {
+            if (strategy_.wg[LoopK] < 1 || strategy_.unroll[LoopK] < 1)
+                throw std::runtime_error("invalid k-parallel-local geometry");
             aux_params_.k0
                     = utils::rnd_up(utils::div_up(k_, strategy_.wg[LoopK]),
                             strategy_.unroll[LoopK]);
@@ -180,9 +190,49 @@ status_t gen_desc_t::finalize(const char *tags) {
                     std::min(strategy_.wg[LoopK],
                             int(utils::div_up(k_, aux_params_.k0))));
         } else {
-            aux_params_.k0 = EvaluateAuxOutput().k0;
-            aux_params_.wgK = EvaluateAuxOutput().wgK;
+            aux_params_.k0 = 0;
+            aux_params_.wgK = 1;
         }
+        aux_params_.kParallel = strategy_.kParallel;
+        aux_params_.kParallelVariable = strategy_.kParallelVariable;
+    } catch (const std::exception &e) {
+        // Reject invalid overrides instead of aborting.
+        VDEBUGINFO(1, primitive, gpu, "%s,%s", "jit::gemm kernel override",
+                e.what());
+        return status::unimplemented;
+    }
+    return status::success;
+}
+#endif
+
+status_t gen_desc_t::finalize(const char *tags) {
+    // Update problem alignments to match catalog entry.
+    if (!isPacked(problem_.A.layout)
+            && problem_.Ta_ext.paddedSize() >= problem_.Ta.paddedSize()) {
+        problem_.A.setAlignment(std::max(
+                problem_.Ta_ext.paddedSize(), entry_->driverInfo.alignment[0]));
+    }
+
+    if (!isPacked(problem_.B.layout)
+            && problem_.Tb_ext.paddedSize() >= problem_.Tb.paddedSize()) {
+        problem_.B.setAlignment(std::max(
+                problem_.Tb_ext.paddedSize(), entry_->driverInfo.alignment[1]));
+    }
+
+    if (!isPacked(problem_.C.layout)) {
+        problem_.C.setAlignment(std::max(problem_.Tc_ext.paddedSize(),
+                entry_->restrictions.alignment[2]));
+    }
+
+    problem_.CO.setAlignment(problem_.Tco.paddedSize());
+
+    // Parse strategy string.
+    strategy_ = GEMMStrategy(hw_, stepping_);
+#ifdef DNNL_DEV_MODE
+    std::string ovr_strategy
+            = gpu_utils::dev_getenv("GEMM_KERNEL", kernel_override_);
+    if (!ovr_strategy.empty()) {
+        CHECK(apply_kernel_override(std::move(ovr_strategy)));
     } else {
 #endif
         strategy_.unroll[LoopM] = entry_->driverInfo.unroll[LoopM];
@@ -983,13 +1033,20 @@ dsl::kernel_t get_dsl_kernel(const GEMMProblem &problem,
 }
 
 std::string dump_kernel(ngen::HW hw, const gemmstone::GEMMProblem &problem,
-        const gemmstone::GEMMStrategy &strategy) {
+        const gemmstone::GEMMStrategy &strategy,
+        const gemmstone::EvaluateAuxOutput *aux = nullptr) {
     auto pstr = problem.toString();
     auto astr = problem.scalarsToString();
     auto sstr = unparseStrategy(hw, problem, strategy);
     if (!astr.empty()) astr += ' ';
-    return pstr + ' ' + std::to_string(strategy.unroll[LoopM]) + ' '
+    auto str = pstr + ' ' + std::to_string(strategy.unroll[LoopM]) + ' '
             + std::to_string(strategy.unroll[LoopN]) + ' ' + astr + sstr;
+    // Append dispatch geometry for k-parallel kernels.
+    if (aux
+            && (aux->kParallel || aux->kParallelVariable || aux->wgK > 1
+                    || aux->k0 > 0))
+        str += serialize_dispatch(*aux);
+    return str;
 }
 
 status_t gen_kernel_t::get_kernel(
@@ -1043,7 +1100,8 @@ void gen_kernel_t::maybe_print_verbose() {
                 desc()->entry().str().c_str());
 
     verbose_printf("info,gpu,gemm,kernel:%s\n",
-            dump_kernel(desc()->hw_, desc()->problem_, desc()->strategy_)
+            dump_kernel(desc()->hw_, desc()->problem_, desc()->strategy_,
+                    desc()->aux_params())
                     .c_str());
 }
 

--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -51,6 +51,33 @@ void entryObserver(
         const kcatalog::Entry *entry, double score, EvaluateAuxOutput aux) {
     gpu_debug() << "consider:" << entry->str() << ",score:" << score;
 }
+
+// Trailing " | dispatch k0=.. wgK=.." section with evaluator-derived geometry
+// the strategy string can't encode; '|' is unused by the strategy grammar.
+constexpr char dispatch_divider = '|';
+
+std::string serialize_dispatch(const EvaluateAuxOutput &aux) {
+    return " | dispatch k0=" + std::to_string(aux.k0) + " wgK="
+            + std::to_string(aux.wgK);
+}
+
+#ifdef DNNL_DEV_MODE
+// Parses and trims the dispatch section off `str`; returns whether present.
+bool parse_dispatch(std::string &str, int64_t &k0, int &wgK) {
+    auto pos = str.find(dispatch_divider);
+    if (pos == std::string::npos) return false;
+    std::stringstream ss(str.substr(pos + 1));
+    std::string tok;
+    while (ss >> tok) {
+        if (tok.rfind("k0=", 0) == 0)
+            k0 = std::stoll(tok.substr(3));
+        else if (tok.rfind("wgK=", 0) == 0)
+            wgK = std::stoi(tok.substr(4));
+    }
+    str.resize(pos);
+    return true;
+}
+#endif
 } // anonymous namespace
 
 bool enable_generator_dsl() {
@@ -96,52 +123,32 @@ static gemmstone::Scalar stringToScalar(std::string val) {
         default: return Scalar(std::stoi(val));
     }
 }
-#endif
 
-status_t gen_desc_t::finalize(const char *tags) {
-    // Update problem alignments to match catalog entry.
-    if (!isPacked(problem_.A.layout)
-            && problem_.Ta_ext.paddedSize() >= problem_.Ta.paddedSize()) {
-        problem_.A.setAlignment(std::max(
-                problem_.Ta_ext.paddedSize(), entry_->driverInfo.alignment[0]));
-    }
-
-    if (!isPacked(problem_.B.layout)
-            && problem_.Tb_ext.paddedSize() >= problem_.Tb.paddedSize()) {
-        problem_.B.setAlignment(std::max(
-                problem_.Tb_ext.paddedSize(), entry_->driverInfo.alignment[1]));
-    }
-
-    if (!isPacked(problem_.C.layout)) {
-        problem_.C.setAlignment(std::max(problem_.Tc_ext.paddedSize(),
-                entry_->restrictions.alignment[2]));
-    }
-
-    problem_.CO.setAlignment(problem_.Tco.paddedSize());
-
-    // Parse strategy string.
-    strategy_ = GEMMStrategy(hw_, stepping_);
-#ifdef DNNL_DEV_MODE
-    std::string ovr_strategy;
-    ovr_strategy = gpu_utils::dev_getenv("GEMM_KERNEL", ovr_strategy);
-    if (!ovr_strategy.empty()) {
+status_t gen_desc_t::apply_kernel_override(std::string ovr_strategy) {
+    using namespace gemmstone;
+    try {
+        // Warning: will override problem data types (including up/down
+        // conversions) - this will cause inaccuracies if precisions/layouts
+        // are chosen that are incompatible with the given problem
         entry_ = nullptr;
         std::stringstream ss(ovr_strategy);
         std::string val;
         ss >> val;
-        gpu_assert(val == "gemm");
+        if (val != "gemm") throw std::runtime_error("expected 'gemm' prefix");
         ss >> val;
         const char *pstr = val.c_str();
         // Cannot modify external data types
         Type ext_dt;
         pstr = parsePrecisions(pstr, ext_dt, problem_.Ta);
-        gpu_assert(ext_dt == problem_.Ta_ext) << "Invalid external A data type";
+        if (ext_dt != problem_.Ta_ext)
+            throw std::runtime_error("invalid external A data type");
         pstr = parsePrecisions(pstr, ext_dt, problem_.Tb);
-        gpu_assert(ext_dt == problem_.Tb_ext) << "Invalid external B data type";
+        if (ext_dt != problem_.Tb_ext)
+            throw std::runtime_error("invalid external B data type");
         if (*pstr == '[') {
             pstr = parsePrecisions(pstr, problem_.Tc, ext_dt);
-            gpu_assert(ext_dt == problem_.Tc_ext)
-                    << "Invalid external C data type";
+            if (ext_dt != problem_.Tc_ext)
+                throw std::runtime_error("invalid external C data type");
         } else {
             pstr = parsePrecision(pstr, problem_.Tc);
         }
@@ -171,13 +178,21 @@ status_t gen_desc_t::finalize(const char *tags) {
         problem_.beta = stringToScalar(val);
 
         ovr_strategy = ss.str().substr(ss.tellg()); // remaining string
+
+        // Strip dispatch section before parseStrategy.
+        int64_t disp_k0 = 0;
+        int disp_wgK = 1;
+        bool have_disp = parse_dispatch(ovr_strategy, disp_k0, disp_wgK);
+
         parseStrategy(ovr_strategy, hw_, problem_, strategy_);
 
-        // TODO: override derived values in aux_params_ in a way that's
-        // consistent with the kernel evaluator (typically requires extra
-        // benchmarking data not supplied with the kernel override string)
-        // Currently: assume the W model because it's simple
-        if (strategy_.kParallelLocal) {
+        // Honor carried dispatch values; else re-derive from the strategy.
+        if (have_disp) {
+            aux_params_.k0 = disp_k0;
+            aux_params_.wgK = disp_wgK;
+        } else if (strategy_.kParallelLocal) {
+            if (strategy_.wg[LoopK] < 1 || strategy_.unroll[LoopK] < 1)
+                throw std::runtime_error("invalid k-parallel-local geometry");
             aux_params_.k0
                     = utils::rnd_up(utils::div_up(k_, strategy_.wg[LoopK]),
                             strategy_.unroll[LoopK]);
@@ -185,9 +200,48 @@ status_t gen_desc_t::finalize(const char *tags) {
                     std::min(strategy_.wg[LoopK],
                             int(utils::div_up(k_, aux_params_.k0))));
         } else {
-            aux_params_.k0 = EvaluateAuxOutput().k0;
-            aux_params_.wgK = EvaluateAuxOutput().wgK;
+            aux_params_ = EvaluateAuxOutput();
         }
+        aux_params_.kParallel = strategy_.kParallel;
+        aux_params_.kParallelVariable = strategy_.kParallelVariable;
+    } catch (const std::exception &e) {
+        // Reject invalid overrides instead of aborting.
+        VDEBUGINFO(1, primitive, gpu, "%s,%s", "jit::gemm kernel override",
+                e.what());
+        return status::unimplemented;
+    }
+    return status::success;
+}
+#endif
+
+status_t gen_desc_t::finalize(const char *tags) {
+    // Update problem alignments to match catalog entry.
+    if (!isPacked(problem_.A.layout)
+            && problem_.Ta_ext.paddedSize() >= problem_.Ta.paddedSize()) {
+        problem_.A.setAlignment(std::max(
+                problem_.Ta_ext.paddedSize(), entry_->driverInfo.alignment[0]));
+    }
+
+    if (!isPacked(problem_.B.layout)
+            && problem_.Tb_ext.paddedSize() >= problem_.Tb.paddedSize()) {
+        problem_.B.setAlignment(std::max(
+                problem_.Tb_ext.paddedSize(), entry_->driverInfo.alignment[1]));
+    }
+
+    if (!isPacked(problem_.C.layout)) {
+        problem_.C.setAlignment(std::max(problem_.Tc_ext.paddedSize(),
+                entry_->restrictions.alignment[2]));
+    }
+
+    problem_.CO.setAlignment(problem_.Tco.paddedSize());
+
+    // Parse strategy string.
+    strategy_ = GEMMStrategy(hw_, stepping_);
+#ifdef DNNL_DEV_MODE
+    std::string ovr_strategy
+            = gpu_utils::dev_getenv("GEMM_KERNEL", kernel_override_);
+    if (!ovr_strategy.empty()) {
+        CHECK(apply_kernel_override(std::move(ovr_strategy)));
     } else {
 #endif
         strategy_.unroll[LoopM] = entry_->driverInfo.unroll[LoopM];
@@ -991,13 +1045,20 @@ dsl::kernel_t get_dsl_kernel(const GEMMProblem &problem,
 }
 
 std::string dump_kernel(ngen::HW hw, const gemmstone::GEMMProblem &problem,
-        const gemmstone::GEMMStrategy &strategy) {
+        const gemmstone::GEMMStrategy &strategy,
+        const gemmstone::EvaluateAuxOutput *aux) {
     auto pstr = problem.toString();
     auto astr = problem.scalarsToString();
     auto sstr = unparseStrategy(hw, problem, strategy);
     if (!astr.empty()) astr += ' ';
-    return pstr + ' ' + std::to_string(strategy.unroll[LoopM]) + ' '
+    auto str = pstr + ' ' + std::to_string(strategy.unroll[LoopM]) + ' '
             + std::to_string(strategy.unroll[LoopN]) + ' ' + astr + sstr;
+    // Append dispatch geometry for k-parallel kernels.
+    if (aux
+            && (aux->kParallel || aux->kParallelVariable || aux->wgK > 1
+                    || aux->k0 > 0))
+        str += serialize_dispatch(*aux);
+    return str;
 }
 
 status_t gen_kernel_t::get_kernel(
@@ -1044,8 +1105,8 @@ status_t gen_kernel_t::get_kernel(
 
 void gen_kernel_t::maybe_print_verbose() {
     gpu_debug() << "kernel:"
-                << dump_kernel(
-                           desc()->hw_, desc()->problem_, desc()->strategy_);
+                << dump_kernel(desc()->hw_, desc()->problem_, desc()->strategy_,
+                           desc()->aux_params());
 }
 
 } // namespace jit

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -17,6 +17,8 @@
 #ifndef GPU_INTEL_GEMM_JIT_GEN_KERNEL_HPP
 #define GPU_INTEL_GEMM_JIT_GEN_KERNEL_HPP
 
+#include <string>
+
 #include "common/c_types_map.hpp"
 #include "gemmstone/driver_info.hpp"
 #include "gemmstone/kernel_catalog.hpp"
@@ -100,6 +102,10 @@ struct gen_desc_t {
         efficient_64b_ = efficient_64b;
     }
 
+    void set_kernel_override(const std::string &kernel) {
+        kernel_override_ = kernel;
+    }
+
 protected:
     compute::gpu_arch_t arch_;
     ngen::HW hw_ = ngen::HW::Unknown;
@@ -113,6 +119,8 @@ protected:
 
     bool efficient_64b_ = false;
 
+    std::string kernel_override_;
+
     /* optional information to fine-tune kernel */
     int m_ = -1, n_ = -1, k_ = -1;
     int eu_count_ = -1;
@@ -120,6 +128,9 @@ protected:
     bool relaxed_acc_ = false;
 
     status_t finalize(const char *tags);
+#ifdef DNNL_DEV_MODE
+    status_t apply_kernel_override(std::string ovr_strategy);
+#endif
     void update_driver_info();
 };
 

--- a/src/gpu/intel/gemm/jit/gen_kernel.hpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.hpp
@@ -17,6 +17,8 @@
 #ifndef GPU_INTEL_GEMM_JIT_GEN_KERNEL_HPP
 #define GPU_INTEL_GEMM_JIT_GEN_KERNEL_HPP
 
+#include <string>
+
 #include "common/c_types_map.hpp"
 #include "gemmstone/driver_info.hpp"
 #include "gemmstone/kernel_catalog.hpp"
@@ -65,6 +67,7 @@ struct gen_desc_t {
 
     const gemmstone::GEMMProblem *problem() const { return &problem_; }
     const gemmstone::GEMMStrategy *strategy() const { return &strategy_; }
+    ngen::HW hw() const { return hw_; }
 
     const gemmstone::CommonDriverInfo *driver_info() const {
         return &driver_info_;
@@ -99,6 +102,10 @@ struct gen_desc_t {
         efficient_64b_ = efficient_64b;
     }
 
+    void set_kernel_override(const std::string &kernel) {
+        kernel_override_ = kernel;
+    }
+
 protected:
     compute::gpu_arch_t arch_;
     ngen::HW hw_ = ngen::HW::Unknown;
@@ -112,6 +119,8 @@ protected:
 
     bool efficient_64b_ = false;
 
+    std::string kernel_override_;
+
     /* optional information to fine-tune kernel */
     int m_ = -1, n_ = -1, k_ = -1;
     int eu_count_ = -1;
@@ -119,6 +128,7 @@ protected:
     bool relaxed_acc_ = false;
 
     status_t finalize(const char *tags);
+    status_t apply_kernel_override(std::string ovr_strategy);
     void update_driver_info();
 };
 
@@ -169,6 +179,10 @@ struct gen_xe_systolic_kernel_desc_t : public gen_desc_t {
 
     static int min_block_k(data_type_t a_type) { return 2048; }
 };
+
+std::string dump_kernel(ngen::HW hw, const gemmstone::GEMMProblem &problem,
+        const gemmstone::GEMMStrategy &strategy,
+        const gemmstone::EvaluateAuxOutput *aux = nullptr);
 
 struct gen_kernel_t : public intel::jit::generator_base_t {
 

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -367,6 +367,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
             if (problem.bqGroupK % wg[LoopK]) stub();
             kchunk0 = lcm(kchunk0, std::max(1, problem.bqGroupK / wg[LoopK]));
         }
+        if (kchunk0 <= 0) stub("k-interleave incompatible with SLM copy here");
         kInterleaveChunk = align_up(kInterleaveChunk, kchunk0);
         kInterleaveChunk = std::max(kInterleaveChunk, kchunk0);
     }
@@ -399,6 +400,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     if (l3PrefetchA) ukAlign = lcm(ukAlign, ka_prefetchL3);
     if (l3PrefetchB) ukAlign = lcm(ukAlign, kb_prefetchL3);
 
+    if (ukAlign <= 0) stub("Zero k-unroll alignment");
     unroll[LoopK] = align_up(unroll[LoopK], ukAlign);
 
     if (unrollKSLM == 0)

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -408,6 +408,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
             if (problem.bqGroupK % wg[LoopK]) stub();
             kchunk0 = lcm(kchunk0, std::max(1, problem.bqGroupK / wg[LoopK]));
         }
+        if (kchunk0 <= 0) stub("k-interleave incompatible with SLM copy here");
         kInterleaveChunk = align_up(kInterleaveChunk, kchunk0);
         kInterleaveChunk = std::max(kInterleaveChunk, kchunk0);
     }
@@ -432,6 +433,7 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
     if (l3PrefetchA) ukAlign = lcm(ukAlign, ka_prefetchL3);
     if (l3PrefetchB) ukAlign = lcm(ukAlign, kb_prefetchL3);
 
+    if (ukAlign <= 0) stub("Zero k-unroll alignment");
     unroll[LoopK] = align_up(unroll[LoopK], ukAlign);
 
     if (unrollKSLM == 0)

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -881,7 +881,7 @@ std::string unparseStrategy(HW hw, const GEMMProblem &problem, const GEMMStrateg
     if (strategy.kParallelLocal)    s << (strategy.shrinkWGK   ? " akr" :
                                           strategy.kInterleave ? " ikr" :
                                                                  " kr");
-    if (strategy.fillGoal)          s << " fg" << strategy.fillGoal * (1. / 16);
+    if (strategy.fillGoal)          s << " fg " << strategy.fillGoal * (1. / 16);
     if (strategy.kInterleave)       s << " ki" << strategy.kInterleaveChunk;
 
     if (strategy.fixedSystolic)

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -898,7 +898,7 @@ std::string unparseStrategy(HW hw, const GEMMProblem &problem, const GEMMStrateg
     if (strategy.kParallelLocal)    s << (strategy.shrinkWGK   ? " akr" :
                                           strategy.kInterleave ? " ikr" :
                                                                  " kr");
-    if (strategy.fillGoal)          s << " fg" << strategy.fillGoal * (1. / 16);
+    if (strategy.fillGoal)          s << " fg " << strategy.fillGoal * (1. / 16);
     if (strategy.kInterleave)       s << " ki" << strategy.kInterleaveChunk;
 
     if (strategy.fixedSystolic)

--- a/src/gpu/intel/gemm/jit/walk_orders.hpp
+++ b/src/gpu/intel/gemm/jit/walk_orders.hpp
@@ -57,8 +57,8 @@ inline void linear_order_args(compute::kernel_arg_list_t &arg_list, int &argn,
     uint32_t ss_count = dev_info->eu_count() / dev_info->max_eus_per_wg();
     uint32_t thread_per_ss = dev_info->hw_threads(info.grfCount) / ss_count;
     uint32_t thread_per_tg = into<uint32_t>(lws.nelems());
-    uint32_t tg_per_ss = thread_per_ss / thread_per_tg;
-    uint32_t concurrent_tg = tg_per_ss * ss_count;
+    uint32_t tg_per_ss = thread_per_tg ? thread_per_ss / thread_per_tg : 0;
+    uint32_t concurrent_tg = std::max(1u, tg_per_ss * ss_count);
 
     arg_list.set(argn++, groups_m);
     arg_list.set(argn++, groups_n);

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -54,6 +54,8 @@ struct gemm_t : public primitive_t {
             gemm_attr.zero_points_ = attr()->zero_points_;
             gemm_attr.post_ops_ = attr()->post_ops_;
             gemm_attr.dropout_ = attr()->dropout_;
+            if (attr()->gpu_attr_)
+                gemm_attr.gpu_attr_ = attr()->gpu_attr_->clone();
 
             auto a_md = src_md(), b_md = weights_md(), c_md = dst_md(),
                  bias_md = weights_md(1);

--- a/src/gpu/intel/matmul/gemm.hpp
+++ b/src/gpu/intel/matmul/gemm.hpp
@@ -54,6 +54,8 @@ struct gemm_t : public primitive_t {
             gemm_attr.zero_points_ = attr()->zero_points_;
             gemm_attr.post_ops_ = attr()->post_ops_;
             gemm_attr.dropout_ = attr()->dropout_;
+            if (attr()->gpu_attr_)
+                gemm_attr.gpu_attr_ = attr()->gpu_attr_->clone();
 
             auto a_md = src_md(), b_md = weights_md(), c_md = dst_md(),
                  bias_md = weights_md(1);
@@ -383,6 +385,8 @@ struct gemm_t : public primitive_t {
 
             return status::success;
         }
+
+        const primitive_desc_t *gemm_pd() const { return gemm_pd_.get(); }
 
         std::shared_ptr<primitive_desc_t> gemm_pd_;
         sum_ab_t sum_ab_ = sum_ab::sum_none;

--- a/src/gpu/intel/primitive_attr.cpp
+++ b/src/gpu/intel/primitive_attr.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/primitive_attr.hpp"
+
+#include "common/c_types_map.hpp"
+#include "common/utils.hpp"
+
+using namespace dnnl::impl;
+using namespace dnnl::impl::gpu::intel;
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_set_kernel_override(
+        primitive_attr_t *attr, const char *kernel) {
+    if (utils::any_null(attr)) return status::invalid_arguments;
+
+    // Preserve any GRF setting already carried by the gpu attribute.
+    int grf_per_thread = 0;
+    if (attr->gpu_attr_) {
+        auto *cur = utils::downcast<gpu_primitive_attr_t *>(
+                attr->gpu_attr_.get());
+        grf_per_thread = cur->grf_per_thread();
+    }
+    return attr->set_gpu_attr(
+            gpu_primitive_attr_t(grf_per_thread, kernel ? kernel : ""));
+}
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_get_kernel_override(
+        const primitive_attr_t *attr, const char **kernel) {
+    if (utils::any_null(attr, kernel)) return status::invalid_arguments;
+
+    *kernel = "";
+    if (attr->gpu_attr_) {
+        auto *cur = utils::downcast<const gpu_primitive_attr_t *>(
+                attr->gpu_attr_.get());
+        *kernel = cur->kernel_override().c_str();
+    }
+    return status::success;
+}

--- a/src/gpu/intel/primitive_attr.cpp
+++ b/src/gpu/intel/primitive_attr.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gpu/intel/primitive_attr.hpp"
+
+#include "common/c_types_map.hpp"
+#include "common/primitive_desc_iface.hpp"
+#include "common/utils.hpp"
+
+#include "gpu/intel/gemm/jit.hpp"
+#include "gpu/intel/matmul/gemm.hpp"
+
+using namespace dnnl::impl;
+using namespace dnnl::impl::gpu::intel;
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_set_kernel_override(
+        primitive_attr_t *attr, const char *kernel) {
+    if (utils::any_null(attr)) return status::invalid_arguments;
+
+    // Preserve any GRF/DPAS setting already carried by the gpu attribute.
+    int grf_per_thread = 0;
+    bool use_dpas = false;
+    if (attr->gpu_attr_) {
+        auto *cur = utils::downcast<gpu_primitive_attr_t *>(
+                attr->gpu_attr_.get());
+        grf_per_thread = cur->grf_per_thread();
+        use_dpas = cur->use_dpas();
+    }
+    return attr->set_gpu_attr(gpu_primitive_attr_t(
+            grf_per_thread, use_dpas, kernel ? kernel : ""));
+}
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_get_kernel_override(
+        const primitive_attr_t *attr, const char **kernel) {
+    if (utils::any_null(attr, kernel)) return status::invalid_arguments;
+
+    *kernel = "";
+    if (attr->gpu_attr_) {
+        auto *cur = utils::downcast<const gpu_primitive_attr_t *>(
+                attr->gpu_attr_.get());
+        *kernel = cur->kernel_override().c_str();
+    }
+    return status::success;
+}
+
+// Deployed (post-preflight/modifyStrategy) gemm strategy string for the kernel
+// the primitive descriptor selected -- the catalog default when no override is
+// set. "" if the chosen impl is not jit:gemm. Points into the pd; valid for its
+// lifetime.
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_get_gemm_kernel(
+        const_dnnl_primitive_desc_t pd, const char **kernel) {
+    if (utils::any_null(pd, kernel)) return status::invalid_arguments;
+    *kernel = "";
+
+    const primitive_desc_t *impl = pd->impl().get();
+    // matmul dispatches to jit:gemm through a nested gemm pd; unwrap it.
+    if (auto *mm = dynamic_cast<const matmul::gemm_t::pd_t *>(impl))
+        impl = mm->gemm_pd();
+    if (auto *g = dynamic_cast<const gemm::gen_t::pd_t *>(impl))
+        *kernel = g->gemm_kernel_str().c_str();
+    return status::success;
+}

--- a/src/gpu/intel/primitive_attr.hpp
+++ b/src/gpu/intel/primitive_attr.hpp
@@ -17,8 +17,11 @@
 #ifndef GPU_INTEL_PRIMITIVE_ATTR_HPP
 #define GPU_INTEL_PRIMITIVE_ATTR_HPP
 
+#include <string>
+
 #include "common/primitive_attr.hpp"
 #include "common/serialization.hpp"
+#include "common/utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -26,35 +29,55 @@ namespace gpu {
 namespace intel {
 
 struct gpu_primitive_attr_t : public primitive_attr_item_t {
-    gpu_primitive_attr_t(int grf_per_thread = 0)
-        : grf_per_thread_(grf_per_thread) {}
+    gpu_primitive_attr_t(
+            int grf_per_thread = 0, std::string kernel_override = {})
+        : grf_per_thread_(grf_per_thread)
+        , kernel_override_(std::move(kernel_override)) {}
 
     std::unique_ptr<primitive_attr_item_t> clone() const override {
-        return utils::make_unique<gpu_primitive_attr_t>(grf_per_thread_);
+        return utils::make_unique<gpu_primitive_attr_t>(
+                grf_per_thread_, kernel_override_);
     }
 
-    bool has_default_values() const override { return grf_per_thread_ == 0; }
+    bool has_default_values() const override {
+        return grf_per_thread_ == 0 && kernel_override_.empty();
+    }
 
     bool is_equal(const primitive_attr_item_t &other) const override {
         auto *other_ptr = utils::downcast<const gpu_primitive_attr_t *>(&other);
-        return grf_per_thread_ == other_ptr->grf_per_thread_;
+        return grf_per_thread_ == other_ptr->grf_per_thread_
+                && kernel_override_ == other_ptr->kernel_override_;
     }
 
-    size_t get_hash() const override { return grf_per_thread_; }
+    size_t get_hash() const override {
+        size_t seed = grf_per_thread_;
+        seed = hash_combine(seed, std::hash<std::string> {}(kernel_override_));
+        return seed;
+    }
 
     void serialize(serialization_stream_t &stream) const override {
         stream.append(grf_per_thread_);
+        stream.append_array(kernel_override_.size(), kernel_override_.c_str());
     }
 
     int grf_per_thread() const { return grf_per_thread_; }
 
+    const std::string &kernel_override() const { return kernel_override_; }
+
 private:
     int grf_per_thread_;
+    std::string kernel_override_;
 };
 
 } // namespace intel
 } // namespace gpu
 } // namespace impl
 } // namespace dnnl
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_set_kernel_override(
+        dnnl_primitive_attr_t attr, const char *kernel);
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_get_kernel_override(
+        const_dnnl_primitive_attr_t attr, const char **kernel);
 
 #endif

--- a/src/gpu/intel/primitive_attr.hpp
+++ b/src/gpu/intel/primitive_attr.hpp
@@ -17,8 +17,11 @@
 #ifndef GPU_INTEL_PRIMITIVE_ATTR_HPP
 #define GPU_INTEL_PRIMITIVE_ATTR_HPP
 
+#include <string>
+
 #include "common/primitive_attr.hpp"
 #include "common/serialization.hpp"
+#include "common/utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -26,48 +29,66 @@ namespace gpu {
 namespace intel {
 
 struct gpu_primitive_attr_t : public primitive_attr_item_t {
-    gpu_primitive_attr_t(int grf_per_thread = 0, bool use_dpas = false)
-        : grf_per_thread_(grf_per_thread), use_dpas_(use_dpas) {}
+    gpu_primitive_attr_t(int grf_per_thread = 0, bool use_dpas = false,
+            std::string kernel_override = {})
+        : grf_per_thread_(grf_per_thread)
+        , use_dpas_(use_dpas)
+        , kernel_override_(std::move(kernel_override)) {}
 
     std::unique_ptr<primitive_attr_item_t> clone() const override {
         return utils::make_unique<gpu_primitive_attr_t>(
-                grf_per_thread_, use_dpas_);
+                grf_per_thread_, use_dpas_, kernel_override_);
     }
 
     bool has_default_values() const override {
-        return grf_per_thread_ == 0 && !use_dpas_;
+        return grf_per_thread_ == 0 && !use_dpas_ && kernel_override_.empty();
     }
 
     bool is_equal(const primitive_attr_item_t &other) const override {
         auto *other_ptr = utils::downcast<const gpu_primitive_attr_t *>(&other);
         return grf_per_thread_ == other_ptr->grf_per_thread_
-                && use_dpas_ == other_ptr->use_dpas_;
+                && use_dpas_ == other_ptr->use_dpas_
+                && kernel_override_ == other_ptr->kernel_override_;
     }
 
     size_t get_hash() const override {
         size_t seed = 0;
         seed = hash_combine(seed, grf_per_thread_);
         seed = hash_combine(seed, use_dpas_);
+        seed = hash_combine(seed, std::hash<std::string> {}(kernel_override_));
         return seed;
     }
 
     void serialize(serialization_stream_t &stream) const override {
         stream.append(grf_per_thread_);
         stream.append(use_dpas_);
+        stream.append_array(kernel_override_.size(), kernel_override_.c_str());
     }
 
     int grf_per_thread() const { return grf_per_thread_; }
     bool use_dpas() const { return use_dpas_; }
     void set_use_dpas(bool value) { use_dpas_ = value; }
 
+    const std::string &kernel_override() const { return kernel_override_; }
+
 private:
     int grf_per_thread_;
     bool use_dpas_ = false;
+    std::string kernel_override_;
 };
 
 } // namespace intel
 } // namespace gpu
 } // namespace impl
 } // namespace dnnl
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_set_kernel_override(
+        dnnl_primitive_attr_t attr, const char *kernel);
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_get_kernel_override(
+        const_dnnl_primitive_attr_t attr, const char **kernel);
+
+extern "C" dnnl_status_t DNNL_API dnnl_impl_gpu_intel_get_gemm_kernel(
+        const_dnnl_primitive_desc_t pd, const char **kernel);
 
 #endif


### PR DESCRIPTION
Changes:

- Added a string `kernel_override` to `gpu_primitive_attr_t`, with `dnnl_impl_gpu_intel_{set,get}_kernel_override` C API to set/query it.
- Wired the override through JIT GEMM dispatch (`gen_t` accepts `smask_t::gpu_attr`, forwards the string to the kernel descriptor).
- Refactored override handling out of `finalize()` into `apply_kernel_override()`, and made it fault-tolerant: invalid strings return `status::unimplemented` instead of aborting.
- Extended  `GEMM_KERNEL` with evaluator-derived dispatch geometry (k0/wgK) via a `| dispatch ... ` section so overrides reproduce k-parallel kernels exactly
- Guarded edge cases: invalid k-parallel geometry and a divide-by-zero in `walk_orders.hpp`

The motivation for the changes is to enable direct GEMM auto-tuning through the oneDNN API.

