### PR TITLE
[WIP] cpu: eliminate implicit narrowing conversions

### DIFF
--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <map>
 #include <vector>
+#include <type_traits>
 
 #include "bfloat16.hpp"
 #include "float16.hpp"
@@ -98,6 +99,18 @@ inline T modulo(const T &dividend, const T &divisor) {
     return result < 0 ? result + divisor : result;
 }
 
+template <typename T, typename U,
+        typename R = typename std::common_type<T, U>::type,
+        typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+inline R modulo(const T &dividend, const U &divisor) {
+    static_assert(std::is_integral<T>::value && std::is_integral<U>::value,
+            "T and U must be integer types.");
+    R d = static_cast<R>(divisor);
+    assert(d > 0);
+    R result = static_cast<R>(dividend) % d;
+    return result < 0 ? result + d : result;
+}
+
 // Computes the additive inverse modulus and returns the result as the least
 // positive residue when the divisor > 0.
 template <typename T>
@@ -108,14 +121,40 @@ inline T additive_inverse_modulo(const T &dividend, const T &divisor) {
     return result > 0 ? divisor - result : 0;
 }
 
+template <typename T, typename U,
+        typename R = typename std::common_type<T, U>::type,
+        typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+inline R additive_inverse_modulo(const T &dividend, const U &divisor) {
+    static_assert(std::is_integral<T>::value && std::is_integral<U>::value,
+            "T and U must be integer types.");
+    R result = modulo(dividend, divisor);
+    return result > 0 ? static_cast<R>(divisor) - result : R(0);
+}
+
 template <typename T>
 constexpr const T &max(const T &a, const T &b) {
     return a > b ? a : b;
 }
 
+template <typename T, typename U,
+        typename R = typename std::common_type<T, U>::type,
+        typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+constexpr R max(const T &a, const U &b) {
+    return static_cast<R>(a) > static_cast<R>(b) ? static_cast<R>(a)
+                                                 : static_cast<R>(b);
+}
+
 template <typename T>
 constexpr const T &min(const T &a, const T &b) {
     return a < b ? a : b;
+}
+
+template <typename T, typename U,
+        typename R = typename std::common_type<T, U>::type,
+        typename = typename std::enable_if<!std::is_same<T, U>::value>::type>
+constexpr R min(const T &a, const U &b) {
+    return static_cast<R>(a) < static_cast<R>(b) ? static_cast<R>(a)
+                                                 : static_cast<R>(b);
 }
 
 template <typename T>

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -438,7 +438,7 @@ inline T nd_iterator_init(T start) {
 template <typename T, typename U, typename W, typename... Args>
 inline T nd_iterator_init(T start, U &x, const W &X, Args &&...tuple) {
     start = nd_iterator_init(start, utils::forward<Args>(tuple)...);
-    x = start % X;
+    x = static_cast<int>(start % X);
     return start / X;
 }
 
@@ -668,6 +668,47 @@ inline bool validate_dims(int ndims, const dims_t dims) {
 }
 
 } // namespace utils
+
+// Checked narrowing cast: wraps static_cast with a dev-mode assertion
+// that the value fits in the target type. Mirrors gpu::intel::into<T>().
+namespace into_impl {
+template <typename out_type, typename in_type>
+inline typename utils::enable_if_t<!std::is_fundamental<out_type>::value
+                || !std::is_fundamental<in_type>::value,
+        bool>
+validate_into(in_type) {
+    return true;
+}
+template <typename out_type, typename in_type>
+inline typename utils::enable_if_t<std::is_fundamental<out_type>::value
+                && std::is_fundamental<in_type>::value,
+        bool>
+validate_into(in_type in) {
+    const double d = static_cast<double>(in);
+    return d <= static_cast<double>(std::numeric_limits<out_type>::max())
+            && d
+            >= static_cast<double>(std::numeric_limits<out_type>::lowest());
+}
+template <typename out_type>
+inline bool validate_into(bool) {
+    return std::is_integral<out_type>::value;
+}
+} // namespace into_impl
+
+template <typename out_type, typename in_type>
+inline out_type into(in_type in) {
+#ifdef DNNL_DEV_MODE
+    assert(into_impl::validate_into<out_type>(in));
+#endif
+    return static_cast<out_type>(in);
+}
+
+// Like into<T>() but skips the dev-mode range check. Use only when
+// wrap-around is intentional (e.g., signed/unsigned reinterpretation).
+template <typename out_type, typename in_type>
+inline out_type relaxed_into(in_type in) {
+    return static_cast<out_type>(in);
+}
 
 int32_t fetch_and_add(int32_t *dst, int32_t val);
 inline void yield_thread() {}

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -116,8 +116,8 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const int h_step = into<int>(nstl::min(jcp.oh_block, jcp.oh - oh));
+        const int w_step = into<int>(nstl::min(jcp.ow_block, jcp.ow - ow));
         if (jcp.im2col_sz && is_problem_3d) {
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
         }
@@ -283,7 +283,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                             curr.sp, step.sp, curr.ic, step.ic);
                 else
                     jit_gemm_convolution_utils::im2col_3d<float>(
-                            jcp, _src, _col, curr.od, 0, jcp.os);
+                            jcp, _src, _col, curr.od, 0, into<int>(jcp.os));
             }
             const data_t one = 1.0;
 
@@ -312,7 +312,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                 // TODO: for "outer threading" we have parallel section within
                 // outermost "parallel". It is not good. Consider to use
                 // "parallel" here with number of threads passed as parameter
-                const int oc_start = curr.g * jcp.oc + curr.oc;
+                const int oc_start = into<int>(curr.g * jcp.oc + curr.oc);
                 if (jcp.with_eltwise || jcp.with_binary) {
                     bool fast_relu_done = false;
                     if (jcp.with_eltwise && jcp.post_ops.len() == 1) {
@@ -325,7 +325,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                                                          : 0;
                                 data_t *d_ = _dst + oc * M;
                                 PRAGMA_OMP_SIMD()
-                                for (int oS = 0; oS < m; ++oS) {
+                                for (int oS = 0; oS < into<int>(m); ++oS) {
                                     d_[oS] += b;
                                     if (d_[oS] < 0) d_[oS] *= eltwise.alpha;
                                     d_[oS] *= eltwise.scale;
@@ -357,7 +357,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                         data_t b = bias[oc_start + oc];
                         data_t *d_ = _dst + oc * M;
                         PRAGMA_OMP_SIMD()
-                        for (int oS = 0; oS < m; ++oS) {
+                        for (int oS = 0; oS < into<int>(m); ++oS) {
                             d_[oS] += b;
                         }
                     });
@@ -389,7 +389,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
 
         if (jcp.loop_order == gemm_loop_rlb)
             for (curr.ic = 0; curr.ic < jcp.ic; curr.ic += step.ic)
-                for (int spatial = start.sp; spatial < end.sp;
+                for (int spatial = into<int>(start.sp); spatial < end.sp;
                         spatial += step.sp) {
                     nd_iterator_init(spatial, curr.n, jcp.mb, curr.g,
                             jcp.ngroups, curr.od, jcp.od, curr.sp, jcp.os);
@@ -404,7 +404,8 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                     }
                 }
         else if (jcp.loop_order == gemm_loop_lrb)
-            for (int spatial = start.sp; spatial < end.sp; spatial += step.sp) {
+            for (int spatial = into<int>(start.sp); spatial < end.sp;
+                    spatial += step.sp) {
                 nd_iterator_init(spatial, curr.n, jcp.mb, curr.g, jcp.ngroups,
                         curr.od, jcp.od, curr.sp, jcp.os);
                 for (curr.ic = 0; curr.ic < jcp.ic; curr.ic += step.ic)
@@ -512,7 +513,7 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_thr_nspc(
                         = diff_src + is * diff_src_os_stride;
                 const data_t *__restrict acc_arr = acc + is * jcp.ic;
                 PRAGMA_OMP_SIMD()
-                for (int ic = 0; ic < jcp.ic; ic++) {
+                for (int ic = 0; ic < into<int>(jcp.ic); ic++) {
                     diff_src_arr[ic] = acc_arr[ic];
                 }
             });
@@ -592,10 +593,12 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
                 if (jcp.im2col_sz) {
                     if (!is_problem_3d)
                         jit_gemm_convolution_utils::col2im(jcp, _col, _diff_src,
-                                os_nb * jcp.os_block, os_block);
+                                into<int>(os_nb * jcp.os_block),
+                                into<int>(os_block));
                     else {
                         jit_gemm_convolution_utils::col2im_3d(jcp, _col,
-                                _diff_src, od, os_nb * jcp.os_block, os_block);
+                                _diff_src, od, into<int>(os_nb * jcp.os_block),
+                                into<int>(os_block));
                     }
                 }
             }
@@ -637,9 +640,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -707,7 +712,7 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                             // Finish the loops early if failure occured.
                             g = g_end;
                             mb = mb_end;
-                            od = jcp.od;
+                            od = into<int>(jcp.od);
                         }
                     }
                 }
@@ -729,10 +734,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
             size_t mb_start {0}, mb_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
@@ -764,10 +770,10 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                         + ((static_cast<size_t>(mb) * jcp.od + od) * jcp.oh
                                   + oh)
                                 * jcp.ow * jcp.ngroups * jcp.oc;
-                const int width_stride = jcp.ngroups * jcp.oc;
+                const int width_stride = into<int>(jcp.ngroups * jcp.oc);
 
                 PRAGMA_OMP_SIMD(reduction(+ : db))
-                for (int ow = 0; ow < jcp.ow; ++ow) {
+                for (int ow = 0; ow < into<int>(jcp.ow); ++ow) {
                     db += diff_dst_arr[ow * width_stride];
                 }
             }
@@ -805,9 +811,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
@@ -855,7 +863,8 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
                             else
                                 jit_gemm_convolution_utils::im2col_3d<float>(
                                         jcp, _src, _col, od,
-                                        os_nb * jcp.os_block, os_block);
+                                        into<int>(os_nb * jcp.os_block),
+                                        into<int>(os_block));
                         }
                         const dim_t LDA = jcp.im2col_sz ? os_block : K;
                         const data_t zero = 0.0, one = 1.0;
@@ -871,8 +880,8 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
                             // Finish the loops early if failure occured.
                             g = g_end;
                             mb = mb_end;
-                            od = jcp.od;
-                            os_nb = jcp.os_nb_block;
+                            od = into<int>(jcp.od);
+                            os_nb = into<int>(jcp.os_nb_block);
                         }
                     }
                 }
@@ -896,10 +905,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -253,11 +253,12 @@ void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
                 T *__restrict imtr_icb = imtr_w + icb * ic_block * ic_stride;
                 PRAGMA_OMP_SIMD()
                 for (dim_t ic = 0; ic < ic_block; ic++) {
-                    imtr_icb[ic * ic_stride] = im_icb[ic] + shift;
+                    imtr_icb[ic * ic_stride]
+                            = relaxed_into<T>(im_icb[ic] + shift);
                 }
             }
             for (dim_t ic = ic_blocked; ic < jcp.ic; ic++) {
-                imtr_w[ic * ic_stride] = im_w[ic] + shift;
+                imtr_w[ic * ic_stride] = relaxed_into<T>(im_w[ic] + shift);
             }
         }
     });
@@ -647,8 +648,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                         for (dim_t ow = 0; ow < ow_start; ++ow)
                             col[col_idx_oh + ow] = shift;
                         for (dim_t ow = ow_start; ow < ow_end; ++ow)
-                            col[col_idx_oh + ow]
-                                    = imtr[imtr_idx_oh + ow] + shift;
+                            col[col_idx_oh + ow] = into<col_dt>(
+                                    imtr[imtr_idx_oh + ow] + shift);
                         for (dim_t ow = ow_end; ow < wb; ++ow)
                             col[col_idx_oh + ow] = shift;
                     }
@@ -683,7 +684,7 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                 for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const dim_t iw = iw_base + ow * sw;
                     const ptrdiff_t im_idx = im_idx_base + iw * im_iw_stride;
-                    col[col_idx_base + ow] = im[im_idx] + shift;
+                    col[col_idx_base + ow] = into<col_dt>(im[im_idx] + shift);
                 }
                 for (dim_t ow = ow_end; ow < wb; ow++)
                     col[col_idx_base + ow] = shift;
@@ -1308,7 +1309,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                         < thr_eff_treshold) // we didn't find suitable h_block
                 {
                     h_block = 1;
-                    int nb_h = oh;
+                    dim_t nb_h = oh;
                     do {
                         dim_t nb_w = div_up(ow, w_block);
                         dim_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
@@ -1717,8 +1718,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             nthr_oc, ocb, osb, oc_per_thr, os_per_thr);
                     // if we don't fit into cache then access to memory is
                     // expensive
-                    dim_t mem_access_cost
-                            = (max_ic_block < 1) ? non_cache_access : 1;
+                    dim_t mem_access_cost = into<dim_t>(
+                            (max_ic_block < 1) ? non_cache_access : 1);
                     max_ic_block = nstl::max(dim_t(1), max_ic_block);
                     // "jcp.ic == 0 ? dim_t(1) : " is to avoid msvc warning 'potential divide by zero'
                     dim_t icb = nstl::max(dim_t(1),
@@ -1743,11 +1744,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     if (jcp.im2col_sz) {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
                         const float col_tail_koeff = (float)osb_caligned / osb;
-                        col_ops = mem_access_cost
+                        col_ops = into<size_t>(mem_access_cost
                                 * (jcp.ks * inp_size * col_tail_koeff
-                                        + jcp.ks * inp_size * col_tail_koeff);
+                                        + jcp.ks * inp_size * col_tail_koeff));
                         if (sw != 1) // im2col with strides is much slower
-                            col_ops *= strided_im2col_k;
+                            col_ops = into<size_t>(col_ops * strided_im2col_k);
                     } else {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
                     }
@@ -1900,7 +1901,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     }
                 }
                 jcp.outer_threading = true;
-                jcp.nthr_oc = best_nthr_oc;
+                jcp.nthr_oc = into<int>(best_nthr_oc);
                 jcp.oc_block = best_ocb;
                 jcp.os_block = best_osb;
                 jcp.ic_block = best_icb;
@@ -2188,12 +2189,12 @@ void bwd_weights_reduction_par_nspc(int ithr, int nthr, size_t g_start,
             const float *__restrict ws_ptr = ws_base + w * jcp.oc;
             if (tidx == 0) {
                 PRAGMA_OMP_SIMD()
-                for (auto oc = 0; oc < jcp.oc; ++oc) {
+                for (auto oc = 0; oc < into<int>(jcp.oc); ++oc) {
                     dwei_ptr[oc] = ws_ptr[oc];
                 }
             } else {
                 PRAGMA_OMP_SIMD()
-                for (auto oc = 0; oc < jcp.oc; ++oc) {
+                for (auto oc = 0; oc < into<int>(jcp.oc); ++oc) {
                     dwei_ptr[oc] += ws_ptr[oc];
                 }
             }

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -92,9 +92,9 @@ static zero_point_call_params_t prepare_zp_params(const conv_gemm_conf_t &jcp,
         const auto zp_comp_size = jcp.oc * jcp.ngroups;
 
         if (jcp.zp.src_is_common) {
-            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(zp_comp_size,
-                    zp_src_comp_scratch, zp_src_comp_from_wei,
-                    *src_zero_points);
+            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(
+                    into<int>(zp_comp_size), zp_src_comp_scratch,
+                    zp_src_comp_from_wei, *src_zero_points);
         } else
             zp_src_comp = zp_src_comp_from_wei;
 
@@ -228,15 +228,15 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
     status_t st = status::success;
 
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        const int oh = ohb * jcp.oh_block;
-        const int ow = owb * jcp.ow_block;
+        const dim_t oh = ohb * jcp.oh_block;
+        const dim_t ow = owb * jcp.ow_block;
         const char *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const int8_t *__restrict wei = wei_base + g * wei_g_stride;
         const int32_t *__restrict wei_comp
                 = _wei_comp ? _wei_comp + g * jcp.oc : nullptr;
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const int h_step = into<int>(nstl::min(jcp.oh_block, jcp.oh - oh));
+        const int w_step = into<int>(nstl::min(jcp.ow_block, jcp.ow - ow));
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt<char>(jcp, src, imtr);
 
@@ -308,8 +308,8 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
                 balance211(N * jcp.oc, nthr, ithr, _start, _end);
 
                 (*pp_ker_)(dst, acc, bia_base, scales, dst_scales[0], sum_scale,
-                        1.f / wei_adj_scale, g, n, _start, _end, zp,
-                        post_ops_binary_rhs_arg_vec, dst_base, ctx,
+                        1.f / wei_adj_scale, into<int>(g), into<int>(n), _start,
+                        _end, zp, post_ops_binary_rhs_arg_vec, dst_base, ctx,
                         *pd()->dst_md(), chunk_desc);
             });
         }

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -404,8 +404,8 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                                     curr_src_ptr, src_strides[0],
                                     src_strides[1], curr_weights,
                                     weights_strides[0], weights_strides[1],
-                                    curr_acc, acc_ldc, src_zero_point,
-                                    wei_zero_point);
+                                    curr_acc, into<int>(acc_ldc),
+                                    src_zero_point, wei_zero_point);
                         }
 
                     } break;
@@ -430,8 +430,8 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                                     curr_src_ptr, src_strides[0],
                                     src_strides[1], curr_weights,
                                     weights_strides[0], weights_strides[1],
-                                    curr_acc, acc_ldc, src_zero_point,
-                                    wei_zero_point);
+                                    curr_acc, into<int>(acc_ldc),
+                                    src_zero_point, wei_zero_point);
                         }
 
                     } break;
@@ -494,8 +494,8 @@ status_t gemm_x8s8s32x_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                 pp_src_and_weights_zero_points(src_compensation,
                         weights_compensation, M, N, K, src, src_strides[0],
                         src_strides[1], weights, weights_strides[0],
-                        weights_strides[1], acc, acc_ldc, src_zero_point,
-                        wei_zero_point);
+                        weights_strides[1], acc, into<int>(acc_ldc),
+                        src_zero_point, wei_zero_point);
             }
 
             bool postops_in_matmul

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -46,7 +46,7 @@ void ref_matmul_t::pd_t::init_scratchpad() {
         const memory_desc_wrapper dst_d(dst_md());
         dim_t group_size = dst_scales.get_group_size();
         dim_t work_amount = dst_d.nelems() / group_size;
-        ntasks_ = std::min<dim_t>(nthr_, work_amount);
+        ntasks_ = into<int>(std::min<dim_t>(nthr_, work_amount));
         scratchpad.template book<float>(
                 key_matmul_dst_in_acc_dt, ntasks_ * group_size);
     }
@@ -320,8 +320,10 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                         d /= dst_scale;
                     }
                     if (dst_rnd_mode == rounding_mode::stochastic)
-                        d = math::stochastic_round_fwd(d, dst_off,
-                                dropout_seed_val, dst_d.data_type());
+                        d = math::stochastic_round_fwd(d,
+                                into<uint32_t>(dst_off),
+                                into<uint32_t>(dropout_seed_val),
+                                dst_d.data_type());
                     io::store_float_value(dst_d.data_type(), d, dst, dst_off);
                     utils::dim_iterator(
                             dst_d.dims(), dst_dims_idx, batch_ndims);
@@ -385,8 +387,10 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                     d *= dst_group_scale;
 
                     if (dst_rnd_mode == rounding_mode::stochastic)
-                        d = math::stochastic_round_fwd(d, dst_off,
-                                dropout_seed_val, dst_d.data_type());
+                        d = math::stochastic_round_fwd(d,
+                                into<uint32_t>(dst_off),
+                                into<uint32_t>(dropout_seed_val),
+                                dst_d.data_type());
                     io::store_float_value(dst_d.data_type(), d, dst, dst_off);
                     utils::dim_iterator(
                             dst_d.dims(), dst_dims_idx, batch_ndims);

--- a/src/cpu/matmul/ref_sparse_matmul.cpp
+++ b/src/cpu/matmul/ref_sparse_matmul.cpp
@@ -83,8 +83,8 @@ status_t ref_sparse_matmul_t::execute(const exec_ctx_t &ctx) const {
                         weights_d.metadata_type(0), 0, wei_row_pointers, k);
             });
 
-            cvt_coo_indices_to_csr_pointers(
-                    wei_buffer_1, wei_row_pointers, weights_d.nnz(), K);
+            cvt_coo_indices_to_csr_pointers(wei_buffer_1, wei_row_pointers,
+                    into<int>(weights_d.nnz()), into<int>(K));
 
             wei_pointers = wei_row_pointers;
         }
@@ -128,8 +128,8 @@ status_t ref_sparse_matmul_t::execute(const exec_ctx_t &ctx) const {
                         src_d.metadata_type(0), 0, src_row_pointers, m);
             });
 
-            cvt_coo_indices_to_csr_pointers(
-                    src_buffer_1, src_row_pointers, src_d.nnz(), M);
+            cvt_coo_indices_to_csr_pointers(src_buffer_1, src_row_pointers,
+                    into<int>(src_d.nnz()), into<int>(M));
             src_pointers = src_row_pointers;
         }
 

--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -82,9 +82,9 @@ status_t nchw_pooling_fwd_t<data_type::f32>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = into<uint8_t>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset] = into<int>(value);
         }
     };
 
@@ -284,9 +284,9 @@ status_t nchw_pooling_fwd_t<d_type>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = into<uint8_t>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset] = into<int>(value);
         }
     };
 

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -195,8 +195,8 @@ struct nchw_pooling_bwd_t : public primitive_t {
 
                 // The value of nbuf_ must be in compliance with arguments of
                 // parallel_nd_ext called from execute_backward for data_type!=f32
-                nbuf_ = nstl::min(static_cast<dim_t>(nthr_),
-                        MB() * utils::div_up(IC(), channel_block_size_));
+                nbuf_ = into<int>(nstl::min(into<dim_t>(nthr_),
+                        MB() * utils::div_up(IC(), channel_block_size_)));
 
                 scratchpad.template book<float>(key_pool_src_bf16cvt,
                         src_sz_ * nbuf_ * channel_block_size_);

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -252,7 +252,7 @@ status_t nhwc_pooling_fwd_t<data_type::f32>::execute_forward(
                 } else {
                     array_nhwc_max(OC, dst + dst_offset_init,
                             src + src_offset_init, ws, ws_offset_init, ws_dt,
-                            kd * KH * KW + kh * KW + kw);
+                            into<int>(kd * KH * KW + kh * KW + kw));
                 }
             }
         } else {
@@ -422,7 +422,7 @@ status_t nhwc_pooling_fwd_t<d_type>::execute_forward(
                     }
                 } else {
                     array_nhwc_max(OC, dst_f32, src_f32, ws, ws_offset_init,
-                            ws_dt, kd * KH * KW + kh * KW + kw);
+                            ws_dt, into<int>(kd * KH * KW + kh * KW + kw));
                 }
             }
         } else {

--- a/src/cpu/nspc_batch_normalization.cpp
+++ b/src/cpu/nspc_batch_normalization.cpp
@@ -110,7 +110,7 @@ status_t nspc_batch_normalization_fwd_t<d_type>::execute_forward(
                                 src + s_off);
                     }
                     PRAGMA_OMP_SIMD()
-                    for (int c = 0; c < C; c++) {
+                    for (dim_t c = 0; c < C; c++) {
                         ws_reduce[C * ithr + c] += _src[c];
                     }
                 }
@@ -150,7 +150,7 @@ status_t nspc_batch_normalization_fwd_t<d_type>::execute_forward(
                                 src + s_off);
                     }
                     PRAGMA_OMP_SIMD()
-                    for (int c = 0; c < C; c++) {
+                    for (dim_t c = 0; c < C; c++) {
                         acc_data_t m = _src[c] - mean_loc[c];
                         ws_reduce[C * ithr + c] += m * m;
                     }
@@ -204,7 +204,7 @@ status_t nspc_batch_normalization_fwd_t<d_type>::execute_forward(
 #if CLANG_WA_02_SAFE_TO_USE_OMP_SIMD
                 PRAGMA_OMP_SIMD()
 #endif
-                for (int c = 0; c < C; c++) {
+                for (dim_t c = 0; c < C; c++) {
                     const size_t c_off = s_off + c;
                     acc_data_t sqrt_variance = static_cast<acc_data_t>(
                             sqrtf(variance_loc[c] + eps));

--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -219,7 +219,7 @@ status_t ref_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         ref_post_ops->execute(d, args);
         if (dst_rnd_mode == rounding_mode::stochastic)
             d = math::stochastic_round_fwd(
-                    d, dst_off, rnd_seed[0], dst_d.data_type());
+                    d, into<uint32_t>(dst_off), rnd_seed[0], dst_d.data_type());
 
         io::store_float_value(dst_d.data_type(), d, dst, dst_off);
     });

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -366,7 +366,7 @@ prepare_zp_pad_comp_ker(const dim_t ndims, const int32_t *src_zero_points,
     const auto get_wei_off
             = [=](dim_t g, dim_t oc, dim_t ic, dim_t kd, dim_t kh, dim_t kw) {
         return get_weights_off(
-                wei_d, with_groups, ndims, g, oc, ic, kd, kh, kw);
+                wei_d, with_groups, into<int>(ndims), g, oc, ic, kd, kh, kw);
     };
 
     return [=](const dim_t g, const dim_t oc, const dim_t od, const dim_t oh,
@@ -452,8 +452,8 @@ static status_t apply_src_zero_point(const exec_ctx_t &ctx,
         const auto oc_off = g * OC + oc;
         const auto dst_off = ref_conv_utils::get_data_off(
                 dst_d, ndims, mb, oc_off, od, oh, ow);
-        int32_t conv_result
-                = conv_output[dst_off] - zp_src_compensation[oc_off];
+        int32_t conv_result = into<int32_t>(
+                conv_output[dst_off] - zp_src_compensation[oc_off]);
 
         if (const auto zp_pad_compensation
                 = zp_pad_comp_ker(g, oc, od, oh, ow)) {

--- a/src/cpu/ref_group_normalization.cpp
+++ b/src/cpu/ref_group_normalization.cpp
@@ -100,7 +100,7 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
         float v_variance = calculate_stats ? 0 : variance[stat_off];
 
         if (calculate_stats) {
-            for_(int c = get_c_start(g); c < get_c_start(g + 1); ++c)
+            for_(int c = into<int>(get_c_start(g)); c < get_c_start(g + 1); ++c)
             for_(int d = 0; d < D; ++d)
             for_(int h = 0; h < H; ++h)
             for (int w = 0; w < W; ++w) {
@@ -110,7 +110,7 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
             }
             v_mean /= C_PER_G * W * H * D;
 
-            for_(int c = get_c_start(g); c < get_c_start(g + 1); ++c)
+            for_(int c = into<int>(get_c_start(g)); c < get_c_start(g + 1); ++c)
             for_(int d = 0; d < D; ++d)
             for_(int h = 0; h < H; ++h)
             for (int w = 0; w < W; ++w) {
@@ -123,7 +123,7 @@ status_t ref_group_normalization_fwd_t::execute(const exec_ctx_t &ctx) const {
         }
         float sqrt_variance = sqrtf(v_variance + eps);
 
-        for (int c = get_c_start(g); c < get_c_start(g + 1); ++c) {
+        for (dim_t c = get_c_start(g); c < get_c_start(g + 1); ++c) {
             float sm = (scale ? scale[ss_d.off(c)] : 1.0f) / sqrt_variance;
             float sv = shift ? shift[ss_d.off(c)] : 0;
 
@@ -308,7 +308,7 @@ status_t ref_group_normalization_bwd_t::execute(const exec_ctx_t &ctx) const {
                 }
             }
         } else {
-            for (int c = get_c_start(g); c < get_c_start(g + 1); ++c) {
+            for (dim_t c = get_c_start(g); c < get_c_start(g + 1); ++c) {
                 float gamma = scale ? scale[ss_d.off(c)] : 1.0f;
                 for_(dim_t d = 0; d < D; ++d)
                 for_(dim_t h = 0; h < H; ++h)

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -90,9 +90,9 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[off] = value;
+                ws[off] = into<uint8_t>(value);
             } else
-                reinterpret_cast<int *>(ws)[off] = value;
+                reinterpret_cast<int *>(ws)[off] = into<int>(value);
         }
     };
 
@@ -139,7 +139,7 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         }
         int num_summands;
         if (alg == alg_kind::pooling_avg_include_padding)
-            num_summands = KW * KH * KD;
+            num_summands = into<int>(KW * KH * KD);
         else {
             auto id_start = od * SD - padF;
             auto ih_start = oh * SH - padT;
@@ -161,9 +161,9 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
             auto iw_end_excluded
                     = iw_end > IW ? (iw_end - IW - 1) / (DW + 1) + 1 : 0;
 
-            num_summands = (KD - id_start_excluded - id_end_excluded)
+            num_summands = into<int>((KD - id_start_excluded - id_end_excluded)
                     * (KH - ih_start_excluded - ih_end_excluded)
-                    * (KW - iw_start_excluded - iw_end_excluded);
+                    * (KW - iw_start_excluded - iw_end_excluded));
         }
         d /= num_summands;
     };
@@ -340,7 +340,7 @@ status_t ref_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
         balance211(diff_src_d.nelems(true), nthr, ithr, start, end);
         if (start == end) return;
 
-        for (int i = start; i < end; i++)
+        for (dim_t i = start; i < end; i++)
             io::store_float_value(data_type::f32, 0, diff_src, i);
     });
 

--- a/src/cpu/ref_reduction.cpp
+++ b/src/cpu/ref_reduction.cpp
@@ -63,7 +63,7 @@ void accumulate(T &acc, const T &src, alg_kind_t alg, float p) {
         case reduction_norm_lp_sum:
         case reduction_norm_lp_power_p_max:
         case reduction_norm_lp_power_p_sum:
-            acc += powf(nstl::abs(src), p);
+            acc += into<T>(powf(nstl::abs(src), p));
             break;
         default: assert(!"unknown alg");
     }

--- a/src/cpu/ref_shuffle.cpp
+++ b/src/cpu/ref_shuffle.cpp
@@ -54,14 +54,15 @@ status_t ref_shuffle_t::execute_(const exec_ctx_t &ctx) const {
     const auto axis_size = pd()->axis_size();
     const auto group_size = pd()->group_size();
 
-    const int transpose_row
-            = pd()->is_fwd() ? group_size : axis_size / group_size;
-    const int transpose_col
-            = pd()->is_fwd() ? axis_size / group_size : group_size;
+    const int transpose_row = into<int>(
+            into<int>(pd()->is_fwd() ? group_size : axis_size / group_size));
+    const int transpose_col = into<int>(
+            into<int>(pd()->is_fwd() ? axis_size / group_size : group_size));
 
     // Precompute transposed axis helper array
     parallel_nd(transpose_col, transpose_row, [=](dim_t i, dim_t j) {
-        scratchpad_ptr[j * transpose_col + i] = i * transpose_row + j;
+        scratchpad_ptr[j * transpose_col + i]
+                = into<int>(i * transpose_row + j);
     });
 
     const dim_t MB = pd()->MB();

--- a/src/cpu/ref_softmax.cpp
+++ b/src/cpu/ref_softmax.cpp
@@ -220,7 +220,7 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
         if (zero_padding) {
             const auto tail = src_d.padded_dims()[axis] - src_d.dims()[axis];
             PRAGMA_OMP_SIMD()
-            for (int i = 0; i < tail; i++)
+            for (dim_t i = 0; i < tail; i++)
                 io::store_float_value(
                         dst_d.data_type(), 0, dst_data, channels_ + i);
         }

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -142,9 +142,9 @@ struct ref_softmax_fwd_t : public primitive_t {
     ref_softmax_fwd_t(const pd_t *apd) : primitive_t(apd) {}
 
     status_t init(engine_t *engine) override {
-        outer_size_ = pd()->outer_size();
-        channels_ = pd()->axis_size();
-        inner_size_ = pd()->inner_size();
+        outer_size_ = into<int>(pd()->outer_size());
+        channels_ = into<int>(pd()->axis_size());
+        inner_size_ = into<int>(pd()->inner_size());
 
         const memory_desc_wrapper src_d(pd()->src_md());
         const memory_desc_wrapper dst_d(pd()->dst_md());
@@ -213,9 +213,9 @@ struct ref_softmax_bwd_t : public primitive_t {
     ref_softmax_bwd_t(const pd_t *apd) : primitive_t(apd) {}
 
     status_t init(engine_t *engine) override {
-        outer_size_ = pd()->outer_size();
-        channels_ = pd()->axis_size();
-        inner_size_ = pd()->inner_size();
+        outer_size_ = into<int>(pd()->outer_size());
+        channels_ = into<int>(pd()->axis_size());
+        inner_size_ = into<int>(pd()->inner_size());
 
         const memory_desc_wrapper data_d(pd()->dst_md());
         const memory_desc_wrapper diff_d(pd()->diff_dst_md());

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -1160,8 +1160,8 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         ? &dst_scales[dst_scales_mask == 0 ? 0 : _offset]
                         : nullptr;
                 ker(i, o, (order_keep && req_comp) ? &cp[_offset] : nullptr,
-                        zp_ptr, src_scales_ptr, dst_scales_ptr, d0_block,
-                        d1_block);
+                        zp_ptr, src_scales_ptr, dst_scales_ptr,
+                        into<int>(d0_block), into<int>(d1_block));
             }
         });
 
@@ -2416,8 +2416,8 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 const dim_t src_zps_off
                         = get_quant_off(input_idx, ndims, src_zps_mask,
                                 src_zps_group0, src_zps_group1, src_zps_md);
-                src_zp_val = io::load_float_value(
-                        src_zps_d.data_type(), src_zero_points, src_zps_off);
+                src_zp_val = into<int>(io::load_float_value(
+                        src_zps_d.data_type(), src_zero_points, src_zps_off));
             }
 
             const auto i_off = input_d.off_l(idx);
@@ -2654,8 +2654,8 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 const dim_t src_zps_off
                         = get_quant_off(input_idx, ndims, src_zps_mask,
                                 src_zps_group0, src_zps_group1, src_zps_md);
-                src_zp_val = io::load_float_value(
-                        src_zps_d.data_type(), src_zero_points, src_zps_off);
+                src_zp_val = into<int>(io::load_float_value(
+                        src_zps_d.data_type(), src_zero_points, src_zps_off));
             }
 
             const auto i_off = input_d.off_l(idx);

--- a/src/cpu/scale_utils.cpp
+++ b/src/cpu/scale_utils.cpp
@@ -115,8 +115,8 @@ const float *precompute_scales(const memory_tracking::grantor_t &scratchpad,
                 const auto wei_scale_stride_oc = wei_scale_per_oc ? 1 : 0;
                 assert(count == wei_scale_count);
                 PRAGMA_OMP_SIMD()
-                for_(int ic = 0; ic < IC; ic++)
-                for (int oc = 0; oc < wei_scale_stride_ic; oc++) {
+                for_(int ic = 0; ic < into<int>(IC); ic++)
+                for (dim_t oc = 0; oc < wei_scale_stride_ic; oc++) {
                     const auto wei_scale_idx = wei_scale_stride_oc * oc
                             + wei_scale_stride_ic * (ic / wei_scale_groups_ic);
                     const auto loc_scale_idx

--- a/src/cpu/simple_resampling.cpp
+++ b/src/cpu/simple_resampling.cpp
@@ -82,13 +82,13 @@ status_t simple_resampling_kernel_t::init() {
 }
 
 status_t simple_resampling_kernel_t::execute(const exec_ctx_t &ctx) const {
-    const int OD = pd_->OD();
-    const int OH = pd_->OH();
-    const int OW = pd_->OW();
-    const int ID = pd_->ID();
-    const int IH = pd_->IH();
-    const int IW = pd_->IW();
-    const int NB_CH = utils::div_up(pd_->C(), inner_stride_);
+    const int OD = into<int>(pd_->OD());
+    const int OH = into<int>(pd_->OH());
+    const int OW = into<int>(pd_->OW());
+    const int ID = into<int>(pd_->ID());
+    const int IH = into<int>(pd_->IH());
+    const int IW = into<int>(pd_->IW());
+    const int NB_CH = into<int>(utils::div_up(pd_->C(), inner_stride_));
 
     if (pd_->is_fwd()) {
         const auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -346,11 +346,11 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
 
     brg->with_bias = (dt_bias == data_type::undef) ? false : true;
     brg->dt_bias = dt_bias;
-    brg->typesize_bias = (dt_bias == data_type::undef)
-            ? 0
-            : types::data_type_size(brg->dt_bias);
+    brg->typesize_bias = into<int>((dt_bias == data_type::undef)
+                    ? 0
+                    : types::data_type_size(brg->dt_bias));
 
-    brg->LDD = LDD;
+    brg->LDD = into<int>(LDD);
     brg->is_runtime_ldd = is_runtime_value(LDD);
     const auto dt_d = dst_md->data_type;
 
@@ -424,7 +424,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         return status::unimplemented;
 
     brg->dt_d = dt_d;
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    brg->typesize_D = into<int>(types::data_type_size(brg->dt_d));
 
     if (!IMPLICATION(brg->is_int8 && brg->dt_d == bf16,
                 is_superset(brg->isa_impl, avx512_core)
@@ -782,7 +782,7 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
         }
     }
 
-    buff->palette_id = amx::get_target_palette();
+    buff->palette_id = into<uint8_t>(amx::get_target_palette());
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -49,7 +49,7 @@ bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
-    const int ref_size = refs_.size();
+    const int ref_size = into<int>(refs_.size());
     if (idx > ref_size - 1) { refs_.resize(idx + 1); }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
@@ -68,7 +68,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
 
     static_offsets_list_.push_back(static_offsets);
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
-    const int ref_size = refs_.size();
+    const int ref_size = into<int>(refs_.size());
     const auto ret = map_.insert({brg, -1});
     if (!ret.second) {
         // if there was no insertion then clean bd_mask and static_offsets
@@ -77,7 +77,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         return ret.first->second;
     }
 
-    int idx = map_.size() - 1;
+    int idx = into<int>(map_.size() - 1);
     if (idx > ref_size - 1) {
         if (ref_size == 0)
             refs_.resize(1);

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -277,10 +277,10 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     // ----- post-ops and store accumulators -----
     const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
 
-    const int postops_regs = brg->attr()
-            ? injector::aux_vec_count(
-                      brg->attr()->post_ops_, brg->isa_impl, true)
-            : 0;
+    const int postops_regs = into<int>(brg->attr()
+                    ? injector::aux_vec_count(
+                              brg->attr()->post_ops_, brg->isa_impl, true)
+                    : 0);
 
     // Emulators: fp8 emulation are supported for amx only
     // In theory, vmm bf16_emu register indices overlap with other vmm
@@ -538,8 +538,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     if (brg->can_dispatch_uker()) {
         // Blocking heuristics for some shapes
         // TODO: Review these criteria
-        const size_t eff_K
-                = brg->reduce_dim * brg->typesize_A * brg->brgattr.K_koef;
+        const size_t eff_K = into<size_t>(
+                brg->reduce_dim * brg->typesize_A * brg->brgattr.K_koef);
         const auto low_K = (L1 - 4 * 1024) / (6 * 16);
 
         // TODO: if rdb_tail != 0 then we should limit
@@ -905,7 +905,8 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     const data_type_t rd_block_dt = get_mac_emu_data_type(
             brg->dt_a, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
     if (rd_block_dt == dnnl_data_type_undef) return status::unimplemented;
-    const int vnni_granularity = data_type_vnni_granularity(rd_block_dt);
+    const int vnni_granularity
+            = into<int>(data_type_vnni_granularity(rd_block_dt));
     brg->rd_block = rd_unroll * vnni_granularity;
     brg->rdb = brg->reduce_dim / brg->rd_block;
     brg->rdb_tail = brg->reduce_dim % brg->rd_block;
@@ -922,12 +923,12 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
 status_t brgemm_blocking(brgemm_desc_t *brg) {
     const data_type_t ld_step_compute_dt = get_mac_emu_data_type(
             brg->dt_b, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
-    brg->ld_step = brg->is_f16_b_non_amx_vnni()
-            ? 2
-            : data_type_vnni_granularity(ld_step_compute_dt);
+    brg->ld_step = into<int>(brg->is_f16_b_non_amx_vnni()
+                    ? 2
+                    : data_type_vnni_granularity(ld_step_compute_dt));
     const data_type_t rd_step_compute_dt
             = get_mac_emu_data_type(brg->dt_b, brg->isa_impl);
-    brg->rd_step = data_type_vnni_granularity(rd_step_compute_dt);
+    brg->rd_step = into<int>(data_type_vnni_granularity(rd_step_compute_dt));
 
     set_isa_impl(brg);
     if (brg->isa_impl == isa_undef) return status::unimplemented;
@@ -1006,10 +1007,10 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     const int compute_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_compute_vmm_count(*brg);
     const int bf16_emu_vregs = brg->is_bf16_emu * 4;
-    const int postops_regs = brg->attr()
-            ? injector::aux_vec_count(
-                      brg->attr()->post_ops_, brg->isa_impl, true)
-            : 0;
+    const int postops_regs = into<int>(brg->attr()
+                    ? injector::aux_vec_count(
+                              brg->attr()->post_ops_, brg->isa_impl, true)
+                    : 0);
 
     const int max_acc_vmms = max_vregs
             - nstl::max(postops_regs,
@@ -1074,10 +1075,10 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->dt_d = brg->dt_c;
     brg->dt_bias = brg->dt_c;
 
-    brg->typesize_A = types::data_type_size(brg->dt_a);
-    brg->typesize_B = types::data_type_size(brg->dt_b);
-    brg->typesize_C = types::data_type_size(brg->dt_c);
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    brg->typesize_A = into<int>(types::data_type_size(brg->dt_a));
+    brg->typesize_B = into<int>(types::data_type_size(brg->dt_b));
+    brg->typesize_C = into<int>(types::data_type_size(brg->dt_c));
+    brg->typesize_D = into<int>(types::data_type_size(brg->dt_d));
 
     brg->isa_user = isa;
 
@@ -1146,10 +1147,10 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->dt_d = brg->dt_c;
     brg->dt_bias = brg->dt_c;
 
-    brg->typesize_A = types::data_type_size(brg->dt_a);
-    brg->typesize_B = types::data_type_size(brg->dt_b);
-    brg->typesize_C = types::data_type_size(brg->dt_c);
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    brg->typesize_A = into<int>(types::data_type_size(brg->dt_a));
+    brg->typesize_B = into<int>(types::data_type_size(brg->dt_b));
+    brg->typesize_C = into<int>(types::data_type_size(brg->dt_c));
+    brg->typesize_D = into<int>(types::data_type_size(brg->dt_d));
 
     brg->isa_user = isa;
     auto is_isa_ok = [&](cpu_isa_t isa) {

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -299,7 +299,7 @@ private:
             if (blocks.empty()) return 0;
             auto n = blocks.size();
             // only last block may be different
-            return ((n - 1) * blocks[0].block + blocks[n - 1].block);
+            return into<int>(((n - 1) * blocks[0].block + blocks[n - 1].block));
         }
     };
 
@@ -740,7 +740,7 @@ int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
     if (brg.brgattr.bd_mask_level != 2)
         return inp_bd;
     else
-        return skipped_bd_mask_buffer_[inp_bd];
+        return into<int>(skipped_bd_mask_buffer_[inp_bd]);
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
@@ -893,9 +893,9 @@ int jit_brgemm_amx_uker_base_t::get_out_bd(
     const auto bd = bdi->pos(bdb) + inp_bd;
     if (brg.brgattr.bd_mask_level) {
         assert(bdi->adj_bd_mask[bd - bdi->pos(0)] == adj_bd_mask_buffer_[bd]);
-        return bdi->adj_bd_mask[bd - bdi->pos(0)];
+        return into<int>(bdi->adj_bd_mask[bd - bdi->pos(0)]);
     } else
-        return bd;
+        return into<int>(bd);
 }
 
 template <typename U>
@@ -981,7 +981,8 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
     for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
     for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
-            auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
+            auto c_offset = C_offset(bi, bdb, 0, into<int>(bi.ldi->pos(ldb)))
+                    + ils_shift;
             tileloadd(Tmm(get_C_tensor(bi, bdb, ldb)),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
         } else {
@@ -1053,7 +1054,7 @@ void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
 
                 if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
-                const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
+                const auto d_offset = D_offset(bi, bdb, bd, into<int>(ldb_pos));
                 rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
                         idx, d_offset);
             }
@@ -1082,7 +1083,8 @@ void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
                 dim_t result = 0;
                 for (auto bd = bd_start; bd < bd_finish; bd++) {
                     if (!is_out_bd(bi.bdi, bdb, bd)) continue;
-                    result = nstl::max(result, D_offset(bi, bdb, bd, ldb_pos));
+                    result = nstl::max(
+                            result, D_offset(bi, bdb, bd, into<int>(ldb_pos)));
                 }
                 return result;
             }();
@@ -1093,7 +1095,7 @@ void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
                 if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
                 auto zmm = accm(bd);
-                const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
+                const auto d_offset = D_offset(bi, bdb, bd, into<int>(ldb_pos));
                 auto addr = EVEX_compress_addr_safe(
                         reg_D, d_offset, reg_long_offt);
 
@@ -1138,7 +1140,8 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
         vcvtdq2ps(zmm_zp_a_val, zmm_zp_a_val);
         reg_zp_comp_a.restore();
 
-        const auto zp_comp_a_off = zp_comp_a_offset(bi.ldi->pos(ldb));
+        const auto zp_comp_a_off
+                = zp_comp_a_offset(into<int>(bi.ldi->pos(ldb)));
         const auto zp_comp_a_addr
                 = EVEX_compress_addr(reg_zp_comp_a, zp_comp_a_off);
         cvt2ps(data_type::s32, zmm_zp_comp_a, zp_comp_a_addr, true, false,
@@ -1170,7 +1173,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
-                    reg_scales, scales_offset(ldi->pos(ldb)));
+                    reg_scales, scales_offset(into<int>(ldi->pos(ldb))));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
             if (brg.is_single_wei_scale) {
                 // Broadcast a single scale value — handle non-f32 types.
@@ -1223,8 +1226,8 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
-            auto ptr_bias
-                    = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
+            auto ptr_bias = EVEX_compress_addr(
+                    reg_bias, bias_offset(into<int>(ldi->pos(ldb))));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
             cvt2ps(brg.dt_bias, zmm_bias(ldb), ptr_bias, true, false, k_mask);
         }
@@ -1263,7 +1266,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
-                    reg_scales, scales_offset(ldi->pos(ldb)));
+                    reg_scales, scales_offset(into<int>(ldi->pos(ldb))));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
             const auto zmm_scale = zmm_scales(ldb);
@@ -1276,7 +1279,8 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                     assert(brg.dt_wei_scales == data_type::f32);
                     // Src scales are set, need to multiply by their value.
                     auto scales_bcast_ptr = EVEX_compress_addr(reg_scales,
-                            scales_offset(ldi->pos(ldb)), /* bcast = */ true);
+                            scales_offset(into<int>(ldi->pos(ldb))),
+                            /* bcast = */ true);
                     vmulps(zmm_scale_masked, zmm_scale, scales_bcast_ptr);
                 } else {
                     switch (brg.dt_wei_scales) {
@@ -1351,7 +1355,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
     for (int bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
-            const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
+            const auto d_offset = D_offset(bi, bdb, bd, into<int>(ldb_pos));
             auto ptr_D = EVEX_compress_addr_safe(reg_D, d_offset, reg_tmp_gpr);
             uni_prefetch(ptr_D, pft, true);
         } else if (are_post_ops_applicable_) {
@@ -1364,7 +1368,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
             //            auto ptr_C = EVEX_compress_addr(reg_C, c_offset);
             //            uni_prefetch(ptr_C, pft, true);
         } else {
-            const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
+            const auto d_offset = D_offset(bi, bdb, bd, into<int>(ldb_pos));
             auto ptr_D = EVEX_compress_addr(reg_D, d_offset);
             uni_prefetch(ptr_D, pft, true);
         }
@@ -1374,8 +1378,8 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
 int jit_brgemm_amx_uker_base_t::calc_ops_CD(
         brgemm_iteration_t &bi) const noexcept {
     const auto &tloop = imap_[bi.apply_postops];
-    return tloop.rdis.size() * bi.ldi->block2() * bi.bdi->block2()
-            * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
+    return into<int>(tloop.rdis.size() * bi.ldi->block2() * bi.bdi->block2()
+            * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs));
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
@@ -1516,8 +1520,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vpbroadcastd(zmm_zp_a_val, reg_zp_a_values.cvt32());
     vcvtdq2ps(zmm_zp_a_val, zmm_zp_a_val);
     reg_zp_comp_a.restore();
-    const auto comp_pad_offset
-            = zp_comp_pad_a_offset(bi, bdb, inp_bd, bi.ldi->pos(ldb));
+    const auto comp_pad_offset = zp_comp_pad_a_offset(
+            bi, bdb, inp_bd, into<int>(bi.ldi->pos(ldb)));
     const auto zp_comp_pad_a_addr
             = EVEX_compress_addr(reg_zp_comp_pad_a, comp_pad_offset);
     cvt2ps(data_type::s32, zmm_zp_comp_a, zp_comp_pad_a_addr, true, false,
@@ -1566,7 +1570,8 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
             reg_per_mn_comp.restore();
             const auto global_ldb = bi.ldi->pos(ldb);
-            const auto delta_off = per_mn_comp_offset(bi, bdb, bd, global_ldb);
+            const auto delta_off
+                    = per_mn_comp_offset(bi, bdb, bd, into<int>(global_ldb));
             const auto delta_ptr = EVEX_compress_addr_safe(
                     reg_per_mn_comp, delta_off, reg_long_offt);
             const auto zmm_delta = zmm_tmp_1();
@@ -1614,7 +1619,8 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         }
 
         if (need_to_apply_alpha_beta_ || bi.skip_accumulation) {
-            const auto c_offset = C_offset(bi, bdb, bd, bi.ldi->pos(ldb));
+            const auto c_offset
+                    = C_offset(bi, bdb, bd, into<int>(bi.ldi->pos(ldb)));
             const auto ptr_C
                     = EVEX_compress_addr_safe(reg_C, c_offset, reg_long_offt);
             apply_alpha_beta_to_vector(
@@ -1787,8 +1793,8 @@ void jit_brgemm_amx_uker_base_t::store_vector(
 
     auto ldb_pos = bi.ldi->pos(ldb);
     auto is_ld_tail = bi.ldi->is_tail(ldb);
-    const auto c_offset = C_offset(bi, bdb, inp_bd, ldb_pos);
-    const auto d_offset = D_offset(bi, bdb, inp_bd, ldb_pos);
+    const auto c_offset = C_offset(bi, bdb, inp_bd, into<int>(ldb_pos));
+    const auto d_offset = D_offset(bi, bdb, inp_bd, into<int>(ldb_pos));
 
     if (bi.apply_postops) {
         auto ptr_D = EVEX_compress_addr_safe(reg_D, d_offset, reg_tmp_gpr);
@@ -1912,7 +1918,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
                     store_vector(bi, bdb, bd, ldb);
             }
         } else if (!brg.interleave_tilestores_) {
-            const auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb));
+            const auto c_offset
+                    = C_offset(bi, bdb, 0, into<int>(bi.ldi->pos(ldb)));
             tilestored(ptr[reg_C + reg_stride_ld_block + c_offset],
                     Tmm(get_C_tensor(bi, bdb, ldb)));
         }
@@ -2120,8 +2127,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     const auto store_tensor_number = current_tensor_number + store_tensor_shift;
 
     const auto &store_bi = do_pre_tilestore ? prev_bi_ : bi;
-    const int max_store_tensor_number
-            = store_bi.bdi->blocks.size() * store_bi.ldi->blocks.size();
+    const int max_store_tensor_number = into<int>(
+            store_bi.bdi->blocks.size() * store_bi.ldi->blocks.size());
     bool perform_store
             = (do_pre_tilestore
                       && (store_tensor_number >= 2
@@ -2144,8 +2151,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     } else {
         const auto store_ldb_ind
                 = do_pre_tilestore ? prev_bi_.ldi->pos(0) : bi.ldi->pos(0);
-        const auto c_offset
-                = C_offset(store_bi, bdb_idx, 0, store_ldb_ind + ldb_idx);
+        const auto c_offset = C_offset(
+                store_bi, bdb_idx, 0, into<int>(store_ldb_ind + ldb_idx));
         tilestored(ptr[reg_C + reg_stride_ld_block + c_offset], acc);
     }
     tilezero(acc);
@@ -2343,7 +2350,7 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
 
     const auto rd_block = bi.rdi->block(0);
     const int vnni_granularity
-            = data_type_vnni_granularity(data_type_t::dnnl_bf16);
+            = into<int>(data_type_vnni_granularity(data_type_t::dnnl_bf16));
     const auto r_end
             = nstl::min(utils::div_up(rd_block, vnni_granularity), num_rows);
 
@@ -2397,13 +2404,13 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     const auto transform_offset
             = use_ils_ ? brg.get_num_C_tiles() * brgemm_desc_t::tilesize : 0;
     const auto max_bdb2 = tloop.bdis[0].block2();
-    const auto max_rdb = tloop.rdis.size();
+    const auto max_rdb = into<int>(tloop.rdis.size());
     const auto matrix_a_offset = transform_offset;
-    const auto matrix_b_offset = transform_offset
+    const auto matrix_b_offset = into<int>(transform_offset
             + brgemm_desc_t::tilesize
                     * (nstl::max<int>(should_save_transform(mk),
                             should_save_transform(matrix_A) * brg.brgattr.max_bs
-                                    * max_bdb2 * max_rdb));
+                                    * max_bdb2 * max_rdb)));
     const auto matrix_offset = is_A ? matrix_a_offset : matrix_b_offset;
     const std::string key
             = std::to_string(bi.bsi->pos) + "_" + std::to_string(offset);
@@ -2419,7 +2426,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     // save offset of the transformation if required.
     if (should_save_transform(mk)) {
         auto buf_idx = transform_buf.size();
-        buf_offt = matrix_offset + buf_idx * brgemm_desc_t::tilesize;
+        buf_offt = into<int>(matrix_offset + buf_idx * brgemm_desc_t::tilesize);
         transform_buf[key] = buf_idx;
     }
 
@@ -2432,18 +2439,18 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     const auto num_col_bytes = palette_.cols[t1.getIdx()];
     if (is_A) {
         if (brg.is_bf32)
-            bf32_downconvert(bi, num_rows, num_col_bytes, reg_base, offset,
-                    reg_stride, reg_buf);
+            bf32_downconvert(bi, num_rows, num_col_bytes, reg_base,
+                    into<int>(offset), reg_stride, reg_buf);
         else
-            fp8_to_f16_upconvert(bi, num_rows, num_col_bytes, reg_base, offset,
-                    reg_stride, reg_buf, dt);
+            fp8_to_f16_upconvert(bi, num_rows, num_col_bytes, reg_base,
+                    into<int>(offset), reg_stride, reg_buf, dt);
     } else {
         if (brg.is_bf32)
             bf32_downconvert_to_vnni(bi, num_rows, num_col_bytes, reg_base,
-                    offset, reg_stride, reg_buf);
+                    into<int>(offset), reg_stride, reg_buf);
         else
             fp8_to_f16_upconvert_to_vnni(bi, num_rows, num_col_bytes, reg_base,
-                    offset, reg_stride, reg_buf, dt);
+                    into<int>(offset), reg_stride, reg_buf, dt);
     }
 
     // load into tmm from the transformed data.
@@ -2456,9 +2463,9 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
         brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
-    if (offset_dst) add(reg_buf, offset_dst);
+    if (offset_dst) add(reg_buf, into<uint32_t>(offset_dst));
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
-    if (offset_dst) sub(reg_buf, offset_dst);
+    if (offset_dst) sub(reg_buf, into<uint32_t>(offset_dst));
 }
 
 bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
@@ -2618,7 +2625,7 @@ void jit_brgemm_amx_uker_base_t::bs_loop_body(brgemm_iteration_t &bi) {
         prefetcht0(ptr[reg_aux1_batch]);
         reg_aux1_batch.save();
     } else {
-        set_A_B_matrices(bi.bsi->pos);
+        set_A_B_matrices(into<int>(bi.bsi->pos));
     }
 
     rdb_loop(bi);
@@ -2635,7 +2642,8 @@ void jit_brgemm_amx_uker_base_t::bs_loop(brgemm_iteration_t &bi) {
 
     const auto &tloop = imap_[bi.apply_postops];
     if (ununroll_bd_loop && was_prev_bi_) {
-        if (bi.bdi->idx != prev_bi_.bdi->idx) add(reg_A, bi.bdi->A_shift);
+        if (bi.bdi->idx != prev_bi_.bdi->idx)
+            add(reg_A, into<uint32_t>(bi.bdi->A_shift));
 
         const auto real_ils
                 = actual_ils(bi.apply_postops, bi.skip_accumulation);
@@ -2646,10 +2654,11 @@ void jit_brgemm_amx_uker_base_t::bs_loop(brgemm_iteration_t &bi) {
         else if (real_ils && prev_bi_.bdi->idx > 0 && prev_bi_.ldi->idx == 0)
             bi_shift = &prev_bi_;
         if (bi_shift != nullptr) {
-            add(reg_C, bi_shift->bdi->C_shift);
-            add(reg_D, bi_shift->bdi->D_shift);
+            add(reg_C, into<uint32_t>(bi_shift->bdi->C_shift));
+            add(reg_D, into<uint32_t>(bi_shift->bdi->D_shift));
             if (brg.req_comp_pads_with_bcast)
-                add(reg_zp_comp_pad_a, bi_shift->bdi->zp_comp_pad_a_shift);
+                add(reg_zp_comp_pad_a,
+                        into<uint32_t>(bi_shift->bdi->zp_comp_pad_a_shift));
         }
     }
 
@@ -2842,10 +2851,10 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (actual_ils(bi.apply_postops, bi.skip_accumulation) && ununroll_bd_loop
             && tloop.ldis.size() == 1) {
         // update reg_C and reg_D if they they were not updated yet
-        add(reg_C, bi.bdi->C_shift);
-        add(reg_D, bi.bdi->D_shift);
+        add(reg_C, into<uint32_t>(bi.bdi->C_shift));
+        add(reg_D, into<uint32_t>(bi.bdi->D_shift));
         if (brg.req_comp_pads_with_bcast)
-            add(reg_zp_comp_pad_a, bi.bdi->zp_comp_pad_a_shift);
+            add(reg_zp_comp_pad_a, into<uint32_t>(bi.bdi->zp_comp_pad_a_shift));
     }
     interleave_store(bi, true);
 }
@@ -3007,7 +3016,8 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                     int bd_block_size = bdi_prefetch.blocks[bdb].block;
                     for (int bd = 0; bd < bd_block_size; bd++) {
                         prf_sprinkled_a.prefetch_offsets.push_back(
-                                A_offset_line(bi_prefetch, bdb, rdb, bd));
+                                A_offset_line(bi_prefetch, into<int>(bdb),
+                                        into<int>(rdb), bd));
                     }
                 }
             }
@@ -3023,7 +3033,8 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                     int rd_block_size = rdi_prefetch.blocks[rdb].block;
                     for (int rd = 0; rd < rd_block_size; rd += brg.rd_step) {
                         prf_sprinkled_b.prefetch_offsets.push_back(
-                                B_offset_line(bi_prefetch, ldb, rdb, rd));
+                                B_offset_line(bi_prefetch, into<int>(ldb),
+                                        into<int>(rdb), rd));
                     }
                 }
             }

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -305,7 +305,7 @@ private:
     }
 
     Vmm accm(dim_t ld_block, dim_t bd, dim_t ld) const noexcept {
-        return Vmm(max_effective_vregs - 1 - (bd * ld_block + ld));
+        return Vmm(into<int>(max_effective_vregs - 1 - (bd * ld_block + ld)));
     }
 
     Vmm bcst(dim_t bd = 0) const noexcept {
@@ -313,7 +313,7 @@ private:
             dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(into<int>(idx));
         } else
             return Vmm(0);
     }
@@ -325,20 +325,20 @@ private:
             dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - ld;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(into<int>(idx));
         }
     }
 
     Vmm gemv_load_a() const noexcept {
         assert(brg.is_gemv);
         const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
-        return Vmm(idx);
+        return Vmm(into<int>(idx));
     }
 
     Vmm gemv_load_b() const noexcept {
         assert(brg.is_gemv);
         const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
-        return Vmm(idx);
+        return Vmm(into<int>(idx));
     }
 
     Vmm vmm_tmp(dim_t i) const noexcept {
@@ -346,7 +346,7 @@ private:
         MAYBE_UNUSED(bd_block);
         assert(IMPLICATION(!brg.is_tmm,
                 i >= 0 && i < max_effective_vregs - bd_block * brg.ld_block2));
-        return Vmm(i);
+        return Vmm(into<int>(i));
     }
 
     Vmm vmm_tail_mask() const noexcept { return vmm_tmp(1); }
@@ -828,7 +828,7 @@ void jit_brgemm_kernel_t<Wmm>::cvt2ps(data_type_t type_in, const Vmm vmm_in,
     if (IMPLICATION(has_tail, is_superset(brg.isa_impl, avx512_core))) {
         vmm = vmm_mask(vmm_in, mask_flag, store, ktail_mask);
     } else {
-        load_data(type_in, vmm_in, op.getAddress(), tail_size);
+        load_data(type_in, vmm_in, op.getAddress(), into<int>(tail_size));
         if (types::is_integral_dt(type_in)) uni_vcvtdq2ps(vmm_in, vmm_in);
         return;
     }
@@ -854,27 +854,27 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::advance_ldb_post_op_regs() {
     if (brg.with_bias) {
         reg_aux_bias.restore();
-        add(reg_aux_bias, bias_offset(1));
+        add(reg_aux_bias, into<uint32_t>(bias_offset(1)));
         reg_aux_bias.save();
     }
     if (brg.with_wei_scales) {
         reg_aux_wei_scales.restore();
-        add(reg_aux_wei_scales, wei_scales_offset(1));
+        add(reg_aux_wei_scales, into<uint32_t>(wei_scales_offset(1)));
         reg_aux_wei_scales.save();
     }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
-        add(reg_aux_zp_comp_a, zp_comp_a_offset(1));
+        add(reg_aux_zp_comp_a, into<uint32_t>(zp_comp_a_offset(1)));
         reg_aux_zp_comp_a.save();
     }
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         reg_aux_zp_c_values.restore();
-        add(reg_aux_zp_c_values, zp_c_values_offset(1));
+        add(reg_aux_zp_c_values, into<uint32_t>(zp_c_values_offset(1)));
         reg_aux_zp_c_values.save();
     }
     if (brg.with_per_mn_compensation) {
         reg_aux_per_mn_comp.restore();
-        add(reg_aux_per_mn_comp, ldb_per_mn_comp_offset(1));
+        add(reg_aux_per_mn_comp, into<uint32_t>(ldb_per_mn_comp_offset(1)));
         reg_aux_per_mn_comp.save();
     }
 }
@@ -883,27 +883,30 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(dim_t ld_block2) {
     if (brg.with_bias) {
         reg_aux_bias.restore();
-        sub(reg_aux_bias, bias_offset(ld_block2 - 1));
+        sub(reg_aux_bias, into<uint32_t>(bias_offset(ld_block2 - 1)));
         reg_aux_bias.save();
     }
     if (brg.with_wei_scales) {
         reg_aux_wei_scales.restore();
-        sub(reg_aux_wei_scales, wei_scales_offset(ld_block2 - 1));
+        sub(reg_aux_wei_scales,
+                into<uint32_t>(wei_scales_offset(ld_block2 - 1)));
         reg_aux_wei_scales.save();
     }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
-        sub(reg_aux_zp_comp_a, zp_comp_a_offset(ld_block2 - 1));
+        sub(reg_aux_zp_comp_a, into<uint32_t>(zp_comp_a_offset(ld_block2 - 1)));
         reg_aux_zp_comp_a.save();
     }
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         reg_aux_zp_c_values.restore();
-        sub(reg_aux_zp_c_values, zp_c_values_offset(ld_block2 - 1));
+        sub(reg_aux_zp_c_values,
+                into<uint32_t>(zp_c_values_offset(ld_block2 - 1)));
         reg_aux_zp_c_values.save();
     }
     if (brg.with_per_mn_compensation) {
         reg_aux_per_mn_comp.restore();
-        sub(reg_aux_per_mn_comp, ldb_per_mn_comp_offset(ld_block2 - 1));
+        sub(reg_aux_per_mn_comp,
+                into<uint32_t>(ldb_per_mn_comp_offset(ld_block2 - 1)));
         reg_aux_per_mn_comp.save();
     }
 }
@@ -912,13 +915,13 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(dim_t adj_bd_block) {
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_b.restore();
-        add(reg_aux_zp_comp_b, bdb_zp_comp_b_offset(1));
+        add(reg_aux_zp_comp_b, into<uint32_t>(bdb_zp_comp_b_offset(1)));
         reg_aux_zp_comp_b.save();
     }
     if (brg.req_comp_pads_with_bcast
             && brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
-        add(reg_aux_zp_comp_a, bdb_compensation_offset(1));
+        add(reg_aux_zp_comp_a, into<uint32_t>(bdb_compensation_offset(1)));
         reg_aux_zp_comp_a.save();
     }
 }
@@ -930,13 +933,15 @@ void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(dim_t bd_block2) {
         if (brg.zp_type_b != brgemm_broadcast_t::none) {
             post_processed = true;
             reg_aux_zp_comp_b.restore();
-            sub(reg_aux_zp_comp_b, bdb_zp_comp_b_offset(bd_block2 - 1));
+            sub(reg_aux_zp_comp_b,
+                    into<uint32_t>(bdb_zp_comp_b_offset(bd_block2 - 1)));
             reg_aux_zp_comp_b.save();
         }
         if (brg.req_comp_pads_with_bcast
                 && brg.zp_type_a != brgemm_broadcast_t::none) {
             reg_aux_zp_comp_a.restore();
-            sub(reg_aux_zp_comp_a, bdb_compensation_offset(bd_block2 - 1));
+            sub(reg_aux_zp_comp_a,
+                    into<uint32_t>(bdb_compensation_offset(bd_block2 - 1)));
             reg_aux_zp_comp_a.save();
         }
     }
@@ -949,51 +954,53 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(dim_t ld_block2, bool is_tail) {
             = (is_tail) ? ldb_C_offset(1, true) : ldb_C_offset(ld_block2);
     dim_t D_offset
             = (is_tail) ? ldb_D_offset(1, true) : ldb_D_offset(ld_block2);
-    add(reg_aux_C, C_offset);
-    add(reg_aux_D, D_offset);
+    add(reg_aux_C, into<uint32_t>(C_offset));
+    add(reg_aux_D, into<uint32_t>(D_offset));
 
     add(reg_b_offset,
-            (is_tail) ? ldb_B_offset(0, true) : ldb_B_offset(ld_block2));
+            into<uint32_t>((is_tail) ? ldb_B_offset(0, true)
+                                     : ldb_B_offset(ld_block2)));
 
     if (brg.with_bias) {
         reg_aux_bias.restore();
         add(reg_aux_bias,
-                (is_tail) ? bias_offset(1, true) : bias_offset(ld_block2));
+                into<uint32_t>((is_tail) ? bias_offset(1, true)
+                                         : bias_offset(ld_block2)));
         reg_aux_bias.save();
     }
     if (brg.req_s8s8_compensation) {
         reg_aux_compensation.restore();
         add(reg_aux_compensation,
-                (is_tail) ? compensations_offset(1, true)
-                          : compensations_offset(ld_block2));
+                into<uint32_t>((is_tail) ? compensations_offset(1, true)
+                                         : compensations_offset(ld_block2)));
         reg_aux_compensation.save();
     }
     if (brg.with_wei_scales) {
         reg_aux_wei_scales.restore();
         add(reg_aux_wei_scales,
-                (is_tail) ? wei_scales_offset(1, true)
-                          : wei_scales_offset(ld_block2));
+                into<uint32_t>((is_tail) ? wei_scales_offset(1, true)
+                                         : wei_scales_offset(ld_block2)));
         reg_aux_wei_scales.save();
     }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
         add(reg_aux_zp_comp_a,
-                (is_tail) ? zp_comp_a_offset(1, true)
-                          : zp_comp_a_offset(ld_block2));
+                into<uint32_t>((is_tail) ? zp_comp_a_offset(1, true)
+                                         : zp_comp_a_offset(ld_block2)));
         reg_aux_zp_comp_a.save();
     }
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         reg_aux_zp_c_values.restore();
         add(reg_aux_zp_c_values,
-                (is_tail) ? zp_c_values_offset(1, true)
-                          : zp_c_values_offset(ld_block2));
+                into<uint32_t>((is_tail) ? zp_c_values_offset(1, true)
+                                         : zp_c_values_offset(ld_block2)));
         reg_aux_zp_c_values.save();
     }
     if (brg.with_per_mn_compensation) {
         reg_aux_per_mn_comp.restore();
         add(reg_aux_per_mn_comp,
-                (is_tail) ? ldb_per_mn_comp_offset(1, true)
-                          : ldb_per_mn_comp_offset(ld_block2));
+                into<uint32_t>((is_tail) ? ldb_per_mn_comp_offset(1, true)
+                                         : ldb_per_mn_comp_offset(ld_block2)));
         reg_aux_per_mn_comp.save();
     }
 }
@@ -1002,25 +1009,25 @@ template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(dim_t bd_block2) {
     if (brg.req_comp_pads_with_bcast && brg.req_s8s8_compensation) {
         reg_buf.restore();
-        add(reg_buf, bdb_compensation_offset(bd_block2));
+        add(reg_buf, into<uint32_t>(bdb_compensation_offset(bd_block2)));
         reg_buf.save();
     }
 
     if (brg.req_comp_pads_with_bcast
             && brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_zp_comp_a.restore();
-        add(reg_zp_comp_a, bdb_zp_comp_a_offset(bd_block2));
+        add(reg_zp_comp_a, into<uint32_t>(bdb_zp_comp_a_offset(bd_block2)));
         reg_zp_comp_a.save();
     }
 
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_zp_comp_b.restore();
-        add(reg_zp_comp_b, bdb_zp_comp_b_offset(bd_block2));
+        add(reg_zp_comp_b, into<uint32_t>(bdb_zp_comp_b_offset(bd_block2)));
         reg_zp_comp_b.save();
     }
     if (brg.with_per_mn_compensation) {
         reg_per_mn_comp.restore();
-        add(reg_per_mn_comp, bdb_per_mn_comp_offset(bd_block2));
+        add(reg_per_mn_comp, into<uint32_t>(bdb_per_mn_comp_offset(bd_block2)));
         reg_per_mn_comp.save();
     }
 }
@@ -1168,7 +1175,8 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
         for_(dim_t bdb = 0; bdb < bd_block2; bdb++)
         for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
             dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
-            tilezero(Tmm(brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail)));
+            tilezero(Tmm(brg.get_C_tensor(
+                    into<int>(bdb), into<int>(idx), is_bdb_tail, is_ld_tail)));
         }
     } else if (brg.is_gemv) {
         for (dim_t bd = 0; bd < brg.gemv_bd_block(); bd++) {
@@ -1247,10 +1255,10 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
 
     if (dt == data_type::f8_e5m2)
         f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+                into<int>(r_end), reg_data_aux, reg_data_stride, reg_buf_aux);
     else if (dt == data_type::f8_e4m3)
         f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+                into<int>(r_end), reg_data_aux, reg_data_stride, reg_buf_aux);
     else
         assert(!"unsupported data type");
 
@@ -2158,8 +2166,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
             if (is_tail && types::data_type_size(brg.dt_b) == sizeof(float))
                 vmaskmovps(addr, vmm_tail_mask(), vmm);
             else
-                store_data(
-                        brg.dt_d, vmm, reg_aux_D, D_offset(bd, ld), ld_block);
+                store_data(brg.dt_d, vmm, reg_aux_D, D_offset(bd, ld),
+                        into<int>(ld_block));
         }
         if (brg.is_runtime_ldd && bd_block > 1 && ld == ld_block2 - 1)
             reg_D_shift_bytes.addTo(reg_aux_D);
@@ -2416,13 +2424,14 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
             if (brg.is_runtime_ldc && bd_block2 > 1) {
                 xor_(reg_dynamic_C_offset, reg_dynamic_C_offset);
                 reg_stride_ld_block.imulTo(
-                        reg_dynamic_C_offset, bdb_C_offset(1));
+                        reg_dynamic_C_offset, into<int>(bdb_C_offset(1)));
                 reg_dynamic_C_offset.save();
             }
 
             if (apply_post_ops && brg.is_runtime_ldd && bd_block2 > 1) {
                 xor_(reg_D_bdb_loop_shift, reg_D_bdb_loop_shift);
-                reg_D_shift_bytes.imulTo(reg_D_bdb_loop_shift, bdb_D_offset(1));
+                reg_D_shift_bytes.imulTo(
+                        reg_D_bdb_loop_shift, into<int>(bdb_D_offset(1)));
                 reg_D_bdb_loop_shift.save();
             }
 
@@ -2431,8 +2440,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
                 for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
                     const dim_t idx = is_ld_tail ? brg.ld_block2 : ldb;
-                    const int c_tensor = brg.get_C_tensor(
-                            bdb, idx, is_bdb_tail, is_ld_tail);
+                    const int c_tensor = brg.get_C_tensor(into<int>(bdb),
+                            into<int>(idx), is_bdb_tail, is_ld_tail);
                     if (do_accum_ops) {
                         if (skip_accumulation) {
                             for (dim_t bd = 0; bd < adj_bd_block; bd++) {
@@ -2469,7 +2478,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                                     is_bdb_tail);
                             if (ldb < ld_block2 - 1) {
                                 advance_ldb_post_op_regs();
-                                add(reg_aux_D, ldb_D_offset(1));
+                                add(reg_aux_D, into<uint32_t>(ldb_D_offset(1)));
                             }
                         } else {
                             store_accumulators_without_post_ops(
@@ -2477,7 +2486,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                         }
 
                         if (ldb < ld_block2 - 1)
-                            add(reg_aux_C, ldb_C_offset(1));
+                            add(reg_aux_C, into<uint32_t>(ldb_C_offset(1)));
 
                         reg_buf.restore();
                     } else {
@@ -2485,21 +2494,23 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                         if (skip_accumulation) tilezero(tmm);
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
                         if (ldb < ld_block2 - 1)
-                            add(reg_aux_C, ldb_C_offset(1));
+                            add(reg_aux_C, into<uint32_t>(ldb_C_offset(1)));
                     }
                 }
-                if (ld_block2 > 1) sub(reg_aux_C, ldb_C_offset(ld_block2 - 1));
+                if (ld_block2 > 1)
+                    sub(reg_aux_C, into<uint32_t>(ldb_C_offset(ld_block2 - 1)));
                 if (bdb < bd_block2 - 1) {
                     if (brg.is_runtime_ldc)
                         reg_dynamic_C_offset.addTo(reg_aux_C);
                     else
-                        add(reg_aux_C, bdb_C_offset(1));
+                        add(reg_aux_C, into<uint32_t>(bdb_C_offset(1)));
                 }
 
                 if (apply_post_ops) {
                     bool post_processed = false;
                     if (ld_block2 > 1) {
-                        sub(reg_aux_D, ldb_D_offset(ld_block2 - 1));
+                        sub(reg_aux_D,
+                                into<uint32_t>(ldb_D_offset(ld_block2 - 1)));
                         restore_ldb_post_op_regs(ld_block2);
                         post_processed |= utils::one_of(true, brg.with_bias,
                                 brg.zp_type_a != brgemm_broadcast_t::none,
@@ -2511,7 +2522,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                         if (brg.is_runtime_ldd)
                             reg_D_bdb_loop_shift.addTo(reg_aux_D);
                         else
-                            add(reg_aux_D, bdb_D_offset(1));
+                            add(reg_aux_D, into<uint32_t>(bdb_D_offset(1)));
 
                         advance_bdb_post_op_regs(adj_bd_block);
                         post_processed |= utils::one_of(true,
@@ -2733,9 +2744,9 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
 
     const bool is_A = matrix_kind == matrix_kind_t::matrix_A;
 
-    const dim_t tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
-                               : brg.get_B_tensor(idx, is_tail);
-    auto t1 = Tmm(tmm_idx);
+    const dim_t tmm_idx = is_A ? brg.get_A_tensor(into<int>(idx), is_tail)
+                               : brg.get_B_tensor(into<int>(idx), is_tail);
+    auto t1 = Tmm(into<int>(tmm_idx));
 
     auto reg_base = is_A ? reg_aux_A : reg_aux_B;
 
@@ -2753,7 +2764,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
                 = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
         if (brg.is_input_convert()) {
             const int vnni_granularity
-                    = data_type_vnni_granularity(data_type::f16);
+                    = into<int>(data_type_vnni_granularity(data_type::f16));
             rd_block = utils::rnd_up(rd_block, vnni_granularity);
         }
 
@@ -2901,16 +2912,16 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
                     is_ld_tail, false);
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                tdpbxxd(Tmm(brg.get_C_tensor(
-                                bdb, idx, is_bdb_tail, is_ld_tail)),
-                        Tmm(brg.get_A_tensor(bdb, is_bdb_tail)),
-                        Tmm(brg.get_B_tensor(idx, is_ld_tail)));
+                tdpbxxd(Tmm(brg.get_C_tensor(into<int>(bdb), into<int>(idx),
+                                is_bdb_tail, is_ld_tail)),
+                        Tmm(brg.get_A_tensor(into<int>(bdb), is_bdb_tail)),
+                        Tmm(brg.get_B_tensor(into<int>(idx), is_ld_tail)));
             }
         }
     }
     if (!is_rd_tail) {
-        add(reg_aux_A, brg.rdb * rdb_A_offset());
-        add(reg_aux_B, brg.rdb * rdb_B_offset());
+        add(reg_aux_A, into<uint32_t>(brg.rdb * rdb_A_offset()));
+        add(reg_aux_B, into<uint32_t>(brg.rdb * rdb_B_offset()));
     }
 }
 
@@ -3000,7 +3011,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
             auto vmm_store = vmm_mask(load(), is_tail, false, ld_tail_mask);
             uni_vmovups(vmm_store, addr);
         } else {
-            load_bytes(load(), addr, ldb_B_offset(0, true));
+            load_bytes(load(), addr, into<int>(ldb_B_offset(0, true)));
         }
 
         if (brg.req_cal_comp_pads) {
@@ -3191,8 +3202,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         const auto is_tail = have_to_load_bytes && bd_by_load_bytes;
         if (is_tail) {
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
-            load_bytes(
-                    xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
+            load_bytes(xmm_tmp, reg_aux_A, offset,
+                    into<int>(rd_tail_size * brg.typesize_A));
             uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
@@ -3255,7 +3266,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     vpermw(vmm_load, f16_perm_odd_vreg(), vmm_load);
                 vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
             } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr, into<int>(ldb_B_offset(0, true)));
                 vcvtph2ps(vmm_load, Xmm(vmm_load.getIdx()));
             } else {
                 uni_vcvtph2psx(vmm_load, addr);
@@ -3271,7 +3282,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 uni_vpmovzxwd(vmm_load, addr);
                 uni_vpslld(vmm_load, vmm_load, 16);
             } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr, into<int>(ldb_B_offset(0, true)));
             } else {
                 uni_vmovups(vmm_load, addr);
             }
@@ -3279,7 +3290,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             if (is_superset(brg.isa_impl, avx512_core)) {
                 uni_vmovups(vmm_load, addr);
             } else {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr, into<int>(ldb_B_offset(0, true)));
             }
         } else {
             uni_vmovups(vmm_load, addr);
@@ -3415,8 +3426,8 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
                         gemm_microkernel(bd_block2, is_bdb_tail, ld_block2,
                                 is_rd_tail, is_ld_tail, vpad, rows_for_rd_tail);
 
-                    add(reg_aux_A, rdb_A_offset());
-                    add(reg_aux_B, rdb_B_offset());
+                    add(reg_aux_A, into<uint32_t>(rdb_A_offset()));
+                    add(reg_aux_B, into<uint32_t>(rdb_B_offset()));
 
                     dec(reg_rdb_loop);
                     cmp(reg_rdb_loop, 0);
@@ -3501,7 +3512,7 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
                                 real_vpad = -brg.bdb_tail;
                         }
                     }
-                    cmp(reg_aux_A_vpad, vpad);
+                    cmp(reg_aux_A_vpad, into<uint32_t>(vpad));
                     jne(Vpad_loop_iter_label[label_vpad + 1], T_NEAR);
                     bs_loop_body(real_vpad, last_bdb);
                     jmp(Vpad_loop_end_label, T_NEAR);
@@ -3612,20 +3623,21 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         if (brg.is_runtime_ldc) {
             reg_C.saveTo(reg_C_backup);
             xor_(reg_C, reg_C);
-            reg_stride_ld_block.imulTo(reg_C, bdb_C_offset(bd_block2));
+            reg_stride_ld_block.imulTo(
+                    reg_C, into<int>(bdb_C_offset(bd_block2)));
             reg_C_backup.addTo(reg_C);
         } else {
-            add(reg_C, bdb_C_offset(bd_block2));
+            add(reg_C, into<uint32_t>(bdb_C_offset(bd_block2)));
         }
         if (brg.is_runtime_ldd) {
             reg_D.saveTo(reg_aux_D_backup);
             xor_(reg_D, reg_D);
-            reg_D_shift_bytes.imulTo(reg_D, bdb_D_offset(bd_block2));
+            reg_D_shift_bytes.imulTo(reg_D, into<int>(bdb_D_offset(bd_block2)));
             reg_aux_D_backup.addTo(reg_D);
         } else {
-            add(reg_D, bdb_D_offset(bd_block2));
+            add(reg_D, into<uint32_t>(bdb_D_offset(bd_block2)));
         }
-        add(reg_a_offset, bdb_A_offset(bd_block2));
+        add(reg_a_offset, into<uint32_t>(bdb_A_offset(bd_block2)));
 
         if (brg.is_per_k_src_scales) {
             const auto adj_bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
@@ -3633,19 +3645,20 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                     = reg_src_scales.getStoragePtr().getRegExp();
             const auto src_scales_offset
                     = adj_bd_block * bd_block2 * brg.src_scale_m_stride;
-            add(dword[src_scales_stack_ptr], src_scales_offset);
+            add(dword[src_scales_stack_ptr], into<uint32_t>(src_scales_offset));
         }
 
         if (brg.is_gemv && brg.treat_y_as_row) {
             if (brg.with_bias) {
                 reg_bias.restore();
-                add(reg_bias, bias_offset(brg.gemv_bd_block()));
+                add(reg_bias, into<uint32_t>(bias_offset(brg.gemv_bd_block())));
                 reg_bias.save();
             }
 
             if (brg.with_wei_scales && !brg.gemv_single_wei_scale()) {
                 reg_wei_scales.restore();
-                add(reg_wei_scales, wei_scales_offset(brg.gemv_bd_block()));
+                add(reg_wei_scales,
+                        into<uint32_t>(wei_scales_offset(brg.gemv_bd_block())));
                 reg_wei_scales.save();
             }
         }
@@ -3938,7 +3951,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         L(sum_zp_scale_data_);
         const dim_t scale_int = float2int(brg.sum_scale);
         for (dim_t i = 0; i < simd; ++i)
-            dd(scale_int);
+            dd(into<uint32_t>(scale_int));
     }
 
     if (brg.is_fp8_via_convert()) {

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -246,7 +246,7 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
                 this->L(loop_srcs);
 
                 accumulate(nloads[id], load_len[id], 0);
-                this->add(reg_src, this->src_ld_ * typesize);
+                this->add(reg_src, into<uint32_t>(this->src_ld_ * typesize));
 
                 this->dec(reg_src_id);
                 this->jnz(loop_srcs, this->T_NEAR);
@@ -291,8 +291,8 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
 
         loop_x();
 
-        this->add(reg_dst, this->dst_step_ * typesize);
-        this->add(reg_src, this->src_step_ * typesize);
+        this->add(reg_dst, into<uint32_t>(this->dst_step_ * typesize));
+        this->add(reg_src, into<uint32_t>(this->src_step_ * typesize));
 
         this->dec(reg_ny);
         this->jnz(ny_loop, this->T_NEAR);

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
@@ -149,11 +149,11 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
     mov(BackUp1, 0);
     mov(BackUp2, 0);
 
-    sal(LDC, SHIFT_C);
+    sal(LDC, into<int>(SHIFT_C));
 
     /* K needs to be multiple of 4 */
-    add(K, UNROLL_K - 1);
-    and_(K, -UNROLL_K);
+    add(K, into<uint32_t>(UNROLL_K - 1));
+    and_(K, into<uint32_t>(-UNROLL_K));
 
     mov(N, Bn);
     mov(A, rcx);
@@ -162,14 +162,14 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     /* Calculating last value for M loop */
     lea(T0, ptr[Bm - 1]);
-    and_(T0, -UNROLL_MM);
+    and_(T0, into<uint32_t>(-UNROLL_MM));
     lea(T1, ptr[Bm - UNROLL_MM]);
     sub(T1, T0);
     mov(FinalM, T1);
 
     /* Calculating last value for N loop */
     lea(T0, ptr[Bn - 1]);
-    and_(T0, -UNROLL_NN);
+    and_(T0, into<uint32_t>(-UNROLL_NN));
     lea(T1, ptr[Bn - UNROLL_NN]);
     sub(T1, T0);
     mov(FinalN, T1);
@@ -179,16 +179,16 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
     /* Updating C address */
     mov(cc1, C);
     mov(cc2, LDC);
-    sal(cc2, SHIFT_UNROLL_N);
+    sal(cc2, into<int>(SHIFT_UNROLL_N));
     add(cc2, cc1);
-    add(C, UNROLL_MM * SIZE_C);
+    add(C, into<uint32_t>(UNROLL_MM * SIZE_C));
 
     mov(bm, UNROLL_MM);
-    cmp(Bm, UNROLL_MM);
+    cmp(Bm, into<uint32_t>(UNROLL_MM));
     cmovle(bm, Bm);
 
     mov(bm0, UNROLL_M);
-    cmp(bm, UNROLL_M);
+    cmp(bm, into<uint32_t>(UNROLL_M));
     cmovle(bm0, bm);
 
     mov(bm1, bm);
@@ -198,21 +198,21 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
     mov(TILEB(0x30), UNROLL_KK / UNROLL_K);
     mov(TILEB(0x31), UNROLL_KK / UNROLL_K);
 
-    sal(bm0, SHIFT_UNROLL_K + SHIFT_A);
-    sal(bm1, SHIFT_UNROLL_K + SHIFT_A);
+    sal(bm0, into<int>(SHIFT_UNROLL_K + SHIFT_A));
+    sal(bm1, into<int>(SHIFT_UNROLL_K + SHIFT_A));
 
     mov(TILEW(0x10), bm0w);
     mov(TILEW(0x12), bm1w);
 
-    sar(bm0, SHIFT_UNROLL_K + SHIFT_A - SHIFT_C);
-    sar(bm1, SHIFT_UNROLL_K + SHIFT_A - SHIFT_C);
+    sar(bm0, into<int>(SHIFT_UNROLL_K + SHIFT_A - SHIFT_C));
+    sar(bm1, into<int>(SHIFT_UNROLL_K + SHIFT_A - SHIFT_C));
 
     mov(TILEW(0x18), bm0w);
     mov(TILEW(0x1a), bm0w);
     mov(TILEW(0x1c), bm1w);
     mov(TILEW(0x1e), bm1w);
 
-    sal(bm, SHIFT_UNROLL_KK + SHIFT_A);
+    sal(bm, into<int>(SHIFT_UNROLL_KK + SHIFT_A));
 
     xor_(FLAG, FLAG);
     mov(T0, 2);
@@ -225,11 +225,11 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     L(loopN);
     mov(bn, UNROLL_NN);
-    cmp(Bn, UNROLL_NN);
+    cmp(Bn, into<uint32_t>(UNROLL_NN));
     cmovle(bn, Bn);
 
     mov(T0, UNROLL_N);
-    cmp(bn, UNROLL_N);
+    cmp(bn, into<uint32_t>(UNROLL_N));
     cmovle(T0, bn);
 
     mov(T1, bn);
@@ -247,7 +247,7 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
     mov(TILEB(0x36), T0b);
     mov(TILEB(0x37), T1b);
 
-    sal(bn, SHIFT_UNROLL_KK + SHIFT_B);
+    sal(bn, into<int>(SHIFT_UNROLL_KK + SHIFT_B));
 
     /* Disabling unnecessary tile */
     test(FLAG, 2);
@@ -392,7 +392,7 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     add(AO, bm);
     add(BO, bn);
-    sub(I, UNROLL_KK);
+    sub(I, into<uint32_t>(UNROLL_KK));
     jg(loopK);
     align(4);
 
@@ -413,24 +413,24 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     /* Updating C address */
     mov(T0, LDC);
-    sal(T0, SHIFT_UNROLL_NN);
+    sal(T0, into<int>(SHIFT_UNROLL_NN));
     add(cc1, T0);
     add(cc2, T0);
 
     /* Checking end of N loop */
-    sub(Bn, UNROLL_NN);
+    sub(Bn, into<uint32_t>(UNROLL_NN));
     cmp(FinalN, Bn);
     jne(loopN);
     align(4);
 
     /* Updating for next A */
     lea(T0, ptr[K + UNROLL_KK - 1]);
-    and_(T0, -UNROLL_KK);
-    sal(T0, SHIFT_UNROLL_MM + SHIFT_A);
+    and_(T0, into<uint32_t>(-UNROLL_KK));
+    sal(T0, into<int>(SHIFT_UNROLL_MM + SHIFT_A));
     add(A, T0);
 
     /* Checking end of M loop */
-    sub(Bm, UNROLL_MM);
+    sub(Bm, into<uint32_t>(UNROLL_MM));
     cmp(FinalM, Bm);
     jne(loopM);
     align(4);

--- a/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_common_gemm_f32.cpp
@@ -1455,7 +1455,7 @@ struct xbyak_gemm_t : public jit_generator_t {
         mov(LDA, ARG_LDA);
 #endif
 
-        cmp(K, STACK_K_CAPACITY);
+        cmp(K, into<uint32_t>(STACK_K_CAPACITY));
         jg(buffer_in_ws, T_NEAR);
 
         // Using 4kB aligned buffer on stack as workspace

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -735,7 +735,8 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
             for (float al : {0.0f, 1.0f, 2.0f}) {
                 for (float be : {0.0f, 1.0f, 2.0f}) {
                     auto &kern = kernels[N - 1][(dim_t)al][(dim_t)be];
-                    kern.reset(new xbyak_gemm_smalln_tn_t(N, be, al));
+                    kern.reset(
+                            new xbyak_gemm_smalln_tn_t(into<int>(N), be, al));
                     st = kern->create_kernel();
                     if (st != dnnl_success) return;
                 }
@@ -773,11 +774,11 @@ static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
     if ((m & 15) == 0) { // Special handling if m is multiple of 16
         // nthr_16: number of threads such that each thread works on
         // 2^n * 16 number of rows.
-        nthr_16 = m >> 4;
+        nthr_16 = into<int>(m >> 4);
         while (nthr_16 > nthr_to_use && (nthr_16 & 1) == 0)
             nthr_16 = nthr_16 >> 1;
         // Ideal number of threads is more than what we can use.
-        nthr_16 = (nthr_16 > nthr_to_use) ? nthr_to_use : nthr_16;
+        nthr_16 = into<int>((nthr_16 > nthr_to_use) ? nthr_to_use : nthr_16);
         /**
          * Check if nthr_16 should be used or nthr_to_use
          * If each thread is working on less than MINROWS rows (based on nthr_16)
@@ -816,7 +817,7 @@ dnnl_status_t jit_avx512_core_gemm_smalln_tn_f32(const char *transa,
 
     if (n <= 0 || m <= 0) return dnnl_success;
 
-    max_num_threads = smalln_set_num_threads(m, k, max_num_threads);
+    max_num_threads = into<int>(smalln_set_num_threads(m, k, max_num_threads));
 
     if (max_num_threads == 1) {
         return sgemm_smalln_tn(m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -1445,7 +1445,7 @@ struct xbyak_gemm_t : public jit_generator_t {
                             = AO1 + (ld_step + section * 4 - OFFSET) * SIZE;
                     for (int off = 0; off < 4; ++off)
                         pextrd(ptr[dst_addr + unroll_m * off * SIZE],
-                                Xmm(ld_step % 2), off);
+                                Xmm(ld_step % 2), into<uint8_t>(off));
                 };
 
                 el_cp(0, 0);
@@ -1983,7 +1983,7 @@ struct xbyak_gemm_t : public jit_generator_t {
         mov(LDA, ARG_LDA);
 #endif
 
-        cmp(K, STACK_K_CAPACITY);
+        cmp(K, into<uint32_t>(STACK_K_CAPACITY));
         jg(buffer_in_ws, T_NEAR);
 
         // Using 4kB aligned buffer on stack as workspace
@@ -2133,7 +2133,7 @@ private:
 #else
     const Reg64 ARG_A = r8;
     const Reg64 ARG_LDA = r9;
-    const int stackOffset = STACKSIZE;
+    const dim_t stackOffset = STACKSIZE;
     const Reg64 A = ARG_A;
     const Reg64 LDA = ARG_LDA;
 #endif

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -135,7 +135,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float += (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc]
+                                = into<c_type>(c_data[i + j * ldc] * beta);
                         c_data[i + j * ldc] += ctemp;
                     }
                 }
@@ -149,7 +150,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float -= (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc]
+                                = into<c_type>(c_data[i + j * ldc] * beta);
                         c_data[i + j * ldc] -= ctemp;
                     }
                 }
@@ -168,8 +170,10 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                                 + beta * (double)c_data[i + j * ldc];
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
-                        c_data[i + j * ldc] += alpha * ctemp;
+                        c_data[i + j * ldc]
+                                = into<c_type>(c_data[i + j * ldc] * beta);
+                        c_data[i + j * ldc] = into<c_type>(
+                                c_data[i + j * ldc] + alpha * ctemp);
                     }
                 }
             }
@@ -273,7 +277,7 @@ static void sum_matrices(dim_t m, dim_t n, mat_t *__restrict dst, dim_t ld_dst,
 
     for (dim_t j = 0; j < n; j++) {
         PRAGMA_OMP_SIMD()
-        for (int i = 0; i < m; i++)
+        for (dim_t i = 0; i < m; i++)
             dst[i + j * ld_dst] += src[i + j * ld_src];
     }
 }
@@ -1281,12 +1285,12 @@ static inline void set_thread_opts_pack(int nthrs,
         block_z = utils::rnd_up(block_z, block_align);
         thread_z = num_blk * block_z;
         if (thread_z * nthr_z > size_z)
-            nthr_z = utils::div_up(size_z, thread_z);
+            nthr_z = into<int>(utils::div_up(size_z, thread_z));
     };
 
     auto choose_m_blocking = [&]() {
         auto align = get_vector_length<c_type>();
-        align = do_m_blocking_only ? arg->um : align;
+        align = into<int>(do_m_blocking_only ? arg->um : align);
         choose_blocking(m, thread_m, nthr_m, arg->bm, block_m, align);
     };
     auto choose_n_blocking = [&]() {
@@ -1623,7 +1627,7 @@ static inline void adjust_thread_count(dim_t m, dim_t n, dim_t k, int *nthrs) {
     if (is_only_avx2)
         if (m > 10 * n && n < *nthrs)
             if (m / *nthrs < veclen * 3)
-                *nthrs = nstl::max(m / veclen / 3, dim_t(1));
+                *nthrs = into<int>(nstl::max(m / veclen / 3, dim_t(1)));
 
     double gemm_cycles = m * n * k / fp_per_cycle;
     gemm_cycles *= is_f32 ? 2.0 : 8.0;

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -378,7 +378,7 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
     }
 
     // Note: um is fixed for a given set of data types and ISA.
-    const int um = this->um;
+    const int um = into<int>(this->um);
 
     static std::once_flag initialized;
     static std::atomic<dnnl_status_t> st(dnnl_success);

--- a/src/cpu/x64/gemm/gemm_utils.hpp
+++ b/src/cpu/x64/gemm/gemm_utils.hpp
@@ -35,8 +35,8 @@ static inline std::tuple<int, int> calc_nthr_2d(int nthrs, dim_t m, dim_t n,
         dim_t block_m, dim_t block_n, dim_t small_m, dim_t small_n,
         dim_t &thread_m, dim_t &thread_n) {
 
-    int nthr_m = static_cast<int>(utils::div_up(m, block_m));
-    int nthr_n = static_cast<int>(utils::div_up(n, block_n));
+    dim_t nthr_m = utils::div_up(m, block_m);
+    dim_t nthr_n = utils::div_up(n, block_n);
 
     if (nthr_m < 1) nthr_m = 1;
     if (nthr_n < 1) nthr_n = 1;
@@ -192,7 +192,7 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
             if (is_f32) {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)
-                    dst_col[i] = alpha * src_col[i];
+                    dst_col[i] = into<T>(alpha * src_col[i]);
             } else {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)
@@ -208,7 +208,7 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
             if (is_f32) {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)
-                    dst_col[i] = alpha * src_col[i * ld_src];
+                    dst_col[i] = into<T>(alpha * src_col[i * ld_src]);
             } else {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)

--- a/src/cpu/x64/gemm/gemv_driver.cpp
+++ b/src/cpu/x64/gemm/gemv_driver.cpp
@@ -405,7 +405,7 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
     if (m <= 0 || n <= 0) return;
 
     dim_t nthr_max = dnnl_get_current_num_threads();
-    dim_t nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
+    dim_t nthr_goal = thread_checker<a_t>(into<int>(nthr_max), m, n, trans);
 
     if (nthr_goal == 1) {
         gemv_kernel_driver(
@@ -427,8 +427,8 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
     // occur due to change thread counts.
     auto nthr_spawn = dnnl_thr_syncable() ? nthr_max : nthr_goal;
     int nbufs_used = 0;
-    parallel(nthr_spawn, [&](int ithr, int nthr) {
-        int nthr_eff = nstl::min(nthr_goal, static_cast<dim_t>(nthr));
+    parallel(into<int>(nthr_spawn), [&](int ithr, int nthr) {
+        int nthr_eff = into<int>(nstl::min(nthr_goal, into<dim_t>(nthr)));
 
         dim_t thread_m = m, off_m = 0;
         dim_t thread_n = n, off_n = 0;
@@ -488,7 +488,7 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
 
     // Reduce on y after each gemv computation is done.
     if (!is_syncable && ybuf) {
-        parallel(nthr_spawn, [&](int ithr, int nthr) {
+        parallel(into<int>(nthr_spawn), [&](int ithr, int nthr) {
             sum_ybufs(ithr, nthr, m, y, incy, ybuf, nbufs_used);
         });
     }

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -232,8 +232,8 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
 
     // Advance all pointers by an immediate
     auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * sizeof(dst_data_t));
-        add(reg_acc, offset * sizeof(acc_data_t));
+        add(reg_dst, into<uint32_t>(offset * sizeof(dst_data_t)));
+        add(reg_acc, into<uint32_t>(offset * sizeof(acc_data_t)));
     };
 
     Xbyak::Label oc_loop, oc_loop_end;
@@ -258,7 +258,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
         const int unroll = 1 << i; // 4, 2, 1
         L(l_simd_loop[i + 1]);
         {
-            const int loop_len = unroll * vlen_;
+            const int loop_len = into<int>(unroll * vlen_);
             cmp(reg_len_iter, loop_len);
             jl(l_simd_loop[i], T_NEAR);
             for (int j = 0; j < unroll; j++)
@@ -443,14 +443,14 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
             col_r[i] = zero_val;
     }
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        int oh = ohb * jcp.oh_block;
-        int ow = owb * jcp.ow_block;
+        int oh = into<int>(ohb * jcp.oh_block);
+        int ow = into<int>(owb * jcp.ow_block);
         const src_data_t *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const wei_data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const int h_step = into<int>(nstl::min(jcp.oh_block, jcp.oh - oh));
+        const int w_step = into<int>(nstl::min(jcp.ow_block, jcp.ow - ow));
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
 
@@ -575,8 +575,9 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
                         spatial * jcp.os_block, os_block, ic, ic_block);
             } else {
                 assert(jcp.ic_block == jcp.ic);
-                jit_gemm_convolution_utils::im2col_3d<src_data_t>(
-                        jcp, src, col, od, spatial * jcp.os_block, os_block);
+                jit_gemm_convolution_utils::im2col_3d<src_data_t>(jcp, src, col,
+                        od, into<int>(spatial * jcp.os_block),
+                        into<int>(os_block));
             }
         }
 
@@ -649,8 +650,10 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
                 const dim_t oc_block
                         = nstl::min(dim_t(oc_end) - oc, jcp.oc_block);
 
-                inner_ker(ic, oc, g, od, nb_os, _src, _weights, _col, _dst_im,
-                        _acc, ic_block, oc_block);
+                inner_ker(into<int>(ic), into<int>(oc), into<int>(g),
+                        into<int>(od), into<int>(nb_os), _src, _weights, _col,
+                        _dst_im, _acc, into<int>(ic_block),
+                        into<int>(oc_block));
             }
             nd_iterator_step(g, jcp.ngroups, n, jcp.mb, od, jcp.od, nb_os,
                     jcp.os_nb_block);
@@ -763,7 +766,7 @@ status_t gemm_bf16_convolution_bwd_data_t<
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
                 PRAGMA_OMP_SIMD()
-                for (int ic = 0; ic < jcp.ic; ++ic)
+                for (int ic = 0; ic < into<int>(jcp.ic); ++ic)
                     diff_src_loc[ic] = acc_loc[ic];
             });
         }
@@ -846,11 +849,13 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
 
                 if (jcp.im2col_sz) {
                     if (!is_problem_3d)
-                        jit_gemm_convolution_utils::col2im(
-                                jcp, _col, acc, os_nb * jcp.os_block, os_block);
+                        jit_gemm_convolution_utils::col2im(jcp, _col, acc,
+                                into<int>(os_nb * jcp.os_block),
+                                into<int>(os_block));
                     else
                         jit_gemm_convolution_utils::col2im_3d(jcp, _col, acc,
-                                od, os_nb * jcp.os_block, os_block);
+                                od, into<int>(os_nb * jcp.os_block),
+                                into<int>(os_block));
                 }
             }
             if (diff_src_data_type == data_type::bf16) {
@@ -989,9 +994,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -1071,7 +1078,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                             // Finish the loops early if failure occured.
                             g = g_end;
                             mb = mb_end;
-                            od = jcp.od;
+                            od = into<int>(jcp.od);
                         }
                     }
                 }
@@ -1096,10 +1103,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
@@ -1192,9 +1200,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
@@ -1242,7 +1252,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                             else
                                 jit_gemm_convolution_utils::im2col_3d<
                                         src_data_t>(jcp, _src, _col, od,
-                                        os_nb * jcp.os_block, os_block);
+                                        into<int>(os_nb * jcp.os_block),
+                                        into<int>(os_block));
                         }
 
                         const dim_t LDA = jcp.im2col_sz ? os_block : K;
@@ -1260,8 +1271,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                             // Finish the loops early if failure occured.
                             g = g_end;
                             mb = mb_end;
-                            od = jcp.od;
-                            os_nb = jcp.os_nb_block;
+                            od = into<int>(jcp.od);
+                            os_nb = into<int>(jcp.os_nb_block);
                         }
                     }
                 }
@@ -1296,10 +1307,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = into<int>(jcp.need_wei_reduction ? jcp.mb : 1);
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    into<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;

--- a/src/cpu/x64/gemm_bf16_inner_product.hpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.hpp
@@ -283,7 +283,7 @@ struct gemm_bf16_inner_product_bwd_weights_t : public primitive_t {
             dim_t OCB_per_thread = utils::div_up(OCB, bias_reduction_nthr_);
 
             OC_per_thread = OCB_per_thread * bias_blksize;
-            nthr_OCB = utils::div_up(OCB, OCB_per_thread);
+            nthr_OCB = into<int>(utils::div_up(OCB, OCB_per_thread));
             nthr_MB = bias_reduction_nthr_ / nthr_OCB;
 
             assert(nthr_OCB * nthr_MB <= bias_reduction_nthr_);

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -50,7 +50,7 @@ register_preserve_guard_t::register_preserve_guard_t(jit_generator_t *host,
         host_->push(reg);
 
     if (!vmm_stack_.empty()) {
-        host_->sub(host_->rsp, vmm_to_preserve_size_bytes_);
+        host_->sub(host_->rsp, into<uint32_t>(vmm_to_preserve_size_bytes_));
 
         auto stack_offset = vmm_to_preserve_size_bytes_;
         for (const auto &vmm : vmm_to_preserve) {
@@ -91,7 +91,7 @@ register_preserve_guard_t::~register_preserve_guard_t() {
     }
 
     if (vmm_to_preserve_size_bytes_)
-        host_->add(host_->rsp, vmm_to_preserve_size_bytes_);
+        host_->add(host_->rsp, into<uint32_t>(vmm_to_preserve_size_bytes_));
 
     while (!reg64_stack_.empty()) {
         host_->pop(reg64_stack_.top());

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -417,9 +417,11 @@ static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
     const auto &out_elem_off_val = rhs_arg_params.vmm_idx_to_out_elem_off_val;
 
     if (rhs_broadcasting_strategy != broadcasting_strategy_t::scalar) {
-        return params_differ(out_addr, vmm_idx1, vmm_idx2)
-                || params_differ(out_reg, vmm_idx1, vmm_idx2)
-                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2);
+        return params_differ(out_addr, into<int>(vmm_idx1), into<int>(vmm_idx2))
+                || params_differ(
+                        out_reg, into<int>(vmm_idx1), into<int>(vmm_idx2))
+                || params_differ(out_elem_off_val, into<int>(vmm_idx1),
+                        into<int>(vmm_idx2));
     }
     return false;
 }
@@ -519,7 +521,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     // Phase 1 Validate temporary vmm user hint
     static constexpr int max_vmm_idx = cpu_isa_traits_t<isa>::n_vregs - 1;
     auto &vmm_hint = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
-    vmm_hint = adjust_temp_vmm_hint(vmm_hint, start_idx, end_idx, max_vmm_idx);
+    vmm_hint = adjust_temp_vmm_hint(into<int>(vmm_hint), into<int>(start_idx),
+            into<int>(end_idx), max_vmm_idx);
 
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const auto src1_desc = get_src1_desc(post_op, dst_d);
@@ -547,7 +550,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = into<int>(dst_d.blocking_desc().inner_blks[0]);
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
                     || !rhs_arg_params.vmm_idx_to_out_reg.empty());
@@ -630,7 +633,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
                                               host_->rax, host_->rdx})
                             : std::initializer_list<Xbyak::Reg64>()),
             (rhs_arg_static_params_.preserve_vmm_helper && dt_helper_vmm_needed
-                            ? std::initializer_list<Xbyak::Xmm>({Vmm(vmm_hint)})
+                            ? std::initializer_list<Xbyak::Xmm>(
+                                      {Vmm(into<int>(vmm_hint))})
                             : std::initializer_list<Xbyak::Xmm>())};
 
     bool vmm0_was_preserved = false;
@@ -644,15 +648,17 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     for (const auto vmm_idx : vmm_idxs) {
         const bool is_start_idx = vmm_idx == start_idx;
         const bool with_tail = rhs_arg_static_params_.is_tail
-                && vmm_tail_idx.find(vmm_idx) != vmm_tail_idx.cend()
+                && vmm_tail_idx.find(into<int>(vmm_idx)) != vmm_tail_idx.cend()
                 && IMPLICATION(rhs_broadcasting_strategy
                                 == broadcasting_strategy_t::scalar,
                         rhs_arg_static_params_.use_exact_tail_scalar_bcast);
-        const Vmm tern_tmp_vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
-        const auto local_vmm_preservation = should_preserve_vmm(
-                vmm_idx, vmm_hint, max_vmm_idx, dt_helper_vmm_needed);
+        const Vmm tern_tmp_vmm(
+                into<int>(rhs_arg_static_params_.rhs_dt_helper_vmm_idx));
+        const auto local_vmm_preservation
+                = should_preserve_vmm(into<int>(vmm_idx), into<int>(vmm_hint),
+                        max_vmm_idx, dt_helper_vmm_needed);
         const bool &vmm_preservation_needed = local_vmm_preservation.first;
-        const Vmm dst_vmm(vmm_idx);
+        const Vmm dst_vmm(into<int>(vmm_idx));
 
         // For binary ops with ternary inputs, a temporary vmm will be needed
         // for the additional input.
@@ -664,7 +670,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
                     broadcasting_strategy_t::no_broadcast, true, true);
 
             const bool ternary_with_tail = rhs_arg_static_params_.is_tail
-                    && vmm_tail_idx.find(vmm_idx) != vmm_tail_idx.cend();
+                    && vmm_tail_idx.find(into<int>(vmm_idx))
+                            != vmm_tail_idx.cend();
 
             load_rhs(rhs2_arg_data_type, tern_tmp_vmm, rhs2_arg_addr,
                     tail_load_mode, ternary_with_tail);
@@ -760,9 +767,9 @@ Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
             // kernels.
             append_no_broadcast_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first,
-                    (!is_ternary_input));
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first, (!is_ternary_input));
 
             return host_->ptr[rhs_addr_reg];
         }
@@ -770,8 +777,9 @@ Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
         case broadcasting_strategy_t::per_oc_spatial: {
             append_oc_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return rhs_broadcasting_strategy
                             == broadcasting_strategy_t::per_oc_spatial
@@ -781,64 +789,71 @@ Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
         case broadcasting_strategy_t::per_oc_d: {
             append_oc_d_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
             return host_->ptr_b[rhs_addr_reg];
         }
         case broadcasting_strategy_t::per_mb_spatial: {
             append_mb_sp_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first,
-                    rhs_d);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first, rhs_d);
 
             return host_->ptr[rhs_addr_reg];
         }
         case broadcasting_strategy_t::per_mb_w: {
             append_mb_w_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return host_->ptr[rhs_addr_reg];
         }
         case broadcasting_strategy_t::per_w: {
             append_w_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return host_->ptr[rhs_addr_reg];
         }
         case broadcasting_strategy_t::per_mb: {
             append_mb_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return host_->ptr_b[rhs_addr_reg];
         }
         case broadcasting_strategy_t::per_hw: {
             append_hw_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return host_->ptr[rhs_addr_reg];
         }
         case broadcasting_strategy_t::batch: {
             append_oc_spatial_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return host_->ptr[rhs_addr_reg];
         }
         case broadcasting_strategy_t::spatial: {
             append_mb_oc_offset(rhs_arg_params.vmm_idx_to_out_addr,
                     rhs_arg_params.vmm_idx_to_out_reg,
-                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
-                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size, is_first);
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    into<int>(vmm_idx), rhs_addr_reg, rhs_helper_reg,
+                    rhs_arg_elem_size, is_first);
 
             return host_->ptr[rhs_addr_reg];
         }
@@ -870,7 +885,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
         if (is_first || !cache_addr) {
             calculate_no_broadcast_base(out_addr, tmp_reg);
             if (elem_size_bytes > 1) {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->sal(tmp_reg, shift_val);
             }
             host_->add(addr_reg, tmp_reg);
@@ -898,8 +913,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
     host_->sub(out_reg,
             host_->ptr[param1_ + rhs_arg_static_params_.dst_orig_offset]);
     host_->shr(out_reg,
-            std::log2(types::data_type_size(
-                    rhs_arg_static_params_.dst_d.data_type())));
+            into<int>(std::log2(types::data_type_size(
+                    rhs_arg_static_params_.dst_d.data_type()))));
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -971,7 +986,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1047,7 +1062,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = into<int>(dst_d.blocking_desc().inner_blks[0]);
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
     const auto r8 = host_->r8;
@@ -1076,7 +1091,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
         const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = into<int>(dst_d.blocking_desc().inner_blks[0]);
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     const auto offset_adj = ((offset_shr % strides[0]) / strides[1]) * blk_size
@@ -1190,7 +1205,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1328,7 +1343,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
                 if (elem_size_bytes == 1) {
                     host_->add(addr_reg, rax);
                 } else {
-                    const int shift_val = std::log2(elem_size_bytes);
+                    const int shift_val = into<int>(std::log2(elem_size_bytes));
                     host_->mov(tmp_reg, rax);
                     host_->sal(tmp_reg, shift_val);
                     host_->add(addr_reg, tmp_reg);
@@ -1448,7 +1463,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, r8);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = into<int>(std::log2(elem_size_bytes));
         host_->mov(tmp_reg, r8);
         host_->sal(tmp_reg, shift_val);
         host_->add(addr_reg, tmp_reg);
@@ -1467,9 +1482,9 @@ void jit_uni_binary_injector_t<isa,
     if (rhs_offset == 0) return;
 
     if (elem_size_bytes == 1) {
-        host_->add(addr_reg, rhs_offset);
+        host_->add(addr_reg, into<uint32_t>(rhs_offset));
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = into<int>(std::log2(elem_size_bytes));
         const uint64_t rhs_offset_bytes = static_cast<uint64_t>(rhs_offset)
                 << shift_val;
         host_->mov(tmp_reg, rhs_offset_bytes);
@@ -1555,7 +1570,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = into<int>(dst_d.blocking_desc().inner_blks[0]);
 
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1587,7 +1602,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
     const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
     const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
     const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = into<int>(dst_d.blocking_desc().inner_blks[0]);
 
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
@@ -1724,7 +1739,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2034,7 +2049,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2168,7 +2183,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2378,7 +2393,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2555,7 +2570,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2726,7 +2741,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = into<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2912,7 +2927,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::inject_binary(
 
     if (process_rhs_arg_using_tmp_vmm) {
 
-        const Vmm tmp_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+        const Vmm tmp_vmm
+                = Vmm(into<int>(rhs_arg_static_params_.rhs_dt_helper_vmm_idx));
 
         if (rhs_addr.isBroadcast())
             execute_broadcast(rhs_arg_data_type, tmp_vmm,
@@ -3282,7 +3298,7 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
 
     if (init_op) init_op();
 
-    const auto res = std::div(tail_size, xmm_size_elem);
+    const auto res = std::div(into<int>(tail_size), xmm_size_elem);
     const auto &ymm_upper_half_op_data_size = res.rem;
     const bool should_load_lower_half = res.quot;
 
@@ -3290,14 +3306,14 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
         ymm_upper_half_op(ymm_upper_half_op_data_size, should_load_lower_half);
 
     if (should_load_lower_half) {
-        const auto tmp_xmm = Xbyak::Xmm(ymm_idx);
+        const auto tmp_xmm = Xbyak::Xmm(into<int>(ymm_idx));
 
         if (ymm_upper_half_op_data_size) push_vmm(host, tmp_xmm);
 
         if (ymm_lower_half_op) ymm_lower_half_op(ymm_upper_half_op_data_size);
 
         if (ymm_upper_half_op_data_size) {
-            const auto tmp_ymm = Xbyak::Ymm(ymm_idx);
+            const auto tmp_ymm = Xbyak::Ymm(into<int>(ymm_idx));
             host->vinsertf128(tmp_ymm, tmp_ymm, host->ptr[host->rsp], 1);
             restore_stack(host, tmp_xmm);
         }
@@ -3314,7 +3330,7 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
 
 static Xbyak::uint8 MM_SHUFFLE(
         Xbyak::uint8 z, Xbyak::uint8 y, Xbyak::uint8 x, Xbyak::uint8 w) {
-    return (((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
+    return into<Xbyak::uint8>(((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
 }
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
@@ -3372,7 +3388,7 @@ struct helper_bcast_tail_t<avx2, Vmm> {
         } else if (data_type == data_type::u8 || data_type == data_type::s8) {
             const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
             for (std::size_t i = 0; i < tail_size; i++)
-                host->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
+                host->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, into<uint8_t>(i));
 
             if (data_type == data_type::s8)
                 host->vpmovsxbd(tmp_vmm, tmp_xmm);
@@ -3395,7 +3411,7 @@ struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
             const auto tmp_lower_vmm =
                     typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
             host->load_bytes(tmp_lower_vmm, rhs_addr,
-                    tail_size * types::data_type_size(data_type));
+                    into<int>(tail_size * types::data_type_size(data_type)));
             if (data_type == data_type::bf16) {
                 host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
                 host->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3517,7 +3533,7 @@ void jit_uni_binary_injector_t<avx,
 
     const auto load_tail_avx_xmm = [&]() {
         for (size_t i = 0; i < tail_size; i++)
-            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, i);
+            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, into<uint8_t>(i));
     };
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
@@ -3549,7 +3565,7 @@ void jit_uni_binary_injector_t<sse41,
 
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
         for (std::size_t i = 0; i < tail_size; i++)
-            host_->pinsrb(tmp_vmm, rhs_addr, i);
+            host_->pinsrb(tmp_vmm, rhs_addr, into<uint8_t>(i));
 
         if (data_type == data_type::s8)
             host_->pmovsxbd(tmp_vmm, tmp_vmm);
@@ -3735,7 +3751,8 @@ struct helper_load_tail_t<avx2, Vmm> {
                     data_type::s8, data_type::u8))
             assert(!"unsupported data type");
 
-        host->load_data(data_type, tmp_vmm, rhs_addr_reg, 0, tail_size);
+        host->load_data(
+                data_type, tmp_vmm, rhs_addr_reg, 0, into<int>(tail_size));
     }
 };
 
@@ -3749,7 +3766,7 @@ struct helper_load_tail_t<avx2_vnni_2, Vmm> {
             const auto tmp_lower_vmm =
                     typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
             host->load_bytes(tmp_lower_vmm, rhs_addr_reg, 0,
-                    tail_size * sizeof(bfloat16_t));
+                    into<int>(tail_size * sizeof(bfloat16_t)));
             if (data_type == data_type::bf16) {
                 host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
                 host->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3812,7 +3829,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
     static constexpr int xmm_size_elem = 4;
-    const auto res = std::div(tail_size, xmm_size_elem);
+    const auto res = std::div(into<int>(tail_size), xmm_size_elem);
     const auto vmm_idx = tmp_vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
 
@@ -3825,7 +3842,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
             for (int i = 0; i < res.rem; i++)
                 host_->vpinsrd(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + offset + i * sizeof(float)],
-                        i);
+                        into<uint8_t>(i));
         };
 
         const auto lower_half_op = [&](int upper_half_data_size) {
@@ -3847,7 +3864,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
             for (int i = 0; i < upper_half_data_size; i++)
                 host_->vpinsrb(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + offset + i * sizeof(int8_t)],
-                        i);
+                        into<uint8_t>(i));
             cvt_to_dword(tmp_xmm);
         };
 
@@ -3870,11 +3887,13 @@ void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::load_rhs_tail_statically(
     if (data_type == data_type::f32 || data_type == data_type::s32) {
         for (size_t i = 0; i < tail_size; i++)
             host_->vpinsrd(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(float)], i);
+                    host_->ptr[rhs_addr_reg + i * sizeof(float)],
+                    into<uint8_t>(i));
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
         for (size_t i = 0; i < tail_size; i++)
             host_->vpinsrb(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)], i);
+                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)],
+                    into<uint8_t>(i));
         if (data_type == data_type::s8)
             host_->vpmovsxbd(tmp_vmm, tmp_vmm);
         else
@@ -3893,7 +3912,7 @@ void jit_uni_binary_injector_t<sse41, Xbyak::Xmm>::load_rhs_tail_statically(
 
     const auto &tail_size = rhs_arg_static_params_.tail_size;
     host_->load_data(data_type, tmp_vmm, rhs_arg_static_params_.rhs_addr_reg, 0,
-            tail_size);
+            into<int>(tail_size));
 }
 
 // Support compare with Address param only when isa is avx512.
@@ -3907,12 +3926,12 @@ jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
     // For GreaterEqual op, replace 0xFFFFFFFF by 1
     // which was returned by vcmpps.
     const auto &cmp_mask = rhs_arg_static_params_.tail_opmask;
-    const Xbyak::Xmm xreg_one
-            = Xbyak::Xmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+    const Xbyak::Xmm xreg_one = Xbyak::Xmm(
+            into<int>(rhs_arg_static_params_.rhs_dt_helper_vmm_idx));
     const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
 
     push_opmask(host_, cmp_mask);
-    host_->vcmpps(cmp_mask, lhs, rhs, cmp_predicate);
+    host_->vcmpps(cmp_mask, lhs, rhs, into<uint8_t>(cmp_predicate));
     host_->mov(reg_tmp, float2int(1));
     host_->uni_vmovq(xreg_one, reg_tmp);
     // broadcast 1.0f with mask
@@ -3928,7 +3947,7 @@ typename std::enable_if<!(std::is_same<T, Xbyak::Zmm>::value
         || std::is_same<T, Xbyak::Address>::value)>::type
 jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
         const Vmm &lhs, const T &rhs, const unsigned int cmp_predicate) const {
-    const int vmm_idx = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
+    const int vmm_idx = into<int>(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
     const Vmm vreg_one = Vmm(vmm_idx);
     const Xbyak::Xmm xreg_one = Xbyak::Xmm(vmm_idx);
     const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
@@ -4045,7 +4064,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::execute_binary(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
         const Vmm &dst, const Xbyak::Operand &rhs) const {
-    Vmm tmp_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+    Vmm tmp_vmm = Vmm(into<int>(rhs_arg_static_params_.rhs_dt_helper_vmm_idx));
     if (is_superset(isa, avx512_core)) {
         assert(rhs.isMEM());
         Vmm dst_vmm = Vmm(dst.getIdx());

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -169,14 +169,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     }
 
     if (need_vmm_stack_ptr(alg_, is_fwd_, alpha_)) {
-        reg_vmm_stack_ptr_ = Reg64(preserved_gpr_indices_[0]);
+        reg_vmm_stack_ptr_ = Reg64(into<int>(preserved_gpr_indices_[0]));
     }
 
     if (save_state_) {
         if (preserve_p_table_) h->push(p_table_);
 
         for (size_t i = 0; i < preserved_gprs_count; ++i)
-            h->push(Reg64(preserved_gpr_indices_[i]));
+            h->push(Reg64(into<int>(preserved_gpr_indices_[i])));
     }
 
     const auto stack_vmm_space = get_stack_vmm_space();
@@ -192,7 +192,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
         const uint32_t mask = ~(static_cast<uint32_t>(vlen_) - 1);
         h->and_(h->rsp, mask);
         h->mov(ptr[h->rsp], reg_vmm_stack_ptr_);
-        h->sub(h->rsp, stack_vmm_space);
+        h->sub(h->rsp, into<uint32_t>(stack_vmm_space));
         h->mov(reg_vmm_stack_ptr_, h->rsp);
     }
 
@@ -204,16 +204,17 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
             if (need_vmm_mask_register_) {
                 size_t i = 0;
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
-                        Vmm(preserved_vmm_tail_indices_[i]));
+                        Vmm(into<int>(preserved_vmm_tail_indices_[i])));
             }
 
             for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_;
                     ++i)
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
-                        Vmm(preserved_vmm_indices_[i
-                                - need_vmm_mask_register_]));
+                        Vmm(into<int>(preserved_vmm_indices_[i
+                                - need_vmm_mask_register_])));
             if (stack_vmm_space)
-                h->add(reg_vmm_stack_ptr_, n_vregs_preserved_ * vlen_);
+                h->add(reg_vmm_stack_ptr_,
+                        into<uint32_t>(n_vregs_preserved_ * vlen_));
         }
 
         load_table_addr();
@@ -237,8 +238,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
         assert(preserve_vmm_);
 
         for (size_t i = 0; i < n_vregs_not_preserved; ++i)
-            h->uni_vmovups(Vmm(preserved_vmm_indices_[idx_off + i
-                                   - need_vmm_mask_register_]),
+            h->uni_vmovups(Vmm(into<int>(preserved_vmm_indices_[idx_off + i
+                                   - need_vmm_mask_register_])),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_not_preserved) * vlen_]);
     }
@@ -254,8 +255,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
         for (size_t i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_
                                    + (i - n_vregs_not_preserved) * vlen_],
-                    Vmm(preserved_vmm_indices_[idx_off + i
-                            - need_vmm_mask_register_]));
+                    Vmm(into<int>(preserved_vmm_indices_[idx_off + i
+                            - need_vmm_mask_register_])));
     }
 
     assign_regs();
@@ -264,18 +265,18 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
     using namespace Xbyak::util;
-    const int stack_vmm_space = get_stack_vmm_space();
+    const int stack_vmm_space = into<int>(get_stack_vmm_space());
 
     if (save_state_ && preserve_vmm_) {
         for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
-            h->uni_vmovups(
-                    Vmm(preserved_vmm_indices_[i - need_vmm_mask_register_]),
+            h->uni_vmovups(Vmm(into<int>(preserved_vmm_indices_[i
+                                   - need_vmm_mask_register_])),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
 
         if (need_vmm_mask_register_) {
             size_t i = 0;
-            h->uni_vmovups(Vmm(preserved_vmm_tail_indices_[i]),
+            h->uni_vmovups(Vmm(into<int>(preserved_vmm_tail_indices_[i])),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
         }
@@ -290,14 +291,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
     if (!save_state_) return;
     for (int i = static_cast<int>(aux_gprs_count(alg_, is_fwd_, alpha_)) - 1;
             i >= 0; --i)
-        h->pop(Reg64(preserved_gpr_indices_[i]));
+        h->pop(Reg64(into<int>(preserved_gpr_indices_[i])));
 
     if (preserve_p_table_) h->pop(p_table_);
 }
 
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
-    vmm_mask_ = Vmm(preserved_vmm_tail_indices_[0]);
+    vmm_mask_ = Vmm(into<int>(preserved_vmm_tail_indices_[0]));
 
     // For avx we need a register to save the upper part of Ymm
     // Note: the number in `aux_vecs_count` is accounted for here.
@@ -312,9 +313,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
                     eltwise_exp_use_dst_for_bwd);
 
     if (preserve_vec_for_avx) {
-        vmm_tmp_ = Vmm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
-        ymm_tmp_ = Ymm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
-        xmm_tmp_ = Xmm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
+        vmm_tmp_ = Vmm(
+                into<int>(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]));
+        ymm_tmp_ = Ymm(
+                into<int>(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]));
+        xmm_tmp_ = Xmm(
+                into<int>(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]));
     }
 }
 
@@ -325,7 +329,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
 template <cpu_isa_t isa, typename Wmm>
 Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(size_t idx) {
     assert(idx < (n_vregs_preserved_ - need_vmm_mask_register_));
-    return Vmm(preserved_vmm_indices_[idx]);
+    return Vmm(into<int>(preserved_vmm_indices_[idx]));
 }
 
 template <cpu_isa_t isa, typename Wmm>
@@ -344,11 +348,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::vec_shift(const Vmm &vmm_dst,
         if (vmm_dst.getIdx() != vmm_src.getIdx()) h->vmovups(ymm_dst, ymm_src);
         h->vextractf128(xmm_tmp_, ymm_dst, 1);
         if (shift_left) {
-            h->vpslld(xmm_dst, xmm_dst, imm);
-            h->vpslld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpslld(xmm_dst, xmm_dst, into<uint8_t>(imm));
+            h->vpslld(xmm_tmp_, xmm_tmp_, into<uint8_t>(imm));
         } else {
-            h->vpsrld(xmm_dst, xmm_dst, imm);
-            h->vpsrld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpsrld(xmm_dst, xmm_dst, into<uint8_t>(imm));
+            h->vpsrld(xmm_tmp_, xmm_tmp_, into<uint8_t>(imm));
         }
         h->vinsertf128(ymm_dst, ymm_dst, xmm_tmp_, 1);
     }
@@ -360,7 +364,8 @@ template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::compute_cmp_mask(const Vmm &vmm_src,
         const Xbyak::Operand &compare_operand, int cmp_predicate) {
     if (is_avx512_) {
-        h->vcmpps(k_mask_, vmm_src, compare_operand, cmp_predicate);
+        h->vcmpps(k_mask_, vmm_src, compare_operand,
+                into<uint8_t>(cmp_predicate));
     } else {
         h->uni_vcmpps(vmm_mask_, vmm_src, compare_operand, cmp_predicate);
     }
@@ -514,8 +519,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
     if (isa == sse41 || isa == avx) {
         assert(aux_gprs_count(alg_, is_fwd_, alpha_) >= XMM_float_lanes_count);
         for (int i = 0; i < XMM_float_lanes_count; i++)
-            gpr_idx[i] = Reg64(preserved_gpr_indices_[i
-                    + need_vmm_stack_ptr(alg_, is_fwd_, alpha_)]);
+            gpr_idx[i] = Reg64(into<int>(preserved_gpr_indices_[i
+                    + need_vmm_stack_ptr(alg_, is_fwd_, alpha_)]));
     }
 
     // We split the positive domain in 33 intervals:
@@ -551,12 +556,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
         switch (isa) {
             case sse41:
                 for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
+                    h->pextrd(
+                            gpr_idx[i].cvt32(), vmm_pol_idx, into<uint8_t>(i));
                 break;
             case avx: {
                 Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
                 for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
+                    h->vpextrd(
+                            gpr_idx[i].cvt32(), xmm_pol_idx, into<uint8_t>(i));
             } break;
             case avx2_vnni_2:
             case avx2:
@@ -578,7 +585,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                     Xbyak::Address coeff_addr
                             = ptr[p_table_ + coeffs_off(coeff_idx)
                                     + gpr_idx[idx] * sizeof(float)];
-                    h->pinsrd(vmm_coeff, coeff_addr, idx);
+                    h->pinsrd(vmm_coeff, coeff_addr, into<uint8_t>(idx));
                 }
                 break;
             case avx: {
@@ -587,7 +594,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                     Xbyak::Address coeff_addr
                             = ptr[p_table_ + coeffs_off(coeff_idx)
                                     + gpr_idx[idx] * sizeof(float)];
-                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
+                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr,
+                            into<uint8_t>(idx));
                 }
             } break;
             case avx2_vnni_2:
@@ -1196,7 +1204,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
                 h->rax, h->rcx, h->rdx, h->rdi, h->rsi, h->rbx};
         size_t n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
 
-        h->sub(h->rsp, n_gprs_to_save * gpr_size);
+        h->sub(h->rsp, into<uint32_t>(n_gprs_to_save * gpr_size));
         for (size_t i = 0; i < n_gprs_to_save; ++i)
             h->mov(h->ptr[h->rsp + i * gpr_size], gprs_to_save[i]);
 
@@ -1204,12 +1212,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         static constexpr int k_mask_size = 8;
         size_t n_k_regs_to_save = 8;
         if (is_avx512_) {
-            h->sub(h->rsp, n_k_regs_to_save * k_mask_size);
+            h->sub(h->rsp, into<uint32_t>(n_k_regs_to_save * k_mask_size));
             for (size_t i = 0; i < n_k_regs_to_save; ++i) {
                 if (mayiuse(avx512_core))
-                    h->kmovq(h->ptr[h->rsp + i * k_mask_size], Opmask(i));
+                    h->kmovq(h->ptr[h->rsp + i * k_mask_size],
+                            Opmask(into<int>(i)));
                 else
-                    h->kmovw(h->ptr[h->rsp + i * k_mask_size], Opmask(i));
+                    h->kmovw(h->ptr[h->rsp + i * k_mask_size],
+                            Opmask(into<int>(i)));
             }
         }
 
@@ -1221,7 +1231,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         // `vlen_` should be replaced with `host_isa::vlen_` and
         // `host_isa::n_vregs_`.
         for (size_t i = 2; i < n_vregs_ + 2; ++i)
-            h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_], Vmm(i - 2));
+            h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
+                    Vmm(into<int>(i - 2)));
         h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_], vmm_src); // src
         h->uni_vmovups(vmm_src, table_val(beta));
         h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + 1 * vlen_], vmm_src); // beta
@@ -1262,24 +1273,25 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
 
         // restore vector registers
         for (size_t i = n_vregs_ + 1; i >= 2; --i)
-            h->uni_vmovups(Vmm(i - 2), h->ptr[reg_vmm_stack_ptr_ + i * vlen_]);
+            h->uni_vmovups(Vmm(into<int>(i - 2)),
+                    h->ptr[reg_vmm_stack_ptr_ + i * vlen_]);
         h->uni_vmovups(vmm_src, h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_]);
 
         // restore k registers
         if (is_avx512_) {
-            for (int i = n_k_regs_to_save - 1; i >= 0; --i) {
+            for (int i = into<int>(n_k_regs_to_save - 1); i >= 0; --i) {
                 if (mayiuse(avx512_core))
                     h->kmovq(Opmask(i), h->ptr[h->rsp + i * k_mask_size]);
                 else
                     h->kmovw(Opmask(i), h->ptr[h->rsp + i * k_mask_size]);
             }
-            h->add(h->rsp, n_k_regs_to_save * k_mask_size);
+            h->add(h->rsp, into<uint32_t>(n_k_regs_to_save * k_mask_size));
         }
 
         // restore gpr registers
-        for (int i = n_gprs_to_save - 1; i >= 0; --i)
+        for (int i = into<int>(n_gprs_to_save - 1); i >= 0; --i)
             h->mov(gprs_to_save[i], h->ptr[h->rsp + i * gpr_size]);
-        h->add(h->rsp, n_gprs_to_save * gpr_size);
+        h->add(h->rsp, into<uint32_t>(n_gprs_to_save * gpr_size));
 
         h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
     }
@@ -2009,96 +2021,149 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
                 case eltwise_relu_use_dst_for_bwd:
                 case eltwise_relu:
                     if (alpha_ == 0.f)
-                        relu_zero_ns_compute_vector_fwd(Vmm(idx));
+                        relu_zero_ns_compute_vector_fwd(Vmm(into<int>(idx)));
                     else
-                        relu_compute_vector_fwd(Vmm(idx));
+                        relu_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
                 case eltwise_elu_use_dst_for_bwd:
-                case eltwise_elu: elu_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_tanh_use_dst_for_bwd:
-                case eltwise_tanh: tanh_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_square: square_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_abs: abs_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_sqrt_use_dst_for_bwd:
-                case eltwise_sqrt: sqrt_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_swish: swish_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_linear: linear_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_soft_relu:
-                    soft_relu_compute_vector_fwd(Vmm(idx));
+                case eltwise_elu:
+                    elu_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
-                case eltwise_mish: mish_compute_vector_fwd(Vmm(idx)); break;
+                case eltwise_tanh_use_dst_for_bwd:
+                case eltwise_tanh:
+                    tanh_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_square:
+                    square_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_abs:
+                    abs_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_sqrt_use_dst_for_bwd:
+                case eltwise_sqrt:
+                    sqrt_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_swish:
+                    swish_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_linear:
+                    linear_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_soft_relu:
+                    soft_relu_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_mish:
+                    mish_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
                 case eltwise_logistic_use_dst_for_bwd:
                 case eltwise_logistic:
-                    logistic_compute_vector_fwd(Vmm(idx));
+                    logistic_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
                 case eltwise_exp_use_dst_for_bwd:
-                case eltwise_exp: exp_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_gelu_tanh:
-                    gelu_tanh_compute_vector_fwd(Vmm(idx));
+                case eltwise_exp:
+                    exp_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
-                case eltwise_log: log_compute_vector_fwd(Vmm(idx)); break;
+                case eltwise_gelu_tanh:
+                    gelu_tanh_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_log:
+                    log_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
                 case eltwise_clip:
                 case eltwise_clip_v2_use_dst_for_bwd:
-                case eltwise_clip_v2: clip_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_pow: pow_compute_vector_fwd(Vmm(idx)); break;
-                case eltwise_gelu_erf:
-                    gelu_erf_compute_vector_fwd(Vmm(idx));
+                case eltwise_clip_v2:
+                    clip_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
-                case eltwise_round: round_compute_vector_fwd(Vmm(idx)); break;
+                case eltwise_pow:
+                    pow_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_gelu_erf:
+                    gelu_erf_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_round:
+                    round_compute_vector_fwd(Vmm(into<int>(idx)));
+                    break;
                 case eltwise_hardswish:
-                    hardswish_compute_vector_fwd(Vmm(idx));
+                    hardswish_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
                 case eltwise_hardsigmoid:
-                    hardsigmoid_compute_vector_fwd(Vmm(idx));
+                    hardsigmoid_compute_vector_fwd(Vmm(into<int>(idx)));
                     break;
                 default: assert(!"unsupported eltwise algorithm");
             }
         } else {
             switch (alg_) {
                 case eltwise_relu_use_dst_for_bwd:
-                case eltwise_relu: relu_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_elu_use_dst_for_bwd:
-                case eltwise_elu: elu_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_tanh_use_dst_for_bwd:
-                case eltwise_tanh: tanh_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_square: square_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_abs: abs_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_sqrt_use_dst_for_bwd:
-                case eltwise_sqrt: sqrt_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_linear: linear_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_soft_relu:
-                    soft_relu_compute_vector_bwd(Vmm(idx));
+                case eltwise_relu:
+                    relu_compute_vector_bwd(Vmm(into<int>(idx)));
                     break;
-                case eltwise_mish: mish_compute_vector_bwd(Vmm(idx)); break;
+                case eltwise_elu_use_dst_for_bwd:
+                case eltwise_elu:
+                    elu_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_tanh_use_dst_for_bwd:
+                case eltwise_tanh:
+                    tanh_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_square:
+                    square_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_abs:
+                    abs_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_sqrt_use_dst_for_bwd:
+                case eltwise_sqrt:
+                    sqrt_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_linear:
+                    linear_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_soft_relu:
+                    soft_relu_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_mish:
+                    mish_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
                 case eltwise_logistic_use_dst_for_bwd:
                 case eltwise_logistic:
-                    logistic_compute_vector_bwd(Vmm(idx));
+                    logistic_compute_vector_bwd(Vmm(into<int>(idx)));
                     break;
                 case eltwise_exp_use_dst_for_bwd:
-                case eltwise_exp: exp_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_gelu_tanh:
-                    gelu_tanh_compute_vector_bwd(Vmm(idx));
+                case eltwise_exp:
+                    exp_compute_vector_bwd(Vmm(into<int>(idx)));
                     break;
-                case eltwise_swish: swish_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_log: log_compute_vector_bwd(Vmm(idx)); break;
+                case eltwise_gelu_tanh:
+                    gelu_tanh_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_swish:
+                    swish_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_log:
+                    log_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
                 case eltwise_clip:
                 case eltwise_clip_v2_use_dst_for_bwd:
-                case eltwise_clip_v2: clip_compute_vector_bwd(Vmm(idx)); break;
-                case eltwise_pow: pow_compute_vector_bwd(Vmm(idx)); break;
+                case eltwise_clip_v2:
+                    clip_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
+                case eltwise_pow:
+                    pow_compute_vector_bwd(Vmm(into<int>(idx)));
+                    break;
                 case eltwise_gelu_erf:
-                    gelu_erf_compute_vector_bwd(Vmm(idx));
+                    gelu_erf_compute_vector_bwd(Vmm(into<int>(idx)));
                     break;
                 case eltwise_hardswish:
-                    hardswish_compute_vector_bwd(Vmm(idx));
+                    hardswish_compute_vector_bwd(Vmm(into<int>(idx)));
                     break;
                 case eltwise_hardsigmoid:
-                    hardsigmoid_compute_vector_bwd(Vmm(idx));
+                    hardsigmoid_compute_vector_bwd(Vmm(into<int>(idx)));
                     break;
                 default: assert(!"unsupported eltwise algorithm");
             }
         }
         if (scale_ != 1.f) {
-            h->uni_vmulps(Vmm(idx), Vmm(idx), table_val(scale));
+            h->uni_vmulps(
+                    Vmm(into<int>(idx)), Vmm(into<int>(idx)), table_val(scale));
         }
     });
 }

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -244,7 +244,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         size_t u0 = u % jcp.reduce_loop_unroll;
         size_t u1 = u / jcp.reduce_loop_unroll;
         return u1 * jcp.reduce_loop_load_step
-                + sizeof(float) * get_load_bwd_w_offset(jcp, i, u0);
+                + sizeof(float) * get_load_bwd_w_offset(jcp, i, into<int>(u0));
     };
 
     auto load_ptr = [this](int u, int i) {
@@ -256,7 +256,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                 offt = (i * jcp.oc_block + u0) * jcp.ic_block;
                 break;
             case backward_weights:
-                offt = get_load_bwd_w_offset(jcp, i, u0);
+                offt = get_load_bwd_w_offset(jcp, i, into<int>(u0));
                 break;
             default:
                 offt = (i * rnd_up(jcp.ic, jcp.ic_block) + u0) * jcp.oc_block;
@@ -612,7 +612,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            into<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(ptr[rsp + reg_dw_binary_output_off], aux_reg_load_data);
                 }
                 break;
@@ -705,32 +706,33 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc = jcp.oc_without_padding;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic = jcp.ic_without_padding;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
@@ -878,8 +880,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         load_blocking_max = is_data_layout_nxc ? jcp.load_dim : 144;
         bcast_blocking = 128; // affects load balancing across threads
         bcast_blocking_max = 192;
-        reduce_blocking = is_data_layout_nxc ? jcp.reduce_dim
-                                             : 128; // affects L1$ utilization
+        reduce_blocking = into<int>(is_data_layout_nxc
+                        ? jcp.reduce_dim
+                        : 128); // affects L1$ utilization
     } else if (jcp.prop_kind == backward_data) {
         jcp.reduce_dim = jcp.oc;
         jcp.reduce_block = jcp.oc_block;
@@ -913,8 +916,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
         bcast_blocking = 128; // affects load balancing across threads
         bcast_blocking_max = 196;
-        reduce_blocking = is_data_layout_nxc ? jcp.reduce_dim
-                                             : 64; // affects L1$ utilization
+        reduce_blocking
+                = into<int>(is_data_layout_nxc ? jcp.reduce_dim
+                                               : 64); // affects L1$ utilization
     } else if (jcp.prop_kind == backward_weights) {
         jcp.reduce_dim = jcp.os;
         jcp.reduce_block = 1;
@@ -934,12 +938,12 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         jcp.bcast_loop_output_step
                 = jcp.oc_block * jcp.ic_block * sizeof(float);
         jcp.bcast_loop_output_substep = jcp.oc_block * jcp.ur * sizeof(float);
-        jcp.bcast_loop_bcast_step = jcp.ic_block
-                * (is_data_layout_nxc ? 1 : jcp.is) * sizeof(float);
+        jcp.bcast_loop_bcast_step = into<int>(jcp.ic_block
+                * (is_data_layout_nxc ? 1 : jcp.is) * sizeof(float));
         jcp.bcast_loop_bcast_substep = jcp.ur * sizeof(float);
 
-        jcp.load_loop_load_step = jcp.oc_block
-                * (is_data_layout_nxc ? 1 : jcp.os) * sizeof(float);
+        jcp.load_loop_load_step = into<int>(jcp.oc_block
+                * (is_data_layout_nxc ? 1 : jcp.os) * sizeof(float));
         jcp.load_loop_iter_step = jcp.oc_block;
 
         /* --- */
@@ -963,7 +967,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         assert(IMPLICATION(
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         const int bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
         const bool no_bcast_tail = jcp.bcast_dim % jcp.bcast_block == 0;
         const bool small_size_for_bcast
@@ -1011,9 +1015,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_reduce_blocking = div_up(reduce_blocking, jcp.reduce_block);
     jcp.nb_reduce_blocking_max = div_up(reduce_blocking_max, jcp.reduce_block);
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     if (jcp.prop_kind == backward_weights) {
         const auto mb_with_nb_reduce

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -105,7 +105,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
     const int stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
     const int nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -318,9 +318,9 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        balance2D(nthr, ithr, into<dim_t>(jcp.mb * jcp.ngroups * jcp_dw->oh),
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end, dim_t(1));
 
         while (ocb_start < ocb_end) {
             int load_step;

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -94,7 +94,7 @@ void jit_avx2_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
             for (int ifm2 = 0; ifm2 < cur_ic_blk; ifm2++) {
                 for (int jj = jj_start; jj < jj_end; jj++) {
                     size_t inp_off = get_input_offset(
-                            ifm2, filter_w_to_input(ki, jj, pad_l));
+                            ifm2, into<int>(filter_w_to_input(ki, jj, pad_l)));
                     vbroadcastss(Ymm(oc_blocks * ur_w + jj),
                             make_safe_addr(
                                     aux_reg_input, inp_off, reg_long_offt));
@@ -155,7 +155,7 @@ void jit_avx2_conv_fwd_kernel_f32_t::oh_step_nopad(
         for (int ifm2 = 0; ifm2 < ic_blk; ifm2++) {
             for (int jj = jj_start; jj < jj_end; jj++) {
                 size_t inp_off = get_input_offset(
-                        ifm2, filter_w_to_input(0, jj, pad_l));
+                        ifm2, into<int>(filter_w_to_input(0, jj, pad_l)));
                 vbroadcastss(Ymm(oc_blocks * ur_w + jj),
                         make_safe_addr(aux_reg_input, inp_off, reg_long_offt));
             }
@@ -174,7 +174,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::oh_step_nopad(
             }
         }
         safe_add(aux_reg_kernel, get_kernel_offset(0, 1, 0), reg_long_offt);
-        safe_add(aux_reg_input, get_input_offset(0, filter_w_to_input(1)),
+        safe_add(aux_reg_input,
+                get_input_offset(0, into<int>(filter_w_to_input(1))),
                 reg_long_offt);
 
         inc(ki_iter);
@@ -392,13 +393,16 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
                 && pad_r == 0) {
             oh_step_nopad(ur_w, pad_l, pad_r, oc_blocks);
             add(aux_reg_input,
-                    get_input_offset(0, filter_h_to_input(1))
-                            - get_input_offset(0, filter_w_to_input(kw)));
+                    into<uint32_t>(
+                            get_input_offset(0, into<int>(filter_h_to_input(1)))
+                            - get_input_offset(
+                                    0, into<int>(filter_w_to_input(kw)))));
         } else {
             oh_step_unroll_kw(ur_w, pad_l, pad_r, oc_blocks);
             safe_add(
                     aux_reg_kernel, get_kernel_offset(0, kw, 0), reg_long_offt);
-            safe_add(aux_reg_input, get_input_offset(0, filter_h_to_input(1)),
+            safe_add(aux_reg_input,
+                    get_input_offset(0, into<int>(filter_h_to_input(1))),
                     reg_long_offt);
         }
 
@@ -410,7 +414,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     L(skip_kh_loop);
 
     if (jcp.ndims == 5) {
-        safe_add(aux_reg_inp_d, get_input_offset(0, filter_d_to_input(1)),
+        safe_add(aux_reg_inp_d,
+                get_input_offset(0, into<int>(filter_d_to_input(1))),
                 reg_long_offt);
         safe_add(aux_reg_ker_d, get_kernel_offset(0, jcp.kw * jcp.kh, 0),
                 reg_long_offt);
@@ -507,8 +512,10 @@ inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
             width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
         else
             width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
-        add(reg_output, get_output_offset(0, ur_w));
+        add(reg_input,
+                into<uint32_t>(get_input_offset(
+                        0, into<int>(filter_w_to_input(0, ur_w, l_pad)))));
+        add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
     }
 
     Label ow_loop;
@@ -518,8 +525,10 @@ inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
         L(ow_loop);
 
         width_blk_step(ur_w, 0, 0, oc_blocks); // "middle"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w)));
-        add(reg_output, get_output_offset(0, ur_w));
+        add(reg_input,
+                into<uint32_t>(get_input_offset(
+                        0, into<int>(filter_w_to_input(0, ur_w)))));
+        add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
 
         inc(oi_iter);
         cmp(oi_iter, n_oi);
@@ -528,8 +537,10 @@ inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
 
     if (r_pad1 > 0 && n_oi >= 0) {
         width_blk_step(ur_w, 0, r_pad1, oc_blocks); // "rpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w)));
-        add(reg_output, get_output_offset(0, ur_w));
+        add(reg_input,
+                into<uint32_t>(get_input_offset(
+                        0, into<int>(filter_w_to_input(0, ur_w)))));
+        add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
     }
 
     if (ur_w_tail != 0)
@@ -603,33 +614,34 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     int ndims = src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -660,8 +672,8 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag_OIxio, wei_tag_Oxio);
     jcp.dst_tag = dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -924,8 +936,9 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
             auto compute = [&](int cur_oc_blk) {
                 for (int ofm2 = 0; ofm2 < cur_oc_blk; ofm2++) {
                     for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        int aux_output_offset = get_ddst_offset(
-                                0, filter_w_to_ddst(ki, jj, jcp.l_pad), ofm2);
+                        int aux_output_offset = into<int>(get_ddst_offset(0,
+                                into<int>(filter_w_to_ddst(ki, jj, jcp.l_pad)),
+                                ofm2));
                         vbroadcastss(Ymm(nb_ic_block * ur_w + jj / stride_w),
                                 ptr[aux_reg_ddst + aux_output_offset]);
                     }
@@ -962,8 +975,10 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
             }
         }
 
-        add(aux_reg_kernel, get_kernel_offset(0, 0, stride_h * kw, 0));
-        sub(aux_reg_ddst, get_ddst_offset(0, (jcp.dilate_h + 1) * ow, 0));
+        add(aux_reg_kernel,
+                into<uint32_t>(get_kernel_offset(0, 0, stride_h * kw, 0)));
+        sub(aux_reg_ddst,
+                into<uint32_t>(get_ddst_offset(0, (jcp.dilate_h + 1) * ow, 0)));
 
         dec(kj);
         cmp(kj, 0);
@@ -973,8 +988,10 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
 
     if (jcp.ndims == 5) {
         sub(aux_reg_dst_d,
-                get_ddst_offset(0, (jcp.dilate_d + 1) * jcp.oh * ow, 0));
-        add(aux_reg_ker_d, get_kernel_offset(0, 0, jcp.kw * jcp.kh, 0));
+                into<uint32_t>(get_ddst_offset(
+                        0, (jcp.dilate_d + 1) * jcp.oh * ow, 0)));
+        add(aux_reg_ker_d,
+                into<uint32_t>(get_kernel_offset(0, 0, jcp.kw * jcp.kh, 0)));
 
         dec(reg_ki);
         cmp(reg_ki, 0);
@@ -985,8 +1002,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     }
 
     if (one_of(jcp.ndims, 3, 4)) {
-        int ddst_oc_shift = get_ddst_offset(1, 0, 0);
-        int kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
+        int ddst_oc_shift = into<int>(get_ddst_offset(1, 0, 0));
+        int kernel_oc_shift = into<int>(get_kernel_offset(1, 0, 0, 0));
 
         add(aux_reg_ddst_oc_loop, ddst_oc_shift);
         add(aux_reg_kernel_oc_loop, kernel_oc_shift);
@@ -1062,8 +1079,9 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::generate() {
     mov(reg_channel, ptr[param1 + GET_OFF(channel)]);
     mov(reg_channel_work, ptr[param1 + GET_OFF(ch_blocks)]);
 
-    int ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
-    int dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
+    int ddst_shift = into<int>(
+            get_ddst_offset(0, into<int>(filter_w_to_ddst(0, jcp.ur_w)), 0));
+    int dsrc_shift = into<int>(get_dsrc_offset(0, jcp.ur_w));
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
 
@@ -1136,35 +1154,36 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     int ndims = diff_src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(diff_src_d.dims()[1] / jcp.ngroups);
 
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? diff_src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     const bool dilate_ok = !((jcp.dilate_w != 0 && jcp.stride_w != 1)
             || (jcp.dilate_d != 0 && jcp.stride_d != 1)
@@ -1193,8 +1212,8 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             = diff_dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
 
-    jcp.typesize_in = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in = into<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(diff_dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -1365,36 +1384,38 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     int ndims = src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? diff_weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>(
+            (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     const auto dat_tag_nxc = pick(ndims - 3, nwc, nhwc, ndhwc);
     const auto dat_tag_ncx = pick(ndims - 3, ncw, nchw, ncdhw);
@@ -1487,8 +1508,8 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(diff_dst_d.data_type()));
 
     const bool is_src_layout_blocked = jcp.src_tag == dat_tag_nCx8c;
     const bool is_dst_layout_blocked = jcp.dst_tag == dat_tag_nCx8c;
@@ -1525,8 +1546,10 @@ jit_avx2_conv_bwd_weights_kernel_f32_t::od_step_comeback_pointers() {
     mov(kj, jcp.kd); //FIXME (Anton): this works only if f_pad = back_pad = 0
     L(kd_comeback_loop);
     {
-        sub(aux_reg_input, get_input_offset(0, jcp.iw * jcp.ih));
-        sub(aux_reg_kernel, get_kernel_offset(jcp.kw * jcp.kh, 0));
+        sub(aux_reg_input,
+                into<uint32_t>(get_input_offset(0, jcp.iw * jcp.ih)));
+        sub(aux_reg_kernel,
+                into<uint32_t>(get_kernel_offset(jcp.kw * jcp.kh, 0)));
         dec(kj);
         cmp(kj, 0);
         jg(kd_comeback_loop, T_NEAR);
@@ -1539,8 +1562,8 @@ jit_avx2_conv_bwd_weights_kernel_f32_t::oh_step_comeback_pointers() {
     Label kh_comeback_loop;
     L(kh_comeback_loop);
     {
-        sub(reg_input, get_input_offset(0, jcp.iw));
-        sub(reg_kernel, get_kernel_offset(jcp.kw, 0));
+        sub(reg_input, into<uint32_t>(get_input_offset(0, jcp.iw)));
+        sub(reg_kernel, into<uint32_t>(get_kernel_offset(jcp.kw, 0)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_comeback_loop, T_NEAR);
@@ -1702,14 +1725,16 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
             compute_ic_block_step(
                     jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
-            add(reg_kernel, get_kernel_offset(0, ic_block_step));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(0, ic_block_step)));
             add(b_ic, ic_block_step);
             cmp(b_ic, ic_block);
             jl(ic_block_loop, T_NEAR);
         }
         add(reg_input,
-                get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+                into<uint32_t>(get_input_offset(0, jcp.iw)
+                        - get_input_offset(ic_block, 0)));
+        add(reg_kernel, into<uint32_t>(get_kernel_offset((jcp.kw - 1), 0)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1729,7 +1754,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
             compute_ic_block_step(
                     jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
-            add(reg_kernel, get_kernel_offset(0, ic_block_step));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(0, ic_block_step)));
             sub(b_ic, ic_block_step);
             cmp(b_ic, ic_block_step);
             jge(ic_block_loop, T_NEAR);
@@ -1740,15 +1766,18 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         if (ic_block_step_tail) {
             compute_ic_block_step(
                     jcp.ow, jcp.l_pad, r_pad, ic_block_step_tail, 0, 0, 0);
-            add(reg_input, get_input_offset(ic_block_step_tail, 0));
-            add(reg_kernel, get_kernel_offset(0, ic_block_step_tail));
+            add(reg_input,
+                    into<uint32_t>(get_input_offset(ic_block_step_tail, 0)));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(0, ic_block_step_tail)));
         }
 
         add(reg_input,
-                get_input_offset(0, jcp.iw) - get_input_offset(ic_tail, 0));
+                into<uint32_t>(get_input_offset(0, jcp.iw)
+                        - get_input_offset(ic_tail, 0)));
         add(reg_kernel,
-                get_kernel_offset(0, ic_block - ic_tail)
-                        + get_kernel_offset((jcp.kw - 1), 0));
+                into<uint32_t>(get_kernel_offset(0, ic_block - ic_tail)
+                        + get_kernel_offset((jcp.kw - 1), 0)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop_ic_tail, T_NEAR);
@@ -1757,8 +1786,10 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
     L(kh_loop_done);
 
     if (jcp.ndims == 5) {
-        add(aux_reg_input, get_input_offset(0, jcp.ih * jcp.iw));
-        add(aux_reg_kernel, get_kernel_offset(jcp.kh * jcp.kw, 0));
+        add(aux_reg_input,
+                into<uint32_t>(get_input_offset(0, jcp.ih * jcp.iw)));
+        add(aux_reg_kernel,
+                into<uint32_t>(get_kernel_offset(jcp.kh * jcp.kw, 0)));
         dec(ki);
         cmp(ki, 0);
         jg(kd_loop, T_NEAR);
@@ -1789,9 +1820,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
     }
 
-    int input_comeback
-            = get_input_offset(0, ur_w_trips * ur_w * stride_w - jcp.l_pad);
-    int output_comeback = get_output_offset(0, ur_w_trips * ur_w);
+    int input_comeback = into<int>(
+            get_input_offset(0, ur_w_trips * ur_w * stride_w - jcp.l_pad));
+    int output_comeback = into<int>(get_output_offset(0, ur_w_trips * ur_w));
 
     if (jcp.ndims == 5) {
         mov(aux_reg_input, reg_input);
@@ -1815,8 +1846,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                 compute_ic_block_step(
                         ur_w, jcp.l_pad, 0, ic_block_step, 0, 0, 0);
                 add(reg_input,
-                        get_input_offset(0, ur_w * stride_w - jcp.l_pad));
-                add(reg_output, get_output_offset(0, ur_w));
+                        into<uint32_t>(get_input_offset(
+                                0, ur_w * stride_w - jcp.l_pad)));
+                add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
             }
 
             if (ur_w_trips > 0) {
@@ -1825,8 +1857,10 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                 L(ow_block_loop);
                 {
                     compute_ic_block_step(ur_w, 0, 0, ic_block_step, 0, 0, 0);
-                    add(reg_output, get_output_offset(0, ur_w));
-                    add(reg_input, get_input_offset(0, ur_w * stride_w));
+                    add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
+                    add(reg_input,
+                            into<uint32_t>(
+                                    get_input_offset(0, ur_w * stride_w)));
 
                     inc(reg_ur_w_trips);
                     cmp(reg_ur_w_trips, ur_w_trips);
@@ -1843,23 +1877,27 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 
             size_t inp_icblk_stride = get_input_offset(ic_block_step, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
-            add(reg_kernel, get_kernel_offset(0, ic_block_step));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(0, ic_block_step)));
 
             add(b_ic, ic_block_step);
             cmp(b_ic, jcp.ic_block);
             jl(ic_block_loop, T_NEAR);
         }
         add(reg_input,
-                get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+                into<uint32_t>(get_input_offset(0, jcp.iw)
+                        - get_input_offset(ic_block, 0)));
+        add(reg_kernel, into<uint32_t>(get_kernel_offset((jcp.kw - 1), 0)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
     }
 
     if (jcp.ndims == 5) {
-        add(aux_reg_input, get_input_offset(0, jcp.ih * jcp.iw));
-        add(aux_reg_kernel, get_kernel_offset(jcp.kh * jcp.kw, 0));
+        add(aux_reg_input,
+                into<uint32_t>(get_input_offset(0, jcp.ih * jcp.iw)));
+        add(aux_reg_kernel,
+                into<uint32_t>(get_kernel_offset(jcp.kh * jcp.kw, 0)));
         dec(ki);
         cmp(ki, 0);
         jg(kd_loop, T_NEAR);
@@ -1879,13 +1917,14 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
     if (t_pad > 0) {
         assert(jcp.kh <= t_pad + jcp.ih); /* [bwd_w:r1] */
         mov(reg_kh, jcp.kh <= t_pad + jcp.ih ? jcp.kh - t_pad : jcp.ih);
-        add(reg_kernel, get_kernel_offset(t_pad * jcp.kw, 0));
+        add(reg_kernel, into<uint32_t>(get_kernel_offset(t_pad * jcp.kw, 0)));
 
         L(oh_tpad_loop);
         {
             compute_oh_step_disp();
-            add(reg_output, get_output_offset(0, jcp.ow));
-            sub(reg_kernel, get_kernel_offset(stride_h * jcp.kw, 0));
+            add(reg_output, into<uint32_t>(get_output_offset(0, jcp.ow)));
+            sub(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(stride_h * jcp.kw, 0)));
 
             inc(reg_oj);
             add(reg_ih_count, stride_h);
@@ -1900,8 +1939,10 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
 
         if (t_pad % stride_h != 0) {
             int inp_corr = stride_h - t_pad % stride_h;
-            add(reg_kernel, get_kernel_offset(inp_corr * jcp.kw, 0));
-            add(reg_input, get_input_offset(0, inp_corr * jcp.iw));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(inp_corr * jcp.kw, 0)));
+            add(reg_input,
+                    into<uint32_t>(get_input_offset(0, inp_corr * jcp.iw)));
         }
     }
     cmp(reg_ih_count, jcp.ih + t_pad - jcp.kh + 1);
@@ -1913,8 +1954,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
     L(oh_loop);
     {
         compute_oh_step_disp();
-        add(reg_input, get_input_offset(0, stride_h * jcp.iw));
-        add(reg_output, get_output_offset(0, jcp.ow));
+        add(reg_input, into<uint32_t>(get_input_offset(0, stride_h * jcp.iw)));
+        add(reg_output, into<uint32_t>(get_output_offset(0, jcp.ow)));
 
         inc(reg_oj);
         add(reg_ih_count, stride_h);
@@ -1936,8 +1977,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
         L(oh_bpad_loop);
         {
             compute_oh_step_disp();
-            add(reg_input, get_input_offset(0, stride_h * jcp.iw));
-            add(reg_output, get_output_offset(0, jcp.ow));
+            add(reg_input,
+                    into<uint32_t>(get_input_offset(0, stride_h * jcp.iw)));
+            add(reg_output, into<uint32_t>(get_output_offset(0, jcp.ow)));
 
             sub(reg_kh, stride_h);
             cmp(reg_kh, 0);

--- a/src/cpu/x64/jit_avx2_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_convolution.cpp
@@ -398,11 +398,13 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
         if (w_njobs == 0) return;
 
         /* reduction dimension */
-        int img_od_start {0}, img_od_end {0}, img {0}, od_s {0};
-        balance211(jcp.mb * jcp.od, rw->balancer().nthr_per_group_,
+        dim_t img_od_start {0}, img_od_end {0};
+        int img {0}, od_s {0};
+        balance211(into<dim_t>(jcp.mb * jcp.od),
+                rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), img_od_start, img_od_end);
 
-        int img_start = img_od_start, img_end = img_od_end;
+        dim_t img_start = img_od_start, img_end = img_od_end;
         nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
         const int img_first = img;
 
@@ -472,8 +474,8 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
-        balance211(jcp.mb, rb->balancer().nthr_per_group_,
+        dim_t img_start {0}, img_end {0};
+        balance211(into<dim_t>(jcp.mb), rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -233,8 +233,8 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const int reduce_mul = into<int>(
+                    bcast_layout_nxc ? jcp.reduce_dim : jcp.reduce_loop_unroll);
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
@@ -250,10 +250,10 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
         int offt;
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+        int lmul = into<int>(jcp.load_block
                 * (load_layout_nxc ? 1
-                                   : utils::rnd_up(
-                                             jcp.reduce_dim, jcp.reduce_block));
+                                   : utils::rnd_up(jcp.reduce_dim,
+                                             jcp.reduce_block)));
         int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
@@ -471,7 +471,8 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
                     mov(aux_reg_load_data,
                             EVEX_compress_addr(rsp, reg_dw_binary_output_off));
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            into<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(EVEX_compress_addr(rsp, reg_dw_binary_output_off),
                             aux_reg_load_data);
                 }
@@ -576,32 +577,33 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc = jcp.oc_without_padding;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic = jcp.ic_without_padding;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
@@ -759,8 +761,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
         jcp.load_loop_load_step
-                = (utils::rnd_up(jcp.reduce_dim, jcp.reduce_block))
-                * jcp.load_block * jcp.typesize_in;
+                = into<int>((utils::rnd_up(jcp.reduce_dim, jcp.reduce_block))
+                        * jcp.load_block * jcp.typesize_in);
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold;
@@ -797,7 +799,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = into<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -813,8 +815,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         jcp.bcast_loop_output_step = jcp.ur * jcp.typesize_out
                 * (is_data_layout_nxc ? jcp.load_dim : jcp.load_block);
         jcp.bcast_loop_output_substep = -1; // unused
-        jcp.bcast_loop_bcast_step = jcp.ur * jcp.typesize_in
-                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block);
+        jcp.bcast_loop_bcast_step = into<int>(jcp.ur * jcp.typesize_in
+                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block));
         jcp.bcast_loop_bcast_substep = -1; // unused
 
         jcp.load_loop_iter_step = jcp.load_block;
@@ -824,19 +826,22 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+        int nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+        int nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
         int nb_load = div_up(jcp.load_dim, jcp.load_block);
         if (is_data_layout_nxc) {
-            reduce_blocking = jcp.reduce_dim;
+            reduce_blocking = into<int>(jcp.reduce_dim);
         } else if (jcp.expl_bcast) {
             if (jcp.load_dim <= BIG_LOAD_DIM && spatial > SMALL_SPATIAL
                     && spatial < BIG_SPATIAL)
-                reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 80);
+                reduce_blocking
+                        = into<int>(nstl::min<dim_t>(jcp.reduce_dim, 80));
             else if (spatial > SMALL_SPATIAL)
-                reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 512);
+                reduce_blocking
+                        = into<int>(nstl::min<dim_t>(jcp.reduce_dim, 512));
             else
-                reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 256);
+                reduce_blocking
+                        = into<int>(nstl::min<dim_t>(jcp.reduce_dim, 256));
         } else {
             reduce_blocking = nb_reduce;
             if (spatial <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -865,8 +870,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 for (dim_t off = start_off, hits = 0; off < sp * nrb;
                         off += wl) {
                     if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                    int max_r_blocking
-                            = simd_w * nstl::max<dim_t>(1, (off + wl) / sp);
+                    int max_r_blocking = into<int>(
+                            simd_w * nstl::max<dim_t>(1, (off + wl) / sp));
                     reduce_blocking
                             = nstl::min(reduce_blocking, max_r_blocking);
                     break;
@@ -882,7 +887,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         }
         load_blocking = jcp.load_dim;
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
+        int load_size = into<int>(jcp.load_dim * jcp.reduce_dim);
         auto bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
@@ -1007,7 +1012,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
                                  div_up(jcp.nthr, jcp.load_grp_count))
                 * jcp.bcast_block;
-        bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+        bcast_blocking
+                = into<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
         bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
         int space_for_bcast = (L2_capacity - /* kernel_size - */
@@ -1032,7 +1038,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     } else if (jcp.prop_kind == backward_weights) {
         jcp.reduce_dim = jcp.is;
 
-        jcp.reduce_block = best_divider(jcp.reduce_dim, 7, 16, true);
+        jcp.reduce_block = best_divider(into<int>(jcp.reduce_dim), 7, 16, true);
         if (jcp.reduce_dim % jcp.reduce_block != 0)
             jcp.reduce_block = best_divider(jcp.iw, 4, jcp.iw, false);
         if (jcp.reduce_block > 256) { jcp.reduce_block = 1; }
@@ -1067,15 +1073,15 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 = jcp.oc_block * jcp.ic_block * jcp.typesize_out;
         jcp.bcast_loop_output_substep
                 = jcp.oc_block * jcp.ur * jcp.typesize_out;
-        jcp.bcast_loop_bcast_step = jcp.ic_block
+        jcp.bcast_loop_bcast_step = into<int>(jcp.ic_block
                 * (is_data_layout_nxc ? 1
                                       : utils::rnd_up(jcp.reduce_dim,
                                                 jcp.reduce_block))
-                * jcp.typesize_in;
+                * jcp.typesize_in);
         jcp.bcast_loop_bcast_substep = jcp.ur * jcp.typesize_in;
 
-        jcp.load_loop_load_step = jcp.typesize_in * jcp.oc_block
-                * (is_data_layout_nxc ? 1 : jcp.os);
+        jcp.load_loop_load_step = into<int>(jcp.typesize_in * jcp.oc_block
+                * (is_data_layout_nxc ? 1 : jcp.os));
         jcp.load_loop_iter_step = jcp.oc_block;
 
         /* --- */
@@ -1089,10 +1095,11 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         assert(IMPLICATION(
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int max_bcast_blocking
+                = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         int min_bcast_blocking = 5;
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         bcast_blocking = best_divider(
                 bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
         bcast_blocking *= jcp.bcast_block;
@@ -1105,12 +1112,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 && jcp.load_dim >= BIG_LOAD_DIM / 2) {
             reduce_blocking = rnd_up(nstl::min(jcp.ow, 256), jcp.reduce_block);
         } else {
-            int max_reduce_blocking
-                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
+            int max_reduce_blocking = into<int>(
+                    nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim));
             int min_reduce_blocking = nstl::min(
                     L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
-            reduce_blocking = best_divider(jcp.reduce_dim, min_reduce_blocking,
-                    max_reduce_blocking, true);
+            reduce_blocking = best_divider(into<int>(jcp.reduce_dim),
+                    min_reduce_blocking, max_reduce_blocking, true);
             reduce_blocking
                     = nstl::max(rnd_dn(reduce_blocking, jcp.reduce_block),
                             jcp.reduce_block);
@@ -1145,9 +1152,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     jcp.nb_reduce_blocking_max
             = utils::div_up(reduce_blocking_max, jcp.reduce_block);
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     return status::success;
 }
@@ -1190,9 +1197,9 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    const int nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     jcp.nthr_g = jcp.ngroups;
     const int nthr = nthreads / jcp.nthr_g;

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -115,7 +115,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
     const int nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -387,9 +387,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        balance2D(nthr, ithr, into<dim_t>(jcp.mb * jcp.ngroups * jcp_dw.oh),
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                dim_t(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
             int load_step;

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -802,31 +802,32 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nthr = jcp.aligned_threads = nthreads;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -1464,7 +1465,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                 for (int jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * (jcp.dilate_w + 1)) % stride_w
                             == 0);
-                    int aux_dst_offset = get_dst_offset(jj, oc, ki);
+                    int aux_dst_offset = into<int>(get_dst_offset(jj, oc, ki));
                     vfmadd231ps(vmm_out(jj, 0), vmm_kernel,
                             EVEX_compress_addr(
                                     aux_reg_dst, aux_dst_offset, true));
@@ -1576,7 +1577,8 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                 }
                 if (jcp.kernel_kind == expl_bcast) {
                     for (int jj = jj_start; jj < jj_end; jj++) {
-                        int aux_output_offset = get_dst_offset(jj, oc, ki);
+                        int aux_output_offset
+                                = into<int>(get_dst_offset(jj, oc, ki));
                         vbroadcastss(vmm_inp(jj, nb_ic_block),
                                 ptr[aux_reg_dst + aux_output_offset]);
                     }
@@ -1884,36 +1886,37 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(diff_src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
 
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? diff_src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
     VDISPATCH_CONV_IC(!((jcp.dilate_w != 0 && jcp.stride_w != 1)
                               || (jcp.dilate_d != 0 && jcp.stride_d != 1)
                               || (jcp.dilate_h != 0 && jcp.stride_h != 1)),
@@ -3076,11 +3079,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
                             + ic1 * jcp.oc_block * jcp.typesize_out],
                     zero);
         add(reg_tmp, jcp.ic_block * jcp.oc_block * jcp.typesize_out);
-        cmp(reg_tmp, kernel_block_bytes);
+        cmp(reg_tmp, into<uint32_t>(kernel_block_bytes));
         jnz(zeroing_loop);
     }
     if (generate_icb_loop) {
-        add(reg_kernel, kernel_block_bytes);
+        add(reg_kernel, into<uint32_t>(kernel_block_bytes));
         sub(reg_icb, jcp.ic_block);
         cmp(reg_icb, 0);
         jg(icb_block_label, T_NEAR);
@@ -3159,7 +3162,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
         if (oc_tail) zmm_out = zmm_out | k_oc_mask | T_z;
         vmovups(zmm_out, ptr[reg_output + reg_tmp]);
         vaddps(Zmm(1), Zmm(1), Zmm(0));
-        add(reg_tmp, oc_mult * jcp.typesize_out);
+        add(reg_tmp, into<uint32_t>(oc_mult * jcp.typesize_out));
         cmp(reg_tmp, reg_oi);
         jl(bias_loop);
     }
@@ -3417,7 +3420,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_kernel, filter_shift * jcp.stride_h);
+        sub(reg_kernel, into<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
@@ -3430,12 +3433,14 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
                 int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_kernel, filter_shift * inp_corr);
-                add(reg_input, input_shift * inp_corr);
+                add(reg_kernel, into<uint32_t>(filter_shift * inp_corr));
+                add(reg_input, into<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+            sub(reg_kernel,
+                    into<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Set filter element count for outside the t_pad region */
@@ -3473,11 +3478,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     }
 
     /* Compute middle block */
-    add(reg_input, input_shift * jcp.stride_h);
+    add(reg_input, into<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_output, output_shift);
+    add(reg_output, into<uint32_t>(output_shift));
     inc(reg_oj);
     cmp(reg_oj, ptr[param + GET_OFF(os_index_end)]);
     jl(loop_begin_label, T_NEAR);
@@ -3549,7 +3554,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
-        sub(reg_kernel, filter_shift * jcp.stride_d);
+        sub(reg_kernel, into<uint32_t>(filter_shift * jcp.stride_d));
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with input */
@@ -3562,12 +3567,14 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
                 int inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
-                add(reg_kernel, filter_shift * inp_corr);
-                add(reg_input_d, input_shift * inp_corr);
+                add(reg_kernel, into<uint32_t>(filter_shift * inp_corr));
+                add(reg_input_d, into<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.f_pad - jcp.od * jcp.stride_d) * filter_shift);
+            sub(reg_kernel,
+                    into<uint32_t>((jcp.f_pad - jcp.od * jcp.stride_d)
+                            * filter_shift));
         }
 
         /* Set filter element count for outside the f_pad region */
@@ -3605,11 +3612,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     }
 
     /* Compute middle block */
-    add(reg_input_d, input_shift * jcp.stride_d);
+    add(reg_input_d, into<uint32_t>(input_shift * jcp.stride_d));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_output_d, output_shift);
+    add(reg_output_d, into<uint32_t>(output_shift));
     inc(reg_d_index);
     cmp(reg_d_index, ptr[param + GET_OFF(os_index_end)]);
     jl(d_loop_label, T_NEAR);
@@ -3952,36 +3959,38 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? diff_weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>(
+            (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -1173,10 +1173,10 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     int ithr_but_oc;
     int ithr_but_ic;
 
-    int img_work, img_start = 0, img_end = 0;
-    int g_work, g_start = 0, g_end = 0;
-    int oc_b_work, oc_b_start = 0, oc_b_end = 0;
-    int ic_b_work, ic_b_start = 0, ic_b_end = 0;
+    dim_t img_work, img_start = 0, img_end = 0;
+    dim_t g_work, g_start = 0, g_end = 0;
+    dim_t oc_b_work, oc_b_start = 0, oc_b_end = 0;
+    dim_t ic_b_work, ic_b_start = 0, ic_b_end = 0;
 
     thread_info_t(const jit_avx512_common_convolution_bwd_weights_t *self,
             const exec_ctx_t &ctx, int ithr)
@@ -1213,20 +1213,21 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
         /* reduction dimension */
         int oh_reduce = jcp.harness == harness_2d_reduction ? jcp.oh : 1;
-        balance211(jcp.mb * jcp.od * oh_reduce, self->nthr_mb_, ithr_mb,
-                img_start, img_end);
+        balance211(into<dim_t>(jcp.mb * jcp.od * oh_reduce), self->nthr_mb_,
+                ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(into<dim_t>(jcp.ngroups), self->nthr_g_, ithr_g, g_start,
+                g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(into<dim_t>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(into<dim_t>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };
@@ -1720,8 +1721,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     if (b_njobs == 0) return;
 
     /* reduction dimension */
-    int img_start {0}, img_end {0};
-    balance211(jcp.mb, rb->balancer().nthr_per_group_,
+    dim_t img_start {0}, img_end {0};
+    balance211(into<dim_t>(jcp.mb), rb->balancer().nthr_per_group_,
             rb->balancer().id_in_group(ti->ithr), img_start, img_end);
 
     /* jobs */

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -117,7 +117,7 @@ size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
 void jit_avx512_core_amx_1x1_fwd_kernel_t::update_buffer_pointers() {
     auto buffer_offset
             = [this](bool shift) { return ((buf_count_ + shift) % 2); };
-    int wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
+    int wsp_shift = into<int>(jcp.typesize_acc * (jcp.wsp_buffer_size / 2));
 
     int postop_shift = wsp_shift * buffer_offset(true);
 
@@ -166,7 +166,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
             int ow = ((jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
             size_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
-            add(out_ptr, out_offset);
+            add(out_ptr, into<uint32_t>(out_offset));
             row_count_ = 0;
             is_store_done_ = true;
         }
@@ -853,12 +853,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::osb_loop(int nb_os) {
         if (do_store) {
             size_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
-            add(out_ptr, out_offset);
+            add(out_ptr, into<uint32_t>(out_offset));
         }
 
         int ih = oh * jcp.stride_h;
         int iw = ow * jcp.stride_w;
-        add(inp_ptr, inp_offset(ih, iw, 0));
+        add(inp_ptr, into<uint32_t>(inp_offset(ih, iw, 0)));
     }
 }
 
@@ -952,7 +952,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                 tc_configure_tile(buff, get_out_tensor(s, i), Cr, Cc);
             }
 
-        buff->palette_id = amx::get_target_palette();
+        buff->palette_id = into<uint8_t>(amx::get_target_palette());
     };
 
     int Ac = jcp.typesize_in
@@ -1007,27 +1007,27 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = avx512_core_amx;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = !is_1d ? src_d.dims()[ndims - 2] : 1;
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = !is_1d ? dst_d.dims()[ndims - 2] : 1;
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = !is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1;
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = !is_1d ? cd.padding[0][ndims - 4] : 0;
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = !is_1d ? cd.strides[ndims - 4] : 1;
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>(is_3d ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>(!is_1d ? src_d.dims()[ndims - 2] : 1);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(!is_1d ? dst_d.dims()[ndims - 2] : 1);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(!is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(!is_1d ? cd.padding[0][ndims - 4] : 0);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(!is_1d ? cd.strides[ndims - 4] : 1);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     VDISPATCH_CONV_IC((jcp.kd == 1 && jcp.kh == 1 && jcp.kw == 1),
@@ -1035,9 +1035,9 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC((jcp.f_pad == 0 && jcp.t_pad == 0 && jcp.l_pad == 0),
             VERBOSE_UNSUPPORTED_FEATURE, "non-zero padding");
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>(is_3d ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>(is_1d ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     jcp.is_depthwise = true && with_groups && everyone_is(1, jcp.ic, jcp.oc);
 
@@ -1193,10 +1193,10 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     p, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -171,7 +171,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
         L(overflow_label);
         {
             compute_ker(ur_w, pad_l, pad_r, last_ic_block_flag, true);
-            add(aux_reg_filt, shift_wei_h_step);
+            add(aux_reg_filt, into<uint32_t>(shift_wei_h_step));
             dec(reg_overflow);
             jne(overflow_label, T_NEAR);
         }
@@ -191,7 +191,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
     {
         compute_ker(ur_w, pad_l, pad_r, last_ic_block_flag, false);
 
-        add(aux_reg_filt, shift_wei_h_step);
+        add(aux_reg_filt, into<uint32_t>(shift_wei_h_step));
         dec(reg_kj);
         jne(kh_label, T_NEAR);
     }
@@ -227,11 +227,11 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
             L(kh_loop_label);
             {
                 compute_ker(ur_w, pad_l, pad_r, last_ic_block_flag, true);
-                add(aux_reg_filt, shift_wei_h_step);
+                add(aux_reg_filt, into<uint32_t>(shift_wei_h_step));
                 dec(reg_kj);
                 jne(kh_loop_label, T_NEAR);
             }
-            add(aux_reg_filt_d, shift_wei_h_step * jcp.kh);
+            add(aux_reg_filt_d, into<uint32_t>(shift_wei_h_step * jcp.kh));
             dec(reg_ki);
             jne(overflow_label, T_NEAR);
         }
@@ -259,7 +259,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
     kh_loop(ur_w, pad_l, pad_r, last_ic_block_flag, handle_h_pad);
 
     if (is_3d) {
-        add(aux_reg_filt_d, shift_wei_h_step * jcp.kh);
+        add(aux_reg_filt_d, into<uint32_t>(shift_wei_h_step * jcp.kh));
         dec(reg_ki);
         jne(kd_label, T_NEAR);
 
@@ -310,13 +310,14 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
     if (do_icb_loop) {
         const size_t shift_wei_icb_step = static_cast<size_t>(jcp.kd) * jcp.kh
                 * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
-        add(reg_filt, sizeof(char) * shift_wei_icb_step);
+        add(reg_filt, into<uint32_t>(sizeof(char) * shift_wei_icb_step));
 
         dec(reg_icb);
         cmp(reg_icb, 0);
         jg(icb_label, T_NEAR);
 
-        sub(reg_filt, sizeof(char) * shift_wei_icb_step * nb_ic);
+        sub(reg_filt,
+                into<uint32_t>(sizeof(char) * shift_wei_icb_step * nb_ic));
     }
 
     if (jcp.oc_without_padding != jcp.oc) {
@@ -366,7 +367,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
         const int cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, l_pad, cur_r_pad, h_padding);
-        add(reg_zp_pbuff, ur_w_shift(ur_w));
+        add(reg_zp_pbuff, into<uint32_t>(ur_w_shift(ur_w)));
 
         l_pad = nstl::max(l_pad - ur_w * jcp.stride_w, 0);
         cur_l_pad_output = nstl::max(cur_l_pad_output - ur_w, 0);
@@ -375,7 +376,8 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
     if (no_pad > 0) {
         const int ur_w = 1;
         if (h_padding) icb_loop(ur_w, 0, 0, true);
-        if (h_padding || jcp.ow_mid) add(reg_zp_pbuff, ur_w_shift(ur_w));
+        if (h_padding || jcp.ow_mid)
+            add(reg_zp_pbuff, into<uint32_t>(ur_w_shift(ur_w)));
     }
     assert(ow + no_pad == ow_start);
 
@@ -387,7 +389,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
         const int cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, 0, cur_r_pad, h_padding);
-        add(reg_zp_pbuff, ur_w_shift(ur_w));
+        add(reg_zp_pbuff, into<uint32_t>(ur_w_shift(ur_w)));
 
         cur_r_pad_output = nstl::max(cur_r_pad_output - ur_w, 0);
     }
@@ -1015,8 +1017,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
             size_t out_h_offset
                     = (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
 
-            add(reg_aux_inp_ptr, inp_h_offset);
-            add(reg_aux_out_ptr, out_h_offset);
+            add(reg_aux_inp_ptr, into<uint32_t>(inp_h_offset));
+            add(reg_aux_out_ptr, into<uint32_t>(out_h_offset));
 
             dec(reg_khc);
             cmp(reg_khc, reg_bover);
@@ -1051,8 +1053,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                             * jcp.ic_without_padding * (jcp.dilate_d + 1);
             pop(reg_aux_out_ptr);
             pop(reg_aux_inp_ptr);
-            add(reg_aux_inp_ptr, inp_d_offset);
-            add(reg_aux_out_ptr, out_d_offset);
+            add(reg_aux_inp_ptr, into<uint32_t>(inp_d_offset));
+            add(reg_aux_out_ptr, into<uint32_t>(out_d_offset));
             dec(reg_kdc);
             jnz(kd_label, T_NEAR);
             L(no_kd_label);
@@ -1064,8 +1066,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 : (size_t)jcp.typesize_in * jcp.ic_block_int_np;
         size_t out_cb_offset = (size_t)jcp.kd * out_d_offset;
 
-        add(reg_inp_ptr, inp_cb_offset);
-        add(reg_out_ptr, out_cb_offset);
+        add(reg_inp_ptr, into<uint32_t>(inp_cb_offset));
+        add(reg_out_ptr, into<uint32_t>(out_cb_offset));
     }
 
     postamble();
@@ -1326,7 +1328,7 @@ size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
     using namespace nstl;
 
     // start padding (s_pad)
-    int s_pad_limit = reduce_to_block(block_size, s_pad_output);
+    int s_pad_limit = into<int>(reduce_to_block(block_size, s_pad_output));
     int s_pad_area_blk = rnd_up(s_pad_limit, block_size);
 
     // middle (no padding)
@@ -1343,7 +1345,7 @@ size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
             = no_pad_area_shift + min(e_pad_output, e_pad_area_overlap);
     int e_pad_area_blk = nstl::max(0, e_pad_output - e_pad_area_overlap);
     // full end padding block
-    int e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
+    int e_pad_limit = into<int>(reduce_to_block(block_size, e_pad_area_blk));
 
     // calculate reduced size of s_pad, middle and e_pad blocks.
     return min((size_t)dim_size,
@@ -1694,11 +1696,14 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
         }
     }
     if (do_store) {
-        add(reg_out_ptr, get_out_shift(width, jcp.typesize_out));
+        add(reg_out_ptr,
+                into<uint32_t>(get_out_shift(width, jcp.typesize_out)));
         if (jcp.req_zero_point_buffer) {
             const size_t sp_shift
                     = accum_with_upper_bound(width, l_pad_output, r_pad_output);
-            add(reg_zero_point_pbuff, get_out_shift(sp_shift, sizeof(int32_t)));
+            add(reg_zero_point_pbuff,
+                    into<uint32_t>(get_out_shift(
+                            into<int>(sp_shift), sizeof(int32_t))));
         }
     }
 }
@@ -1744,12 +1749,15 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
 
         if (row_count_
                 == prv_width_ * jcp.nb_oc_blocking * jcp.nb_oh_blocking) {
-            add(reg_out_ptr, get_out_shift(prv_width_, jcp.typesize_out));
+            add(reg_out_ptr,
+                    into<uint32_t>(
+                            get_out_shift(prv_width_, jcp.typesize_out)));
             if (jcp.req_zero_point_buffer) {
                 const size_t sp_shift = accum_with_upper_bound(
                         prv_width_, l_pad_output, r_pad_output);
                 add(reg_zero_point_pbuff,
-                        get_out_shift(sp_shift, sizeof(int32_t)));
+                        into<uint32_t>(get_out_shift(
+                                into<int>(sp_shift), sizeof(int32_t))));
                 if (!w_padding.empty()) w_padding.pop();
             }
             row_count_ = 0;
@@ -1830,7 +1838,7 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         store_output(width, tail, do_store, handle_h_blk, t_pad_output,
                 b_pad_output, l_pad_output, r_pad_output, is_last_oh_block);
 
-        add(reg_inp_ptr, get_inp_shift());
+        add(reg_inp_ptr, into<uint32_t>(get_inp_shift()));
 
         return;
     }
@@ -1905,7 +1913,7 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
             b_pad_output, l_pad_output, r_pad_output, is_last_oh_block,
             zp_3d_pad);
 
-    add(reg_inp_ptr, get_inp_shift());
+    add(reg_inp_ptr, into<uint32_t>(get_inp_shift()));
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
@@ -1916,7 +1924,7 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
         const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
         const size_t height_limit = reduce_to_blocked_dims(
                 jcp.oh, oh_step_size, jcp.t_pad_output, jcp.b_pad_output);
-        const int ur_h = div_up(height_limit, oh_step_size);
+        const dim_t ur_h = div_up(height_limit, oh_step_size);
         assert(6 >= ur_h);
 
         // Use a jump-table to execute the corresponding block
@@ -1939,9 +1947,10 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
         const bool local_is_buffer_empty = is_buffer_empty_;
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
-        int cur_b_pad = height_limit
-                - reduce_to_block(oh_step_size, jcp.b_pad_output);
+        int cur_t_pad
+                = into<int>(reduce_to_block(oh_step_size, jcp.t_pad_output));
+        int cur_b_pad = into<int>(
+                height_limit - reduce_to_block(oh_step_size, jcp.b_pad_output));
         for (int u = 0; u < ur_h; u++) {
             bool last = u == ur_h - 1;
             L(h_blk_label[u]);
@@ -2028,8 +2037,8 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
         const int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call == 0
                 ? ow_blocks_per_call
                 : jcp.ow_blocks % ow_blocks_per_call;
-        const int width_limit = reduce_to_blocked_dims(
-                jcp.ow, ow_step_size, jcp.l_pad_output, jcp.r_pad_output);
+        const int width_limit = into<int>(reduce_to_blocked_dims(
+                jcp.ow, ow_step_size, jcp.l_pad_output, jcp.r_pad_output));
         const int ur_w = div_up(width_limit, ow_step_size);
         assert(6 >= ur_w);
         // Use a jump-table to execute the corresponding block
@@ -2046,14 +2055,17 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
         }
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
-        int cur_r_pad
-                = width_limit - reduce_to_block(ow_step_size, jcp.r_pad_output);
+        int cur_l_pad
+                = into<int>(reduce_to_block(ow_step_size, jcp.l_pad_output));
+        int cur_r_pad = into<int>(
+                width_limit - reduce_to_block(ow_step_size, jcp.r_pad_output));
         int zp_offset = 0;
         for (int u = 0; u < ur_w; u++) {
             const bool last = u == ur_w - 1;
             L(w_blk_label[u]);
-            if (u > 0) add(reg_zero_point_pbuff, zp_offset * zp_addr_shift);
+            if (u > 0)
+                add(reg_zero_point_pbuff,
+                        into<uint32_t>(zp_offset * zp_addr_shift));
             compute_ow_loop_body(last,
                     last ? last_owb_tile_blocks : ow_blocks_per_call, cur_l_pad,
                     cur_r_pad);
@@ -2181,7 +2193,8 @@ void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                     c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = into<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
@@ -2308,33 +2321,33 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = avx512_core_amx;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
 
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = !is_1d ? src_d.dims()[ndims - 2] : 1;
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = !is_1d ? dst_d.dims()[ndims - 2] : 1;
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = !is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1;
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = !is_1d ? cd.padding[0][ndims - 4] : 0;
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = !is_1d ? cd.strides[ndims - 4] : 1;
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>(is_3d ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>(!is_1d ? src_d.dims()[ndims - 2] : 1);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(!is_1d ? dst_d.dims()[ndims - 2] : 1);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(!is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(!is_1d ? cd.padding[0][ndims - 4] : 0);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(!is_1d ? cd.strides[ndims - 4] : 1);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.dilate_d = is_3d ? cd.dilates[ndims - 5] : 0;
-    jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>(is_3d ? cd.dilates[ndims - 5] : 0);
+    jcp.dilate_h = into<int>(!is_1d ? cd.dilates[ndims - 4] : 0);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
     const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
@@ -2586,10 +2599,10 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -3017,8 +3030,8 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
                 * jcp.ohp * jcp.owp * jcp.oc_block_int;
         pop(reg_ptr_aux_inp_h);
         pop(reg_ptr_aux_out);
-        sub(reg_ptr_aux_inp_h, inp_d_offset);
-        add(reg_ptr_aux_out, out_d_offset);
+        sub(reg_ptr_aux_inp_h, into<uint32_t>(inp_d_offset));
+        add(reg_ptr_aux_out, into<uint32_t>(out_d_offset));
 
         dec(reg_kd);
         jnz(kd_label, T_NEAR);
@@ -3457,7 +3470,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
         store_output_block(width, do_store, /* is_last_ih_blks = */ false);
         L(label_done);
     }
-    if (do_store) add(reg_out_ptr, get_out_shift(width));
+    if (do_store) add(reg_out_ptr, into<uint32_t>(get_out_shift(width)));
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
@@ -3476,7 +3489,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
 
         if (row_count_
                 == prv_width_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking) {
-            add(reg_out_ptr, get_out_shift(prv_width_));
+            add(reg_out_ptr, into<uint32_t>(get_out_shift(prv_width_)));
 
             is_store_done_save_ = is_store_done_;
             prv_width_save_ = prv_width_;
@@ -3505,7 +3518,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
         store_output_vector(zmm_out, icb, ihb, tw);
     }
     is_store_done_save_ = true;
-    add(reg_out_ptr, get_out_shift(prv_width_save_));
+    add(reg_out_ptr, into<uint32_t>(get_out_shift(prv_width_save_)));
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
@@ -3545,11 +3558,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
                 }
             }
         }
-        add(reg_inp_ptr, get_inp_ocb_step());
-        add(reg_wei_ptr, get_wei_ocb_step());
+        add(reg_inp_ptr, into<uint32_t>(get_inp_ocb_step()));
+        add(reg_wei_ptr, into<uint32_t>(get_wei_ocb_step()));
     }
-    sub(reg_inp_ptr, get_inp_ocb_step() * jcp.nb_oc_int);
-    sub(reg_wei_ptr, get_wei_ocb_step() * jcp.nb_oc_int);
+    sub(reg_inp_ptr, into<uint32_t>(get_inp_ocb_step() * jcp.nb_oc_int));
+    sub(reg_wei_ptr, into<uint32_t>(get_wei_ocb_step() * jcp.nb_oc_int));
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_kd_loop(
@@ -3591,8 +3604,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_kd_loop(
         //  and so on...
         //
         // hence, step through 'reg_inp_ptr' in ascending order:
-        add(reg_inp_ptr, get_inp_d_step());
-        add(reg_wei_ptr, get_wei_d_step());
+        add(reg_inp_ptr, into<uint32_t>(get_inp_d_step()));
+        add(reg_wei_ptr, into<uint32_t>(get_wei_d_step()));
 
         dec(reg_kd);
         jz(end_kd_compute_label, T_NEAR);
@@ -3618,7 +3631,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_kd_loop(
 
     store_output(width, do_store);
 
-    add(reg_inp_ptr, get_inp_shift());
+    add(reg_inp_ptr, into<uint32_t>(get_inp_shift()));
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_iw_loop() {
@@ -3765,7 +3778,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
                     get_out_tensor(h, i), c_row, c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = into<uint8_t>(amx::get_target_palette());
 }
 
 status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
@@ -3813,36 +3827,36 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = is_f16 ? avx512_core_amx_fp16 : avx512_core_amx;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
 
-    jcp.mb = diff_src_d.dims()[0];
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.mb = into<int>(diff_src_d.dims()[0]);
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(diff_src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? diff_src_d.dims()[2] : 1;
-    jcp.ih = !is_1d ? diff_src_d.dims()[ndims - 2] : 1;
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = !is_1d ? diff_dst_d.dims()[ndims - 2] : 1;
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = !is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1;
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = !is_1d ? cd.padding[0][ndims - 4] : 0;
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = !is_1d ? cd.strides[ndims - 4] : 1;
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>(is_3d ? diff_src_d.dims()[2] : 1);
+    jcp.ih = into<int>(!is_1d ? diff_src_d.dims()[ndims - 2] : 1);
+    jcp.iw = into<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(!is_1d ? diff_dst_d.dims()[ndims - 2] : 1);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(!is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(!is_1d ? cd.padding[0][ndims - 4] : 0);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(!is_1d ? cd.strides[ndims - 4] : 1);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     // No bias for xf16 case to simplify integration with ref_deconvolution
     jcp.with_bias = bias_md && !is_xf16_convolution
             && cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.dilate_d = is_3d ? cd.dilates[ndims - 5] : 0;
-    jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>(is_3d ? cd.dilates[ndims - 5] : 0);
+    jcp.dilate_h = into<int>(!is_1d ? cd.dilates[ndims - 4] : 0);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_CONV_IC(!(jcp.dilate_d != 0 && jcp.stride_d != 1),
             "unsupported stride/dilation values");
@@ -3972,10 +3986,10 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in = into<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -4125,7 +4139,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
             tc_configure_tile((palette_config_t *)tcfg_buff,
                     get_wei_tensor(ocb, icb), c_row, c_col * jcp.typesize_out);
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = into<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::od_step_comeback_pointers() {
@@ -4133,8 +4148,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::od_step_comeback_pointers() {
     mov(kj, reg_kd_count);
     L(kd_comeback_label);
     {
-        sub(reg_src, get_src_offset(0, 0, filter_d_to_src(1)));
-        sub(reg_kernel, get_kernel_offset(0, jcp.kh * jcp.kw));
+        sub(reg_src, into<uint32_t>(get_src_offset(0, 0, filter_d_to_src(1))));
+        sub(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kh * jcp.kw)));
         dec(kj);
         jnz(kd_comeback_label, T_NEAR);
     }
@@ -4145,8 +4160,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::oh_step_comeback_pointers() {
     mov(kj, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_src, get_src_offset(0, 0, filter_h_to_src(1)));
-        sub(reg_kernel, get_kernel_offset(0, jcp.kw));
+        sub(reg_src, into<uint32_t>(get_src_offset(0, 0, filter_h_to_src(1))));
+        sub(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
         dec(kj);
         jnz(kh_comeback_label, T_NEAR);
     }
@@ -4245,8 +4260,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         {
             emit_block();
 
-            add(reg_src, get_src_offset(0, 0, 1));
-            add(reg_ddst, get_ddst_offset(0, 1));
+            add(reg_src, into<uint32_t>(get_src_offset(0, 0, 1)));
+            add(reg_ddst, into<uint32_t>(get_ddst_offset(0, 1)));
             add(reg_j, 1);
             cmp(reg_j, reg_h);
             jb(h_loop);
@@ -4327,13 +4342,13 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
             or_(reg_ker, 1);
 
             L(skip_ker_zeroing);
-            add(reg_ker, get_kernel_offset(0, jcp.kw));
+            add(reg_ker, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
             jmp(kh_loop_end, T_NEAR);
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp, into<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(reg_ohs, reg_tmp, into<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4384,7 +4399,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
                             Tmm(get_wei_tensor(ocb, icb)));
 
                 mov(reg_ker, reg_tmp);
-                add(reg_ker, get_kernel_offset(jcp.ic_block, 0));
+                add(reg_ker,
+                        into<uint32_t>(get_kernel_offset(jcp.ic_block, 0)));
                 add(reg_kw, 1);
                 cmp(reg_kw, jcp.kw);
                 jl(kw_loop);
@@ -4416,11 +4432,11 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 
     if (!single_kh_kw_loop) {
         auto ker_reset_offset = get_kernel_offset(0, jcp.kw * jcp.kh);
-        sub(reg_ker, ker_reset_offset);
+        sub(reg_ker, into<uint32_t>(ker_reset_offset));
         and_(reg_ker, ~1); // Clear the zeroing flag for subsequent updates
 
-        add(reg_src, first_src_block_step);
-        add(reg_ddst, ddst_block_step);
+        add(reg_src, into<uint32_t>(first_src_block_step));
+        add(reg_ddst, into<uint32_t>(ddst_block_step));
 
         int num_innermost_iters
                 = (jcp.oh - h_last_block_size) / h_block_size - 1;
@@ -4432,9 +4448,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
             L(h_block_loop);
             {
                 emit_kh_kw_loop(false, false);
-                sub(reg_ker, ker_reset_offset);
-                add(reg_src, src_row_step * h_block_size);
-                add(reg_ddst, ddst_block_step);
+                sub(reg_ker, into<uint32_t>(ker_reset_offset));
+                add(reg_src, into<uint32_t>(src_row_step * h_block_size));
+                add(reg_ddst, into<uint32_t>(ddst_block_step));
 
                 kmovw(reg_tmp_w, reg_h_block);
                 sub(reg_tmp_w, 1);
@@ -4504,7 +4520,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
         }
     }
     safe_add(reg_src, get_src_offset(ic_block, 0), reg_long_offt);
-    add(reg_kernel, get_kernel_offset(ic_block, 0));
+    add(reg_kernel, into<uint32_t>(get_kernel_offset(ic_block, 0)));
 }
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_diff_bias_init(int ocb) {
@@ -4536,13 +4552,13 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_diff_bias_row(
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
         compute_step();
-        add(reg_ddst, get_ddst_offset(2));
+        add(reg_ddst, into<uint32_t>(get_ddst_offset(2)));
         sub(reg_tmp, 1);
         jnz(ow_loop, T_NEAR);
     }
     if (jcp.tr_ow % 2) compute_step();
 
-    if (niters > 0) sub(reg_ddst, get_ddst_offset(2 * niters));
+    if (niters > 0) sub(reg_ddst, into<uint32_t>(get_ddst_offset(2 * niters)));
 
     if (is_partial) {
         mov(reg_tmp, ptr[param + GET_OFF(bias)]);
@@ -4569,7 +4585,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_compute_diff_bias(
         Label bias_loop, skip_label_local;
 
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+                into<uint32_t>(
+                        jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size));
 
         switch (jcp.harness) {
             case harness_2d_reduction:
@@ -4589,7 +4607,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_compute_diff_bias(
         L(bias_loop);
         {
             compute_diff_bias_row(false, ocb);
-            add(reg_ddst, get_ddst_offset(0, 1));
+            add(reg_ddst, into<uint32_t>(get_ddst_offset(0, 1)));
 
             sub(reg_oj, 1);
             jnz(bias_loop, T_NEAR);
@@ -4627,7 +4645,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_step_common(
 
             L(ic_tail_label);
             compute_ic_loop(ic_tail, nb_ic_blocking, nb_oc_blocking);
-            add(reg_kernel, get_kernel_offset(jcp.ic_block - ic_tail, 0));
+            add(reg_kernel,
+                    into<uint32_t>(
+                            get_kernel_offset(jcp.ic_block - ic_tail, 0)));
             safe_add(reg_src,
                     get_src_offset(0, 0, filter_h_to_src(1))
                             - get_src_offset(ic_tail, 0),
@@ -4657,18 +4677,20 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_step_common(
         ic_loop(nb_ic_blocking, nb_oc_blocking);
 
         if (jcp.dilate_h > 0) {
-            add(reg_src, get_src_offset(0, 0, jcp.dilate_h));
+            add(reg_src, into<uint32_t>(get_src_offset(0, 0, jcp.dilate_h)));
         }
         // substract pointer shift made within ic block loop
         // and move to next kh index
-        add(reg_kernel, get_kernel_offset(-ic_block, jcp.kw));
+        add(reg_kernel, into<uint32_t>(get_kernel_offset(-ic_block, jcp.kw)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_label, T_NEAR);
     }
     if (jcp.ndims == 5) {
-        add(aux_reg_src, get_src_offset(0, 0, filter_d_to_src(1)));
-        add(aux_reg_kernel, get_kernel_offset(0, jcp.kh * jcp.kw));
+        add(aux_reg_src,
+                into<uint32_t>(get_src_offset(0, 0, filter_d_to_src(1))));
+        add(aux_reg_kernel,
+                into<uint32_t>(get_kernel_offset(0, jcp.kh * jcp.kw)));
         dec(ki);
         cmp(ki, 0);
         jg(kd_label, T_NEAR);
@@ -4785,13 +4807,13 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
-        add(reg_kernel, filter_step_size * underflow);
+        add(reg_kernel, into<uint32_t>(filter_step_size * underflow));
         if (is_dilated) {
             const int tail = t_pad % dilate_h;
             const int shift = tail == 0 ? 0 : dilate_h - tail;
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_offset], reg_ih_shift);
-            add(reg_src, src_step_size * shift);
+            add(reg_src, into<uint32_t>(src_step_size * shift));
         }
 
         if (is_partial) {
@@ -4806,17 +4828,17 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
                 cmp(reg_ih_shift, dilate_h);
                 jl(oh_dilate_setup_label_shift, T_NEAR);
                 // unshift src as new kernel element enters
-                sub(reg_src, src_step_size * (dilate_h - 1));
+                sub(reg_src, into<uint32_t>(src_step_size * (dilate_h - 1)));
                 xor_(reg_ih_shift, reg_ih_shift);
             }
             // kernel overlap only changes when (t_pad + oj) % dilate_h == 0
             add(reg_kh, stride_h);
-            sub(reg_kernel, filter_step_size * stride_h);
+            sub(reg_kernel, into<uint32_t>(filter_step_size * stride_h));
             if (is_dilated) {
                 jmp(oh_dilate_setup_label_noshift, T_NEAR);
                 L(oh_dilate_setup_label_shift);
                 // shift src as old kernel element progresses
-                add(reg_src, src_step_size * stride_h);
+                add(reg_src, into<uint32_t>(src_step_size * stride_h));
                 L(oh_dilate_setup_label_noshift);
             }
             sub(reg_oj_setup, 1);
@@ -4835,7 +4857,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
         // Loop
         L(oh_tpad_label);
         compute_oh_step_common(nb_ic_blocking, nb_oc_blocking);
-        add(reg_ddst, ddst_step_size);
+        add(reg_ddst, into<uint32_t>(ddst_step_size));
         if (is_dilated) {
             mov(reg_ih_shift, ptr[rsp + ih_dilate_offset]);
             inc(reg_ih_shift);
@@ -4843,18 +4865,18 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             cmp(reg_ih_shift, dilate_h);
             jl(oh_dilate_label_shift, T_NEAR);
             // unshift src as new kernel element enters
-            sub(reg_src, src_step_size * (dilate_h - 1));
+            sub(reg_src, into<uint32_t>(src_step_size * (dilate_h - 1)));
             xor_(reg_ih_shift, reg_ih_shift);
             mov(ptr[rsp + ih_dilate_offset], reg_ih_shift);
         }
         // kernel overlap only changes when (t_pad + oj) % dilate_h == 0
         add(reg_kh, stride_h);
-        sub(reg_kernel, filter_step_size * stride_h);
+        sub(reg_kernel, into<uint32_t>(filter_step_size * stride_h));
         if (is_dilated) {
             jmp(oh_dilate_label_noshift, T_NEAR);
             L(oh_dilate_label_shift);
             // shift src as old kernel element progresses
-            add(reg_src, src_step_size * stride_h);
+            add(reg_src, into<uint32_t>(src_step_size * stride_h));
             L(oh_dilate_label_noshift);
         }
         inc(reg_oj);
@@ -4879,8 +4901,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             L(oh_tpad_tail_label);
             {
                 compute_oh_step_common(nb_ic_blocking, nb_oc_blocking);
-                add(reg_ddst, ddst_step_size);
-                sub(reg_kernel, filter_step_size * stride_h);
+                add(reg_ddst, into<uint32_t>(ddst_step_size));
+                sub(reg_kernel, into<uint32_t>(filter_step_size * stride_h));
 
                 inc(reg_oj);
 
@@ -4893,8 +4915,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             }
         }
         if (body_src_start_offset != 0) {
-            add(reg_kernel, filter_step_size * body_src_start_offset);
-            add(reg_src, src_step_size * body_src_start_offset);
+            add(reg_kernel,
+                    into<uint32_t>(filter_step_size * body_src_start_offset));
+            add(reg_src, into<uint32_t>(src_step_size * body_src_start_offset));
         }
         L(oh_tpad_tail_label_end);
     }
@@ -4911,8 +4934,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
     L(oh_label);
     {
         compute_oh_step_common(nb_ic_blocking, nb_oc_blocking);
-        add(reg_src, src_step_size * stride_h);
-        add(reg_ddst, ddst_step_size);
+        add(reg_src, into<uint32_t>(src_step_size * stride_h));
+        add(reg_ddst, into<uint32_t>(ddst_step_size));
 
         inc(reg_oj);
 
@@ -4972,8 +4995,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
         L(oh_bpad_label);
         {
             compute_oh_step_common(nb_ic_blocking, nb_oc_blocking);
-            add(reg_src, src_step_size * stride_h);
-            add(reg_ddst, ddst_step_size);
+            add(reg_src, into<uint32_t>(src_step_size * stride_h));
+            add(reg_ddst, into<uint32_t>(ddst_step_size));
 
             if (is_dilated) {
                 mov(reg_ih_shift, ptr[rsp + ih_dilate_offset]);
@@ -5025,8 +5048,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
         const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(
-                0, nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw);
+        const int kd_offset = into<int>(get_kernel_offset(
+                0, nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw));
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -5062,7 +5085,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
-        sub(reg_kernel, filter_shift * jcp.stride_d);
+        sub(reg_kernel, into<uint32_t>(filter_shift * jcp.stride_d));
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
@@ -5075,12 +5098,14 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
                 int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
-                add(reg_kernel, filter_shift * src_corr);
-                add(reg_src_d, src_shift * src_corr);
+                add(reg_kernel, into<uint32_t>(filter_shift * src_corr));
+                add(reg_src_d, into<uint32_t>(src_shift * src_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.f_pad - jcp.od * jcp.stride_d) * filter_shift);
+            sub(reg_kernel,
+                    into<uint32_t>((jcp.f_pad - jcp.od * jcp.stride_d)
+                            * filter_shift));
         }
 
         /* Apply correction */
@@ -5113,11 +5138,11 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
     }
 
     /* Compute middle block */
-    add(reg_src_d, src_shift * jcp.stride_d);
+    add(reg_src_d, into<uint32_t>(src_shift * jcp.stride_d));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_ddst_d, ddst_shift);
+    add(reg_ddst_d, into<uint32_t>(ddst_shift));
     inc(reg_d_index);
     if (is_partial)
         cmp(reg_d_index, ptr[param + GET_OFF(os_index_end)]);
@@ -5242,35 +5267,37 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? diff_weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>(
+            (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -5372,7 +5399,8 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, format_tag::x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia
+            = into<int>(jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0);
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
@@ -5691,7 +5719,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 // start of diff_bias kernel
 dim_t jit_avx512_core_amx_bwd_bias_kernel_t::get_ddst_offset(
         dim_t w_idx, dim_t hd_idx) const {
-    int ow_per_oc = data_type_vnni_granularity(jcp.ddst_dt);
+    dim_t ow_per_oc = data_type_vnni_granularity(jcp.ddst_dt);
     if (ow_per_oc == 0) {
         assert(!"Invalid vnni granularity.");
         return 0;
@@ -5789,13 +5817,14 @@ void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias_row(int ocb) {
         mov(reg_tmp, niters);
         L(ow_loop);
         compute_step();
-        add(reg_ddst, get_ddst_offset(sp_substep));
+        add(reg_ddst, into<uint32_t>(get_ddst_offset(sp_substep)));
         sub(reg_tmp, 1);
         jnz(ow_loop, T_NEAR);
     }
     if (jcp.tr_ow % jcp.typesize_in) compute_step();
 
-    if (niters > 0) sub(reg_ddst, get_ddst_offset(sp_substep * niters));
+    if (niters > 0)
+        sub(reg_ddst, into<uint32_t>(get_ddst_offset(sp_substep * niters)));
 }
 
 void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias(
@@ -5806,7 +5835,9 @@ void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias(
 
         // pointer to diff_dst
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+                into<uint32_t>(
+                        jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size));
 
         // number of rows
         mov(reg_oj, reg_nrows);
@@ -5848,7 +5879,7 @@ void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias(
         L(bias_loop);
         {
             compute_diff_bias_row(ocb);
-            add(reg_ddst, get_ddst_offset(0, 1));
+            add(reg_ddst, into<uint32_t>(get_ddst_offset(0, 1)));
 
             sub(reg_oj, 1);
             jnz(bias_loop, T_NEAR);

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -1079,9 +1079,9 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
     int ithr_but_ic = 0;
 
     int img_start = 0, img_end = 0, img_work = 0;
-    int g_start = 0, g_end = 0, g_work = 0;
-    int oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
-    int ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
+    dim_t g_start = 0, g_end = 0, g_work = 0;
+    dim_t oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
+    dim_t ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
 
     thread_info_t(const jit_avx512_core_amx_convolution_bwd_weights_t *self,
             const exec_ctx_t &ctx, int ithr)
@@ -1140,15 +1140,16 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(into<dim_t>(jcp.ngroups), self->nthr_g_, ithr_g, g_start,
+                g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(into<dim_t>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(into<dim_t>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         if (jcp.transform_to_vnni) {
             if (ic_b_start % 2 != 0) ic_b_start++;
             if (ic_b_end != jcp.nb_ic && ic_b_end % 2 != 0) ic_b_end++;
@@ -1951,7 +1952,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::store_in_vnni_format(
     const auto icb2_work = div_up(ti->ic_b_work, 2);
     const auto work = ti->g_work * ti->oc_b_work * icb2_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, jcp.nthr_mb, ti->ithr_mb, start, end);
     int sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
     nd_iterator_init(start, sub_g_start, ti->g_work, sub_oc_b_start,

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -151,9 +151,10 @@ Address jit_avx512_core_bf16_1x1_conv_kernel_t::output_ptr(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift = is_output_layout_nxc
-                ? jcp.load_block
-                : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
+        int i_load_shift = into<int>(is_output_layout_nxc
+                        ? jcp.load_block
+                        : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
+                                * jcp.load_block);
         int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
         int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
@@ -195,7 +196,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::apply_postops(
                     [&](const bool mask_flag, const int i_load,
                             const int i_ur) {
                 const int aux_output_l_off
-                        = get_output_offset(i_load, i_ur, true);
+                        = into<int>(get_output_offset(i_load, i_ur, true));
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
                 vmm_idxs.emplace(vmm_idx);
@@ -282,11 +283,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
-            offt = (i_reduce == jcp.reduce_loop_unroll)
-                    ? (jcp.bcast_dim + i_ur) * reduce_mul
-                    : i_ur * reduce_mul + i_reduce;
+            const int reduce_mul = into<int>(
+                    bcast_layout_nxc ? jcp.reduce_dim : jcp.reduce_loop_unroll);
+            offt = into<int>((i_reduce == jcp.reduce_loop_unroll)
+                            ? (jcp.bcast_dim + i_ur) * reduce_mul
+                            : i_ur * reduce_mul + i_reduce);
         } else {
             if (jcp.uses_permw_transposition) {
                 int rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
@@ -303,10 +304,10 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     auto load_ptr = [this, load_layout_nxc](int i_reduce, int i_load) {
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+        int lmul = into<int>(jcp.load_block
                 * (load_layout_nxc ? 1
-                                   : utils::rnd_up(
-                                             jcp.reduce_dim, jcp.reduce_block));
+                                   : utils::rnd_up(jcp.reduce_dim,
+                                             jcp.reduce_block)));
         int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         int offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
@@ -315,8 +316,8 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
 
     auto store_buffer_ptr = [this](int i_load, int i_ur) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift
-                = jcp.load_block * (is_output_layout_nxc ? 1 : jcp.bcast_dim);
+        int i_load_shift = into<int>(
+                jcp.load_block * (is_output_layout_nxc ? 1 : jcp.bcast_dim));
         int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
         int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_acc;
@@ -861,7 +862,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     L(reduce_loop);
     {
         fma_block(false);
-        add(aux_reg_bcast_data, jcp.reduce_loop_bcast_step);
+        add(aux_reg_bcast_data, into<uint32_t>(jcp.reduce_loop_bcast_step));
         add(aux_reg_load_data, jcp.reduce_loop_load_step);
         sub(reduce_loop_iter, jcp.reduce_loop_unroll);
         cmp(reduce_loop_iter, jcp.reduce_loop_unroll);
@@ -955,7 +956,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::compute_diff_bias(
     L(reduce_loop);
     {
         compute_diff_bias_block(false);
-        add(aux_reg_load_data, get_load_offset(reduce_step, 0));
+        add(aux_reg_load_data, into<uint32_t>(get_load_offset(reduce_step, 0)));
         sub(reduce_loop_iter, reduce_step);
         cmp(reduce_loop_iter, reduce_step);
         jge(reduce_loop, T_NEAR);
@@ -1088,23 +1089,28 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
             case forward_inference:
                 add(reg_bias_data,
                         load_loop_blk * jcp.load_block * jcp.typesize_bia);
-                add(reg_output_data, off_with_dw_conv);
+                add(reg_output_data, into<uint32_t>(off_with_dw_conv));
                 add(reg_store_buf,
-                        load_loop_blk * jcp.load_block * jcp.typesize_acc
-                                * (is_out_layout_nxc() ? 1 : jcp.bcast_dim));
+                        into<uint32_t>(load_loop_blk * jcp.load_block
+                                * jcp.typesize_acc
+                                * (is_out_layout_nxc() ? 1 : jcp.bcast_dim)));
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(rcx, EVEX_compress_addr(rsp, reg_dw_binary_output_off));
-                    add(rcx, offst_wo_dw_conv - off_with_dw_conv);
+                    add(rcx,
+                            into<uint32_t>(
+                                    offst_wo_dw_conv - off_with_dw_conv));
                     mov(EVEX_compress_addr(rsp, reg_dw_binary_output_off), rcx);
                 }
                 break;
             case backward_data:
                 add(reg_output_data,
-                        load_loop_blk * jcp.load_block * jcp.typesize_out
-                                * (is_out_layout_nxc() ? 1 : jcp.bcast_dim));
+                        into<uint32_t>(load_loop_blk * jcp.load_block
+                                * jcp.typesize_out
+                                * (is_out_layout_nxc() ? 1 : jcp.bcast_dim)));
                 add(reg_store_buf,
-                        load_loop_blk * jcp.load_block * jcp.typesize_acc
-                                * (is_out_layout_nxc() ? 1 : jcp.bcast_dim));
+                        into<uint32_t>(load_loop_blk * jcp.load_block
+                                * jcp.typesize_acc
+                                * (is_out_layout_nxc() ? 1 : jcp.bcast_dim)));
                 break;
             case backward_weights:
                 for (int i_load = 0; i_load < load_loop_blk; i_load++)
@@ -1210,32 +1216,33 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                                         : bf16_emulation_t::get_isa();
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.oc_without_padding = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
+    jcp.ic_without_padding = into<int>(src_d.dims()[1] / jcp.ngroups);
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
@@ -1245,7 +1252,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             ? pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.data_type,
                       data_type::undef, cd.diff_bias_desc.data_type)
             : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia
+            = into<int>(jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0);
 
     jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
     jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
@@ -1343,15 +1351,15 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
     jcp.typesize_acc = sizeof(float);
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
-        jcp.typesize_out = types::data_type_size(dst_d.data_type());
+        jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+        jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
         jcp.dst_dt = dst_d.data_type();
     } else if (jcp.prop_kind == backward_data) {
-        jcp.typesize_in = types::data_type_size(dst_d.data_type());
-        jcp.typesize_out = types::data_type_size(src_d.data_type());
+        jcp.typesize_in = into<int>(types::data_type_size(dst_d.data_type()));
+        jcp.typesize_out = into<int>(types::data_type_size(src_d.data_type()));
         jcp.dst_dt = src_d.data_type();
     } else if (jcp.prop_kind == backward_weights) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
+        jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
         jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
         jcp.dst_dt = weights_d.data_type();
     }
@@ -1411,8 +1419,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
         jcp.load_loop_load_step
-                = utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
-                * jcp.load_block * jcp.typesize_in;
+                = into<int>(utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
+                        * jcp.load_block * jcp.typesize_in);
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold, ur_step;
@@ -1454,7 +1462,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = into<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i -= ur_step) {
                 int i_tail = jcp.os % i;
@@ -1472,8 +1480,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_loop_output_step
                 = jcp.ur * (is_data_layout_nxc ? jcp.load_dim : jcp.load_block);
         jcp.bcast_loop_output_substep = -1; // unused
-        jcp.bcast_loop_bcast_step = jcp.typesize_in * jcp.ur
-                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block);
+        jcp.bcast_loop_bcast_step = into<int>(jcp.typesize_in * jcp.ur
+                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block));
         jcp.bcast_loop_bcast_substep = -1; // unused
 
         jcp.load_loop_iter_step = jcp.load_block;
@@ -1483,22 +1491,25 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+        int nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+        int nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
         int nb_load = div_up(jcp.load_dim, jcp.load_block);
 
         if (is_data_layout_nxc
                 || (jcp.prop_kind == backward_data && reduce_src)) {
-            reduce_blocking = jcp.reduce_dim;
+            reduce_blocking = into<int>(jcp.reduce_dim);
         } else {
             if (jcp.expl_bcast) {
                 if (jcp.load_dim <= BIG_LOAD_DIM && spatial > SMALL_SPATIAL
                         && spatial < BIG_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 160);
+                    reduce_blocking
+                            = into<int>(nstl::min<dim_t>(jcp.reduce_dim, 160));
                 else if (spatial > SMALL_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 1024);
+                    reduce_blocking
+                            = into<int>(nstl::min<dim_t>(jcp.reduce_dim, 1024));
                 else
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 512);
+                    reduce_blocking
+                            = into<int>(nstl::min<dim_t>(jcp.reduce_dim, 512));
             } else {
                 reduce_blocking = nb_reduce;
                 if (spatial <= SMALL_SPATIAL
@@ -1520,7 +1531,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             int max_hits = 7;
             if (jcp.bcast_dim * reduce_blocking > way_size * max_hits) {
                 int nrb = reduce_blocking / simd_w;
-                int sp = jcp.bcast_dim;
+                int sp = into<int>(jcp.bcast_dim);
                 int wl = way_size / simd_w;
                 for (int start_off = 0; start_off < jcp.ur; start_off++) {
                     for (int off = start_off, hits = 0; off < sp * nrb;
@@ -1537,7 +1548,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
         load_blocking = jcp.load_dim;
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
+        int load_size = into<int>(jcp.load_dim * jcp.reduce_dim);
         auto bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
@@ -1599,7 +1610,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
                                  div_up(jcp.nthr, jcp.load_grp_count))
                 * jcp.bcast_block;
-        bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+        bcast_blocking
+                = into<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
         bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
         int space_for_bcast = (L2_capacity - /* kernel_size - */
@@ -1629,10 +1641,12 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 && IMPLICATION(ndims == 5, jcp.oc <= 64);
 
         if (jcp.uses_permw_transposition) {
-            int rdim = nstl::min<dim_t>(256, jcp.reduce_dim);
-            jcp.reduce_block = best_divider(jcp.reduce_dim, 7, rdim, true, 2);
+            int rdim = into<int>(nstl::min<dim_t>(256, jcp.reduce_dim));
+            jcp.reduce_block
+                    = best_divider(into<int>(jcp.reduce_dim), 7, rdim, true, 2);
         } else
-            jcp.reduce_block = best_divider(jcp.reduce_dim, 8, 16, true, 2);
+            jcp.reduce_block
+                    = best_divider(into<int>(jcp.reduce_dim), 8, 16, true, 2);
 
         if (jcp.reduce_dim % jcp.reduce_block != 0) {
             jcp.reduce_block = best_divider(
@@ -1666,16 +1680,16 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_loop_output_step = jcp.oc_block * jcp.ic_block;
         jcp.bcast_loop_output_substep
                 = jcp.oc_block * jcp.ur * jcp.typesize_out;
-        jcp.bcast_loop_bcast_step = jcp.typesize_in * jcp.ic_block
+        jcp.bcast_loop_bcast_step = into<int>(jcp.typesize_in * jcp.ic_block
                 * (jcp.uses_permw_transposition
                                 ? (is_data_layout_nxc ? 1 : jcp.reduce_dim)
-                                : rnd_up(jcp.reduce_dim, 2));
+                                : rnd_up(jcp.reduce_dim, 2)));
         jcp.bcast_loop_bcast_substep = jcp.typesize_in * jcp.ur
                 * (jcp.uses_permw_transposition ? 1 : 2);
-        jcp.load_loop_load_step = jcp.typesize_in * jcp.oc_block
+        jcp.load_loop_load_step = into<int>(jcp.typesize_in * jcp.oc_block
                 * (jcp.uses_permw_transposition
                                 ? (is_data_layout_nxc ? 1 : jcp.os)
-                                : rnd_up(jcp.reduce_dim, 2));
+                                : rnd_up(jcp.reduce_dim, 2)));
         jcp.load_loop_iter_step = jcp.oc_block;
 
         /* --- */
@@ -1687,10 +1701,11 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
         load_blocking_max = load_blocking;
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int max_bcast_blocking
+                = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         int min_bcast_blocking = 5;
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         bcast_blocking = best_divider(
                 bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
         bcast_blocking *= jcp.bcast_block;
@@ -1701,12 +1716,12 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
 
         // for reduction balance
-        int max_reduce_blocking
-                = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
+        int max_reduce_blocking = into<int>(
+                nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim));
         int min_reduce_blocking
                 = nstl::min(L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
-        reduce_blocking = best_divider(
-                jcp.reduce_dim, min_reduce_blocking, max_reduce_blocking, true);
+        reduce_blocking = best_divider(into<int>(jcp.reduce_dim),
+                min_reduce_blocking, max_reduce_blocking, true);
         reduce_blocking = nstl::max(
                 rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block);
 
@@ -1742,9 +1757,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
     jcp.nb_reduce_blocking_max
             = utils::div_up(reduce_blocking_max, jcp.reduce_block);
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     /* adjust the thread decomposition
      * to improve the perf for small size problem
@@ -1855,9 +1870,9 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    const int nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     jcp.nthr_g = jcp.ngroups;
     const int nthr = nthreads / jcp.nthr_g;

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -153,7 +153,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
     const int nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -402,9 +402,10 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr, into<dim_t>(jcp.mb * jcp.ngroups * jcp_dw->oh),
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                dim_t(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
             int load_step;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -667,14 +667,14 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         } else {
             if (n_oi == 0) {
                 compute_loop(ur_w, l_pad, r_pad1);
-                add(reg_src, src_shift_pad);
-                add(reg_dst, dst_shift);
+                add(reg_src, into<uint32_t>(src_shift_pad));
+                add(reg_dst, into<uint32_t>(dst_shift));
                 if (ur_w_tail != 0) { compute_loop(ur_w_tail, 0, r_pad); }
             } else {
                 if (l_pad > 0) {
                     compute_loop(ur_w, l_pad, 0);
-                    add(reg_src, src_shift_pad);
-                    add(reg_dst, dst_shift);
+                    add(reg_src, into<uint32_t>(src_shift_pad));
+                    add(reg_dst, into<uint32_t>(dst_shift));
                     inc(reg_oi);
                 }
                 if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -682,8 +682,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
                     L(ow_loop_label);
                     {
                         compute_loop(ur_w, 0, 0);
-                        add(reg_src, src_shift);
-                        add(reg_dst, dst_shift);
+                        add(reg_src, into<uint32_t>(src_shift));
+                        add(reg_dst, into<uint32_t>(dst_shift));
 
                         inc(reg_oi);
                         cmp(reg_oi, n_oi);
@@ -692,8 +692,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
                 }
                 if (r_pad1 > 0) {
                     compute_loop(ur_w, 0, r_pad1);
-                    add(reg_src, src_shift);
-                    add(reg_dst, dst_shift);
+                    add(reg_src, into<uint32_t>(src_shift));
+                    add(reg_dst, into<uint32_t>(dst_shift));
                 }
                 if (ur_w_tail != 0) { compute_loop(ur_w_tail, 0, r_pad); }
             }
@@ -738,8 +738,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         mov(reg_oi, n_oi_first_ow_block);
         if (l_pad > 0) {
             compute_loop(ur_w, l_pad, 0);
-            add(reg_src, src_shift_pad);
-            add(reg_dst, dst_shift);
+            add(reg_src, into<uint32_t>(src_shift_pad));
+            add(reg_dst, into<uint32_t>(dst_shift));
             dec(reg_oi);
         }
         jmp(oi_loop_label, T_NEAR);
@@ -750,7 +750,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
 
         if (l_pad > 0) {
             // just to consider left padding, not compute
-            add(reg_src, src_shift_pad_second_block);
+            add(reg_src, into<uint32_t>(src_shift_pad_second_block));
         }
 
         // set number of iteration for oi-loop
@@ -769,8 +769,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         jle(oi_loop_end_label, T_NEAR);
 
         compute_loop(ur_w, 0, 0);
-        add(reg_src, src_shift);
-        add(reg_dst, dst_shift);
+        add(reg_src, into<uint32_t>(src_shift));
+        add(reg_dst, into<uint32_t>(dst_shift));
         dec(reg_oi);
         jmp(oi_loop_start_label, T_NEAR);
         L(oi_loop_end_label);
@@ -796,8 +796,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         // last oi block with right padding
         L(last_oi_label);
         compute_loop(ur_w, 0, r_pad1);
-        add(reg_src, src_shift);
-        add(reg_dst, dst_shift);
+        add(reg_src, into<uint32_t>(src_shift));
+        add(reg_dst, into<uint32_t>(dst_shift));
 
         mov(reg_owb, ptr[param1 + GET_OFF(owb)]);
         cmp(reg_owb, jcp.nb_ow - 1); // last ow_block?
@@ -851,39 +851,41 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.has_vnni = true;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
     jcp.dst_dt = dst_d.data_type();
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia
+            = into<int>(jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -1338,8 +1340,9 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
             L(oc_tail_jmp[ki]);
         }
 
-        add(aux_reg_ker, get_kernel_offset(0, 0, 0, stride_h));
-        sub(aux_reg_dst, get_diff_dst_offset(filter_h_to_dst(1), 0));
+        add(aux_reg_ker, into<uint32_t>(get_kernel_offset(0, 0, 0, stride_h)));
+        sub(aux_reg_dst,
+                into<uint32_t>(get_diff_dst_offset(filter_h_to_dst(1), 0)));
 
         dec(reg_kj);
         cmp(reg_kj, 0);
@@ -1347,8 +1350,10 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
     }
 
     if (jcp.ndims == 5) {
-        sub(aux_reg_dst_d, get_diff_dst_offset(filter_d_to_dst(1), 0));
-        add(aux_reg_ker_d, get_kernel_offset(0, 0, 0, 0, jcp.stride_d));
+        sub(aux_reg_dst_d,
+                into<uint32_t>(get_diff_dst_offset(filter_d_to_dst(1), 0)));
+        add(aux_reg_ker_d,
+                into<uint32_t>(get_kernel_offset(0, 0, 0, 0, jcp.stride_d)));
 
         dec(reg_ki);
         cmp(reg_ki, 0);
@@ -1358,15 +1363,15 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
     // End of OC Loop
     auto diff_dst_step = get_diff_dst_offset(0, 0, 1);
     auto ker_step = get_kernel_offset(0, jcp.oc_block, 0);
-    add(reg_dst, diff_dst_step);
-    add(reg_ker, ker_step);
+    add(reg_dst, into<uint32_t>(diff_dst_step));
+    add(reg_ker, into<uint32_t>(ker_step));
 
     sub(reg_oc, jcp.oc_block);
     cmp(reg_oc, 0);
     jg(ocb_label, T_NEAR);
 
-    sub(reg_dst, diff_dst_step * jcp.nb_oc);
-    sub(reg_ker, ker_step * jcp.nb_oc);
+    sub(reg_dst, into<uint32_t>(diff_dst_step * jcp.nb_oc));
+    sub(reg_ker, into<uint32_t>(ker_step * jcp.nb_oc));
 
     L(skip_compute_label);
     store_output(ur_w);
@@ -1518,8 +1523,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         compute_loop(ur_w, l_overflow, 0);
         if (threaded && head_n_oi == 0 && head_thread != pretail_thread)
             jmp(end_label, T_NEAR);
-        add(reg_src, src_shift);
-        add(reg_dst, dst_shift);
+        add(reg_src, into<uint32_t>(src_shift));
+        add(reg_dst, into<uint32_t>(dst_shift));
     }
     L(body_label);
     if (n_oi > 0) {
@@ -1528,8 +1533,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         {
             compute_loop(ur_w, body_l_overflow, body_r_overflow);
             if (n_oi > 1 || r_overflow1 > 0 || ur_w_tail != 0) {
-                add(reg_src, src_shift);
-                add(reg_dst, dst_shift);
+                add(reg_src, into<uint32_t>(src_shift));
+                add(reg_dst, into<uint32_t>(dst_shift));
             }
             if (n_oi > 1) {
                 sub(reg_oi, 1);
@@ -1548,8 +1553,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
             if (threaded && tail_thread != pretail_thread)
                 jmp(end_label, T_NEAR);
             else {
-                add(reg_src, src_shift);
-                add(reg_dst, dst_shift);
+                add(reg_src, into<uint32_t>(src_shift));
+                add(reg_dst, into<uint32_t>(dst_shift));
             }
         }
     }
@@ -1583,35 +1588,36 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(diff_src_d.dims()[1] / jcp.ngroups);
 
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? diff_src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
     jcp.dst_dt = cd.diff_src_desc.data_type;
     jcp.nb_iw = 1;
     jcp.iw_block = jcp.iw;
@@ -1749,8 +1755,8 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     int l_overflow = nstl::max(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
+    jcp.typesize_in = into<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(diff_src_d.data_type()));
 
     /* Find the best blocking with maximum number of compute instructions
        per ur_w * nb_ic_blocking compute loops. Number of required registers
@@ -1876,9 +1882,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kd_count);
     L(kd_comeback_label);
     {
-        sub(reg_src, get_src_offset(0, 0, filter_d_to_src(1)));
+        sub(reg_src, into<uint32_t>(get_src_offset(0, 0, filter_d_to_src(1))));
         sub(reg_kernel,
-                get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw));
+                into<uint32_t>(
+                        get_kernel_offset(0, into<dim_t>(jcp.kh) * jcp.kw)));
         dec(kj);
         cmp(kj, 0);
         jg(kd_comeback_label, T_NEAR);
@@ -1890,8 +1897,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_src, get_src_offset(0, 0, filter_h_to_src(1)));
-        sub(reg_kernel, get_kernel_offset(0, jcp.kw));
+        sub(reg_src, into<uint32_t>(get_src_offset(0, 0, filter_h_to_src(1))));
+        sub(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -2133,18 +2140,19 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         // Overflow and underflow happen in different data reorder rounds
         kxnorw(overflow_stride_mask, overflow_stride_mask,
                 overflow_stride_mask);
-        kshiftlw(underflow_mask, overflow_stride_mask, pad_l);
+        kshiftlw(underflow_mask, overflow_stride_mask, into<uint8_t>(pad_l));
         kshiftlw(underflow_stride_mask, overflow_stride_mask,
-                pad_l >= str_w ? pad_l - str_w : 0);
-        kshiftrw(overflow_mask, overflow_stride_mask, reorder_pad_r);
+                into<uint8_t>(pad_l >= str_w ? pad_l - str_w : 0));
+        kshiftrw(overflow_mask, overflow_stride_mask,
+                into<uint8_t>(reorder_pad_r));
         kshiftrw(overflow_stride_mask, overflow_stride_mask,
-                reorder_stride_pad_r);
+                into<uint8_t>(reorder_stride_pad_r));
     } else if (reorder_size - reorder_overflow > reorder_block) {
         // Overflow and underflow happen in the same round for loading the data
         // at the stride offset.
         kxnorw(overflow_mask, overflow_mask, overflow_mask);
-        kshiftlw(underflow_mask, overflow_mask, pad_l);
-        kshiftrw(overflow_mask, overflow_mask, reorder_pad_r);
+        kshiftlw(underflow_mask, overflow_mask, into<uint8_t>(pad_l));
+        kshiftrw(overflow_mask, overflow_mask, into<uint8_t>(reorder_pad_r));
         mov(reg_tmp.cvt32(), pad_l_mask_strided & pad_r_mask_strided);
         kmovw(underflow_stride_mask, reg_tmp.cvt32());
     } else {
@@ -2615,13 +2623,13 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_diff_bias_row(
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
         compute_step(false);
-        add(reg_ddst, get_ddst_offset(2));
+        add(reg_ddst, into<uint32_t>(get_ddst_offset(2)));
         sub(reg_tmp, 1);
         jnz(ow_loop, T_NEAR);
     }
     if (jcp.tr_ow % 2) compute_step(true);
 
-    if (niters > 0) sub(reg_ddst, get_ddst_offset(2 * niters));
+    if (niters > 0) sub(reg_ddst, into<uint32_t>(get_ddst_offset(2 * niters)));
 
     if (is_partial) {
         mov(reg_tmp, ptr[param + GET_OFF(bias)]);
@@ -2663,7 +2671,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     L(bias_loop);
     {
         compute_diff_bias_row(false);
-        add(reg_ddst, get_ddst_offset(0, 1));
+        add(reg_ddst, into<uint32_t>(get_ddst_offset(0, 1)));
 
         sub(reg_oj, 1);
         jnz(bias_loop, T_NEAR);
@@ -2787,9 +2795,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         const int ic_tail_loop_work = rnd_up(ic_tail, ic_block_step);
         for (int i_b_ic = 0; i_b_ic < jcp.ic_block; i_b_ic += ic_block_step) {
-            const int src_offset = get_src_offset(i_b_ic, 0);
+            const int src_offset = into<int>(get_src_offset(i_b_ic, 0));
             compute_ic_block_step(ur_w, l_pad, r_pad, ic_block_step, src_offset,
-                    get_kernel_offset(i_b_ic, 0), 0, true);
+                    into<int>(get_kernel_offset(i_b_ic, 0)), 0, true);
             if (generate_icb_loop || ic_tail) sub(reg_icb, ic_block_step);
             // We relax the boundary for reg_icb, as the src is already
             // converted to vnni_format with appropriate padding either through
@@ -2808,7 +2816,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         const auto kernel_icb_loop_shift_bytes = get_kernel_offset(
                 0, static_cast<dim_t>(jcp.kd) * jcp.kh * jcp.kw);
         if (generate_icb_loop) {
-            add(reg_src, src_icb_loop_shift_bytes);
+            add(reg_src, into<uint32_t>(src_icb_loop_shift_bytes));
             safe_add(reg_kernel, kernel_icb_loop_shift_bytes, reg_long_offt);
 
             assert(jcp.uses_permw_transposition);
@@ -2822,17 +2830,19 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             mov(reg_src, ptr[rsp + icb_loop_src_ptr]);
         }
 
-        add(reg_src, get_src_offset(0, 0, filter_h_to_src(1)));
-        add(reg_kernel, get_kernel_offset(0, jcp.kw));
+        add(reg_src, into<uint32_t>(get_src_offset(0, 0, filter_h_to_src(1))));
+        add(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_label, T_NEAR);
     }
 
     if (jcp.ndims == 5) {
-        add(aux_reg_src, get_src_offset(0, 0, filter_d_to_src(1)));
+        add(aux_reg_src,
+                into<uint32_t>(get_src_offset(0, 0, filter_d_to_src(1))));
         add(aux_reg_kernel,
-                get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw));
+                into<uint32_t>(
+                        get_kernel_offset(0, into<dim_t>(jcp.kh) * jcp.kw)));
         dec(ki);
         cmp(ki, 0);
         jg(kd_label, T_NEAR);
@@ -2896,7 +2906,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
                     ur_w, l_pad, r_pad, ic_block_step, 0, 0, 0, true);
             assert(jcp.ic_block % jcp.ic_block_step == 0);
             safe_add(reg_src, src_offset, reg_long_offt);
-            add(reg_kernel, get_kernel_offset(ic_block_step, 0));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(ic_block_step, 0)));
             add(b_ic, ic_block_step);
             if (generate_icb_loop || ic_tail) sub(reg_icb, ic_block_step);
             // We relax the boundary for reg_icb, as the src is already
@@ -2929,20 +2940,23 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
                 mov(reg_kernel, ptr[rsp + icb_loop_ker_ptr]);
                 mov(reg_src, ptr[rsp + icb_loop_src_ptr]);
 
-                add(reg_src, get_src_offset(0, 0, filter_h_to_src(1)));
-                add(reg_kernel, get_kernel_offset(0, jcp.kw));
+                add(reg_src,
+                        into<uint32_t>(
+                                get_src_offset(0, 0, filter_h_to_src(1))));
+                add(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
             } else {
                 add(reg_src,
-                        get_src_offset(0, 0, filter_h_to_src(1))
-                                - jcp.typesize_in * ic_block);
+                        into<uint32_t>(get_src_offset(0, 0, filter_h_to_src(1))
+                                - jcp.typesize_in * ic_block));
             }
         } else if (ic_tail) {
             // restore pointers
             mov(reg_kernel, ptr[rsp + icb_loop_ker_ptr]);
             mov(reg_src, ptr[rsp + icb_loop_src_ptr]);
 
-            add(reg_src, get_src_offset(0, 0, filter_h_to_src(1)));
-            add(reg_kernel, get_kernel_offset(0, jcp.kw));
+            add(reg_src,
+                    into<uint32_t>(get_src_offset(0, 0, filter_h_to_src(1))));
+            add(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
         } else if (jcp.is_1stconv && !jcp.transpose_src) {
             // Fixup reg_src to point to the correct location
             safe_add(reg_src,
@@ -2951,20 +2965,24 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
                     reg_long_offt);
         } else {
             if (jcp.dilate_h > 0)
-                add(reg_src, get_src_offset(0, 0, jcp.dilate_h));
+                add(reg_src,
+                        into<uint32_t>(get_src_offset(0, 0, jcp.dilate_h)));
         }
         if (!generate_icb_loop && !ic_tail)
             // substract pointer shift made within ic block loop
             // and move to next kh index
-            add(reg_kernel, get_kernel_offset(-ic_block, jcp.kw));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(-ic_block, jcp.kw)));
         dec(kj);
         cmp(kj, 0);
         jg(kh_label, T_NEAR);
     }
     if (jcp.ndims == 5) {
-        add(aux_reg_src, get_src_offset(0, 0, filter_d_to_src(1)));
+        add(aux_reg_src,
+                into<uint32_t>(get_src_offset(0, 0, filter_d_to_src(1))));
         add(aux_reg_kernel,
-                get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw));
+                into<uint32_t>(
+                        get_kernel_offset(0, into<dim_t>(jcp.kh) * jcp.kw)));
         dec(ki);
         cmp(ki, 0);
         jg(kd_label, T_NEAR);
@@ -3016,8 +3034,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                 ur_w_blocks--;
                 compute_ic_block_step(ur_w, l_pad, 0, ic_block_step, 0, 0, 0);
                 add(reg_src,
-                        get_src_offset(0, filter_w_to_src(0, ur_w, l_pad)));
-                add(reg_ddst, get_ddst_offset(ur_w));
+                        into<uint32_t>(get_src_offset(
+                                0, filter_w_to_src(0, ur_w, l_pad))));
+                add(reg_ddst, into<uint32_t>(get_ddst_offset(ur_w)));
             }
 
             if (ur_w_blocks > 0) {
@@ -3026,8 +3045,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                 {
                     compute_ic_block_step(ur_w, 0, 0, ic_block_step, 0, 0, 0);
                     add(reg_src,
-                            get_src_offset(0, filter_w_to_src(0, ur_w, 0)));
-                    add(reg_ddst, get_ddst_offset(ur_w));
+                            into<uint32_t>(get_src_offset(
+                                    0, filter_w_to_src(0, ur_w, 0))));
+                    add(reg_ddst, into<uint32_t>(get_ddst_offset(ur_w)));
 
                     inc(reg_ur_w_trips);
                     cmp(reg_ur_w_trips, ur_w_blocks);
@@ -3040,11 +3060,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                         ur_w_tail, 0, r_pad, ic_block_step, 0, 0, 0, true);
             }
 
-            sub(reg_src, src_comeback);
-            sub(reg_ddst, ddst_comeback);
+            sub(reg_src, into<uint32_t>(src_comeback));
+            sub(reg_ddst, into<uint32_t>(ddst_comeback));
 
             safe_add(reg_src, src_offset, reg_long_offt);
-            add(reg_kernel, get_kernel_offset(ic_block_step, 0));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(ic_block_step, 0)));
         };
 
         mov(kj, reg_kh);
@@ -3081,9 +3102,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                 cmp(reg_icb, jcp.simd_w);
                 je(skip_ic_tail_offset_compensation);
                 add(reg_kernel,
-                        get_kernel_offset(
+                        into<uint32_t>(get_kernel_offset(
                                 jcp.ic_block - rnd_up(ic_tail, ic_block_step),
-                                0));
+                                0)));
                 safe_add(reg_src,
                         get_src_offset(0, 0, filter_h_to_src(1))
                                 - get_src_offset(
@@ -3099,11 +3120,13 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                                 - src_offset * (jcp.ic_block / ic_block_step),
                         reg_long_offt);
             } else if (jcp.dilate_h > 0) {
-                add(reg_src, get_src_offset(0, 0, jcp.dilate_h));
+                add(reg_src,
+                        into<uint32_t>(get_src_offset(0, 0, jcp.dilate_h)));
             }
             // substract pointer shift made within ic block loop
             // and move to next kh index
-            add(reg_kernel, get_kernel_offset(-ic_block, jcp.kw));
+            add(reg_kernel,
+                    into<uint32_t>(get_kernel_offset(-ic_block, jcp.kw)));
             dec(kj);
             cmp(kj, 0);
             jg(kh_label, T_NEAR);
@@ -3129,17 +3152,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                             ur_w, l_pad, 0, ic_block_step, 0, 0, 0);
                     safe_add(reg_src, src_icbstep_shift * ic_block_step,
                             reg_long_offt);
-                    add(reg_kernel, get_kernel_offset(ic_block_step, 0));
+                    add(reg_kernel,
+                            into<uint32_t>(
+                                    get_kernel_offset(ic_block_step, 0)));
 
                     add(b_ic, ic_block_step);
                     cmp(b_ic, ic_work);
                     jl(ic_block_label_padl, T_NEAR);
                 }
                 safe_sub(reg_src, src_icbstep_shift * ic_work, reg_long_offt);
-                sub(reg_kernel, get_kernel_offset(ic_work, 0));
+                sub(reg_kernel, into<uint32_t>(get_kernel_offset(ic_work, 0)));
                 add(reg_src,
-                        get_src_offset(0, filter_w_to_src(0, ur_w, l_pad)));
-                add(reg_ddst, get_ddst_offset(ur_w));
+                        into<uint32_t>(get_src_offset(
+                                0, filter_w_to_src(0, ur_w, l_pad))));
+                add(reg_ddst, into<uint32_t>(get_ddst_offset(ur_w)));
             }
 
             if (ur_w_blocks > 0) {
@@ -3156,7 +3182,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                                 ur_w, 0, 0, ic_block_step, 0, 0, 0);
                         safe_add(reg_src, src_icbstep_shift * ic_block_step,
                                 reg_long_offt);
-                        add(reg_kernel, get_kernel_offset(ic_block_step, 0));
+                        add(reg_kernel,
+                                into<uint32_t>(
+                                        get_kernel_offset(ic_block_step, 0)));
 
                         add(b_ic, ic_block_step);
                         cmp(b_ic, ic_work);
@@ -3164,9 +3192,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                     }
                     safe_sub(reg_src, src_icbstep_shift * ic_work,
                             reg_long_offt);
-                    sub(reg_kernel, get_kernel_offset(ic_work, 0));
-                    add(reg_src, get_src_offset(0, filter_w_to_src(0, ur_w)));
-                    add(reg_ddst, get_ddst_offset(ur_w));
+                    sub(reg_kernel,
+                            into<uint32_t>(get_kernel_offset(ic_work, 0)));
+                    add(reg_src,
+                            into<uint32_t>(get_src_offset(
+                                    0, filter_w_to_src(0, ur_w))));
+                    add(reg_ddst, into<uint32_t>(get_ddst_offset(ur_w)));
 
                     inc(reg_ur_w_trips);
                     cmp(reg_ur_w_trips, ur_w_blocks);
@@ -3185,18 +3216,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                             ur_w_tail, 0, r_pad, ic_block_step, 0, 0, 0, true);
                     safe_add(reg_src, src_icbstep_shift * ic_block_step,
                             reg_long_offt);
-                    add(reg_kernel, get_kernel_offset(ic_block_step, 0));
+                    add(reg_kernel,
+                            into<uint32_t>(
+                                    get_kernel_offset(ic_block_step, 0)));
 
                     add(b_ic, ic_block_step);
                     cmp(b_ic, ic_work);
                     jl(ic_block_label_tail, T_NEAR);
                 }
                 safe_sub(reg_src, src_icbstep_shift * ic_work, reg_long_offt);
-                sub(reg_kernel, get_kernel_offset(ic_work, 0));
+                sub(reg_kernel, into<uint32_t>(get_kernel_offset(ic_work, 0)));
             }
 
-            sub(reg_src, src_comeback);
-            sub(reg_ddst, ddst_comeback);
+            sub(reg_src, into<uint32_t>(src_comeback));
+            sub(reg_ddst, into<uint32_t>(ddst_comeback));
         };
 
         mov(kj, reg_kh);
@@ -3219,7 +3252,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
             ic_loop(ic_block_step);
 
             if (generate_icb_loop) {
-                add(reg_src, get_src_offset(ic_block, 0));
+                add(reg_src, into<uint32_t>(get_src_offset(ic_block, 0)));
                 safe_add(reg_kernel,
                         get_kernel_offset(0,
                                 static_cast<dim_t>(jcp.kd) * jcp.kh * jcp.kw),
@@ -3235,17 +3268,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
                 mov(reg_src, ptr[rsp + icb_loop_src_ptr]);
             }
 
-            add(reg_src, get_src_offset(0, 0, filter_h_to_src(1)));
-            add(reg_kernel, get_kernel_offset(0, jcp.kw));
+            add(reg_src,
+                    into<uint32_t>(get_src_offset(0, 0, filter_h_to_src(1))));
+            add(reg_kernel, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
             dec(kj);
             cmp(kj, 0);
             jg(kh_label, T_NEAR);
         }
     }
     if (jcp.ndims == 5) {
-        add(aux_reg_src, get_src_offset(0, 0, filter_d_to_src(1)));
+        add(aux_reg_src,
+                into<uint32_t>(get_src_offset(0, 0, filter_d_to_src(1))));
         add(aux_reg_kernel,
-                get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw));
+                into<uint32_t>(
+                        get_kernel_offset(0, into<dim_t>(jcp.kh) * jcp.kw)));
         dec(ki);
         cmp(ki, 0);
         jg(kd_label, T_NEAR);
@@ -3335,13 +3371,13 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
         for (int ic1 = 0; ic1 < jcp.ic_block; ic1++)
             vmovups(ptr[reg_kernel + reg_tmp + get_kernel_offset(ic1, 0)],
                     zero);
-        add(reg_tmp, get_kernel_offset(jcp.ic_block, 0));
-        cmp(reg_tmp, kernel_block_bytes);
+        add(reg_tmp, into<uint32_t>(get_kernel_offset(jcp.ic_block, 0)));
+        cmp(reg_tmp, into<uint32_t>(kernel_block_bytes));
         jnz(zeroing_loop);
     }
 
     if (generate_icb_loop) {
-        add(reg_kernel, kernel_block_bytes);
+        add(reg_kernel, into<uint32_t>(kernel_block_bytes));
         sub(reg_icb, jcp.ic_block);
         cmp(reg_icb, 0);
         jg(icb_block_label, T_NEAR);
@@ -3396,13 +3432,13 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
-        add(reg_kernel, filter_step_size * underflow);
+        add(reg_kernel, into<uint32_t>(filter_step_size * underflow));
         if (is_dilated) {
             const int tail = t_pad % dilate_h;
             const int shift = tail == 0 ? 0 : dilate_h - tail;
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_shift], reg_ih_shift);
-            add(reg_src, src_step_size * shift);
+            add(reg_src, into<uint32_t>(src_step_size * shift));
         }
 
         if (is_partial) {
@@ -3417,17 +3453,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
                 cmp(reg_ih_shift, dilate_h);
                 jl(oh_dilate_setup_label_shift, T_NEAR);
                 // unshift src as new kernel element enters
-                sub(reg_src, src_step_size * (dilate_h - 1));
+                sub(reg_src, into<uint32_t>(src_step_size * (dilate_h - 1)));
                 xor_(reg_ih_shift, reg_ih_shift);
             }
             // kernel overlap only changes when (t_pad + oj) % dilate_h == 0
             add(reg_kh, stride_h);
-            sub(reg_kernel, filter_step_size * stride_h);
+            sub(reg_kernel, into<uint32_t>(filter_step_size * stride_h));
             if (is_dilated) {
                 jmp(oh_dilate_setup_label_noshift, T_NEAR);
                 L(oh_dilate_setup_label_shift);
                 // shift src as old kernel element progresses
-                add(reg_src, src_step_size * stride_h);
+                add(reg_src, into<uint32_t>(src_step_size * stride_h));
                 L(oh_dilate_setup_label_noshift);
             }
             sub(reg_oj_setup, 1);
@@ -3446,7 +3482,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         // Loop
         L(oh_tpad_label);
         compute_oh_step_disp();
-        add(reg_ddst, ddst_step_size);
+        add(reg_ddst, into<uint32_t>(ddst_step_size));
         if (is_dilated) {
             mov(reg_ih_shift, ptr[rsp + ih_dilate_shift]);
             inc(reg_ih_shift);
@@ -3454,18 +3490,18 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             cmp(reg_ih_shift, dilate_h);
             jl(oh_dilate_label_shift, T_NEAR);
             // unshift src as new kernel element enters
-            sub(reg_src, src_step_size * (dilate_h - 1));
+            sub(reg_src, into<uint32_t>(src_step_size * (dilate_h - 1)));
             xor_(reg_ih_shift, reg_ih_shift);
             mov(ptr[rsp + ih_dilate_shift], reg_ih_shift);
         }
         // kernel overlap only changes when (t_pad + oj) % dilate_h == 0
         add(reg_kh, stride_h);
-        sub(reg_kernel, filter_step_size * stride_h);
+        sub(reg_kernel, into<uint32_t>(filter_step_size * stride_h));
         if (is_dilated) {
             jmp(oh_dilate_label_noshift, T_NEAR);
             L(oh_dilate_label_shift);
             // shift src as old kernel element progresses
-            add(reg_src, src_step_size * stride_h);
+            add(reg_src, into<uint32_t>(src_step_size * stride_h));
             L(oh_dilate_label_noshift);
         }
         inc(reg_oj);
@@ -3490,8 +3526,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             L(oh_tpad_tail_label);
             {
                 compute_oh_step_disp();
-                add(reg_ddst, ddst_step_size);
-                sub(reg_kernel, filter_step_size * stride_h);
+                add(reg_ddst, into<uint32_t>(ddst_step_size));
+                sub(reg_kernel, into<uint32_t>(filter_step_size * stride_h));
 
                 inc(reg_oj);
 
@@ -3504,8 +3540,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             }
         }
         if (body_src_start_offset != 0) {
-            add(reg_kernel, filter_step_size * body_src_start_offset);
-            add(reg_src, src_step_size * body_src_start_offset);
+            add(reg_kernel,
+                    into<uint32_t>(filter_step_size * body_src_start_offset));
+            add(reg_src, into<uint32_t>(src_step_size * body_src_start_offset));
         }
         L(oh_tpad_tail_label_end);
     }
@@ -3522,8 +3559,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
     L(oh_label);
     {
         compute_oh_step_disp();
-        add(reg_src, src_step_size * stride_h);
-        add(reg_ddst, ddst_step_size);
+        add(reg_src, into<uint32_t>(src_step_size * stride_h));
+        add(reg_ddst, into<uint32_t>(ddst_step_size));
 
         inc(reg_oj);
 
@@ -3583,8 +3620,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         L(oh_bpad_label);
         {
             compute_oh_step_disp();
-            add(reg_src, src_step_size * stride_h);
-            add(reg_ddst, ddst_step_size);
+            add(reg_src, into<uint32_t>(src_step_size * stride_h));
+            add(reg_ddst, into<uint32_t>(ddst_step_size));
 
             if (is_dilated) {
                 mov(reg_ih_shift, ptr[rsp + ih_dilate_shift]);
@@ -3638,9 +3675,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
         const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(0,
+        const int kd_offset = into<int>(get_kernel_offset(0,
                 nstl::min(jcp.kd - 1, kd_front_pad) * static_cast<dim_t>(jcp.kh)
-                        * jcp.kw);
+                        * jcp.kw));
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -3676,7 +3713,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
-        sub(reg_kernel, filter_shift * jcp.stride_d);
+        sub(reg_kernel, into<uint32_t>(filter_shift * jcp.stride_d));
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
@@ -3689,13 +3726,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
                 int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
-                add(reg_kernel, filter_shift * src_corr);
+                add(reg_kernel, into<uint32_t>(filter_shift * src_corr));
                 // for src, subtract src_common_shift that gets added later.
-                add(reg_src_d, src_shift * src_corr - src_common_shift);
+                add(reg_src_d,
+                        into<uint32_t>(
+                                src_shift * src_corr - src_common_shift));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.f_pad - jcp.od * jcp.stride_d) * filter_shift);
+            sub(reg_kernel,
+                    into<uint32_t>((jcp.f_pad - jcp.od * jcp.stride_d)
+                            * filter_shift));
         }
 
         /* Apply correction */
@@ -3727,11 +3768,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
     }
 
     /* Compute middle block */
-    add(reg_src_d, src_common_shift);
+    add(reg_src_d, into<uint32_t>(src_common_shift));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_ddst_d, ddst_shift);
+    add(reg_ddst_d, into<uint32_t>(ddst_shift));
     inc(reg_d_index);
     if (is_partial)
         cmp(reg_d_index, ptr[param + GET_OFF(os_index_end)]);
@@ -3854,8 +3895,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
             L(w_loop);
             {
                 emit_step(def_step_size, false);
-                add(reg_src, get_src_offset(0, def_step_size));
-                add(reg_ddst, get_ddst_offset(def_step_size));
+                add(reg_src, into<uint32_t>(get_src_offset(0, def_step_size)));
+                add(reg_ddst, into<uint32_t>(get_ddst_offset(def_step_size)));
                 sub(reg_i, 1);
                 jnz(w_loop);
             }
@@ -3863,8 +3904,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
             // reset reg_src and reg_ddst because emit_h_loop expects
             // unmodified pointers
             int w_offset = num_w_iters * def_step_size;
-            sub(reg_src, get_src_offset(0, w_offset));
-            sub(reg_ddst, get_ddst_offset(w_offset));
+            sub(reg_src, into<uint32_t>(get_src_offset(0, w_offset)));
+            sub(reg_ddst, into<uint32_t>(get_ddst_offset(w_offset)));
         }
     };
 
@@ -3877,8 +3918,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         {
             emit_block();
 
-            add(reg_src, get_src_offset(0, 0, 1));
-            add(reg_ddst, get_ddst_offset(0, 1));
+            add(reg_src, into<uint32_t>(get_src_offset(0, 0, 1)));
+            add(reg_ddst, into<uint32_t>(get_ddst_offset(0, 1)));
             add(reg_j, 1);
             cmp(reg_j, reg_h);
             jb(h_loop);
@@ -3947,7 +3988,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
             {
                 for (int ic1 = 0; ic1 < jcp.ic_block; ic1++)
                     vmovups(ker_addr(ic1), zmm0);
-                add(reg_ker, get_kernel_offset(jcp.ic_block, 0));
+                add(reg_ker,
+                        into<uint32_t>(get_kernel_offset(jcp.ic_block, 0)));
                 sub(reg_tmp, 1);
                 jnz(zeroing_loop, T_NEAR);
             }
@@ -3957,13 +3999,13 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
             jmp(kh_loop_end, T_NEAR);
 
             L(skip_ker_zeroing);
-            add(reg_ker, get_kernel_offset(0, jcp.kw));
+            add(reg_ker, into<uint32_t>(get_kernel_offset(0, jcp.kw)));
             jmp(kh_loop_end, T_NEAR);
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp, into<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(reg_ohs, reg_tmp, into<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4007,7 +4049,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 }
 
                 mov(reg_ker, reg_tmp);
-                add(reg_ker, get_kernel_offset(jcp.ic_block, 0));
+                add(reg_ker,
+                        into<uint32_t>(get_kernel_offset(jcp.ic_block, 0)));
                 add(reg_kw, 1);
                 cmp(reg_kw, jcp.kw);
                 jl(kw_loop);
@@ -4040,11 +4083,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     if (!single_kh_kw_loop) {
         auto ker_reset_offset
                 = get_kernel_offset(0, static_cast<dim_t>(jcp.kw) * jcp.kh);
-        sub(reg_ker, ker_reset_offset);
+        sub(reg_ker, into<uint32_t>(ker_reset_offset));
         and_(reg_ker, ~1); // Clear the zeroing flag for subsequent updates
 
-        add(reg_src, first_src_block_step);
-        add(reg_ddst, ddst_block_step);
+        add(reg_src, into<uint32_t>(first_src_block_step));
+        add(reg_ddst, into<uint32_t>(ddst_block_step));
 
         int num_innermost_iters
                 = (jcp.oh - h_last_block_size) / h_block_size - 1;
@@ -4056,9 +4099,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
             L(h_block_loop);
             {
                 emit_kh_kw_loop(false, false);
-                sub(reg_ker, ker_reset_offset);
-                add(reg_src, src_row_step * h_block_size);
-                add(reg_ddst, ddst_block_step);
+                sub(reg_ker, into<uint32_t>(ker_reset_offset));
+                add(reg_src, into<uint32_t>(src_row_step * h_block_size));
+                add(reg_ddst, into<uint32_t>(ddst_block_step));
 
                 kmovw(reg_tmp_w, reg_h_block);
                 sub(reg_tmp_w, 1);
@@ -4200,35 +4243,37 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? diff_weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>(
+            (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -4329,7 +4374,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia
+            = into<int>(jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0);
 
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -159,7 +159,7 @@ private:
     }
 
     inline dim_t get_src_offset(dim_t ic_idx, dim_t isp) {
-        int icb = ic_idx / jcp.ic_block;
+        dim_t icb = ic_idx / jcp.ic_block;
         int ic = ic_idx % jcp.ic_block;
         dim_t isp_str = is_src_layout_nxc()
                 ? static_cast<dim_t>(jcp.ngroups) * jcp.ic

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -779,9 +779,9 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
     int ithr_but_ic = 0;
 
     int img_start = 0, img_end = 0, img_work = 0;
-    int g_start = 0, g_end = 0, g_work = 0;
-    int oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
-    int ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
+    dim_t g_start = 0, g_end = 0, g_work = 0;
+    dim_t oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
+    dim_t ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
 
     thread_info_t(const jit_avx512_core_bf16_convolution_bwd_weights_t *self,
             const exec_ctx_t &ctx, int ithr)
@@ -848,15 +848,16 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(into<dim_t>(jcp.ngroups), self->nthr_g_, ithr_g, g_start,
+                g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(into<dim_t>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(into<dim_t>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -427,10 +427,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, into<uint32_t>(wei_ch_stride));
+                add(reg_input, into<uint32_t>(inp_ch_stride));
+                add(reg_output, into<uint32_t>(out_ch_stride));
+                if (jcp.with_bias) add(reg_bias, into<uint32_t>(bias_stride));
                 sub(reg_ch_blocks, ch_step);
                 cmp(reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -489,7 +489,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
         if (n_oi == 0) {
             compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, into<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
@@ -497,7 +497,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
             if (l_pad > 0) {
                 compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, into<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -505,8 +505,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, into<uint32_t>(inp_shift));
+                    add(reg_output, into<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -515,8 +515,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, into<uint32_t>(inp_shift));
+                add(reg_output, into<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -693,7 +693,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
             }
 
             add(aux1_reg_kernel, ch_blk * stride_w * jcp.typesize_in);
-            sub(aux1_reg_ddst, sp_step * jcp.typesize_in);
+            sub(aux1_reg_ddst, into<uint32_t>(sp_step * jcp.typesize_in));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
@@ -701,7 +701,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         }
 
         add(aux_reg_kernel, kw * ch_blk * stride_h * jcp.typesize_in);
-        sub(aux_reg_ddst, ow * sp_step * jcp.typesize_in);
+        sub(aux_reg_ddst, into<uint32_t>(ow * sp_step * jcp.typesize_in));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -730,7 +730,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         for (int w = 0; w < ur_str_w; w++) {
             size_t sp_offset = w * stride_w * sp_step;
             size_t ch_offset = ch * ch_block_step;
-            int dsrc_off = sp_offset + ch_offset;
+            dim_t dsrc_off = sp_offset + ch_offset;
             auto zmm_dsrc = get_acc_reg(ch * ur_str_w + w);
             Zmm mm_zmm_dsrc // mm: maybe masked
                     = mask_flag ? zmm_dsrc | k_ch_tail_mask : zmm_dsrc;
@@ -800,9 +800,11 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
             {
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
-                add(reg_kernel, wei_ch_stride * jcp.typesize_in);
-                add(reg_dsrc, data_ch_stride * jcp.typesize_out);
-                add(reg_ddst, data_ch_stride * jcp.typesize_in);
+                add(reg_kernel,
+                        into<uint32_t>(wei_ch_stride * jcp.typesize_in));
+                add(reg_dsrc,
+                        into<uint32_t>(data_ch_stride * jcp.typesize_out));
+                add(reg_ddst, into<uint32_t>(data_ch_stride * jcp.typesize_in));
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -842,8 +844,9 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, jcp.typesize_out * jcp.stride_w * ch_step);
-            add(reg_ddst, jcp.typesize_in * ch_step);
+            add(reg_dsrc,
+                    into<uint32_t>(jcp.typesize_out * jcp.stride_w * ch_step));
+            add(reg_ddst, into<uint32_t>(jcp.typesize_in * ch_step));
 
             sub(reg_ur_str_w, unroll_w);
             jmp(unroll_w_label);
@@ -874,7 +877,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
             const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
-            cmp(reg_ch_blocks, channel_step);
+            cmp(reg_ch_blocks, into<uint32_t>(channel_step));
             je(masking_done, T_NEAR);
             // Prepare masks for tail
             Reg32 reg_tmp_32 = reg_tmp.cvt32();
@@ -1069,7 +1072,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
         L(ow_blk_label);
         {
             compute_bias_step_unroll(unroll_w, is_last_ch);
-            add(reg_tmp_output, unroll_w * ch_offset);
+            add(reg_tmp_output, into<uint32_t>(unroll_w * ch_offset));
 
             dec(reg_iter_ow_blk);
             cmp(reg_iter_ow_blk, 0);
@@ -1078,7 +1081,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
 
         if (tail_w > 0) {
             compute_bias_step_unroll(tail_w, is_last_ch);
-            add(reg_tmp_output, tail_w * ch_offset);
+            add(reg_tmp_output, into<uint32_t>(tail_w * ch_offset));
         }
 
         inc(reg_oh);
@@ -1209,14 +1212,14 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter_kh_loop() {
     {
         store_filter();
 
-        add(reg_tmp_filter, filter_offset_kw);
+        add(reg_tmp_filter, into<uint32_t>(filter_offset_kw));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
     }
 
     /* Comeback pointers */
-    sub(reg_tmp_filter, filter_offset_kh);
+    sub(reg_tmp_filter, into<uint32_t>(filter_offset_kh));
 }
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::deploy_zero_filter() {
@@ -1256,8 +1259,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
                 unroll_w, l_pad, pad_offset, ow_block, is_last_ch);
         store_filter();
 
-        add(reg_tmp_filter, filter_offset);
-        add(reg_tmp_input, input_offset);
+        add(reg_tmp_filter, into<uint32_t>(filter_offset));
+        add(reg_tmp_input, into<uint32_t>(input_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
@@ -1268,8 +1271,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
     mov(reg_kh_aux, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_tmp_input, input_offset);
-        sub(reg_tmp_filter, filter_offset);
+        sub(reg_tmp_input, into<uint32_t>(input_offset));
+        sub(reg_tmp_filter, into<uint32_t>(filter_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -1348,7 +1351,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_tmp_filter, filter_shift * jcp.stride_h);
+        sub(reg_tmp_filter, into<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
@@ -1361,13 +1364,14 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
                 int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_tmp_filter, filter_shift * inp_corr);
-                add(reg_tmp_input, input_shift * inp_corr);
+                add(reg_tmp_filter, into<uint32_t>(filter_shift * inp_corr));
+                add(reg_tmp_input, into<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
             sub(reg_tmp_filter,
-                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+                    into<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Apply correction: reset value of 'reg_kh' to scenario outside of
@@ -1402,11 +1406,11 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     }
 
     /* Compute middle block */
-    add(reg_tmp_input, input_shift * jcp.stride_h);
+    add(reg_tmp_input, into<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_tmp_output, output_shift);
+    add(reg_tmp_output, into<uint32_t>(output_shift));
     inc(reg_oh);
     cmp(reg_oh, reg_oh_worksize);
     jl(loop_begin_label, T_NEAR);
@@ -1465,8 +1469,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (l_pad && do_unroll_w) {
         compute_h_loop(unroll_w, l_pad, 0, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, into<uint32_t>(data_offset));
+        add(reg_input_baddr, into<uint32_t>(data_offset * jcp.stride_w));
         unroll_trips--;
         pad_offset = l_pad;
         l_pad = 0;
@@ -1481,8 +1485,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     }
     if (unroll_trips > 0) {
         compute_h_loop(unroll_w, l_pad, pad_offset, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, into<uint32_t>(data_offset));
+        add(reg_input_baddr, into<uint32_t>(data_offset * jcp.stride_w));
     }
     if (do_ow_blk_loop) {
         dec(reg_iter_ow_blk);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -382,10 +382,10 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking, false);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, into<uint32_t>(wei_ch_stride));
+                add(reg_input, into<uint32_t>(inp_ch_stride));
+                add(reg_output, into<uint32_t>(out_ch_stride));
+                if (jcp.with_bias) add(reg_bias, into<uint32_t>(bias_stride));
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -444,7 +444,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
         if (n_oi == 0) {
             compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, into<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
@@ -452,7 +452,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
             if (l_pad > 0) {
                 compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, into<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -460,8 +460,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, into<uint32_t>(inp_shift));
+                    add(reg_output, into<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -470,8 +470,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, into<uint32_t>(inp_shift));
+                add(reg_output, into<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -46,16 +46,16 @@ void fp8_conversion_e5m2_t::prepare_table() {
             case 2: index = i + 1; break;
             case 3: index = i - 2; break;
         }
-        host_->db(index);
+        host_->db(into<int>(index));
     }
     // Data for bf16
     for (size_t i = 0; i < 32; ++i) {
         size_t index = 4 * (i / 2) + (i % 2);
-        host_->db(index);
+        host_->db(into<int>(index));
     }
     for (size_t i = 32; i < 64; ++i) {
         size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
-        host_->db(index);
+        host_->db(into<int>(index));
     }
 
     // Other tables are not needed if fp8 is native
@@ -87,11 +87,11 @@ void fp8_conversion_e4m3_t::prepare_table() {
     host_->L(label_vnni_permute_index_table_);
     for (size_t i = 0; i < 32; ++i) {
         size_t index = 4 * (i / 2) + (i % 2);
-        host_->db(index);
+        host_->db(into<int>(index));
     }
     for (size_t i = 32; i < 64; ++i) {
         size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
-        host_->db(index);
+        host_->db(into<int>(index));
     }
 
     host_->L(label_table_from_f8_);

--- a/src/cpu/x64/jit_avx512_core_resampling.cpp
+++ b/src/cpu/x64/jit_avx512_core_resampling.cpp
@@ -81,7 +81,7 @@ struct jit_avx512_core_resampling_kernel_t
             stride_w_ = inner_stride_;
         }
 
-        number_of_loops_ = (inner_stride_ / simd_w());
+        number_of_loops_ = (into<unsigned int>(inner_stride_ / simd_w()));
         tail_size_ = inner_stride_ % simd_w();
         stack_size_needed_ = 0;
 
@@ -340,7 +340,7 @@ private:
             add(reg_tmp_idx, 1);
             max(reg_tmp_idx, 0);
             min(reg_tmp_idx, y_max);
-            cmp(curr_position, x_max - 1);
+            cmp(curr_position, into<uint32_t>(x_max - 1));
             mov(reg_tmp, y_max);
             cmove(reg_tmp_idx, reg_tmp);
             mov(ptr[c_range.end.linear[1]], reg_tmp_idx);
@@ -435,7 +435,7 @@ private:
                     xmm_w_coeff, zmm_weight, reg_curr_w, pd_->IW(), rm_w);
             // curr_w * stride_w_
             if (!pd_->is_fwd()) mov(reg_curr_w, ptr[ow.loop_counter]);
-            imul(reg_offset, reg_curr_w, stride_w_);
+            imul(reg_offset, reg_curr_w, into<int>(stride_w_));
         }
         if (rm_h != rounding_mode::none) {
             // out: Wh, curr_h
@@ -445,7 +445,7 @@ private:
             vmulps(zmm_weight, zmm_weight, zmm_tmp_weight);
             // curr_w * stride_w_ + curr_h * stride_h_
             if (!pd_->is_fwd()) mov(reg_curr_h, ptr[oh.loop_counter]);
-            imul(reg_tmp, reg_curr_h, stride_h_);
+            imul(reg_tmp, reg_curr_h, into<int>(stride_h_));
             add(reg_offset, reg_tmp);
         }
         if (rm_d != rounding_mode::none) {
@@ -456,12 +456,13 @@ private:
             vmulps(zmm_weight, zmm_weight, zmm_tmp_weight);
             // curr_w * stride_w_ + curr_h * stride_h_ + curr_d * stride_d_
             if (!pd_->is_fwd()) mov(reg_curr_d, ptr[od.loop_counter]);
-            imul(reg_tmp, reg_curr_d, stride_d_);
+            imul(reg_tmp, reg_curr_d, into<int>(stride_d_));
             add(reg_offset, reg_tmp);
         }
 
-        add(reg_offset, channel_offset);
-        imul(reg_offset, reg_offset, types::data_type_size(src_data_type()));
+        add(reg_offset, into<uint32_t>(channel_offset));
+        imul(reg_offset, reg_offset,
+                into<int>(types::data_type_size(src_data_type())));
 
         // read src
         io_->at(src_data_type())
@@ -683,18 +684,20 @@ private:
             mov(reg_curr_d, ptr[od.loop_counter]);
         }
 
-        imul(reg_offset, reg_curr_w, stride_w_); // iw * stride_w_
-        imul(reg_tmp, reg_curr_h, stride_h_);
+        imul(reg_offset, reg_curr_w,
+                into<int>(stride_w_)); // iw * stride_w_
+        imul(reg_tmp, reg_curr_h, into<int>(stride_h_));
         add(reg_offset, reg_tmp); // iw * stride_w_ + ih * stride_h_
-        imul(reg_tmp, reg_curr_d, stride_d_);
+        imul(reg_tmp, reg_curr_d, into<int>(stride_d_));
         add(reg_offset,
                 reg_tmp); // iw * stride_w_ + ih * stride_h_ + id * stride_d_
 
         add(reg_offset,
-                channel_offset); // iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset
+                into<uint32_t>(
+                        channel_offset)); // iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset
         imul(reg_offset, reg_offset,
-                types::data_type_size(
-                        src_data_type())); // (iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset)*dt_size
+                into<int>(types::data_type_size(
+                        src_data_type()))); // (iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset)*dt_size
 
         if (pd_->is_fwd()) {
             // read nearest to dst

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -324,7 +324,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        int offt = into<int>((i_load * jcp.reduce_dim + u0) * jcp.load_block);
 
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
@@ -620,7 +620,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
     L(reduce_loop);
     {
         fma_block(false);
-        add(aux_reg_bcast_data, jcp.reduce_loop_bcast_step);
+        add(aux_reg_bcast_data, into<uint32_t>(jcp.reduce_loop_bcast_step));
         add(aux_reg_load_data, jcp.reduce_loop_load_step);
         sub(reduce_loop_iter, jcp.reduce_loop_unroll);
         jg(reduce_loop, T_NEAR);
@@ -904,34 +904,34 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
 
     const bool is_1d = ndims == 3;
     const bool is_3d = ndims == 5;
 
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = into<int>(is_3d ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>(is_1d ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(is_1d ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(is_1d ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(is_1d ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
     jcp.signed_input = (src_d.data_type() == data_type::s8);
@@ -1066,10 +1066,10 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 1024;
@@ -1105,7 +1105,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             && (jcp.oh <= size_treshold && jcp.ow <= size_treshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs; // mobilenet_v2 performance improvement
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = into<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
         const int spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
@@ -1117,7 +1117,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = into<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -1154,14 +1154,15 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             = jcp.ur * jcp.ngroups * jcp.ic_without_padding * jcp.typesize_in;
     jcp.bcast_loop_bcast_substep = -1; // unused
 
-    jcp.load_loop_load_step = jcp.reduce_dim * jcp.load_block * jcp.typesize_in;
+    jcp.load_loop_load_step
+            = into<int>(jcp.reduce_dim * jcp.load_block * jcp.typesize_in);
 
     jcp.load_loop_iter_step = jcp.load_block;
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    int nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    int nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -1191,7 +1192,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
                              div_up(jcp.nthr, jcp.load_grp_count))
             * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+    bcast_blocking = into<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
     bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
     int space_for_bcast = (L2_capacity - /* kernel_size - */
@@ -1234,9 +1235,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     jcp.nb_reduce_blocking = reduce_blocking / jcp.reduce_block;
     jcp.nb_reduce_blocking_max = reduce_blocking_max / jcp.reduce_block;
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     // miniumum size of load dim chunk for work distribution within threads
     jcp.nb_load_chunk = 1;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -139,7 +139,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
     // override some constants for fused dw_conv
     const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
@@ -429,9 +429,10 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr, into<dim_t>(jcp.mb * jcp.ngroups * jcp_dw->oh),
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                dim_t(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
             int load_step;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -477,7 +477,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](int ii, int ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -426,11 +426,11 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
+        int gb = into<int>(gg * jcp.nb_ch_blocking);
         int g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
+        int ih_s = into<int>(-jcp.t_pad + oh_s * jcp.stride_h);
+        int ow_s = into<int>(owb * jcp.ow_block);
         int iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -105,12 +105,12 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     const bool is_2d = ndims == 4;
     const bool is_3d = ndims == 5;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
+    jcp.id = into<int>(is_3d ? src_d.dims()[2] : 1);
+    jcp.oc_without_padding = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic_without_padding = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.is_depthwise = true && with_groups
             && utils::everyone_is(
                     1, jcp.ic_without_padding, jcp.oc_without_padding);
@@ -200,21 +200,21 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     }
 
     jcp.prop_kind = cd.prop_kind;
-    jcp.mb = src_d.dims()[0];
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.ih = into<int>(is_1d ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(is_1d ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(is_1d ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(is_1d ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     if (jcp.is_depthwise) {
         jcp.ch_block = 16;
@@ -247,9 +247,9 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     VDISPATCH_DECONVOLUTION_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_TAG);
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>(is_3d ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>(is_1d ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_DECONVOLUTION_IC(
             !(!IMPLICATION(jcp.dilate_d, jcp.stride_d == 1)
@@ -301,10 +301,10 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -553,7 +553,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
         const auto kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
                 * sizeof(int32_t);
 
-        add(reg_zp_src_pad_comp, kh_offset);
+        add(reg_zp_src_pad_comp, into<uint32_t>(kh_offset));
         mov(zp_src_pad_comp_addr, reg_zp_src_pad_comp);
     }
 
@@ -635,7 +635,8 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                     vmm_inp(jj, jcp.nb_oc_blocking).getIdx());
                             for (int r = 0; r < tail_size; ++r)
                                 vpinsrb(xmm_tmp, xmm_tmp,
-                                        ptr[aux_reg_src + aux_src_off + r], r);
+                                        ptr[aux_reg_src + aux_src_off + r],
+                                        into<uint8_t>(r));
                             vpbroadcastd(
                                     vmm_inp(jj, jcp.nb_oc_blocking), xmm_tmp);
                         } else {
@@ -1690,9 +1691,10 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
-                        ? kh_lo * wht_kh_stride
-                        : 0;
+                int wei_stride
+                        = into<int>((!jcp.signed_input && !jcp.src_zero_point)
+                                        ? kh_lo * wht_kh_stride
+                                        : 0);
                 p.src = src_w + ih_max * src_h_stride;
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
                 p.filt = wht_w + wei_stride;
@@ -1917,9 +1919,10 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
-                        ? kh_lo * wht_kh_stride
-                        : 0;
+                int wei_stride
+                        = into<int>((!jcp.signed_input && !jcp.src_zero_point)
+                                        ? kh_lo * wht_kh_stride
+                                        : 0);
                 p.src = src_w + ih_max * src_h_stride;
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
                 p.filt = wht_w + wei_stride;

--- a/src/cpu/x64/jit_avx512_sparse_decompress_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_sparse_decompress_kernel.hpp
@@ -57,7 +57,7 @@ struct jit_avx512_sparse_decompress_kernel_t : public jit_generator_t {
         }
 
         blk_sz_ = a_outter_blk_sz_ * b_blk_sz_ * a_inner_blk_sz_;
-        nblks_to_decompress_ = bgmmc.K_blk * b_blk_sz_ / blk_sz_;
+        nblks_to_decompress_ = into<int>(bgmmc.K_blk * b_blk_sz_ / blk_sz_);
     }
 
     void tile_configure(const char *palette) const { (*this)(palette); }

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -187,25 +187,25 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_FEATURE, "dilations are not supported");
 
     jcp = zero<decltype(jcp)>();
-    jcp.ngroups = weights_d.dims()[0];
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[3] : 1;
-    jcp.kh = weights_d.dims()[ndims - 1];
-    jcp.kw = weights_d.dims()[ndims];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = cd.padding[0][is_3d];
-    jcp.l_pad = cd.padding[0][is_3d + 1];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = cd.strides[is_3d];
-    jcp.stride_w = cd.strides[is_3d + 1];
+    jcp.ngroups = into<int>(weights_d.dims()[0]);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
+    jcp.id = into<int>(is_3d ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[3] : 1);
+    jcp.kh = into<int>(weights_d.dims()[ndims - 1]);
+    jcp.kw = into<int>(weights_d.dims()[ndims]);
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(cd.padding[0][is_3d]);
+    jcp.l_pad = into<int>(cd.padding[0][is_3d + 1]);
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(cd.strides[is_3d]);
+    jcp.stride_w = into<int>(cd.strides[is_3d + 1]);
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, jcp.kd);
     jcp.b_pad = calculate_end_padding(
@@ -279,8 +279,8 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
 
     // to avoid cache concurrent access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jcp.adjusted_batch_size
-            = div_up(rnd_up(jcp.kd * jcp.kh * jcp.kw * sc_size, 4096), sc_size);
+    jcp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jcp.kd * jcp.kh * jcp.kw * sc_size, 4096), sc_size));
     CHECK(init_brdgmm_conf());
 
     init_batch_elements();
@@ -475,7 +475,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                 const size_t ow_tail_block
                         = (work_per_thr / jcp.nb_ch) % jcp.ow;
                 if (ow_tail_block && (jcp.ow % ow_tail_block == 0))
-                    jcp.ow_block = ow_tail_block;
+                    jcp.ow_block = into<int>(ow_tail_block);
                 else { jcp.ow_block = jcp.ow; }
             } else {
                 const int max_ow_block = is_superset(jcp.isa, avx512_core)
@@ -495,7 +495,8 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                 const size_t work_per_thr = div_up(work_amount, jcp.nthr);
                 const size_t ch_tail_block = work_per_thr % jcp.nb_ch;
                 if (ch_tail_block && (jcp.nb_ch % ch_tail_block == 0))
-                    jcp.nb_ch_blocking = ch_tail_block * jcp.ch_block;
+                    jcp.nb_ch_blocking
+                            = into<int>(ch_tail_block * jcp.ch_block);
                 else
                     jcp.nb_ch_blocking = jcp.ngroups;
             } else {
@@ -508,7 +509,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
             jcp.chb_tail = jcp.ngroups % jcp.nb_ch_blocking;
         }
 
-        const int n_owb_kernels = std::ceil(log2(jcp.nb_ow));
+        const int n_owb_kernels = into<int>(std::ceil(log2(jcp.nb_ow)));
         const int num_kernels = 1 /*full ow*/ + n_owb_kernels
                 + (jcp.chb_tail != 0) + (jcp.nb_ch_blocking != jcp.ngroups)
                 + (jcp.ow_tail != 0);
@@ -700,9 +701,9 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                 cur_n_owb = jcp.nb_ow;
             } else {
                 // The ow_tail kernel is processed alone, subtract if it exists.
-                const int log_rem_owb = log2(rem_row_owb
+                const int log_rem_owb = into<int>(log2(rem_row_owb
                         - (owb + rem_row_owb >= jcp.nb_ow)
-                                * (jcp.ow_tail != 0));
+                                * (jcp.ow_tail != 0)));
                 cur_n_owb = (1 << log_rem_owb);
                 ker_idx = log_rem_owb + 1; // add 1 as 0th is full row.
             }

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -121,9 +121,9 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     && jcp_.M_tail > 0 && vM == jcp_.M && is_accum_kernel;
             if (skip_rtus_M_blk) continue;
 
-            const int rtus_k = is_accum_kernel
-                    ? jcp_.rtus_ic_size
-                    : jcp_.ic_without_padding - jcp_.rtus_ic_size;
+            const int rtus_k = into<int>(is_accum_kernel
+                            ? jcp_.rtus_ic_size
+                            : jcp_.ic_without_padding - jcp_.rtus_ic_size);
             const bool is_last_m_kernel = vM == jcp_.M_tail || jcp_.nb_os == 1;
             const bool use_rtus_K = rtus_compute_partial_k && is_last_m_kernel;
             const auto brgemm_K = use_rtus_K ? rtus_k : vK;
@@ -176,7 +176,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         const auto vM = params.M_;
         const auto vN = params.N_;
         const auto vK = params.K_;
-        const int LDA = params.LDA_;
+        const dim_t LDA = params.LDA_;
 
         const int k_accum_idx = params.k_accum_idx_;
         const bool req_k_accum = one_of(k_accum_idx, 0, 2);

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -223,7 +223,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
                 auto M_mask = (iM >= vM) ? 0 : 1;
                 for (int ww = 0; ww < jcp_.ow_block && ibrgM < sm_size;
                         ww++, ibrgM++, iM += M_mask) {
-                    bd_mask[ibrgM] = M_mask;
+                    bd_mask[ibrgM] = into<char>(M_mask);
                 }
                 for (int kk = 0; kk < jcp_.oskip && ibrgM < sm_size;
                         kk++, ibrgM++) {
@@ -678,7 +678,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             if (kw_f == jcp_.kw && kw_s == 0) break;
         }
     }
-    brgs_sz_ = brgemm_descriptors_->refs_size();
+    brgs_sz_ = into<int>(brgemm_descriptors_->refs_size());
 
     brgemm_convolution_utils::set_amx_wsp_per_thread(jcp_);
     auto scratchpad = scratchpad_registry().registrar();
@@ -730,8 +730,8 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernel(
     bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
     bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // inp
     bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // out
-    bcfg->typesize_C = types::data_type_size(bcfg->dt_c);
-    bcfg->typesize_D = types::data_type_size(bcfg->dt_d);
+    bcfg->typesize_C = into<int>(types::data_type_size(bcfg->dt_c));
+    bcfg->typesize_D = into<int>(types::data_type_size(bcfg->dt_d));
     bcfg->alpha = !is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer);
     bcfg->beta = is_init ? 0 : 1;
     // See the comment in `add_po_kernels` why `*_pd->attr()` is needed so far.
@@ -800,7 +800,7 @@ int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
             || comp_oh_kh_b.empty())
         return 0;
 
-    const int comp_oh_e = comp_oh_kh_b.size();
+    const int comp_oh_e = into<int>(comp_oh_kh_b.size());
     const int oh_block
             = jcp.is_os_blocking ? nstl::min(jcp.oh_block, jcp.oh - oh) : 1;
     for (int comp_oh_b = 0; comp_oh_b < comp_oh_e; comp_oh_b++) {
@@ -854,9 +854,10 @@ inline int brgemm_convolution_fwd_t<isa>::get_comp_offset(const int g,
     const auto comp_idx
             = get_comp_ker_idx(kd_b, kd_e, kh_b, kh_e, kw_b, kw_e, cur_comp_oh);
     assert(IMPLICATION(jcp.req_cal_comp_pad, comp_idx >= 0));
-    return jcp.req_cal_comp_pad ? g * comp_ocb_sz + ocb * comp_ker_sz
-                    + comp_idx * comp_kw_sz + cur_comp_ow * comp_ow_sz
-                                : (g * jcp.nb_oc + ocb) * jcp.oc_block;
+    return into<int>(jcp.req_cal_comp_pad
+                    ? g * comp_ocb_sz + ocb * comp_ker_sz
+                            + comp_idx * comp_kw_sz + cur_comp_ow * comp_ow_sz
+                    : (g * jcp.nb_oc + ocb) * jcp.oc_block);
 }
 
 template <cpu_isa_t isa>
@@ -949,7 +950,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         ajcp.is_nspc = true;
         ajcp.is_bf32 = jcp.is_bf32;
         ajcp.is_tf32 = jcp.is_tf32;
-        ajcp.typesize_in = jcp.src_dsz;
+        ajcp.typesize_in = into<int>(jcp.src_dsz);
         ajcp.ic_block_int = jcp.amx_w;
 
         ajcp.src_dt = jcp.src_dt;
@@ -981,7 +982,8 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         wjcp.inp_oc_block = 16;
         wjcp.rd = _pd->rd;
         wjcp.is_rd_padded_to_block = jcp.is_rd_padded_to_block;
-        wjcp.inp_ocb_offs = KH * KW * jcp.ic * wjcp.inp_oc_block * wei_dsz;
+        wjcp.inp_ocb_offs
+                = into<int>(KH * KW * jcp.ic * wjcp.inp_oc_block * wei_dsz);
 
         const auto oc_chunks = jcp.oc_block / wjcp.inp_oc_block;
         const auto inp_nb_oc = div_up(jcp.oc, wjcp.inp_oc_block);
@@ -1150,8 +1152,8 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
                             = oh + comp_oh_kh_b.size() - comp_oh_idx;
                     const auto comp_oh_end
                             = jcp.is_os_blocking ? oh_end : oh + 1;
-                    for (int comp_oh = comp_oh_begin; comp_oh < comp_oh_end;
-                            comp_oh++) {
+                    for (int comp_oh = into<int>(comp_oh_begin);
+                            comp_oh < comp_oh_end; comp_oh++) {
                         comp_oh_kh_b.push_back(oh_kh_b[comp_oh]);
                         comp_oh_kh_e.push_back(oh_kh_e[comp_oh]);
                     }
@@ -1546,7 +1548,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
         vpad_k = vpad_next_k;
     }
 
-    const int max_ker_sz = adjusted_k.size();
+    const int max_ker_sz = into<int>(adjusted_k.size());
     const auto comp_buffer_ow = jcp.exec_type != exec_vpad ? jcp.ow : 1;
     // TODO: revise the thread distribution here because the work_amount may be
     // insufficient
@@ -1573,12 +1575,18 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
                     kh_ee {kh_es[k]}, kw_bb {kw_bs[k]}, kw_ee {kw_es[k]};
             assert(kd_ee > kd_bb && kh_ee > kh_bb && kw_ee > kw_bb);
 
-            const auto kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
-            const auto kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
-            const auto kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
-            const auto kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
-            const auto kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
-            const auto kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
+            const auto kd_b = maybe_invert_range(
+                    into<int>(kd_bb), into<int>(kd_ee), KD);
+            const auto kd_e = maybe_invert_range(
+                    into<int>(kd_ee), into<int>(kd_bb), KD);
+            const auto kh_b = maybe_invert_range(
+                    into<int>(kh_bb), into<int>(kh_ee), KH);
+            const auto kh_e = maybe_invert_range(
+                    into<int>(kh_ee), into<int>(kh_bb), KH);
+            const auto kw_b = maybe_invert_range(
+                    into<int>(kw_bb), into<int>(kw_ee), KW);
+            const auto kw_e = maybe_invert_range(
+                    into<int>(kw_ee), into<int>(kw_bb), KW);
 
             const auto inp_oc_block
                     = is_relo_with_relo_weights ? 16 : jcp.oc_block;
@@ -1960,8 +1968,8 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
             const int ih = nstl::max(0, ih_s);
             p.t_overflow = nstl::max(0, -ih_s);
             p.b_overflow = nstl::min<int>(kh_eff, nstl::max(0, ih_e - jcp.ih));
-            p.kh_padding
-                    = nstl::max<int>(0, (kh_eff - p.t_overflow - p.b_overflow));
+            p.kh_padding = nstl::max<int>(
+                    0, (into<int>(kh_eff - p.t_overflow - p.b_overflow)));
             p.kh_offset = kh_eff;
 
             const int iw_s = ow * jcp.stride_w - jcp.l_pad;
@@ -1969,7 +1977,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
             p.f_overflow = nstl::max(0, -iw_s);
             p.back_overflow = nstl::max(0, iw_e - jcp.iw);
             p.kw_padding = nstl::max<int>(
-                    0, jcp.iwp - p.f_overflow - p.back_overflow);
+                    0, into<int>(jcp.iwp - p.f_overflow - p.back_overflow));
 
             const auto first_actual_h = ih;
             inp_offset_start
@@ -2032,8 +2040,8 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                     int size_to_sero = 0;
                     const auto zero_elem_size
                             = (dim_t)src_dsz * jcp.inp_ic_block;
-                    size_to_sero
-                            = zero_elem_size * (jcp.iw_block - actual_iw_block);
+                    size_to_sero = into<int>(
+                            zero_elem_size * (jcp.iw_block - actual_iw_block));
                     for (size_t iih = 0; iih < cp.h_count; iih++) {
                         void *const __restrict p_zeroing = (char *)cp.dst
                                 + (dim_t)src_dsz * iih * _pd->pbuf_w_sz

--- a/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
@@ -74,13 +74,13 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::store(
 template <>
 void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Xbyak::Ymm>::load(
         const Xbyak::Ymm &x, const Xbyak::Address &addr, const int load_size) {
-    load_bytes(x, addr, jcp.dst_dsz * load_size, true);
+    load_bytes(x, addr, into<int>(jcp.dst_dsz * load_size), true);
 }
 
 template <>
 void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Xbyak::Ymm>::store(
         const Xbyak::Address &addr, const Xbyak::Ymm &x, const int store_size) {
-    store_bytes(x, addr, jcp.dst_dsz * store_size);
+    store_bytes(x, addr, into<int>(jcp.dst_dsz * store_size));
 }
 
 template <typename Vmm>
@@ -117,8 +117,10 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
             const auto iw_off = iw * jcp.ic_without_padding * jcp.dst_dsz;
             auto nvec = is_ic_tail ? n_tail_vec : n_vec;
             for (size_t iv = 0; iv < nvec; iv++) {
-                load(vmm_tmp, ptr[inp_ptr + iw_off + iv * VL], simd_w);
-                store(ptr[dst_ptr + iw_off + iv * VL], vmm_tmp, simd_w);
+                load(vmm_tmp, ptr[inp_ptr + iw_off + iv * VL],
+                        into<int>(simd_w));
+                store(ptr[dst_ptr + iw_off + iv * VL], vmm_tmp,
+                        into<int>(simd_w));
             }
             const auto last_inp_off = inp_ptr + iw_off + nvec * VL;
             const auto last_dst_off = dst_ptr + iw_off + nvec * VL;
@@ -139,8 +141,8 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
                     load(zmm_tmp_mask, ptr[last_inp_off]);
                     store(ptr[last_dst_off] | kblock_tail_mask, vmm_tmp);
                 } else {
-                    load(vmm_tmp, ptr[last_inp_off], block_tail);
-                    store(ptr[last_dst_off], vmm_tmp, block_tail);
+                    load(vmm_tmp, ptr[last_inp_off], into<int>(block_tail));
+                    store(ptr[last_dst_off], vmm_tmp, into<int>(block_tail));
                 }
             }
         }

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -287,7 +287,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
             }
         }
     }
-    brgs_sz_ = brgs_->refs_size();
+    brgs_sz_ = into<int>(brgs_->refs_size());
 
     auto scratchpad = scratchpad_registry().registrar();
     brgemm_convolution_bwd_utils::init_scratchpad(scratchpad, jcp_);
@@ -433,8 +433,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::add_po_kernel(
     bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
     bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt;
     bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt;
-    bcfg->typesize_C = types::data_type_size(bcfg->dt_c);
-    bcfg->typesize_D = types::data_type_size(bcfg->dt_d);
+    bcfg->typesize_C = into<int>(types::data_type_size(bcfg->dt_c));
+    bcfg->typesize_D = into<int>(types::data_type_size(bcfg->dt_d));
     bcfg->alpha
             = (!is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer)) ? 1 : 0;
     bcfg->beta = is_init ? 0 : 1;
@@ -516,9 +516,10 @@ int brgemm_convolution_bwd_strided_t<isa>::get_comp_offset(const int g,
 
     assert(IMPLICATION(jcp.req_cal_comp_pad, comp_idx >= 0));
 
-    return jcp.req_cal_comp_pad ? g * comp_icb_sz + icb * comp_ker_sz
-                    + comp_idx * comp_kw_sz + comp_iw * comp_iw_sz
-                                : (g * jcp.nb_ic + icb) * jcp.ic_block;
+    return into<int>(jcp.req_cal_comp_pad
+                    ? g * comp_icb_sz + icb * comp_ker_sz
+                            + comp_idx * comp_kw_sz + comp_iw * comp_iw_sz
+                    : (g * jcp.nb_ic + icb) * jcp.ic_block);
 }
 
 template <cpu_isa_t isa>
@@ -1356,7 +1357,8 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
             = bias ? bias + (bias_d.blk_off(g_ic) * bia_dsz) : nullptr;
     int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0}, kw_b(0), kw_e(0);
     int kd_s_(0), kh_s_(0), kd_f_(0), kh_f_(0);
-    _pd->get_kw_range(iw, iw_raw, kw_s, kw_full_s, kw_full_f, kw_f);
+    _pd->get_kw_range(
+            into<int>(iw), into<int>(iw_raw), kw_s, kw_full_s, kw_full_f, kw_f);
 
     // od = (id + FP - kd * DD) / SD <-- general relation for all sets of (od, id, kd) that overlap
     // for a given index from diff_src, we need to find the appropriate stride sector
@@ -1461,7 +1463,8 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const auto kdhw_loop = [&]() {
         if (kw_e - kw_b <= 0 || kw_b >= jcp.kw) return;
         int iw_b {0}, M_without_overflow {0};
-        _pd->get_iw_range(iw, iw_raw, kw_b, iw_b, M_without_overflow);
+        _pd->get_iw_range(into<int>(iw), into<int>(iw_raw), kw_b, iw_b,
+                M_without_overflow);
         const auto iw_e = iw_b + M_without_overflow;
         const auto do_init
                 = btc.occ == 0 && kd_b == kd_s && kh_b == kh_s && kw_b == kw_s;
@@ -1515,11 +1518,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         const auto iw_ee = iw_b + (M_without_overflow * SW);
         perform_outwork(diff_src_base, diff_src, btc.c_buffer, bias_w, btc.id,
-                btc.ih, iw, iw_raw, g_ic, is_ic_tail, iw_b, iw_ee, kd_l, kh_l,
-                post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
-                btc.src_zp_comp_ptr, btc.dst_zp_vals, btc.s8s8_comp_ptr,
-                comp_ker_offs, do_init, do_postwork, false, btc.src_scales,
-                btc.wei_scales, btc.dst_scales);
+                btc.ih, into<int>(iw), into<int>(iw_raw), g_ic, is_ic_tail,
+                iw_b, iw_ee, kd_l, kh_l, post_ops_binary_rhs_arg_vec.data(),
+                btc.src_zp_val, btc.src_zp_comp_ptr, btc.dst_zp_vals,
+                btc.s8s8_comp_ptr, comp_ker_offs, do_init, do_postwork, false,
+                btc.src_scales, btc.wei_scales, btc.dst_scales);
     };
 
     if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s && kw_s < jcp.kw) {
@@ -1567,8 +1570,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
         const auto do_init = btc.occ == 0;
         const auto do_postwork = need_postwork && btc.occ == (oc_chunks - 1);
         perform_outwork(diff_src_base, diff_src, btc.c_buffer, bias_w, btc.id,
-                btc.ih, iw, iw_raw, g_ic, is_ic_tail, iw, iw, kd_l_full,
-                kh_l_full, post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
+                btc.ih, into<int>(iw), into<int>(iw_raw), g_ic, is_ic_tail,
+                into<int>(iw), into<int>(iw), kd_l_full, kh_l_full,
+                post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
                 btc.src_zp_comp_ptr, btc.dst_zp_vals, btc.s8s8_comp_ptr, 0,
                 do_init, do_postwork, false, btc.src_scales, btc.wei_scales,
                 btc.dst_scales);
@@ -1772,9 +1776,10 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
         k_l = kd_l * kh_l * kw_l;
 
         const auto comp_ker_offs = kd_l * kh_l > 0
-                ? get_comp_offset(
-                          btc.g, btc.icb, iw, kd_s, kd_f, kh_s, kh_f, 0, KW)
-                : get_comp_offset(btc.g, btc.icb, iw, 0, 0, 0, 0, 0, 0);
+                ? get_comp_offset(btc.g, btc.icb, into<int>(iw), kd_s, kd_f,
+                          kh_s, kh_f, 0, KW)
+                : get_comp_offset(
+                          btc.g, btc.icb, into<int>(iw), 0, 0, 0, 0, 0, 0);
 
         if (nb_oc_b > 0) {
             const auto do_postops_here = do_postwork && !is_oc_tail;
@@ -1852,8 +1857,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
             if (!need_out_buffer) {
                 const dim_t iw_raw = static_cast<dim_t>(btc.iwb) * jcp.iw_block;
                 perform_outwork(diff_src_base, diff_src, btc.c_buffer, bias_w,
-                        btc.id, btc.ih, iw, iw_raw, g_ic, is_ic_tail, iw, iw, 0,
-                        0, post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
+                        btc.id, btc.ih, into<int>(iw), into<int>(iw_raw), g_ic,
+                        is_ic_tail, into<int>(iw), into<int>(iw), 0, 0,
+                        post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
                         btc.src_zp_comp_ptr, btc.dst_zp_vals, btc.s8s8_comp_ptr,
                         0, do_init, do_postwork, false, btc.src_scales,
                         btc.wei_scales, btc.dst_scales);

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
@@ -104,13 +104,13 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::store(
 template <>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Xbyak::Ymm>::load(
         const Xbyak::Ymm &x, const Xbyak::Address &addr, const int load_size) {
-    load_bytes(x, addr, jcp.src_dsz * load_size, true);
+    load_bytes(x, addr, into<int>(jcp.src_dsz * load_size), true);
 }
 
 template <>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Xbyak::Ymm>::store(
         const Xbyak::Address &addr, const Xbyak::Ymm &x, const int store_size) {
-    store_bytes(x, addr, jcp.src_dsz * store_size);
+    store_bytes(x, addr, into<int>(jcp.src_dsz * store_size));
 }
 
 template <typename Vmm>
@@ -227,7 +227,7 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::generate() {
             // TODO: adjust step to improve zeroing efficiency for small oc
             for (dim_t ow = 0; ow < dst_w_block; ow++)
                 zero_oc_block(is_oc_tail, ow * dst_w_offset);
-            add(aux_dst_ptr, dst_h_offset);
+            add(aux_dst_ptr, into<uint32_t>(dst_h_offset));
 
             dec(kh_over);
             jnz(kh_tover_label, T_NEAR);
@@ -243,8 +243,8 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::generate() {
             copy_iw_block(is_oc_tail);
             auto inp_h_offset = jcp.ow * ow_size;
 
-            add(aux_inp_ptr, inp_h_offset);
-            add(aux_dst_ptr, dst_h_offset);
+            add(aux_inp_ptr, into<uint32_t>(inp_h_offset));
+            add(aux_dst_ptr, into<uint32_t>(dst_h_offset));
 
             dec(reg_hc);
             cmp(reg_hc, reg_b_pad);
@@ -260,7 +260,7 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::generate() {
             // TODO: adjust step to improve zeroing efficiency for small oc
             for (dim_t ow = 0; ow < dst_w_block; ow++)
                 zero_oc_block(is_oc_tail, ow * dst_w_offset);
-            add(aux_dst_ptr, dst_h_offset);
+            add(aux_dst_ptr, into<uint32_t>(dst_h_offset));
 
             dec(reg_hc);
             jnz(kh_bover_label, T_NEAR);
@@ -271,8 +271,8 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::generate() {
         auto inp_cb_offset = oc_block_sz;
         auto dst_cb_offset = jcp.ohp * dst_h_offset;
 
-        add(inp_ptr, inp_cb_offset);
-        add(dst_ptr, dst_cb_offset);
+        add(inp_ptr, into<uint32_t>(inp_cb_offset));
+        add(dst_ptr, into<uint32_t>(dst_cb_offset));
     };
 
     for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1435,27 +1435,28 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.isa = isa;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
-    jcp.oc_without_padding = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(diff_src_d.dims()[0]);
+    jcp.oc_without_padding = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
     jcp.oc = jcp.oc_without_padding;
-    jcp.ic_without_padding = diff_src_d.dims()[1];
+    jcp.ic_without_padding = into<int>(diff_src_d.dims()[1]);
     jcp.ic = jcp.ic_without_padding / jcp.ngroups;
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>((ndims == 5) ? diff_src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? diff_dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     VDISPATCH_CONV_IC(!everyone_is(1, jcp.stride_d, jcp.stride_h, jcp.stride_w),
             VERBOSE_UNSUPPORTED_FEATURE, "unit strides are not supported");
@@ -1464,9 +1465,9 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     jcp.is_deconv = cd.use_inversion;
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_CONV_IC(everyone_is(0, jcp.dilate_d, jcp.dilate_h, jcp.dilate_w),
             VERBOSE_UNSUPPORTED_FEATURE, "non-zero dilations are detected");
@@ -1522,7 +1523,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = jcp.is_f32_f16 || jcp.is_f32_bf16 ? jcp.src_dt : jcp.wei_dt;
     const data_type_t last_oc_block_dt
             = get_mac_emu_data_type(wei_dt, isa, isa == avx512_core_fp16);
-    jcp.vnni_block = data_type_vnni_granularity(last_oc_block_dt);
+    jcp.vnni_block = into<int>(data_type_vnni_granularity(last_oc_block_dt));
 
     // TODO: optimize grouped convolutions with small oc
     const bool is_grouped_small_oc
@@ -1706,7 +1707,7 @@ void set_k_range(int P, int D, int S, dim_t i, dim_t O, int K, int &k_s,
         int &k_f, bool is_w) {
     int s(0), o_test(0);
     while (true) {
-        o_test = i + P - s * D;
+        o_test = into<int>(i + P - s * D);
         if (o_test % S == 0) break;
         s++;
     }
@@ -2049,8 +2050,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                     jcp.kd_block_pad * jcp.kh_block_pad * jcp.kw_block_pad);
     // to avoid cache concurrent write access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jcp.adjusted_batch_size
-            = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+    jcp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size));
 
     CHECK(pick_tags(jcp, diff_dst_md, weights_md, diff_src_md, bias_md));
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -147,14 +147,14 @@ status_t brgemm_convolution_bwd_weights_t::pd_t::init(engine_t *engine) {
                 VDISPATCH_CONV_IC(lda2_size <= INT_MAX,
                         VERBOSE_UNSUPPORTED_FEATURE,
                         "lda2_size > INT_MAX is not supported");
-                brgattr.LDA2 = lda2_size;
+                brgattr.LDA2 = into<int>(lda2_size);
 
                 const auto ldb2_size = static_cast<size_t>(jcp_.tr_ow)
                         * jcp_.oc_block * jcp_.oh_block * jcp_.od;
                 VDISPATCH_CONV_IC(ldb2_size <= INT_MAX,
                         VERBOSE_UNSUPPORTED_FEATURE,
                         "ldb2_size > INT_MAX is not supported");
-                brgattr.LDB2 = ldb2_size;
+                brgattr.LDB2 = into<int>(ldb2_size);
 
                 brgattr.LDC2_M = jcp_.oc_block * jcp_.kd * jcp_.kh * jcp_.kw;
                 brgattr.LDC2_N = jcp_.nb_ic * jcp_.ic_block * jcp_.oc_block
@@ -417,7 +417,8 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         oc_b_work = oc_b_end - oc_b_start;
 
         if (jcp.transform_to_vnni) {
-            const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+            const int vnni_granularity
+                    = into<int>(data_type_vnni_granularity(jcp.wei_dt));
             if (vnni_granularity == 0) {
                 assert(!"Invalid vnni granularity.");
                 return;
@@ -519,8 +520,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 
     void trans_src_nxc(char *tr_src, const char *src_base, int tr_icb,
             int row_count, int ih_s) const {
-        const int src_stride = jcp.iw * jcp.ngroups * jcp.ic * jcp.src_dsz;
-        const int tr_src_stride = jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
+        const int src_stride
+                = into<int>(jcp.iw * jcp.ngroups * jcp.ic * jcp.src_dsz);
+        const int tr_src_stride
+                = into<int>(jcp.tr_iw * jcp.ic_block * jcp.src_dsz);
 
         int sp_work = row_count;
         const char *src = src_base;
@@ -547,8 +550,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     void trans_dst_nxc(char *tr_diff_dst, const char *diff_dst_base,
             int spatial_start, dim_t spatial_start_offset, int ocb_start,
             dim_t chb_stride, int row_count) const {
-        const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc * jcp.dst_dsz;
-        const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block * jcp.dst_dsz;
+        const int diff_dst_stride
+                = into<int>(jcp.ow * jcp.ngroups * jcp.oc * jcp.dst_dsz);
+        const int tr_diff_dst_stride
+                = into<int>(jcp.tr_ow * jcp.oc_block * jcp.dst_dsz);
         int work_rest = row_count;
         int max_spatial_work = jcp.od * jcp.oh;
         int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
@@ -1248,7 +1253,8 @@ void brgemm_convolution_bwd_weights_t::store_in_vnni_format(
     const auto &jcp = pd()->jcp_;
     if (one_of(0, ti->g_work, ti->oc_b_work, ti->ic_b_work)) return;
 
-    const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+    const int vnni_granularity
+            = into<int>(data_type_vnni_granularity(jcp.wei_dt));
     if (vnni_granularity == 0) {
         assert(!"Invalid vnni granularity.");
         return;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
@@ -179,7 +179,8 @@ private:
 
     inline dim_t wei_offset_ext(int g, int oc_b, int ic_b) const {
         const auto &jcp = pd()->jcp_;
-        const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+        const int vnni_granularity
+                = into<int>(data_type_vnni_granularity(jcp.wei_dt));
         if (vnni_granularity == 0) {
             assert(!"Invalid vnni granularity.");
             return 0;

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -37,8 +37,8 @@ jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::
                 const jit_brgemm_conv_conf_t &ajcp)
     : jit_generator_t(jit_name())
     , jcp_(ajcp)
-    , inp_dsz_(jcp_.wei_dsz)
-    , out_dsz_(jcp_.acc_dsz)
+    , inp_dsz_(into<int>(jcp_.wei_dsz))
+    , out_dsz_(into<int>(jcp_.acc_dsz))
     , nb_ic_(utils::div_up(
               jcp_.prop_kind == backward_data ? jcp_.oc : jcp_.ic, 4))
     , inp_ic_sz_(static_cast<size_t>(inp_dsz_)
@@ -169,8 +169,10 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow(
     {
         cmp(reg_ker_l, 1);
         je(label_ker_end, T_NEAR);
-        if (jcp_.src_zero_point) add(reg_aux_zp_comp_out, out_ker_sz_);
-        if (jcp_.s8s8_compensation_required) add(reg_aux_comp_out, out_ker_sz_);
+        if (jcp_.src_zero_point)
+            add(reg_aux_zp_comp_out, into<uint32_t>(out_ker_sz_));
+        if (jcp_.s8s8_compensation_required)
+            add(reg_aux_comp_out, into<uint32_t>(out_ker_sz_));
         copy_ow_body(n_block, ow_b, ow_e);
         dec(reg_ker_l);
         jmp(label_ker_loop, T_NEAR);
@@ -227,7 +229,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::icb_loop(const int icb,
         cmp(reg_icb, 0);
         je(label_loop_end, T_NEAR);
         compute(ic_step, m_block, n_block, 0, false);
-        add(reg_aux_in, ic_step * m_block * inp_ic_sz_);
+        add(reg_aux_in, into<uint32_t>(ic_step * m_block * inp_ic_sz_));
         dec(reg_icb);
         jmp(label_icb_loop, T_NEAR);
     }
@@ -255,16 +257,18 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::kdh_loop(const int icb,
             je(label_kh_end, T_NEAR);
             icb_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block);
             add(reg_aux_kh_in,
-                    jcp_.prop_kind == backward_data ? inp_kh_sz_ * jcp_.stride_h
-                                                    : inp_kh_sz_);
+                    into<uint32_t>(jcp_.prop_kind == backward_data
+                                    ? inp_kh_sz_ * jcp_.stride_h
+                                    : inp_kh_sz_));
             dec(reg_kh_l);
             jmp(label_kh_loop, T_NEAR);
         }
         L_aligned(label_kh_end);
 
         add(reg_aux_kd_in,
-                jcp_.prop_kind == backward_data ? inp_kd_sz_ * jcp_.stride_d
-                                                : inp_kd_sz_);
+                into<uint32_t>(jcp_.prop_kind == backward_data
+                                ? inp_kd_sz_ * jcp_.stride_d
+                                : inp_kd_sz_));
         dec(reg_kd_l);
         jmp(label_kd_loop, T_NEAR);
     }
@@ -323,7 +327,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::bwd_kw_iw_loop(const int icb,
                 has_kw_computed = true;
             }
         }
-        add(reg_in, inp_kw_sz_);
+        add(reg_in, into<uint32_t>(inp_kw_sz_));
     }
 }
 
@@ -381,11 +385,12 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::fwd_kw_ow_loop(const int icb,
             store_accumulators(m_block, n_block, ow_b, ow_e);
         }
         add(reg_in,
-                jcp_.prop_kind == backward_data ? inp_kw_sz_ * jcp_.stride_w
-                                                : inp_kw_sz_);
+                into<uint32_t>(jcp_.prop_kind == backward_data
+                                ? inp_kw_sz_ * jcp_.stride_w
+                                : inp_kw_sz_));
     }
 
-    copy_ow(m_block, n_block, 0, comp_ow_l);
+    copy_ow(m_block, n_block, 0, into<int>(comp_ow_l));
 }
 template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::kw_loop_base(const int icb,
@@ -402,8 +407,9 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::kw_loop_base(const int icb,
         je(label_loop_end, T_NEAR);
         kdh_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block);
         add(reg_in,
-                jcp_.prop_kind == backward_data ? inp_kw_sz_ * jcp_.stride_w
-                                                : inp_kw_sz_);
+                into<uint32_t>(jcp_.prop_kind == backward_data
+                                ? inp_kw_sz_ * jcp_.stride_w
+                                : inp_kw_sz_));
         dec(reg_kw_l);
         jmp(label_kw_loop, T_NEAR);
     }
@@ -444,8 +450,8 @@ int jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::compute_ic_step(
     int best_ic_step = 1;
     float best_block_eff = 0.f;
 
-    int max_ic_step
-            = nstl::min(static_cast<size_t>(m_block), div_up(nb_ic_, m_block));
+    int max_ic_step = into<int>(
+            nstl::min(into<size_t>(m_block), div_up(nb_ic_, m_block)));
 
     // Introduce ic_step to increase kernel efficiency
     // Compute the ic_step based on the optimal kernel efficiency
@@ -509,8 +515,9 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::generate() {
     const int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : n_max_regs_;
 
     const size_t m_max_regs = max_regs / n_block;
-    const int m_block = nstl::min(m_max_regs, nb_ic_);
-    const int ic_step = compute_ic_step(m_max_regs, m_block, n_block);
+    const int m_block = into<int>(nstl::min(m_max_regs, nb_ic_));
+    const int ic_step
+            = compute_ic_step(into<int>(m_max_regs), m_block, n_block);
 
     assert(m_block * n_block <= max_regs);
 
@@ -524,11 +531,13 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::generate() {
     mov(reg_use_inversion, ptr[param1 + GET_OFF(use_inversion)]);
     cmp(reg_use_inversion, 0);
     jz(label_kw_without_inversion, T_NEAR);
-    kw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block, true);
+    kw_loop(into<int>(icb), into<int>(icb_tail), ic_step, m_block,
+            into<int>(mb_tail), n_block, true);
     jmp(label_done, T_NEAR);
 
     L_aligned(label_kw_without_inversion);
-    kw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block, false);
+    kw_loop(into<int>(icb), into<int>(icb_tail), ic_step, m_block,
+            into<int>(mb_tail), n_block, false);
 
     L_aligned(label_done);
 
@@ -596,8 +605,10 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store(
         cmp(reg_ker_l, 0);
         je(label_done, T_NEAR);
         store_accumulators(n_block, ow_b, ow_e);
-        if (jcp_.src_zero_point) add(reg_aux_zp_comp_out, out_ker_sz_);
-        if (jcp_.s8s8_compensation_required) add(reg_aux_comp_out, out_ker_sz_);
+        if (jcp_.src_zero_point)
+            add(reg_aux_zp_comp_out, into<uint32_t>(out_ker_sz_));
+        if (jcp_.s8s8_compensation_required)
+            add(reg_aux_comp_out, into<uint32_t>(out_ker_sz_));
         dec(reg_ker_l);
         jmp(label_ker_loop, T_NEAR);
     }
@@ -661,7 +672,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::compute(
             vpmovsxbd(vmm_tmp, addr);
             vpsubd(vmm, vmm, vmm_tmp);
         }
-        add(reg_aux_in, inp_kh_sz_);
+        add(reg_aux_in, into<uint32_t>(inp_kh_sz_));
         dec(reg_kh_l);
         jmp(label_kh_loop, T_NEAR);
     }
@@ -720,8 +731,8 @@ jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::
                 const jit_brgemm_conv_conf_t &ajcp)
     : jit_generator_t(jit_name())
     , jcp_(ajcp)
-    , inp_dsz_(jcp_.wei_dsz)
-    , out_dsz_(jcp_.acc_dsz)
+    , inp_dsz_(into<int>(jcp_.wei_dsz))
+    , out_dsz_(into<int>(jcp_.acc_dsz))
     , inp_oc_block_(static_cast<size_t>(16))
     , inp_ic_sz_(static_cast<size_t>(inp_dsz_) * inp_oc_block_)
     , inp_kw_sz_(static_cast<size_t>(inp_ic_sz_) * jcp_.ic

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
@@ -207,7 +207,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::generate() {
                 // TODO: adjust step to improve zeroing efficiency for small ic
                 for (dim_t iw = 0; iw < dst_w_block; iw++)
                     zero_ic_block(is_ic_tail, iw * dst_w_offset);
-                add(aux_dst_ptr, dst_h_offset);
+                add(aux_dst_ptr, into<uint32_t>(dst_h_offset));
 
                 dec(kh_over);
                 jnz(kh_tover_label, T_NEAR);
@@ -224,8 +224,8 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::generate() {
             copy_ow_block(is_ic_tail);
             auto inp_h_offset = jcp.iw * iw_size;
 
-            add(aux_inp_ptr, inp_h_offset);
-            add(aux_dst_ptr, dst_h_offset);
+            add(aux_inp_ptr, into<uint32_t>(inp_h_offset));
+            add(aux_dst_ptr, into<uint32_t>(dst_h_offset));
 
             dec(reg_hc);
             cmp(reg_hc, reg_b_pad);
@@ -245,7 +245,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::generate() {
                 // TODO: adjust step to improve zeroing efficiency for small ic
                 for (dim_t iw = 0; iw < dst_w_block; iw++)
                     zero_ic_block(is_ic_tail, iw * dst_w_offset);
-                add(aux_dst_ptr, dst_h_offset);
+                add(aux_dst_ptr, into<uint32_t>(dst_h_offset));
 
                 dec(reg_hc);
                 jnz(kh_bover_label, T_NEAR);
@@ -259,8 +259,8 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::generate() {
         auto inp_cb_offset = ic_block_offset;
         auto dst_cb_offset = jcp.ihp * dst_h_offset;
 
-        add(inp_ptr, inp_cb_offset);
-        add(dst_ptr, dst_cb_offset);
+        add(inp_ptr, into<uint32_t>(inp_cb_offset));
+        add(dst_ptr, into<uint32_t>(dst_cb_offset));
     };
 
     for (int icb = 0; icb < jcp.nb_ic_blocking; icb++) {
@@ -458,8 +458,8 @@ void jit_avx512_core_brgemm_conv_rtus_kernel_t::generate() {
 
             auto inp_w_step = jcp.stride_w * iw_size;
             auto out_w_step = ic_block_offset;
-            add(aux_inp_ptr, inp_w_step);
-            add(aux_dst_ptr, out_w_step);
+            add(aux_inp_ptr, into<uint32_t>(inp_w_step));
+            add(aux_dst_ptr, into<uint32_t>(out_w_step));
 
             dec(reg_kwp);
             jnz(label_kwp_begin, T_NEAR);
@@ -480,8 +480,8 @@ void jit_avx512_core_brgemm_conv_rtus_kernel_t::generate() {
 
             auto inp_h_step = jcp.stride_h * jcp.iw * iw_size;
             auto out_h_step = jcp.ow * ic_block_offset;
-            add(aux_inp_ptr, inp_h_step);
-            add(aux_dst_ptr, out_h_step);
+            add(aux_inp_ptr, into<uint32_t>(inp_h_step));
+            add(aux_dst_ptr, into<uint32_t>(out_h_step));
 
             dec(reg_khp);
             jnz(label_khp_begin, T_NEAR);

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -570,7 +570,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
         const size_t ic_stride = exec_type == exec_trans
                 ? inp_ic_block
                 : ngroups * ic_without_padding;
-        LDA = kh_koef * stride_w * ic_stride;
+        LDA = into<int>(kh_koef * stride_w * ic_stride);
     }
     bool reduce_kw = ow == 1 && !is_reduced_rtus;
     if (reduce_kw) { LDA *= ext_kw; }
@@ -970,11 +970,13 @@ float brg_blocking_t::est_eff() {
     int nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
     if (!is_os_blocking) {
         const auto dim_oh = nb_sp * dim_sp;
-        nb_oh_thr = nstl::min(static_cast<dim_t>(nb_oh), div_up(job, dim_oh));
+        nb_oh_thr
+                = into<int>(nstl::min(into<dim_t>(nb_oh), div_up(job, dim_oh)));
         oh_thr = nstl::min(oh, nb_oh_thr * oh_block);
 
         const auto dim_od = nb_oh * dim_oh;
-        nb_od_thr = nstl::min(static_cast<dim_t>(nb_od), div_up(job, dim_od));
+        nb_od_thr
+                = into<int>(nstl::min(into<dim_t>(nb_od), div_up(job, dim_od)));
         od_thr = nstl::min(od, nb_od_thr * od_block);
     }
 
@@ -1001,7 +1003,7 @@ float brg_blocking_t::est_eff() {
     // oh_block almost all is 1. TODO: manage oh_block != 1
     // -- harness: loop by oh_blocks --
     l++;
-    src_is = kd * kh * rnd_inp_simd(sp_thr, kw, ic);
+    src_is = kd * kh * rnd_inp_simd(into<int>(sp_thr), kw, ic);
     loop[l].src.set(oh_block * src_is, 1);
     loop[l].dst.set(sp_thr * rnd_oc_for_sp, 1);
     loop[l].wei.set(wei_op * simd_w, nb_oh_thr);
@@ -1087,7 +1089,7 @@ float brg_blocking_t::est_eff() {
 void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         int kh_block_, bool maybe_use_buffer, int max_ow_block_thr) {
 
-    unsigned est_k_amount = ic * oc_block * wei_dsz;
+    unsigned est_k_amount = into<unsigned int>(ic * oc_block * wei_dsz);
 
     kd_block = kd_block_;
     kh_block = kh_block_;
@@ -1432,7 +1434,7 @@ float brg_blocking_t::est_eff_1x1() {
         loop[l].src.set(sp_block * rnd_simd(ic), nb_oc_thr);
         loop[l].dst.set(sp_block * oc_block, 1);
         wei_is = oc_block * ic;
-        wei_op = nsimd_oc_thr * ic;
+        wei_op = into<int>(nsimd_oc_thr * ic);
         loop[l].wei.set(wei_is, 1);
     }
 
@@ -1466,7 +1468,8 @@ float brg_blocking_t::est_eff_1x1() {
     if (loop_order != loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
-        loop[l].src.set(od_thr * oh_thr * rnd_simd(sp_thr * ic_blocking_size),
+        loop[l].src.set(od_thr * oh_thr
+                        * rnd_simd(into<int>(sp_thr * ic_blocking_size)),
                 nb_oc_thr);
         loop[l].dst.set(oc_block * od_thr * oh_thr * sp_thr, 1);
         loop[l].wei.set(oc_block * ic, 1);
@@ -1484,7 +1487,7 @@ float brg_blocking_t::est_eff_1x1() {
             * ic_blocking_size;
     const auto dst_op = static_cast<dim_t>(mb_thr) * nsimd_oc_thr * od_thr
             * oh_thr * sp_thr;
-    wei_op = nsimd_oc_thr * ic;
+    wei_op = into<int>(nsimd_oc_thr * ic);
 
     // for "real" application set bench_iterations to 1
     const auto iterations = bench_iterations;
@@ -1697,31 +1700,32 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc_without_padding = dst_d.dims()[1];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc_without_padding = into<int>(dst_d.dims()[1]);
     jcp.oc = jcp.oc_without_padding / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic = jcp.ic_without_padding;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>((ndims == 5) ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     jcp.os = jcp.od * jcp.oh * jcp.ow;
 
@@ -1787,7 +1791,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                                                                    : jcp.wei_dt;
     const data_type_t vnni_block_dt
             = get_mac_emu_data_type(vnni_dt, isa, isa == avx10_1_512);
-    jcp.vnni_block = data_type_vnni_granularity(vnni_block_dt);
+    jcp.vnni_block = into<int>(data_type_vnni_granularity(vnni_block_dt));
 
     if (one_of(jcp.prop_kind, prop_kind::forward_training,
                 prop_kind::forward_inference)
@@ -2354,8 +2358,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     // to avoid cache concurrent write access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jcp.adjusted_batch_size
-            = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+    jcp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size));
 
     if (!jcp.wei_plain)
         CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
@@ -2603,8 +2607,8 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.gemm_batch_size = jcp.nb_ic_blocking;
     // to avoid cache concurrent access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jcp.adjusted_batch_size
-            = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+    jcp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size));
 
     if (is_amx(isa)) {
         // heuristic for small mb
@@ -3179,7 +3183,7 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
             && everyone_is(0, jcp.f_pad, jcp.back_pad, jcp.t_pad, jcp.b_pad))
         jcp.var_bs = false;
 
-    jcp.typesize_in = jcp.src_dsz;
+    jcp.typesize_in = into<int>(jcp.src_dsz);
     jcp.typesize_out = sizeof(float);
 
     bool ok = true
@@ -3372,15 +3376,15 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_ocb_chunk = tr_ocb_chunk_allowed && (jcp.oh * jcp.ow > 38 * 38);
     jcp.tr_icb_chunk = false;
 
-    const int irow_size = jcp.src_dsz * jcp.tr_iw * jcp.ic_block
+    const int irow_size = into<int>(jcp.src_dsz * jcp.tr_iw * jcp.ic_block
             * div_up(jcp.nb_ic, jcp.nthr_ic_b)
-            * 2 /*we have real and transposed input */;
-    const int orow_size = jcp.dst_dsz * jcp.tr_ow * jcp.oc_block
+            * 2 /*we have real and transposed input */);
+    const int orow_size = into<int>(jcp.dst_dsz * jcp.tr_ow * jcp.oc_block
             * div_up(jcp.nb_oc, jcp.nthr_oc_b)
-            * 2 /*we have real and transposed diff_dst*/;
-    int oh_block_limit = nstl::max(1.f,
+            * 2 /*we have real and transposed diff_dst*/);
+    int oh_block_limit = into<int>(nstl::max(1.f,
             nstl::max(0.f, 0.8f * brg_blocking_t::L2 - jcp.kh * irow_size)
-                    / (irow_size + orow_size));
+                    / (irow_size + orow_size)));
     // try to split oh by equal oh blocks
     oh_block_limit = div_up(jcp.oh, div_up(jcp.oh, oh_block_limit));
     jcp.oh_block = utils::saturate(1, jcp.oh, oh_block_limit);
@@ -3430,9 +3434,9 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
 
     const int iframe_size = irow_size * jcp.id;
     const int oframe_size = orow_size * jcp.od;
-    int od_block_limit = nstl::max(1.f,
+    int od_block_limit = into<int>(nstl::max(1.f,
             nstl::max(0.f, 0.8f * brg_blocking_t::L2 - jcp.kd * iframe_size)
-                    / (iframe_size + oframe_size));
+                    / (iframe_size + oframe_size)));
     // try to split od by equal od blocks
     od_block_limit = div_up(jcp.od, div_up(jcp.od, od_block_limit));
     jcp.od_block = utils::saturate(1, jcp.od, od_block_limit);
@@ -3450,8 +3454,8 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.gemm_batch_size = jcp.max_batch;
     // to avoid cache concurrent access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jcp.adjusted_batch_size
-            = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+    jcp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size));
 
     return status::success;
 }

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -1122,7 +1122,7 @@ struct brgemm_inner_product_bwd_weights_t<isa>::thread_info_t {
                     = div_up(sp_ic_chunks, jbgp.nthr_ic_b);
             const size_t num_sp_ic_chunks_per_thread
                     = thread_local_input_buffers_ ? 1 : sp_ic_chunks_per_thr;
-            sp_ic_chunks_per_thread_ = num_sp_ic_chunks_per_thread;
+            sp_ic_chunks_per_thread_ = into<int>(num_sp_ic_chunks_per_thread);
             const size_t block_A_size = dt_sz * jbgp.LDA * jbgp.M;
             const size_t os_chunk_A_buffer
                     = jbgp.gemm_batch_size * block_A_size;

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -661,8 +661,8 @@ status_t jit_brgemm_ip_fwd_conf_t::init_conf(cpu_isa_t isa,
 
     // to avoid cache concurrent write access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jbgp.adjusted_batch_size
-            = div_up(rnd_up(jbgp.gemm_batch_size * sc_size, 4096), sc_size);
+    jbgp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jbgp.gemm_batch_size * sc_size, 4096), sc_size));
 
     if ((is_amx_xf16 || jbgp.is_bf32) && adjust_thread_balance()) {
         // Adjust oc_block to improve thread balancing
@@ -914,8 +914,8 @@ status_t jit_brgemm_ip_bwd_d_conf_t::init_conf(cpu_isa_t isa,
     jbgp.gemm_batch_size = jbgp.nb_oc_blocking;
     // to avoid cache concurrent write access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jbgp.adjusted_batch_size
-            = div_up(rnd_up(jbgp.gemm_batch_size * sc_size, 4096), sc_size);
+    jbgp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jbgp.gemm_batch_size * sc_size, 4096), sc_size));
 
     jbgp.use_buffer = jbgp.src_dt != jbgp.acc_dt || jbgp.nthr_oc_b > 1;
 
@@ -927,9 +927,9 @@ status_t jit_brgemm_ip_bwd_d_conf_t::init_conf(cpu_isa_t isa,
     jbgp.N_tail = jbgp.ic % jbgp.ic_block;
     jbgp.K_tail = jbgp.use_buffer_a ? 0 : jbgp.oc % jbgp.oc_block;
 
-    jbgp.LDA = jbgp.use_buffer_a
-            ? static_cast<dim_t>(jbgp.K) * jbgp.nb_oc_blocking
-            : jbgp.oc_without_padding;
+    jbgp.LDA = into<int>(jbgp.use_buffer_a
+                    ? into<dim_t>(jbgp.K) * jbgp.nb_oc_blocking
+                    : jbgp.oc_without_padding);
     jbgp.LDB = jbgp.N;
     CHECK(safe_dim_to_int(
             jbgp.LDD, static_cast<dim_t>(jbgp.ic_without_padding) * jbgp.ks()));
@@ -1246,8 +1246,8 @@ status_t jit_brgemm_ip_bwd_w_conf_t::init_conf(cpu_isa_t isa,
     jbgp.gemm_batch_size = jbgp.nb_os_blocking;
     // to avoid cache concurrent write access from different threads
     size_t sc_size = sizeof(brgemm_batch_element_t);
-    jbgp.adjusted_batch_size
-            = div_up(rnd_up(jbgp.gemm_batch_size * sc_size, 4096), sc_size);
+    jbgp.adjusted_batch_size = into<int>(
+            div_up(rnd_up(jbgp.gemm_batch_size * sc_size, 4096), sc_size));
 
     jbgp.use_buffer = IMPLICATION(!has_weights_buffer, jbgp.nthr_mb > 1);
 

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -36,10 +36,10 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::
                       : ajbgp.dst_dt)
     , bia_dt_(ajbgp.bia_dt)
     , acc_dt_(ajbgp.acc_dt)
-    , ddst_typesize_(types::data_type_size(ddst_dt_))
-    , bia_typesize_(types::data_type_size(bia_dt_))
-    , acc_typesize_(types::data_type_size(acc_dt_))
-    , mult_(data_type_vnni_granularity(ddst_dt_)) {}
+    , ddst_typesize_(into<int>(types::data_type_size(ddst_dt_)))
+    , bia_typesize_(into<int>(types::data_type_size(bia_dt_)))
+    , acc_typesize_(into<int>(types::data_type_size(acc_dt_)))
+    , mult_(into<int>(data_type_vnni_granularity(ddst_dt_))) {}
 
 // This version is used from MatMul for src tensor.
 template <typename Vmm>
@@ -56,9 +56,9 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_diff_bias_t<Vmm>::
     // MatMul `reduce` buffer.
     , bia_dt_(bgmmc.reduce_dt)
     , acc_dt_(bgmmc.acc_dt)
-    , ddst_typesize_(types::data_type_size(ddst_dt_))
-    , bia_typesize_(types::data_type_size(bia_dt_))
-    , acc_typesize_(types::data_type_size(acc_dt_))
+    , ddst_typesize_(into<int>(types::data_type_size(ddst_dt_)))
+    , bia_typesize_(into<int>(types::data_type_size(bia_dt_)))
+    , acc_typesize_(into<int>(types::data_type_size(acc_dt_)))
     // Unused.
     , mult_(0) {
     // This kernel must be called after the copy A routine because it assumes

--- a/src/cpu/x64/jit_brgemm_transpose_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_transpose_utils.cpp
@@ -341,8 +341,8 @@ void jit_brgemm_trans_m_k_f32_t::transpose(int nrows, int ncolumns) {
     L(K_loop);
     if (num_nrows_loop > 0) transpose_ker(transpose_size, ncolumns);
     if (num_nrows_loop > 1 || (num_nrows_loop > 0 && nrows_tail > 0)) {
-        add(reg_src, src_shift);
-        add(reg_tr_src, tr_src_shift);
+        add(reg_src, into<uint32_t>(src_shift));
+        add(reg_tr_src, into<uint32_t>(tr_src_shift));
     }
     if (num_nrows_loop > 1) {
         dec(reg_row_loop);
@@ -353,8 +353,8 @@ void jit_brgemm_trans_m_k_f32_t::transpose(int nrows, int ncolumns) {
 
     if (num_nrows_loop > 1 || nrows_tail > 0) {
         // reset pointers
-        sub(reg_src, src_shift * num_nrows_loop);
-        sub(reg_tr_src, tr_src_shift * num_nrows_loop);
+        sub(reg_src, into<uint32_t>(src_shift * num_nrows_loop));
+        sub(reg_tr_src, into<uint32_t>(tr_src_shift * num_nrows_loop));
     }
 }
 
@@ -414,8 +414,8 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
         L(M_loop);
         transpose(nrows, transpose_size);
         if (conf_->ic_block > transpose_size) {
-            add(reg_src, m_src_shift);
-            add(reg_tr_src, m_tr_src_shift);
+            add(reg_src, into<uint32_t>(m_src_shift));
+            add(reg_tr_src, into<uint32_t>(m_tr_src_shift));
             sub(reg_loop_M, transpose_size);
             cmp(reg_loop_M, transpose_size);
             jge(M_loop, T_NEAR);
@@ -438,8 +438,8 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
         L(batch_loop);
 
         compute_M(is_os_tail);
-        add(reg_src_base, batch_src_shift);
-        add(reg_tr_src_base, batch_tr_src_shift);
+        add(reg_src_base, into<uint32_t>(batch_src_shift));
+        add(reg_tr_src_base, into<uint32_t>(batch_tr_src_shift));
 
         sub(reg_loop_batch, 1);
         jnz(batch_loop, T_NEAR);
@@ -774,7 +774,7 @@ void jit_brgemm_trans_m_k_bf16_t::generate() {
                     is_os_tail ? last_os_block_tail : transpose_size,
                     transpose_size);
             add(reg_m_src, M_src_shift);
-            add(reg_m_tr_src, M_tr_src_shift);
+            add(reg_m_tr_src, into<uint32_t>(M_tr_src_shift));
         }
         sub(reg_loop_M, transpose_size);
         cmp(reg_loop_M, transpose_size);
@@ -805,7 +805,7 @@ void jit_brgemm_trans_m_k_bf16_t::generate() {
         L(K_loop);
         {
             compute_m_loop(reg_k_src, reg_k_tr_src, false);
-            add(reg_k_src, K_src_shift);
+            add(reg_k_src, into<uint32_t>(K_src_shift));
             add(reg_k_tr_src, K_tr_src_shift);
         }
         sub(reg_loop_K, transpose_size);
@@ -831,8 +831,8 @@ void jit_brgemm_trans_m_k_bf16_t::generate() {
     {
         compute_k_loop(reg_batch_src, reg_batch_tr_src);
 
-        add(reg_batch_src, batch_src_shift);
-        add(reg_batch_tr_src, batch_tr_src_shift);
+        add(reg_batch_src, into<uint32_t>(batch_src_shift));
+        add(reg_batch_tr_src, into<uint32_t>(batch_tr_src_shift));
     }
     sub(reg_loop_batch, 1);
     jnz(batch_loop, T_NEAR);
@@ -1079,7 +1079,7 @@ void jit_brgemm_trans_m_k_f16_t::generate() {
         transpose_16x16(nrows, transpose_size);
         if (conf_->ic_block > transpose_size) {
             add(reg_src, m_src_shift);
-            add(reg_tr_src, m_tr_src_shift);
+            add(reg_tr_src, into<uint32_t>(m_tr_src_shift));
             sub(reg_loop_M, transpose_size);
             cmp(reg_loop_M, transpose_size);
             jge(M_loop, T_NEAR);
@@ -1102,8 +1102,8 @@ void jit_brgemm_trans_m_k_f16_t::generate() {
         L(batch_loop);
 
         compute_M(is_os_tail);
-        add(reg_src_base, batch_src_shift);
-        add(reg_tr_src_base, batch_tr_src_shift);
+        add(reg_src_base, into<uint32_t>(batch_src_shift));
+        add(reg_tr_src_base, into<uint32_t>(batch_tr_src_shift));
 
         sub(reg_loop_batch, 1);
         jnz(batch_loop, T_NEAR);
@@ -1252,8 +1252,8 @@ void jit_brgemm_copy_to_coarse_t::copy_os_loop() {
     L(loop_os);
 
     copy_row_loop();
-    add(reg_data, data_stride_);
-    add(reg_tr_data, tr_data_stride_);
+    add(reg_data, into<uint32_t>(data_stride_));
+    add(reg_tr_data, into<uint32_t>(tr_data_stride_));
 
     dec(reg_os_work);
     jnz(loop_os, T_NEAR);
@@ -1407,7 +1407,7 @@ void jit_trans_to_vnni_t::maybe_zero_pad_col(reg64_t dst) {
                     dst, i * tr_src_stride, reg_long_offt);
             vmovups(addr, zmm_zero);
         }
-        add(reg_col_tr_src, tr_src_col_shift);
+        add(reg_col_tr_src, into<uint32_t>(tr_src_col_shift));
     }
 }
 
@@ -1571,8 +1571,8 @@ void jit_trans_to_vnni_t::generate() {
         {
             transpose(reg_col_tr_src, reg_col_src, nrows, transpose_size,
                     pad_by_zeroes);
-            add(reg_col_src, src_col_shift);
-            add(reg_col_tr_src, tr_src_col_shift);
+            add(reg_col_src, into<uint32_t>(src_col_shift));
+            add(reg_col_tr_src, into<uint32_t>(tr_src_col_shift));
         }
         sub(reg_loop_col, transpose_size);
         cmp(reg_loop_col, transpose_size);
@@ -1597,7 +1597,8 @@ void jit_trans_to_vnni_t::generate() {
             mov(reg_loop_col, ptr[param1 + GET_OFF(current_col_size)]);
             cmp(reg_loop_col, conf_->oc_block);
             je(col_pad_done, T_NEAR);
-            if (col_tail > 0) add(reg_col_tr_src, tr_src_col_shift);
+            if (col_tail > 0)
+                add(reg_col_tr_src, into<uint32_t>(tr_src_col_shift));
             maybe_zero_pad_col(reg_col_tr_src);
             L(col_pad_done);
         }
@@ -1617,8 +1618,8 @@ void jit_trans_to_vnni_t::generate() {
         {
             compute_col_loop(reg_row_src, reg_row_tr_src, false);
 
-            add(reg_row_src, src_row_shift);
-            add(reg_row_tr_src, tr_src_row_shift);
+            add(reg_row_src, into<uint32_t>(src_row_shift));
+            add(reg_row_tr_src, into<uint32_t>(tr_src_row_shift));
         }
         sub(reg_loop_row, transpose_size);
         cmp(reg_loop_row, transpose_size);
@@ -1643,8 +1644,8 @@ void jit_trans_to_vnni_t::generate() {
     {
         compute_row_loop(reg_batch_src, reg_batch_tr_src);
 
-        add(reg_batch_src, src_batch_shift);
-        add(reg_batch_tr_src, tr_src_batch_shift);
+        add(reg_batch_src, into<uint32_t>(src_batch_shift));
+        add(reg_batch_tr_src, into<uint32_t>(tr_src_batch_shift));
     }
     sub(reg_loop_batch, 1);
     jnz(batch_loop, T_NEAR);
@@ -1790,8 +1791,8 @@ void jit_copy_f32_t::generate() {
         L(batch_loop);
 
         copy_block(nrows, ncolumns);
-        add(reg_src, src_batch_shift);
-        add(reg_tr_src, tr_src_batch_shift);
+        add(reg_src, into<uint32_t>(src_batch_shift));
+        add(reg_tr_src, into<uint32_t>(tr_src_batch_shift));
 
         sub(reg_loop_batch, 1);
         jnz(batch_loop, T_NEAR);
@@ -1993,8 +1994,8 @@ void jit_copy_f16_t::generate() {
         L(batch_loop);
 
         copy_block(is_row_tail, is_col_tail);
-        add(reg_src, src_batch_shift);
-        add(reg_tr_src, tr_src_batch_shift);
+        add(reg_src, into<uint32_t>(src_batch_shift));
+        add(reg_tr_src, into<uint32_t>(tr_src_batch_shift));
 
         sub(reg_loop_batch, 1);
         jnz(batch_loop, T_NEAR);
@@ -2047,7 +2048,7 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
 
     preamble();
 
-    const int vnni_width = data_type_vnni_granularity(wjcp.wei_dt);
+    const int vnni_width = into<int>(data_type_vnni_granularity(wjcp.wei_dt));
     const auto wei_dsz = types::data_type_size(wjcp.wei_dt);
     const auto inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
     const auto out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
@@ -2092,10 +2093,10 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
                     copy_zmm(false);
 
                 add(aux_reg_src, wjcp.inp_ocb_offs);
-                add(aux_reg_dst, inp_ocb_size);
+                add(aux_reg_dst, into<uint32_t>(inp_ocb_size));
             }
-            add(reg_src, inp_ocb_size);
-            add(reg_dst, out_ocb_size);
+            add(reg_src, into<uint32_t>(inp_ocb_size));
+            add(reg_dst, into<uint32_t>(out_ocb_size));
         }
     };
 
@@ -2404,8 +2405,8 @@ void jit_brgemm_trans_wei_f32_t::generate() {
         L(N_loop);
 
         transpose(transpose_size, is_oc_tail ? oc_tail : transpose_size);
-        add(reg_src, N_src_shift);
-        add(reg_tr_src, N_tr_src_shift);
+        add(reg_src, into<uint32_t>(N_src_shift));
+        add(reg_tr_src, into<uint32_t>(N_tr_src_shift));
 
         sub(reg_loop_N, transpose_size);
         cmp(reg_loop_N, transpose_size);
@@ -2429,8 +2430,8 @@ void jit_brgemm_trans_wei_f32_t::generate() {
 
     L(K_loop);
     compute_N(false);
-    add(reg_src_base, K_src_shift);
-    add(reg_tr_src_base, K_tr_src_shift);
+    add(reg_src_base, into<uint32_t>(K_src_shift));
+    add(reg_tr_src_base, into<uint32_t>(K_tr_src_shift));
 
     sub(reg_loop_K, transpose_size);
     cmp(reg_loop_K, transpose_size);
@@ -2621,8 +2622,8 @@ void jit_brgemm_trans_wei_bf16_t::generate() {
 
         transpose_16x16_vnni(
                 transpose_size, is_oc_tail ? oc_tail : transpose_size);
-        add(reg_src, N_src_shift);
-        add(reg_tr_src, N_tr_src_shift);
+        add(reg_src, into<uint32_t>(N_src_shift));
+        add(reg_tr_src, into<uint32_t>(N_tr_src_shift));
 
         sub(reg_loop_N, transpose_size);
         cmp(reg_loop_N, transpose_size);
@@ -2647,8 +2648,8 @@ void jit_brgemm_trans_wei_bf16_t::generate() {
 
     L(K_loop);
     compute_N(false);
-    add(reg_src_base, K_src_shift);
-    add(reg_tr_src_base, K_tr_src_shift);
+    add(reg_src_base, into<uint32_t>(K_src_shift));
+    add(reg_tr_src_base, into<uint32_t>(K_tr_src_shift));
 
     sub(reg_loop_K, transpose_size);
     cmp(reg_loop_K, transpose_size);
@@ -2901,8 +2902,8 @@ void jit_brgemm_trans_wei_f16_t::generate() {
         L(N_loop);
 
         transpose_16x16(transpose_size, is_oc_tail ? oc_tail : transpose_size);
-        add(reg_src, N_src_shift);
-        add(reg_tr_src, N_tr_src_shift);
+        add(reg_src, into<uint32_t>(N_src_shift));
+        add(reg_tr_src, into<uint32_t>(N_tr_src_shift));
 
         sub(reg_loop_N, transpose_size);
         cmp(reg_loop_N, transpose_size);
@@ -2926,8 +2927,8 @@ void jit_brgemm_trans_wei_f16_t::generate() {
 
     L(K_loop);
     compute_N(false);
-    add(reg_src_base, K_src_shift);
-    add(reg_tr_src_base, K_tr_src_shift);
+    add(reg_src_base, into<uint32_t>(K_src_shift));
+    add(reg_tr_src_base, into<uint32_t>(K_tr_src_shift));
 
     sub(reg_loop_K, transpose_size);
     cmp(reg_loop_K, transpose_size);

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -382,7 +382,7 @@ void jit_pp_kernel_t<isa>::advance_binary_postops_per_oc_off(const T &offset) {
 
     if (this->ndims_ == 2) {
         Xbyak::Label end;
-        cmp(binary_post_op_oc_off_reg, this->OC_);
+        cmp(binary_post_op_oc_off_reg, into<uint32_t>(this->OC_));
         jl(end, T_NEAR);
         xor_(binary_post_op_oc_off_reg, binary_post_op_oc_off_reg);
         L(end);
@@ -401,7 +401,8 @@ void jit_pp_kernel_t<isa>::update_binary_postops_per_tensor_off() {
     mov(binary_post_op_offset_reg, reg_dst);
     sub(binary_post_op_offset_reg, ptr[rsp + reg_origin_dst_ptr_]);
     sar(binary_post_op_offset_reg,
-            std::log2(types::data_type_size(get_data_type(arg_t::dst))));
+            into<int>(std::log2(
+                    types::data_type_size(get_data_type(arg_t::dst)))));
     mov(binary_post_op_current_offset_on_stack, binary_post_op_offset_reg);
 }
 
@@ -425,12 +426,13 @@ void jit_pp_kernel_t<isa>::advance_binary_postops_channel_bcast_off(
 template <cpu_isa_t isa>
 void jit_pp_kernel_t<isa>::advance_binary_postops_off(const size_t offset) {
     if (offset) {
+        const auto off32 = into<uint32_t>(offset);
         if (any_binary_postop_is_per_oc_bcast_type_)
-            advance_binary_postops_per_oc_off(offset);
+            advance_binary_postops_per_oc_off(off32);
         if (any_binary_postop_is_no_bcast_type_)
             update_binary_postops_per_tensor_off();
         if (any_binary_postop_is_oc_bcast_type_)
-            advance_binary_postops_channel_bcast_off(offset);
+            advance_binary_postops_channel_bcast_off(off32);
     }
 }
 
@@ -513,7 +515,7 @@ void jit_pp_kernel_t<isa>::load_tail(const Vmm v, const arg_t arg_num,
         if (utils::one_of(dt, s8, u8)) {
             const Xbyak::Xmm x = Xbyak::Xmm(v.getIdx());
             for (size_t i = 0; i < tail; i++)
-                uni_vpinsrb(x, x, get_address(arg_num, i + off), i);
+                uni_vpinsrb(x, x, get_address(arg_num, i + off), into<int>(i));
             if (dt == s8)
                 uni_vpmovsxbd(v, v);
             else
@@ -525,8 +527,8 @@ void jit_pp_kernel_t<isa>::load_tail(const Vmm v, const arg_t arg_num,
             } else {
                 const size_t dt_size = types::data_type_size(f32);
                 for (size_t i = 0; i < tail; i++)
-                    uni_vpinsrd(
-                            v, v, get_address(arg_num, i * dt_size + off), i);
+                    uni_vpinsrd(v, v, get_address(arg_num, i * dt_size + off),
+                            into<int>(i));
             }
         }
     }
@@ -607,7 +609,7 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Ymm v,
             case s8:
             case u8:
                 for (size_t i = 0; i < tail; i++)
-                    vpextrb(get_address(arg_num, off + i), x, i);
+                    vpextrb(get_address(arg_num, off + i), x, into<uint8_t>(i));
                 break;
             case f32:
             case s32: vmaskmovps(dst, vmm_rem_mask, v); break;
@@ -649,13 +651,14 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Xmm v,
             case s8:
             case u8:
                 for (size_t i = 0; i < tail; i++)
-                    uni_vpextrb(get_address(arg_num, off + i), v, i);
+                    uni_vpextrb(get_address(arg_num, off + i), v, into<int>(i));
                 break;
             case f32:
             case s32: {
                 const size_t dt_size = types::data_type_size(f32);
                 for (size_t i = 0; i < tail; i++)
-                    uni_vpextrd(get_address(arg_num, off + i * dt_size), v, i);
+                    uni_vpextrd(get_address(arg_num, off + i * dt_size), v,
+                            into<int>(i));
             } break;
             default: assert(!"unimplemented");
         }
@@ -794,11 +797,12 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
     // Advance all pointers by an immediate
     auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * this->dst_data_type_size_);
-        add(reg_acc, offset * this->acc_data_type_size_);
+        add(reg_dst, into<uint32_t>(offset * this->dst_data_type_size_));
+        add(reg_acc, into<uint32_t>(offset * this->acc_data_type_size_));
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
-            add(reg_scales, offset * sizeof(float));
-        if (this->do_bias()) add(reg_bias, offset * this->bias_data_type_size_);
+            add(reg_scales, into<uint32_t>(offset * sizeof(float)));
+        if (this->do_bias())
+            add(reg_bias, into<uint32_t>(offset * this->bias_data_type_size_));
         if (this->do_binary_ || this->do_prelu_) {
             advance_binary_postops_off(offset);
         }
@@ -806,12 +810,16 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
     // Advance all pointers by a value stored in a register
     auto advance_ptrs_reg = [&](const Reg64 offset) {
-        lea(reg_dst, ptr[reg_dst + offset * this->dst_data_type_size_]);
-        lea(reg_acc, ptr[reg_acc + offset * this->acc_data_type_size_]);
+        lea(reg_dst,
+                ptr[reg_dst + offset * into<int>(this->dst_data_type_size_)]);
+        lea(reg_acc,
+                ptr[reg_acc + offset * into<int>(this->acc_data_type_size_)]);
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
             lea(reg_scales, ptr[reg_scales + offset * sizeof(float)]);
         if (this->do_bias())
-            lea(reg_bias, ptr[reg_bias + offset * this->bias_data_type_size_]);
+            lea(reg_bias,
+                    ptr[reg_bias
+                            + offset * into<int>(this->bias_data_type_size_)]);
         if (this->do_binary_ || this->do_prelu_)
             advance_binary_postops_off(offset);
     };
@@ -821,10 +829,12 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
         if (!this->has_trivial_mb_stride()) {
             lea(reg_dst,
                     ptr[reg_dst
-                            + reg_dst_mb_stride * this->dst_data_type_size_]);
+                            + reg_dst_mb_stride
+                                    * into<int>(this->dst_data_type_size_)]);
             lea(reg_acc,
                     ptr[reg_acc
-                            + reg_acc_mb_stride * this->acc_data_type_size_]);
+                            + reg_acc_mb_stride
+                                    * into<int>(this->acc_data_type_size_)]);
         }
         if ((this->do_binary_ || this->do_prelu_)
                 && any_binary_postop_is_no_bcast_type_)
@@ -836,7 +846,9 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
     auto rewind_ptrs = [&]() {
         neg(reg_oc);
         if (this->do_bias())
-            lea(reg_bias, ptr[reg_bias + reg_oc * this->bias_data_type_size_]);
+            lea(reg_bias,
+                    ptr[reg_bias
+                            + reg_oc * into<int>(this->bias_data_type_size_)]);
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
             lea(reg_scales, ptr[reg_scales + reg_oc * sizeof(float)]);
 
@@ -846,7 +858,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
     // Process one row of reg_tmp elements
     auto process_runtime_oc = [&]() {
         Label l_loop, l_loop_tail, l_loop_end;
-        cmp(reg_tmp, vlen);
+        cmp(reg_tmp, into<uint32_t>(vlen));
         jl(l_loop_tail, T_NEAR);
 
         L(l_loop);
@@ -854,8 +866,8 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
             compute(0, 0, true);
             advance_ptrs_imm(vlen);
 
-            sub(reg_tmp, vlen);
-            cmp(reg_tmp, vlen);
+            sub(reg_tmp, into<uint32_t>(vlen));
+            cmp(reg_tmp, into<uint32_t>(vlen));
             jge(l_loop, T_NEAR);
         }
 
@@ -941,7 +953,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
             assert(!!OC_loop || !!OC_tail);
 
-            const int vlen_tail = OC_tail % vlen;
+            const int vlen_tail = into<int>(OC_tail % vlen);
             if (vlen_tail) prepare_mask(vlen_tail);
 
             if (OC_loop) {
@@ -950,9 +962,9 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
                 L(l_oc_loop);
                 {
                     for (size_t offset = 0; offset < OC_loop; offset += vlen)
-                        compute(offset, offset / vlen, false);
+                        compute(offset, into<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop);
-                    sub(reg_tmp, OC_loop);
+                    sub(reg_tmp, into<uint32_t>(OC_loop));
                     jnz(l_oc_loop);
                 }
             }
@@ -960,7 +972,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
             if (OC_tail) {
                 for (size_t offset = 0; offset < OC_tail; offset += vlen) {
                     const bool use_mask = (offset + vlen) > OC_tail;
-                    compute(offset, offset / vlen, false,
+                    compute(offset, into<int>(offset / vlen), false,
                             use_mask ? vlen_tail : 0);
                 }
                 advance_ptrs_imm(OC_tail);
@@ -968,7 +980,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
             if (any_binary_postop_is_per_oc_sp_bcast_type_
                     && this->ndims_ <= 3) {
-                static constexpr size_t offset_oc_spatial = 1;
+                static constexpr uint32_t offset_oc_spatial = 1;
                 advance_binary_postops_per_oc_off(offset_oc_spatial);
             }
 
@@ -1030,7 +1042,7 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         load_and_cvt(vmm_bias, arg_t::bias, 0, this->OC_, false);
 
         // write repeated MB*OC entries into stack
-        sub(rsp, mb_oc_blk * sizeof(uint32_t));
+        sub(rsp, into<uint32_t>(mb_oc_blk * sizeof(uint32_t)));
         for (size_t i = 0; i < mb_step; ++i)
             cvt_and_store(vmm_bias, arg_t::stack,
                     i * this->OC_ * sizeof(uint32_t), this->OC_);
@@ -1043,13 +1055,13 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         uni_vcvtdq2ps(vmm_bias, vmm_bias);
     L(mb_main_loop);
     {
-        cmp(reg_len, mb_oc_blk);
+        cmp(reg_len, into<uint32_t>(mb_oc_blk));
         jl(end_main_loop, T_NEAR);
 
-        compute(!expl_broadcast ? tail_size : 0);
-        add(reg_dst, mb_oc_blk * this->dst_data_type_size_);
-        add(reg_acc, mb_oc_blk * this->acc_data_type_size_);
-        sub(reg_len, mb_oc_blk);
+        compute(into<int>(!expl_broadcast ? tail_size : 0));
+        add(reg_dst, into<uint32_t>(mb_oc_blk * this->dst_data_type_size_));
+        add(reg_acc, into<uint32_t>(mb_oc_blk * this->acc_data_type_size_));
+        sub(reg_len, into<uint32_t>(mb_oc_blk));
         jmp(mb_main_loop, T_NEAR);
     }
     L(end_main_loop);
@@ -1060,12 +1072,12 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         if (tail_size) prepare_mask(tail_size);
         L(mb_tail_loop);
         {
-            cmp(reg_len, tail_size);
+            cmp(reg_len, into<uint32_t>(tail_size));
             jl(runtime_tail, T_NEAR);
-            compute(tail_size);
-            add(reg_dst, tail_size * this->dst_data_type_size_);
-            add(reg_acc, tail_size * this->acc_data_type_size_);
-            sub(reg_len, tail_size);
+            compute(into<int>(tail_size));
+            add(reg_dst, into<uint32_t>(tail_size * this->dst_data_type_size_));
+            add(reg_acc, into<uint32_t>(tail_size * this->acc_data_type_size_));
+            sub(reg_len, into<uint32_t>(tail_size));
             jmp(mb_tail_loop, T_NEAR);
         }
         // Load tail in runtime if len < mb_tail * oc
@@ -1080,12 +1092,12 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
                 sub(reg_rem_mask, 1);
                 kmovq(kreg_rem_mask, reg_rem_mask);
             }
-            compute(tail_size, !is_avx512_);
+            compute(into<int>(tail_size), !is_avx512_);
         }
         L(end_runtime_tail);
     }
 
-    if (!expl_broadcast) add(rsp, mb_oc_blk * sizeof(uint32_t));
+    if (!expl_broadcast) add(rsp, into<uint32_t>(mb_oc_blk * sizeof(uint32_t)));
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_conv_zp_src_pad_comp.cpp
@@ -184,7 +184,7 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::check_bound(
         const Xbyak::Reg64 &reg_dim, const Xbyak::Address &result_addr,
         const dim_t bound_value, const bound bound_kind) {
 
-    host_->cmp(reg_dim, bound_value);
+    host_->cmp(reg_dim, into<uint32_t>(bound_value));
     if (bound_kind == lower)
         host_->setl(result_addr);
     else
@@ -232,8 +232,8 @@ void jit_gemm_x8s8s32x_zp_pad_comp_helper_t::
         host_->mov(reg_zp_pad_comp_tmp_, zp_pad_com_w_);
     }
 
-    host_->imul(
-            reg_zp_pad_comp_tmp_, reg_zp_pad_comp_tmp_, jcp_.oc * jcp_.ngroups);
+    host_->imul(reg_zp_pad_comp_tmp_, reg_zp_pad_comp_tmp_,
+            into<int>(jcp_.oc * jcp_.ngroups));
     host_->add(reg_zp_pad_comp_tmp_, g_oc_offset);
     host_->imul(reg_zp_pad_comp_tmp_, reg_zp_pad_comp_tmp_, sizeof(int32_t));
     host_->mov(reg_zp_pad_comp_, zp_pad_com_base_);

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -263,11 +263,11 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
 }
 
 Xbyak::Zmm jit_pp_ker_t::reserve_zmm() {
-    return Xbyak::Zmm(number_of_reserved_zmm_regs_++);
+    return Xbyak::Zmm(into<int>(number_of_reserved_zmm_regs_++));
 }
 
 int jit_pp_ker_t::vreg_dst_idx(const int idx) const noexcept {
-    return (number_of_reserved_zmm_regs_ + idx * zmm_step_);
+    return into<int>((number_of_reserved_zmm_regs_ + idx * zmm_step_));
 }
 
 Xbyak::Zmm jit_pp_ker_t::get_vreg_dst(int idx) const {
@@ -275,11 +275,11 @@ Xbyak::Zmm jit_pp_ker_t::get_vreg_dst(int idx) const {
 }
 
 Xbyak::Zmm jit_pp_ker_t::get_vreg_bias(int idx) const {
-    return Xbyak::Zmm(vreg_dst_idx(idx) + bias_step_factor_);
+    return Xbyak::Zmm(into<int>(vreg_dst_idx(idx) + bias_step_factor_));
 }
 
 Xbyak::Zmm jit_pp_ker_t::get_vreg_prev_dst(int idx) const {
-    return Xbyak::Zmm(vreg_dst_idx(idx) + sum_step_factor_);
+    return Xbyak::Zmm(into<int>(vreg_dst_idx(idx) + sum_step_factor_));
 }
 
 Xbyak::Zmm jit_pp_ker_t::get_masked_vreg_dst(int idx, bool apply_mask) const {
@@ -393,7 +393,7 @@ void jit_pp_ker_t::generate() {
 #undef PARAM_OFF
 
     mov(reg_rem_mask_vlen_, 1);
-    shl(reg_rem_mask_vlen_, vlen);
+    shl(reg_rem_mask_vlen_, into<int>(vlen));
     sub(reg_rem_mask_vlen_, 1);
     kmovq(kreg_rem_mask_vlen_, reg_rem_mask_vlen_);
 
@@ -479,20 +479,22 @@ void jit_pp_ker_t::generate() {
     // Advance all pointers by an immediate
     const auto advance_ptrs_imm
             = [&](const size_t offset, const size_t binary_offset) {
-        add(reg_dst_, offset * dst_data_type_size_);
-        add(reg_acc_, offset * sizeof(acc_data_t));
+        add(reg_dst_, into<uint32_t>(offset * dst_data_type_size_));
+        add(reg_acc_, into<uint32_t>(offset * sizeof(acc_data_t)));
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            add(reg_scales_, offset * sizeof(float));
+            add(reg_scales_, into<uint32_t>(offset * sizeof(float)));
         }
-        if (jcp_.with_bias) add(reg_bias_, offset * bias_data_type_size_);
+        if (jcp_.with_bias)
+            add(reg_bias_, into<uint32_t>(offset * bias_data_type_size_));
         if (jcp_.zp.src_exists) {
-            add(reg_zp_src_comp_, offset * sizeof(int32_t));
+            add(reg_zp_src_comp_, into<uint32_t>(offset * sizeof(int32_t)));
 
             if (zp_pad_comp_helper_) {
                 zp_pad_comp_helper_->zp_src_comp_pad_operation(
                         [&](const Xbyak::Reg64 &reg_zp_pad_comp) {
-                    add(reg_zp_pad_comp, offset * sizeof(int32_t));
+                    add(reg_zp_pad_comp,
+                            into<uint32_t>(offset * sizeof(int32_t)));
                 });
             }
         }
@@ -501,14 +503,15 @@ void jit_pp_ker_t::generate() {
     // Advance all pointers by a value stored in a register
     const auto advance_ptrs_reg
             = [&](const Reg64 offset, const Reg64 binary_offset) {
-        lea(reg_dst_, ptr[reg_dst_ + offset * dst_data_type_size_]);
+        lea(reg_dst_, ptr[reg_dst_ + offset * into<int>(dst_data_type_size_)]);
         lea(reg_acc_, ptr[reg_acc_ + offset * sizeof(acc_data_t)]);
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
             lea(reg_scales_, ptr[reg_scales_ + offset * sizeof(float)]);
         }
         if (jcp_.with_bias)
-            lea(reg_bias_, ptr[reg_bias_ + offset * bias_data_type_size_]);
+            lea(reg_bias_,
+                    ptr[reg_bias_ + offset * into<int>(bias_data_type_size_)]);
 
         if (jcp_.zp.src_exists) {
             lea(reg_zp_src_comp_,
@@ -526,18 +529,21 @@ void jit_pp_ker_t::generate() {
     // Rewind pointers that point to data that is indexed by output channel
     // (bias or per-oc scaling factors)
     const auto rewind_ptrs = [&]() {
-        if (jcp_.with_bias) sub(reg_bias_, jcp_.oc * bias_data_type_size_);
+        if (jcp_.with_bias)
+            sub(reg_bias_, into<uint32_t>(jcp_.oc * bias_data_type_size_));
         if (jcp_.zp.src_exists) {
             const auto offset = jcp_.oc * sizeof(int32_t);
-            sub(reg_zp_src_comp_, offset);
+            sub(reg_zp_src_comp_, into<uint32_t>(offset));
             if (zp_pad_comp_helper_)
                 zp_pad_comp_helper_->load_next_point_zp_src_comp_pad_addr();
         }
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            sub(reg_scales_, jcp_.oc * sizeof(float));
+            sub(reg_scales_, into<uint32_t>(jcp_.oc * sizeof(float)));
         }
-        add(reg_dst_, (jcp_.dst_os_stride - jcp_.oc) * dst_data_type_size_);
+        add(reg_dst_,
+                into<uint32_t>(
+                        (jcp_.dst_os_stride - jcp_.oc) * dst_data_type_size_));
     };
 
     //                    <--------- OC --------------->
@@ -565,14 +571,14 @@ void jit_pp_ker_t::generate() {
         sub(reg_len_, reg_tmp_);
 
         Label prologue_loop, prologue_loop_tail, prologue_loop_end;
-        cmp(reg_tmp_, vlen);
+        cmp(reg_tmp_, into<uint32_t>(vlen));
         jle(prologue_loop_tail, T_NEAR);
         L(prologue_loop);
         {
-            compute(0, max_unroll_ - 1, false);
+            compute(0, into<int>(max_unroll_ - 1), false);
             advance_ptrs_imm(vlen, vlen);
-            sub(reg_tmp_, vlen);
-            cmp(reg_tmp_, vlen);
+            sub(reg_tmp_, into<uint32_t>(vlen));
+            cmp(reg_tmp_, into<uint32_t>(vlen));
             jge(prologue_loop, T_NEAR);
         }
 
@@ -584,7 +590,7 @@ void jit_pp_ker_t::generate() {
         jz(prologue_loop_end, T_NEAR);
 
         kmovq(kreg_rem_mask_short_, reg_rem_mask_short_);
-        compute(0, max_unroll_ - 1, true);
+        compute(0, into<int>(max_unroll_ - 1), true);
         advance_ptrs_reg(reg_tmp_, reg_tmp_);
 
         L(prologue_loop_end);
@@ -595,7 +601,7 @@ void jit_pp_ker_t::generate() {
     // Main loop
     Label main_loop_end;
     {
-        cmp(reg_len_, jcp_.oc);
+        cmp(reg_len_, into<uint32_t>(jcp_.oc));
         jle(main_loop_end, T_NEAR);
 
         Label main_loop;
@@ -613,7 +619,7 @@ void jit_pp_ker_t::generate() {
 
             assert(!!OC_loop || !!OC_tail);
 
-            const int vlen_tail = OC_tail % vlen;
+            const dim_t vlen_tail = OC_tail % vlen;
             if (vlen_tail) {
                 unsigned tail_mask = (1 << vlen_tail) - 1;
                 mov(reg_tmp_, tail_mask);
@@ -626,9 +632,9 @@ void jit_pp_ker_t::generate() {
                 L(oc_loop);
                 {
                     for (size_t offset = 0; offset < OC_loop; offset += vlen)
-                        compute(offset, offset / vlen, false);
+                        compute(offset, into<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop, vlen);
-                    sub(reg_tmp_, OC_loop);
+                    sub(reg_tmp_, into<uint32_t>(OC_loop));
                     jnz(oc_loop);
                 }
             }
@@ -636,7 +642,7 @@ void jit_pp_ker_t::generate() {
             if (OC_tail) {
                 for (size_t offset = 0; offset < OC_tail; offset += vlen) {
                     bool use_mask = (offset + vlen) > OC_tail;
-                    compute(offset, offset / vlen, use_mask);
+                    compute(offset, into<int>(offset / vlen), use_mask);
                 }
                 const size_t oc_tail_rem = OC_tail % vlen;
                 const size_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
@@ -644,8 +650,8 @@ void jit_pp_ker_t::generate() {
             }
 
             rewind_ptrs();
-            sub(reg_len_, jcp_.oc);
-            cmp(reg_len_, jcp_.oc);
+            sub(reg_len_, into<uint32_t>(jcp_.oc));
+            cmp(reg_len_, into<uint32_t>(jcp_.oc));
             jge(main_loop, T_NEAR);
         }
     }
@@ -658,14 +664,14 @@ void jit_pp_ker_t::generate() {
         je(epilogue_end, T_NEAR);
 
         Label epilogue_loop, epilogue_loop_tail;
-        cmp(reg_len_, vlen);
+        cmp(reg_len_, into<uint32_t>(vlen));
         jle(epilogue_loop_tail, T_NEAR);
         L(epilogue_loop);
         {
             compute(0, 0, false);
-            sub(reg_len_, vlen);
+            sub(reg_len_, into<uint32_t>(vlen));
             advance_ptrs_imm(vlen, vlen);
-            cmp(reg_len_, vlen);
+            cmp(reg_len_, into<uint32_t>(vlen));
             jge(epilogue_loop, T_NEAR);
         }
 

--- a/src/cpu/x64/jit_generator.cpp
+++ b/src/cpu/x64/jit_generator.cpp
@@ -85,7 +85,8 @@ void jit_generator_t::transpose(const Xbyak::Reg64 &reg_src,
             // Load the remaining xf16 values one by one.
             for (int i = 0; i < rem; i++) {
                 vpinsrw(xmm_tmp, xmm_tmp,
-                        ptr[reg_src + r * src_stride + (c + i) * dt_size], i);
+                        ptr[reg_src + r * src_stride + (c + i) * dt_size],
+                        into<uint8_t>(i));
             }
         }
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -82,8 +82,8 @@ inline void tc_configure_tile(palette_config_t *tc, int t, int rows, int cols) {
     const bool rows_ok = (size_t)t < sizeof(tc->rows) / sizeof(tc->rows[0]);
     const bool cols_ok = (size_t)t < sizeof(tc->cols) / sizeof(tc->cols[0]);
     if (rows_ok && cols_ok) {
-        tc->rows[t] = rows;
-        tc->cols[t] = cols;
+        tc->rows[t] = into<uint8_t>(rows);
+        tc->cols[t] = into<uint16_t>(cols);
     } else {
         assert(!"out of range");
     }
@@ -207,10 +207,10 @@ public:
 
     void preamble() {
         if (xmm_to_preserve) {
-            sub(rsp, xmm_to_preserve * xmm_len);
+            sub(rsp, into<uint32_t>(xmm_to_preserve * xmm_len));
             for (size_t i = 0; i < xmm_to_preserve; ++i)
                 uni_vmovdqu(ptr[rsp + i * xmm_len],
-                        Xbyak::Xmm(xmm_to_preserve_start + i));
+                        Xbyak::Xmm(into<int>(xmm_to_preserve_start + i)));
         }
         for (size_t i = 0; i < num_abi_save_gpr_regs; ++i) {
             push(Xbyak::Reg64(abi_save_gpr_regs[i]));
@@ -254,7 +254,8 @@ public:
     // Note: that we cannot use RBP inside as we override it in preamble
     // for address computation in EVEX instructions
     inline Xbyak::RegExp get_stack_params_address(bool after_prolog = true) {
-        int saved_regs_size = after_prolog ? get_size_of_abi_save_regs() : 0;
+        int saved_regs_size
+                = into<int>(after_prolog ? get_size_of_abi_save_regs() : 0);
 #ifdef _WIN32
         // Using stack layout described in MS ABI
         // (https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=vs-2019)
@@ -285,9 +286,9 @@ public:
             pop(Xbyak::Reg64(abi_save_gpr_regs[num_abi_save_gpr_regs - 1 - i]));
         if (xmm_to_preserve) {
             for (size_t i = 0; i < xmm_to_preserve; ++i)
-                uni_vmovdqu(Xbyak::Xmm(xmm_to_preserve_start + i),
+                uni_vmovdqu(Xbyak::Xmm(into<int>(xmm_to_preserve_start + i)),
                         ptr[rsp + i * xmm_len]);
-            add(rsp, xmm_to_preserve * xmm_len);
+            add(rsp, into<uint32_t>(xmm_to_preserve * xmm_len));
         }
         uni_vzeroupper();
         ret();
@@ -370,7 +371,7 @@ public:
             mov(reg_offt, raw_offt);
             add(base, reg_offt);
         } else {
-            add(base, raw_offt);
+            add(base, into<uint32_t>(raw_offt));
         }
     }
 
@@ -380,7 +381,7 @@ public:
             mov(reg_offt, raw_offt);
             sub(base, reg_offt);
         } else {
-            sub(base, raw_offt);
+            sub(base, into<uint32_t>(raw_offt));
         }
     }
 
@@ -1437,7 +1438,7 @@ public:
     void uni_vpslld(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpslld(x, op, imm);
+            vpslld(x, op, into<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) movdqa(x, op);
             pslld(x, imm);
@@ -1445,13 +1446,13 @@ public:
     }
     void uni_vpslld(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpslld(x, op, imm);
+        vpslld(x, op, into<uint8_t>(imm));
     }
 
     void uni_vpsrld(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpsrld(x, op, imm);
+            vpsrld(x, op, into<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) uni_vmovups(x, op);
             psrld(x, imm);
@@ -1459,7 +1460,7 @@ public:
     }
     void uni_vpsrld(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpsrld(x, op, imm);
+        vpsrld(x, op, into<uint8_t>(imm));
     }
 
     void uni_vmaxps(const Xbyak::Xmm &x, const Xbyak::Operand &op1,
@@ -1535,15 +1536,15 @@ public:
     void uni_vcmpps(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, int cmp_predicate) {
         if (is_valid_isa(avx))
-            vcmpps(x1, x2, op, cmp_predicate);
+            vcmpps(x1, x2, op, into<uint8_t>(cmp_predicate));
         else {
             if (x1.getIdx() != x2.getIdx()) uni_vmovups(x1, x2);
-            cmpps(x1, op, cmp_predicate);
+            cmpps(x1, op, into<uint8_t>(cmp_predicate));
         }
     }
     void uni_vcmpps(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, int cmp_predicate) {
-        vcmpps(x1, x2, op, cmp_predicate);
+        vcmpps(x1, x2, op, into<uint8_t>(cmp_predicate));
     }
 
     void uni_vtestps(const Xbyak::Xmm &x1, const Xbyak::Operand &op) {
@@ -1587,7 +1588,7 @@ public:
             const Xbyak::Operand &op, const int imm) {
         assert(!x1.isZMM() && !x2.isZMM());
         if (is_valid_isa(avx))
-            vblendps(x1, x2, op, imm);
+            vblendps(x1, x2, op, into<uint8_t>(imm));
         else {
             if (!x1.isEqualIfNotInherited(x2)) movups(x1, x2);
             blendps(x1, op, imm);
@@ -1599,9 +1600,9 @@ public:
         if (is_valid_isa(avx512_core))
             vrndscaleps(x, op, imm & 0x3);
         else if (is_valid_isa(avx))
-            vroundps(x, op, imm);
+            vroundps(x, op, into<uint8_t>(imm));
         else
-            roundps(x, op, imm);
+            roundps(x, op, into<uint8_t>(imm));
     }
 
     void uni_vroundps(
@@ -1609,7 +1610,7 @@ public:
         if (is_valid_isa(avx512_core))
             vrndscaleps(x, op, imm & 0x3);
         else
-            vroundps(x, op, imm);
+            vroundps(x, op, into<uint8_t>(imm));
     }
 
     void uni_vroundps(
@@ -1769,50 +1770,50 @@ public:
     void uni_vpinsrb(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrb(x1, x2, op, imm);
+            vpinsrb(x1, x2, op, into<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrb(x1, op, imm);
+            pinsrb(x1, op, into<uint8_t>(imm));
         }
     }
 
     void uni_vpinsrb(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrb(x1, x2, op, imm);
+        vpinsrb(x1, x2, op, into<uint8_t>(imm));
     }
 
     void uni_vpinsrd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrd(x1, x2, op, imm);
+            vpinsrd(x1, x2, op, into<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrd(x1, op, imm);
+            pinsrd(x1, op, into<uint8_t>(imm));
         }
     }
     void uni_vpinsrd(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrd(x1, x2, op, imm);
+        vpinsrd(x1, x2, op, into<uint8_t>(imm));
     }
 
     void uni_vpinsrq(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrq(x1, x2, op, imm);
+            vpinsrq(x1, x2, op, into<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrq(x1, op, imm);
+            pinsrq(x1, op, into<uint8_t>(imm));
         }
     }
     void uni_vpinsrq(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrq(x1, x2, op, imm);
+        vpinsrq(x1, x2, op, into<uint8_t>(imm));
     }
 
     void uni_vpinsrw(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrw(x1, x2, op, imm);
+            vpinsrw(x1, x2, op, into<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             pinsrw(x1, op, imm);
@@ -1820,56 +1821,56 @@ public:
     }
     void uni_vpinsrw(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrw(x1, x2, op, imm);
+        vpinsrw(x1, x2, op, into<uint8_t>(imm));
     }
 
     void uni_vpextrb(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrb(op, x, imm);
+            vpextrb(op, x, into<uint8_t>(imm));
         else
-            pextrb(op, x, imm);
+            pextrb(op, x, into<uint8_t>(imm));
     }
 
     void uni_vpextrb(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrb(op, x, imm);
+        vpextrb(op, x, into<uint8_t>(imm));
     }
 
     void uni_vpextrw(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrw(op, x, imm);
+            vpextrw(op, x, into<uint8_t>(imm));
         else
-            pextrw(op, x, imm);
+            pextrw(op, x, into<uint8_t>(imm));
     }
     void uni_vpextrw(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrw(op, x, imm);
+        vpextrw(op, x, into<uint8_t>(imm));
     }
 
     void uni_vpextrd(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrd(op, x, imm);
+            vpextrd(op, x, into<uint8_t>(imm));
         else
-            pextrd(op, x, imm);
+            pextrd(op, x, into<uint8_t>(imm));
     }
     void uni_vpextrd(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrd(op, x, imm);
+        vpextrd(op, x, into<uint8_t>(imm));
     }
 
     void uni_vpextrq(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrq(op, x, imm);
+            vpextrq(op, x, into<uint8_t>(imm));
         else
-            pextrq(op, x, imm);
+            pextrq(op, x, into<uint8_t>(imm));
     }
     void uni_vpextrq(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrq(op, x, imm);
+        vpextrq(op, x, into<uint8_t>(imm));
     }
 
     void uni_vpmaxsd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
@@ -1945,7 +1946,7 @@ public:
     void uni_vpslldq(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpslldq(x, op, imm);
+            vpslldq(x, op, into<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) movdqa(x, op);
             pslldq(x, imm);
@@ -1953,7 +1954,7 @@ public:
     }
     void uni_vpslldq(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpslldq(x, op, imm);
+        vpslldq(x, op, into<uint8_t>(imm));
     }
 
     void uni_vpmovsxwd(const Xbyak::Xmm &x, const Xbyak::Operand &op) {
@@ -2731,7 +2732,7 @@ public:
         jmp(label_tbl_end, T_NEAR);
         for (size_t i = 1; i < simd_w; i++) {
             L(l_case[i]);
-            tail_process(i);
+            tail_process(into<int>(i));
             jmp(label_tbl_end, T_NEAR);
         }
         L(label_tbl_end);

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -348,7 +348,7 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate_reduce_loop(
     L(reduce_loop);
     {
         fma_block(false);
-        add(aux_reg_bcast_data, jcp.reduce_loop_bcast_step);
+        add(aux_reg_bcast_data, into<uint32_t>(jcp.reduce_loop_bcast_step));
         add(aux_reg_load_data, jcp.reduce_loop_load_step);
         sub(reduce_loop_iter, jcp.reduce_loop_unroll);
         jg(reduce_loop, T_NEAR);
@@ -474,17 +474,19 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate() {
             case forward_inference:
                 add(reg_bias_data,
                         load_loop_blk * jcp.oc_block * sizeof(float));
-                add(reg_output_data, offst_with_dw_conv);
+                add(reg_output_data, into<uint32_t>(offst_with_dw_conv));
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            into<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(ptr[rsp + reg_dw_binary_output_off], aux_reg_load_data);
                 }
                 break;
             case backward_data:
                 add(reg_output_data,
-                        load_loop_blk * jcp.is * jcp.ic_block * sizeof(float));
+                        into<uint32_t>(load_loop_blk * jcp.is * jcp.ic_block
+                                * sizeof(float)));
                 break;
             case backward_weights:
                 for (int i = 0; i < load_loop_blk; i++)
@@ -569,25 +571,25 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
 
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kh = into<int>((ndims == 3) ? 1 : weights_d.dims()[with_groups + 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][0]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[0];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[0]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
@@ -709,8 +711,9 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         load_blocking_max = is_data_layout_nxc ? jcp.load_dim : 144;
         bcast_blocking = 128; // affects load balancing across threads
         bcast_blocking_max = 192;
-        reduce_blocking = is_data_layout_nxc ? jcp.reduce_dim
-                                             : 128; // affects L1$ utilization
+        reduce_blocking = into<int>(is_data_layout_nxc
+                        ? jcp.reduce_dim
+                        : 128); // affects L1$ utilization
     } else if (jcp.prop_kind == backward_data) {
         jcp.reduce_dim = jcp.oc;
         jcp.reduce_block = jcp.oc_block;
@@ -759,10 +762,12 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         jcp.bcast_loop_output_step
                 = jcp.oc_block * jcp.ic_block * sizeof(float);
         jcp.bcast_loop_output_substep = jcp.oc_block * jcp.ur * sizeof(float);
-        jcp.bcast_loop_bcast_step = jcp.ic_block * jcp.is * sizeof(float);
+        jcp.bcast_loop_bcast_step
+                = into<int>(jcp.ic_block * jcp.is * sizeof(float));
         jcp.bcast_loop_bcast_substep = jcp.ur * sizeof(float);
 
-        jcp.load_loop_load_step = jcp.oc_block * jcp.os * sizeof(float);
+        jcp.load_loop_load_step
+                = into<int>(jcp.oc_block * jcp.os * sizeof(float));
         jcp.load_loop_iter_step = jcp.oc_block;
 
         /* --- */
@@ -782,7 +787,7 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         load_blocking_max = load_blocking;
         assert(jcp.load_dim % load_blocking == 0);
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         while (true) {
             if (bcast_blocking <= 9)
                 break;
@@ -816,9 +821,9 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_load_blocking_max = load_blocking_max / jcp.load_block;
     jcp.nb_reduce_blocking = reduce_blocking / jcp.reduce_block;
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     return status::success;
 }

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -85,7 +85,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     auto par_conv = jit_1x1_conv_args_t();
 
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     const int nb_ic = jcp.nb_reduce;
     const int nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -272,9 +272,9 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr, into<dim_t>(jcp.mb * jcp.ngroups * jcp_dw.oh),
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end, dim_t(1));
 
         while (ocb_start < ocb_end) {
             int load_step;

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -79,7 +79,7 @@ void jit_sse41_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         for (int ifm2 = 0; ifm2 < ic_blk; ifm2++) {
             for (int jj = jj_start; jj < jj_end; jj++) {
                 size_t inp_off = get_input_offset(
-                        ifm2, filter_w_to_input(ki, jj, pad_l));
+                        ifm2, into<int>(filter_w_to_input(ki, jj, pad_l)));
                 movss(Xmm(oc_blocks * ur_w + jj + 1),
                         ptr[aux_reg_input + inp_off]);
                 shufps(Xmm(oc_blocks * ur_w + jj + 1),
@@ -114,7 +114,7 @@ void jit_sse41_conv_fwd_kernel_f32_t::oh_step_nopad(
         for (int ifm2 = 0; ifm2 < ic_blk; ifm2++) {
             for (int jj = jj_start; jj < jj_end; jj++) {
                 size_t inp_off = get_input_offset(
-                        ifm2, filter_w_to_input(0, jj, pad_l));
+                        ifm2, into<int>(filter_w_to_input(0, jj, pad_l)));
                 movss(Xmm(oc_blocks * ur_w + jj + 1),
                         ptr[aux_reg_input + inp_off]);
                 shufps(Xmm(oc_blocks * ur_w + jj + 1),
@@ -130,8 +130,10 @@ void jit_sse41_conv_fwd_kernel_f32_t::oh_step_nopad(
                 }
             }
         }
-        add(aux_reg_kernel, get_kernel_offset(0, 1, 0));
-        add(aux_reg_input, get_input_offset(0, filter_w_to_input(1)));
+        add(aux_reg_kernel, into<uint32_t>(get_kernel_offset(0, 1, 0)));
+        add(aux_reg_input,
+                into<uint32_t>(
+                        get_input_offset(0, into<int>(filter_w_to_input(1)))));
 
         inc(ki_iter);
         cmp(ki_iter, kw);
@@ -247,12 +249,18 @@ void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
     {
         if (jcp.kw >= 5 && pad_l == 0 && pad_r == 0) {
             oh_step_nopad(ur_w, pad_l, pad_r, oc_blocks);
-            sub(aux_reg_input, get_input_offset(0, filter_w_to_input(kw)));
-            add(aux_reg_input, get_input_offset(0, filter_h_to_input(1)));
+            sub(aux_reg_input,
+                    into<uint32_t>(get_input_offset(
+                            0, into<int>(filter_w_to_input(kw)))));
+            add(aux_reg_input,
+                    into<uint32_t>(get_input_offset(
+                            0, into<int>(filter_h_to_input(1)))));
         } else {
             oh_step_unroll_kw(ur_w, pad_l, pad_r, oc_blocks);
-            add(aux_reg_kernel, get_kernel_offset(0, kw, 0));
-            add(aux_reg_input, get_input_offset(0, filter_h_to_input(1)));
+            add(aux_reg_kernel, into<uint32_t>(get_kernel_offset(0, kw, 0)));
+            add(aux_reg_input,
+                    into<uint32_t>(get_input_offset(
+                            0, into<int>(filter_h_to_input(1)))));
         }
 
         dec(kj);
@@ -312,8 +320,10 @@ inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
             width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
         else
             width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
-        add(reg_output, get_output_offset(0, ur_w));
+        add(reg_input,
+                into<uint32_t>(get_input_offset(
+                        0, into<int>(filter_w_to_input(0, ur_w, l_pad)))));
+        add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
     }
 
     Label ow_loop;
@@ -323,8 +333,10 @@ inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
         L(ow_loop);
 
         width_blk_step(ur_w, 0, 0, oc_blocks); // "middle"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w)));
-        add(reg_output, get_output_offset(0, ur_w));
+        add(reg_input,
+                into<uint32_t>(get_input_offset(
+                        0, into<int>(filter_w_to_input(0, ur_w)))));
+        add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
 
         inc(oi_iter);
         cmp(oi_iter, n_oi);
@@ -333,8 +345,10 @@ inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
 
     if (r_pad1 > 0 && n_oi >= 0) {
         width_blk_step(ur_w, 0, r_pad1, oc_blocks); // "rpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w)));
-        add(reg_output, get_output_offset(0, ur_w));
+        add(reg_input,
+                into<uint32_t>(get_input_offset(
+                        0, into<int>(filter_w_to_input(0, ur_w)))));
+        add(reg_output, into<uint32_t>(get_output_offset(0, ur_w)));
     }
 
     if (ur_w_tail != 0)
@@ -396,28 +410,28 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     const int ndims = src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
 
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kh = into<int>((ndims == 3) ? 1 : weights_d.dims()[with_groups + 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][0]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[0];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[0]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[0];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_h = into<int>((ndims == 3) ? 0 : cd.dilates[0]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_sse41_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_convolution.cpp
@@ -76,13 +76,13 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     oh, jcp.oh);
             for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
+                int ocb = into<int>(ocbb * jcp.nb_oc_blocking);
                 int ocb_num = jcp.nb_oc_blocking;
 
                 for (int icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
+                    const int ij = into<int>(oh * jcp.stride_h);
                     const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
                     const int i_b_overflow
                             = nstl::max(jcp.ih,

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -39,9 +39,9 @@ struct jit_trans_iw_ic_t : public jit_trans_src_t, public jit_generator_t {
     jit_trans_iw_ic_t(const jit_conv_conf_t *conf)
         : jit_trans_src_t(conf)
         , jit_generator_t(jit_name())
-        , typesize(conf->src_dt == data_type::undef
+        , typesize(into<int>(conf->src_dt == data_type::undef
                           ? 2
-                          : types::data_type_size(conf->src_dt))
+                          : types::data_type_size(conf->src_dt)))
         , is_layout_nxc(utils::one_of(conf_->src_tag, format_tag::ndhwc,
                   format_tag::nhwc, format_tag::nwc)) {}
 
@@ -649,19 +649,20 @@ void jit_trans_iw_ic_t::generate() {
         if (str_w > 1) {
             int tr_src_shift = s;
             int src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
-            add(reg_src, src_shift * src_mult * typesize);
+            add(reg_src, into<uint32_t>(src_shift * src_mult * typesize));
             add(reg_tr_src, tr_src_shift * tr_iw_s * typesize);
-            add(reg_src_prf, src_shift * src_mult * typesize);
+            add(reg_src_prf, into<uint32_t>(src_shift * src_mult * typesize));
             add(reg_tr_src_prf, tr_src_shift * tr_iw_s * typesize);
         }
 
         if (left_pad > 0 && loop_iters > 0) {
             loop_iters--;
             transpose(transpose_size, left_pad, 0, nontemporal_stores);
-            add(reg_src, src_step);
-            add(reg_tr_src, tr_src_step + left_pad * typesize);
-            add(reg_src_prf, src_step);
-            add(reg_tr_src_prf, tr_src_step + left_pad * typesize);
+            add(reg_src, into<uint32_t>(src_step));
+            add(reg_tr_src, into<uint32_t>(tr_src_step + left_pad * typesize));
+            add(reg_src_prf, into<uint32_t>(src_step));
+            add(reg_tr_src_prf,
+                    into<uint32_t>(tr_src_step + left_pad * typesize));
         }
 
         if (loop_iters) {
@@ -670,10 +671,10 @@ void jit_trans_iw_ic_t::generate() {
             L(loop);
             {
                 transpose(transpose_size, 0, 0, nontemporal_stores);
-                add(reg_src, src_step);
-                add(reg_tr_src, tr_src_step);
-                add(reg_src_prf, src_step);
-                add(reg_tr_src_prf, tr_src_step);
+                add(reg_src, into<uint32_t>(src_step));
+                add(reg_tr_src, into<uint32_t>(tr_src_step));
+                add(reg_src_prf, into<uint32_t>(src_step));
+                add(reg_tr_src_prf, into<uint32_t>(tr_src_step));
                 sub(reg_loop, 1);
                 jnz(loop);
             }
@@ -691,14 +692,14 @@ struct jit_trans_ow_oc_t : public jit_trans_dst_t, public jit_generator_t {
     jit_trans_ow_oc_t(const jit_conv_conf_t *conf)
         : jit_trans_dst_t(conf)
         , jit_generator_t(jit_name())
-        , typesize(conf->dst_dt == data_type::undef
+        , typesize(into<int>(conf->dst_dt == data_type::undef
                           ? 2
-                          : types::data_type_size(conf->dst_dt))
+                          : types::data_type_size(conf->dst_dt)))
         , is_layout_nxc(utils::one_of(conf_->dst_tag, format_tag::ndhwc,
                   format_tag::nhwc, format_tag::nwc))
-        , vnni_block(conf->dst_dt == data_type::undef
+        , vnni_block(into<int>(conf->dst_dt == data_type::undef
                           ? 2
-                          : data_type_vnni_granularity(conf->dst_dt)) {}
+                          : data_type_vnni_granularity(conf->dst_dt))) {}
 
     void operator()(const ctx_t *ctx) override {
         jit_generator_t::operator()(ctx);
@@ -1037,9 +1038,9 @@ void jit_trans_ow_oc_t::generate() {
         L(loop);
         {
             transpose(transpose_size, nontemporal_stores);
-            add(reg_src, src_step);
-            add(reg_tr_src, tr_src_step);
-            add(reg_src_prf, src_step);
+            add(reg_src, into<uint32_t>(src_step));
+            add(reg_tr_src, into<uint32_t>(tr_src_step));
+            add(reg_src_prf, into<uint32_t>(src_step));
             sub(reg_loop, 1);
             jnz(loop);
         }
@@ -1051,7 +1052,9 @@ void jit_trans_ow_oc_t::generate() {
         const auto zero_tail = zero_tr_ow - zero_loop_iters * transpose_size;
 
         // shift over tail
-        add(reg_tr_src, (size_t)oc_block * rnd_up(tail, vnni_block) * typesize);
+        add(reg_tr_src,
+                into<uint32_t>((size_t)oc_block * rnd_up(tail, vnni_block)
+                        * typesize));
 
         // zero the tr_ow - ow
         if (zero_loop_iters) {
@@ -1060,7 +1063,7 @@ void jit_trans_ow_oc_t::generate() {
             L(zero_loop);
             {
                 transpose(transpose_size, nontemporal_stores, false);
-                add(reg_tr_src, tr_src_step);
+                add(reg_tr_src, into<uint32_t>(tr_src_step));
                 sub(reg_loop, 1);
                 jnz(zero_loop);
             }
@@ -1136,7 +1139,8 @@ void jit_transpose4x16_src_t::transpose(int nrows) {
     }
 
     for (size_t i = nrows; i < 4; i++) {
-        vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
+        vpxord(src_zmm(into<int>(i)), src_zmm(into<int>(i)),
+                src_zmm(into<int>(i)));
     }
 
     vmovupd(tmp0, src0);
@@ -1201,7 +1205,7 @@ void jit_transpose4x16_src_t::generate() {
     preamble();
 
     const int ic_block = params->ic_block;
-    const int is = params->is;
+    const int is = into<int>(params->is);
     int tail = is % transpose_size;
 
     src_stride = ic_block * typesize;
@@ -1275,7 +1279,7 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     /* Reorder part of F32 weights tensor
        from [VNNI_GRANULARITY][I][kd][kh][kw][16i][16o] to VNNI format [kd][kh][kw][16i][16o][VNNI_GRANULARITY][i]
        and down-convert it to required float. */
-    const int ts_out = types::data_type_size(out_dt_);
+    const dim_t ts_out = types::data_type_size(out_dt_);
     const int ts_inp = 4;
     const int simd_w = 16;
 
@@ -1316,7 +1320,7 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     auto get_zmm_src = [&](int idx, int ic) { return Zmm(4 * idx + ic); };
     auto get_zmm_bf16 = [&](int ic) { return Zmm(16 + ic); };
 
-    const int vnni_granularity = data_type_vnni_granularity(out_dt_);
+    const int vnni_granularity = into<int>(data_type_vnni_granularity(out_dt_));
 
     Xbyak::Label prm_table, zero_buffer;
     Xbyak::Label kd_loop_label, kh_loop_label;
@@ -1477,10 +1481,10 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
         L(prm_table);
         uint8_t prm_array[64];
         for (size_t i = 0; i < 16; i++) {
-            prm_array[4 * i] = i;
-            prm_array[4 * i + 1] = i + 16;
-            prm_array[4 * i + 2] = i + 32;
-            prm_array[4 * i + 3] = i + 48;
+            prm_array[4 * i] = into<uint8_t>(i);
+            prm_array[4 * i + 1] = into<uint8_t>(i + 16);
+            prm_array[4 * i + 2] = into<uint8_t>(i + 32);
+            prm_array[4 * i + 3] = into<uint8_t>(i + 48);
         }
 
         for (size_t i = 0; i < 64; ++i)

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -87,7 +87,7 @@ inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
     if (ndims == 4) self->rtus_.conv_d_.strides[1] = 1;
     utils::array_set(self->rtus_.conv_d_.padding[0], 0, 2);
     if (ndims == 4) utils::array_set(self->rtus_.conv_d_.padding[1], 0, 2);
-    const int ic = src_d->dims[1];
+    const int ic = into<int>(src_d->dims[1]);
     if (self->desc()->prop_kind == prop_kind::backward_data) {
         data_type_t data_type = self->rtus_.conv_d_.diff_src_desc.data_type;
         src_d = &(self->rtus_.conv_d_.diff_src_desc = *dst_d);
@@ -235,7 +235,7 @@ struct rtus_driver_t : public jit_generator_t {
         vlen_ = reg_v.getBit() / 8;
         vlen_shift_ = 0;
 
-        int tvlen = is_nspc_ ? typesize_ : vlen_;
+        int tvlen = into<int>(is_nspc_ ? typesize_ : vlen_);
         while (tvlen > 1) {
             tvlen /= 2;
             vlen_shift_++;
@@ -391,23 +391,24 @@ struct rtus_driver_t : public jit_generator_t {
 
             L(ic_loop);
             {
-                cmp(reg_cur_icb, load_store_size);
+                cmp(reg_cur_icb, into<uint32_t>(load_store_size));
                 jl(ic_loop_tail, T_NEAR);
 
                 if (src_to_ws_) {
-                    load_reg(reg_v, reg_cur_src, 0, load_store_size);
-                    store_reg(reg_ws, reg_v, 0, load_store_size);
+                    load_reg(reg_v, reg_cur_src, 0, into<int>(load_store_size));
+                    store_reg(reg_ws, reg_v, 0, into<int>(load_store_size));
                 } else {
-                    load_reg(reg_v, reg_ws, 0, load_store_size);
-                    store_reg(reg_cur_src, reg_v, 0, load_store_size);
+                    load_reg(reg_v, reg_ws, 0, into<int>(load_store_size));
+                    store_reg(
+                            reg_cur_src, reg_v, 0, into<int>(load_store_size));
                     for (int w = 1; w < stride_w_; ++w)
                         store_reg(reg_cur_src, reg_zero, w * w_step_factor,
-                                load_store_size);
+                                into<int>(load_store_size));
                 }
-                add(reg_ws, load_store_size);
-                add(reg_cur_src, load_store_size);
+                add(reg_ws, into<uint32_t>(load_store_size));
+                add(reg_cur_src, into<uint32_t>(load_store_size));
 
-                sub(reg_cur_icb, load_store_size);
+                sub(reg_cur_icb, into<uint32_t>(load_store_size));
                 jmp(ic_loop, T_NEAR);
             }
 
@@ -418,23 +419,24 @@ struct rtus_driver_t : public jit_generator_t {
 
                 if (src_to_ws_) {
                     load_reg(reg_v | tail_mask, reg_cur_src, 0,
-                            load_store_tail_size);
-                    store_reg(
-                            reg_ws, reg_v | tail_mask, 0, load_store_tail_size);
+                            into<int>(load_store_tail_size));
+                    store_reg(reg_ws, reg_v | tail_mask, 0,
+                            into<int>(load_store_tail_size));
                 } else {
-                    load_reg(
-                            reg_v | tail_mask, reg_ws, 0, load_store_tail_size);
+                    load_reg(reg_v | tail_mask, reg_ws, 0,
+                            into<int>(load_store_tail_size));
                     store_reg(reg_cur_src, reg_v | tail_mask, 0,
-                            load_store_tail_size);
+                            into<int>(load_store_tail_size));
                     for (int w = 1; w < stride_w_; ++w)
                         store_reg(reg_cur_src, reg_zero | tail_mask,
-                                w * w_step_factor, load_store_tail_size);
+                                w * w_step_factor,
+                                into<int>(load_store_tail_size));
                 }
             }
             L(ic_loop_finish);
 
-            add(reg_ws_copy, w_step_factor);
-            add(reg_src, stride_w_ * w_step_factor);
+            add(reg_ws_copy, into<uint32_t>(w_step_factor));
+            add(reg_src, into<uint32_t>(stride_w_ * w_step_factor));
 
             // for 1d or stride_h=1 convolutions the loop over h should be skipped
             const bool skip_oh_step = src_step_h_ == iw_;
@@ -446,25 +448,29 @@ struct rtus_driver_t : public jit_generator_t {
                 jl(skip_h_step, T_NEAR);
 
                 if (src_to_ws_) {
-                    add(reg_src, (src_step_h_ - iw_) * w_step_factor);
+                    add(reg_src,
+                            into<uint32_t>(
+                                    (src_step_h_ - iw_) * w_step_factor));
                 } else {
                     mov(reg_cur_src_fin, reg_cur_src);
-                    add(reg_cur_src_fin, (src_step_h_ - iw_) * w_step_factor);
+                    add(reg_cur_src_fin,
+                            into<uint32_t>(
+                                    (src_step_h_ - iw_) * w_step_factor));
                     Label ih_loop_nhwc, ic_ih_loop_nhwc, ic_tail_ih_loop_nhwc,
                             ic_finish_ih_loop_nhwc;
                     L(ih_loop_nhwc);
                     mov(reg_cur_src, reg_src);
                     mov(reg_cur_icb, reg_icb);
                     L(ic_ih_loop_nhwc);
-                    cmp(reg_cur_icb, load_store_size);
+                    cmp(reg_cur_icb, into<uint32_t>(load_store_size));
                     jl(ic_tail_ih_loop_nhwc, T_NEAR);
 
                     for (int w = 0; w < stride_w_; ++w)
                         store_reg(reg_cur_src, reg_zero, w * w_step_factor,
-                                load_store_size);
+                                into<int>(load_store_size));
 
-                    add(reg_cur_src, load_store_size);
-                    sub(reg_cur_icb, load_store_size);
+                    add(reg_cur_src, into<uint32_t>(load_store_size));
+                    sub(reg_cur_icb, into<uint32_t>(load_store_size));
                     jnz(ic_ih_loop_nhwc, T_NEAR);
 
                     L(ic_tail_ih_loop_nhwc);
@@ -473,11 +479,12 @@ struct rtus_driver_t : public jit_generator_t {
 
                     for (int w = 0; w < stride_w_; ++w)
                         store_reg(reg_cur_src, reg_zero | tail_mask,
-                                w * w_step_factor, load_store_tail_size);
+                                w * w_step_factor,
+                                into<int>(load_store_tail_size));
 
                     L(ic_finish_ih_loop_nhwc);
 
-                    add(reg_src, stride_w_ * w_step_factor);
+                    add(reg_src, into<uint32_t>(stride_w_ * w_step_factor));
                     cmp(reg_src, reg_cur_src_fin);
                     jl(ih_loop_nhwc, T_NEAR);
                 }
@@ -551,22 +558,22 @@ inline status_t init_rtus_driver(conv_t *self) {
 
     const auto &cd = *conf.desc();
     const int ndims = conf.ndims();
-    const int stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
-    const int stride_w = cd.strides[ndims - 3];
+    const int stride_h = into<int>((conf.ndims() == 3) ? 1 : cd.strides[0]);
+    const int stride_w = into<int>(cd.strides[ndims - 3]);
 
     const bool is_bwd_data = cd.prop_kind == prop_kind::backward_data;
     const auto &src_d = is_bwd_data ? *conf.diff_src_md() : *conf.src_md();
 
-    const int ih = ndims == 3 ? 1 : src_d.dims[2];
-    const int iw = src_d.dims[ndims - 1];
-    const int ic = src_d.dims[1];
+    const int ih = into<int>(ndims == 3 ? 1 : src_d.dims[2]);
+    const int iw = into<int>(src_d.dims[ndims - 1]);
+    const int ic = into<int>(src_d.dims[1]);
 
     const auto src_tag = memory_desc_wrapper(src_d).matches_one_of_tag(
             format_tag::nhwc, format_tag::nwc);
     const bool is_nspc = src_tag != format_tag::undef;
     const int src_step_h = stride_h * iw;
     const int src_step_icb = !is_nspc ? ih * iw : 1;
-    const int ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
+    const int ws_step_icb = into<int>(!is_nspc ? conf.jcp_.is : 1);
     const bool src_to_ws = !is_bwd_data;
     const size_t typesize
             = types::data_type_size(self->pd()->invariant_src_md()->data_type);

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -767,8 +767,8 @@ struct jit_bnorm_t : public jit_generator_t {
                     size_t base_reg = i % regs;
                     body(base_reg, i);
                 }
-                add(reg_soff, factor * spat_step);
-                sub(reg_ctr, factor);
+                add(reg_soff, into<uint32_t>(factor * spat_step));
+                sub(reg_ctr, into<uint32_t>(factor));
                 jnz(label);
             }
             if (jbp_->is_spatial_thr_) {
@@ -780,7 +780,7 @@ struct jit_bnorm_t : public jit_generator_t {
             size_t base_reg = i % regs;
             body(base_reg, i);
         }
-        if (loop_tail) add(reg_soff, loop_tail * spat_step);
+        if (loop_tail) add(reg_soff, into<uint32_t>(loop_tail * spat_step));
 
         for (size_t i = 0; i < num_active_regs; i++)
             fini(i);
@@ -793,17 +793,17 @@ struct jit_bnorm_t : public jit_generator_t {
             uni_vmovups(Vmm(0), vmmword[reg_rbuf1 + reg_coff]);
             spat_loop(spat_size, unroll_blocks, unroll_regs,
                     [this](size_t base_reg) {
-                Vmm v = Vmm(base_reg * 2);
+                Vmm v = Vmm(into<int>(base_reg * 2));
                 if (base_reg) uni_vpxor(v, v, v);
             }, [this](size_t base_reg, size_t i) {
-                Vmm v0 = Vmm(base_reg * 2 + 0);
-                Vmm v1 = Vmm(base_reg * 2 + 1);
+                Vmm v0 = Vmm(into<int>(base_reg * 2 + 0));
+                Vmm v1 = Vmm(into<int>(base_reg * 2 + 1));
                 size_t offt = i * vlen_spat_data_;
                 uni_vmovups_spat_data(v1, vmmword[reg_src + reg_soff + offt]);
                 uni_vaddps(v0, v0, v1);
             }, [this](size_t base_reg) {
                 Vmm b = Vmm(0);
-                Vmm v = Vmm(base_reg * 2);
+                Vmm v = Vmm(into<int>(base_reg * 2));
                 if (base_reg) uni_vaddps(b, b, v);
             });
             uni_vmovups(vmmword[reg_rbuf1 + reg_coff], Vmm(0));
@@ -836,7 +836,7 @@ struct jit_bnorm_t : public jit_generator_t {
                     if (!is_ch_blks_tail)
                         uni_vaddps(Vmm(ch_idx + 1), Vmm(ch_idx + 1), vsrc_odd);
                 }
-                add(reg_soff_nspc, spat_step);
+                add(reg_soff_nspc, into<uint32_t>(spat_step));
             }
         };
 
@@ -863,7 +863,7 @@ struct jit_bnorm_t : public jit_generator_t {
                         uni_vfmadd231ps(Vmm(ch_idx + 1), vsrc_odd, vsrc_odd);
                     }
                 }
-                add(reg_soff_nspc, spat_step);
+                add(reg_soff_nspc, into<uint32_t>(spat_step));
             }
         };
 
@@ -876,7 +876,7 @@ struct jit_bnorm_t : public jit_generator_t {
                             vsrc, vmmword[reg_src + reg_soff_nspc + offt]);
                     uni_vaddps(Vmm(ch_idx), Vmm(ch_idx), vsrc);
                 }
-                add(reg_soff_nspc, spat_step);
+                add(reg_soff_nspc, into<uint32_t>(spat_step));
             }
         };
 
@@ -891,7 +891,7 @@ struct jit_bnorm_t : public jit_generator_t {
                     uni_vsubps(vsrc, vsrc, vmean_ch);
                     uni_vfmadd231ps(Vmm(ch_idx), vsrc, vsrc);
                 }
-                add(reg_soff_nspc, spat_step);
+                add(reg_soff_nspc, into<uint32_t>(spat_step));
             }
         };
 
@@ -914,7 +914,8 @@ struct jit_bnorm_t : public jit_generator_t {
             num_spat_pts = 1;
         } else {
             mov(reg_ctr, spat_size);
-            num_spat_pts = nstl::min((size_t)num_spat_pts, spat_size);
+            num_spat_pts
+                    = into<int>(nstl::min((size_t)num_spat_pts, spat_size));
             // TODO: unroll by spatial
             if (spat_size % num_spat_pts != 0) num_spat_pts = 1;
         }
@@ -1065,7 +1066,7 @@ struct jit_bnorm_t : public jit_generator_t {
                             vmmword[reg_dst + reg_soff_nspc + offt], vdata,
                             stream_store_allowed);
                 }
-                add(reg_soff_nspc, spat_step);
+                add(reg_soff_nspc, into<uint32_t>(spat_step));
                 sub(reg_ctr, num_spat_pts);
                 jnz(spatial, T_NEAR);
             }
@@ -1130,12 +1131,12 @@ struct jit_bnorm_t : public jit_generator_t {
             uni_vmovups(Vmm(0), vmmword[reg_rbuf1 + reg_coff]);
             spat_loop(spat_size, unroll_blocks, unroll_regs,
                     [this](size_t base_reg) {
-                Vmm v = Vmm(base_reg * 3);
+                Vmm v = Vmm(into<int>(base_reg * 3));
                 if (base_reg > 0) uni_vpxor(v, v, v);
             }, [this](size_t base_reg, size_t i) {
-                Vmm v = Vmm(3 * base_reg);
-                Vmm vtmp0 = Vmm(3 * base_reg + 1);
-                Vmm vtmp1 = Vmm(3 * base_reg + 2);
+                Vmm v = Vmm(into<int>(3 * base_reg));
+                Vmm vtmp0 = Vmm(into<int>(3 * base_reg + 1));
+                Vmm vtmp1 = Vmm(into<int>(3 * base_reg + 2));
                 size_t offt = i * vlen_spat_data_;
                 uni_vmovups_spat_data(
                         vtmp0, vmmword[reg_src + reg_soff + offt]);
@@ -1148,7 +1149,7 @@ struct jit_bnorm_t : public jit_generator_t {
                 uni_vfmadd231ps(v, vtmp1, vtmp1);
             }, [this](size_t base_reg) {
                 Vmm b = Vmm(0);
-                Vmm v = Vmm(base_reg * 3);
+                Vmm v = Vmm(into<int>(base_reg * 3));
                 if (base_reg) uni_vaddps(b, b, v);
             });
             uni_vmovups(vmmword[reg_rbuf1 + reg_coff], Vmm(0));
@@ -1195,8 +1196,8 @@ struct jit_bnorm_t : public jit_generator_t {
             // Process next image
             if (jbp_->is_nspc_) {
                 // Can use static offset since we comeback after spatial loop
-                add(reg_src, mb_offt);
-                add(reg_soff, mb_offt);
+                add(reg_src, into<uint32_t>(mb_offt));
+                add(reg_soff, into<uint32_t>(mb_offt));
             } else {
                 add(reg_soff, reg_mb_stride_Bc);
             }
@@ -1266,8 +1267,8 @@ struct jit_bnorm_t : public jit_generator_t {
             // Process next image
             if (jbp_->is_nspc_) {
                 // Can use static offset since we comeback after spatial loop
-                add(reg_src, mb_offt);
-                add(reg_soff, mb_offt);
+                add(reg_src, into<uint32_t>(mb_offt));
+                add(reg_soff, into<uint32_t>(mb_offt));
             } else {
                 add(reg_soff, reg_mb_stride_Bc);
             }
@@ -1343,7 +1344,7 @@ struct jit_bnorm_t : public jit_generator_t {
 
             const auto spat_loop_body = [this](size_t base_reg, size_t i,
                                                 bool stream_store_allowed) {
-                const Vmm v = Vmm(base_reg);
+                const Vmm v = Vmm(into<int>(base_reg));
                 const size_t offt = i * vlen_spat_data_;
                 uni_vmovups_spat_data(v, vmmword[reg_src + reg_soff + offt]);
                 uni_vsubps(v, v, vmean);
@@ -1366,9 +1367,9 @@ struct jit_bnorm_t : public jit_generator_t {
                         uni_vmaxps(v, v, vzero);
                 } else if (with_relu) { // --flags=R
                     if (isa == avx512_core)
-                        fwd_process_relu_avx512_common(v, offt);
+                        fwd_process_relu_avx512_common(v, into<int>(offt));
                     else
-                        fwd_process_relu_avx2(v, offt);
+                        fwd_process_relu_avx2(v, into<int>(offt));
                 }
                 if (stream_store_allowed) {
                     uni_vmovntps(vmmword[reg_dst + reg_soff + offt], v);
@@ -1482,10 +1483,10 @@ struct jit_bnorm_t : public jit_generator_t {
             // Process next image
             if (jbp_->is_nspc_) {
                 // Can use static offset since we comeback after spatial loop
-                add(reg_src, mb_offt);
-                add(reg_dst, mb_offt);
-                add(reg_soff, mb_offt);
-                add(reg_ws, ws_mb_offt);
+                add(reg_src, into<uint32_t>(mb_offt));
+                add(reg_dst, into<uint32_t>(mb_offt));
+                add(reg_soff, into<uint32_t>(mb_offt));
+                add(reg_ws, into<uint32_t>(ws_mb_offt));
             } else {
                 add(reg_soff, reg_mb_stride_Bc);
             }
@@ -1512,26 +1513,26 @@ struct jit_bnorm_t : public jit_generator_t {
             spat_loop(spat_size, 1, 1, [this](size_t base_reg) {
                 if (base_reg > 0) {
                     for (int i = 0; i < 2; i++) {
-                        Vmm v(base_reg * 5 + i);
+                        Vmm v(into<int>(base_reg * 5 + i));
                         uni_vpxor(v, v, v);
                     }
                 }
             }, [this](size_t base_reg, size_t i) {
                 // TODO: use single set of tmp regs and let ROB handle the rest
-                Vmm o0 = Vmm(base_reg * 5 + 0);
-                Vmm o1 = Vmm(base_reg * 5 + 1);
-                Vmm t1 = Vmm(base_reg * 5 + 2);
-                Vmm t2 = Vmm(base_reg * 5 + 3);
-                Vmm t3 = Vmm(base_reg * 5 + 4);
+                Vmm o0 = Vmm(into<int>(base_reg * 5 + 0));
+                Vmm o1 = Vmm(into<int>(base_reg * 5 + 1));
+                Vmm t1 = Vmm(into<int>(base_reg * 5 + 2));
+                Vmm t2 = Vmm(into<int>(base_reg * 5 + 3));
+                Vmm t3 = Vmm(into<int>(base_reg * 5 + 4));
                 size_t offt = i * vlen_spat_data_;
                 uni_vmovups_spat_data(t1, vmmword[reg_src + reg_soff + offt]);
                 uni_vmovups_spat_data(
                         t2, vmmword[reg_diff_dst + reg_soff + offt]);
                 if (with_relu) {
                     if (isa == avx512_core)
-                        bwd_process_relu_avx512_common(t2, offt);
+                        bwd_process_relu_avx512_common(t2, into<int>(offt));
                     else if (isa == avx2)
-                        bwd_process_relu_avx2(t2, offt);
+                        bwd_process_relu_avx2(t2, into<int>(offt));
                     else
                         assert(false);
                 }
@@ -1547,8 +1548,8 @@ struct jit_bnorm_t : public jit_generator_t {
                 Vmm b0 = Vmm(0);
                 Vmm b1 = Vmm(1);
                 if (base_reg) {
-                    uni_vaddps(b0, b0, Vmm(base_reg * 5 + 0));
-                    uni_vaddps(b1, b1, Vmm(base_reg * 5 + 1));
+                    uni_vaddps(b0, b0, Vmm(into<int>(base_reg * 5 + 0)));
+                    uni_vaddps(b1, b1, Vmm(into<int>(base_reg * 5 + 1)));
                 }
             });
             uni_vmovups(vmmword[reg_rbuf1 + reg_coff], Vmm(0));
@@ -1609,7 +1610,7 @@ struct jit_bnorm_t : public jit_generator_t {
                 uni_vfmadd231ps(vdiff_gamma_ch, vsrc, vdiff_dst);
                 uni_vaddps(vdiff_beta_ch, vdiff_beta_ch, vdiff_dst);
             }
-            add(reg_soff_nspc, spat_step);
+            add(reg_soff_nspc, into<uint32_t>(spat_step));
             sub(reg_ctr, num_spat_pts);
             jnz(spatial, T_NEAR);
         }
@@ -1691,17 +1692,17 @@ struct jit_bnorm_t : public jit_generator_t {
                     = [](size_t base_reg) { UNUSED(base_reg); };
             const auto spat_loop_body = [this](size_t base_reg, size_t i,
                                                 bool stream_store_allowed) {
-                const Vmm v(base_reg * 2 + 0);
-                const Vmm t(base_reg * 2 + 1);
-                const Vmm t1(base_reg * 2 + 2);
+                const Vmm v(into<int>(base_reg * 2 + 0));
+                const Vmm t(into<int>(base_reg * 2 + 1));
+                const Vmm t1(into<int>(base_reg * 2 + 2));
                 const size_t offt = i * vlen_spat_data_;
                 uni_vmovups_spat_data(
                         v, vmmword[reg_diff_dst + reg_soff + offt]);
                 if (with_relu) {
                     if (isa == avx512_core)
-                        bwd_process_relu_avx512_common(v, offt);
+                        bwd_process_relu_avx512_common(v, into<int>(offt));
                     else if (isa == avx2)
-                        bwd_process_relu_avx2(v, offt);
+                        bwd_process_relu_avx2(v, into<int>(offt));
                     else
                         assert(false);
                 }
@@ -1838,7 +1839,7 @@ struct jit_bnorm_t : public jit_generator_t {
                             vmmword[reg_diff_src + reg_soff_nspc + offt],
                             vdiff_data, stream_store_allowed);
                 }
-                add(reg_soff_nspc, spat_step);
+                add(reg_soff_nspc, into<uint32_t>(spat_step));
                 sub(reg_ctr, num_spat_pts);
                 jnz(spatial, T_NEAR);
             }
@@ -1947,10 +1948,10 @@ struct jit_bnorm_t : public jit_generator_t {
             // Process next image
             if (jbp_->is_nspc_) {
                 // Can use static offset since we comeback after spatial loop
-                add(reg_src, mb_offt);
-                add(reg_diff_dst, mb_offt);
-                add(reg_soff, mb_offt);
-                add(reg_ws, ws_mb_offt);
+                add(reg_src, into<uint32_t>(mb_offt));
+                add(reg_diff_dst, into<uint32_t>(mb_offt));
+                add(reg_soff, into<uint32_t>(mb_offt));
+                add(reg_ws, into<uint32_t>(ws_mb_offt));
             } else {
                 add(reg_soff, reg_mb_stride_Bc);
             }
@@ -2037,11 +2038,12 @@ struct jit_bnorm_t : public jit_generator_t {
             // Process next image
             if (jbp_->is_nspc_) {
                 // Can use static offset since we comeback after spatial loop
-                if (!pd_->use_global_stats()) add(reg_src, mb_offt);
-                add(reg_diff_dst, mb_offt);
-                add(reg_diff_src, mb_offt);
-                add(reg_soff, mb_offt);
-                add(reg_ws, ws_mb_offt);
+                if (!pd_->use_global_stats())
+                    add(reg_src, into<uint32_t>(mb_offt));
+                add(reg_diff_dst, into<uint32_t>(mb_offt));
+                add(reg_diff_src, into<uint32_t>(mb_offt));
+                add(reg_soff, into<uint32_t>(mb_offt));
+                add(reg_ws, into<uint32_t>(ws_mb_offt));
             } else {
                 add(reg_soff, reg_mb_stride_Bc);
             }
@@ -2179,7 +2181,7 @@ struct driver_t : public c_compatible {
         dim_t W = pd_->W();
         dim_t SP = D * H * W;
         dim_t img_size = C_PADDED * SP;
-        const int vlen_spat_data = ker_.spat_step;
+        const dim_t vlen_spat_data = ker_.spat_step;
 
         typename jit_bnorm_t<isa>::call_params_t p;
 
@@ -2218,13 +2220,13 @@ struct driver_t : public c_compatible {
                 p.N_nthr = jbp_.N_nthr_last_iter_ * jbp_.S_nthr_last_iter_;
             }
 
-            global_C_blk_s = jbp_.do_blocking_ ? (C_blk_s == -1)
-                            ? -1
-                            : it * jbp_.C_blks_per_iter_ + C_blk_s
-                                               : C_blk_s;
+            global_C_blk_s = into<int>(jbp_.do_blocking_ ? (C_blk_s == -1)
+                                    ? -1
+                                    : it * jbp_.C_blks_per_iter_ + C_blk_s
+                                                         : C_blk_s);
 
-            int C_blks_thr = C_blk_e - C_blk_s;
-            int N_thr = N_e - N_s;
+            dim_t C_blks_thr = C_blk_e - C_blk_s;
+            dim_t N_thr = N_e - N_s;
 
             if (C_blks_thr == 0 || N_thr == 0) continue;
 
@@ -2290,7 +2292,7 @@ struct driver_t : public c_compatible {
     void init_barriers(const memory_tracking::grantor_t &scratchpad) {
         auto barriers = scratchpad.get<barrier::ctx_64_t>(key_barrier);
         if (barriers) {
-            const int n_barriers = get_c_padded(pd_) / simd_w;
+            const dim_t n_barriers = get_c_padded(pd_) / simd_w;
             for (int i = 0; i < n_barriers; ++i)
                 barrier::ctx_init(&barriers[i]);
         }

--- a/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization_s8.cpp
@@ -286,7 +286,7 @@ struct jit_bnorm_s8_t<avx512_core> : public jit_bnorm_base_t<avx512_core> {
             {
                 if (need_tail) {
                     for (size_t tl = 0; tl < c_tail_; tl++)
-                        vpinsrb(x, x, src_ptr(tl), tl);
+                        vpinsrb(x, x, src_ptr(tl), into<uint8_t>(tl));
                     vpmovsxbd(v, x);
                 } else
                     vpmovsxbd(v, src_ptr());
@@ -305,7 +305,7 @@ struct jit_bnorm_s8_t<avx512_core> : public jit_bnorm_base_t<avx512_core> {
                 if (need_tail) {
                     vpmovsdb(x, v);
                     for (size_t tl = 0; tl < c_tail_; tl++)
-                        vpextrb(dst_ptr(tl), x, tl);
+                        vpextrb(dst_ptr(tl), x, into<uint8_t>(tl));
                 } else
                     vpmovsdb(dst_ptr(), v);
 
@@ -315,9 +315,11 @@ struct jit_bnorm_s8_t<avx512_core> : public jit_bnorm_base_t<avx512_core> {
             }
 
             // reg_tmp checks c_in_xmm_ channels ahead for further tail process
-            add(reg_tmp, sizeof(data_t) * c_in_xmm_);
-            add(reg_channel_offt_1byte, sizeof(data_t) * c_in_xmm_);
-            add(reg_channel_offt_4byte, sizeof(float) * c_in_xmm_);
+            add(reg_tmp, into<uint32_t>(sizeof(data_t) * c_in_xmm_));
+            add(reg_channel_offt_1byte,
+                    into<uint32_t>(sizeof(data_t) * c_in_xmm_));
+            add(reg_channel_offt_4byte,
+                    into<uint32_t>(sizeof(float) * c_in_xmm_));
             cmp(reg_tmp, reg_channel_offt_count);
             jle(c_loop);
         }
@@ -424,9 +426,10 @@ struct jit_bnorm_s8_t<avx2> : public jit_bnorm_base_t<avx2> {
                 if (need_tail) {
                     for (size_t tl = 0; tl < c_tail_; tl++) {
                         if (tl < simd_w_) {
-                            vpinsrb(x0, x0, src_ptr(tl), tl);
+                            vpinsrb(x0, x0, src_ptr(tl), into<uint8_t>(tl));
                         } else {
-                            vpinsrb(x1, x1, src_ptr(tl), tl - simd_w_);
+                            vpinsrb(x1, x1, src_ptr(tl),
+                                    into<uint8_t>(tl - simd_w_));
                         }
                     }
                     vpmovsxbd(v0, x0);
@@ -468,7 +471,7 @@ struct jit_bnorm_s8_t<avx2> : public jit_bnorm_base_t<avx2> {
 
                 if (need_tail) {
                     for (size_t tl = 0; tl < c_tail_; tl++) {
-                        vpextrb(dst_ptr(tl), x0, tl);
+                        vpextrb(dst_ptr(tl), x0, into<uint8_t>(tl));
                     }
                 } else {
                     // due to vpacksswb produces 32 integers in ymm, and top
@@ -482,9 +485,11 @@ struct jit_bnorm_s8_t<avx2> : public jit_bnorm_base_t<avx2> {
             }
 
             // reg_tmp checks c_in_xmm_ channels ahead for further tail process
-            add(reg_tmp, sizeof(data_t) * c_in_xmm_);
-            add(reg_channel_offt_1byte, sizeof(data_t) * c_in_xmm_);
-            add(reg_channel_offt_4byte, sizeof(float) * c_in_xmm_);
+            add(reg_tmp, into<uint32_t>(sizeof(data_t) * c_in_xmm_));
+            add(reg_channel_offt_1byte,
+                    into<uint32_t>(sizeof(data_t) * c_in_xmm_));
+            add(reg_channel_offt_4byte,
+                    into<uint32_t>(sizeof(float) * c_in_xmm_));
             cmp(reg_tmp, reg_channel_offt_count);
             jle(c_loop);
         }
@@ -500,8 +505,10 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
             bool need_tail) override {
         if (need_tail) {
             for (size_t tl = 0; tl < c_tail_ % simd_w_; tl++) {
-                pinsrd(vmean, mean_ptr(offt + tl * sizeof(float)), tl);
-                pinsrd(vsqrtvar, var_ptr(offt + tl * sizeof(float)), tl);
+                pinsrd(vmean, mean_ptr(offt + tl * sizeof(float)),
+                        into<uint8_t>(tl));
+                pinsrd(vsqrtvar, var_ptr(offt + tl * sizeof(float)),
+                        into<uint8_t>(tl));
             }
         } else {
             movups(vmean, mean_ptr(offt));
@@ -512,7 +519,8 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
     void load_scale(const Vmm &vscale, size_t offt, bool need_tail) override {
         if (need_tail) {
             for (size_t tl = 0; tl < c_tail_ % simd_w_; tl++) {
-                pinsrd(vscale, scale_ptr(offt + tl * sizeof(float)), tl);
+                pinsrd(vscale, scale_ptr(offt + tl * sizeof(float)),
+                        into<uint8_t>(tl));
             }
         } else {
             movups(vscale, scale_ptr(offt));
@@ -522,7 +530,8 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
     void load_shift(const Vmm &vshift, size_t offt, bool need_tail) override {
         if (need_tail) {
             for (size_t tl = 0; tl < c_tail_ % simd_w_; tl++) {
-                pinsrd(vshift, shift_ptr(offt + tl * sizeof(float)), tl);
+                pinsrd(vshift, shift_ptr(offt + tl * sizeof(float)),
+                        into<uint8_t>(tl));
             }
         } else {
             movups(vshift, shift_ptr(offt));
@@ -574,9 +583,10 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
                 if (need_tail) {
                     for (size_t tl = 0; tl < copy_range; tl++) {
                         if (tl < simd_w_) {
-                            pinsrb(v0, src_ptr(tl), tl);
+                            pinsrb(v0, src_ptr(tl), into<uint8_t>(tl));
                         } else {
-                            pinsrb(v1, src_ptr(tl), (tl - simd_w_));
+                            pinsrb(v1, src_ptr(tl),
+                                    (into<uint8_t>(tl - simd_w_)));
                         }
                     }
                     pmovsxbd(v0, v0);
@@ -619,7 +629,7 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
                 // into a single vector register and use movups instead
                 // of byte stores.
                 for (size_t tl = 0; tl < copy_range; tl++) {
-                    pextrb(dst_ptr(tl), v0, tl);
+                    pextrb(dst_ptr(tl), v0, into<uint8_t>(tl));
                 }
 
                 add(reg_spat_offt, reg_channel_offt_count);
@@ -628,9 +638,11 @@ struct jit_bnorm_s8_t<sse41> : public jit_bnorm_base_t<sse41> {
             }
 
             // reg_tmp checks c_in_xmm_ channels ahead for further tail process
-            add(reg_tmp, sizeof(data_t) * c_in_xmm_);
-            add(reg_channel_offt_1byte, sizeof(data_t) * c_in_xmm_);
-            add(reg_channel_offt_4byte, sizeof(float) * c_in_xmm_);
+            add(reg_tmp, into<uint32_t>(sizeof(data_t) * c_in_xmm_));
+            add(reg_channel_offt_1byte,
+                    into<uint32_t>(sizeof(data_t) * c_in_xmm_));
+            add(reg_channel_offt_4byte,
+                    into<uint32_t>(sizeof(float) * c_in_xmm_));
             cmp(reg_tmp, reg_channel_offt_count);
             jle(c_loop);
         }

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -213,8 +213,8 @@ status_t jit_uni_binary_t::pd_t::init(engine_t *engine) {
     if (conf_.is_src_different_layouts) {
         const auto &strides0 = src0_md_.blocking_desc().strides;
         const auto &strides1 = src1_md_.blocking_desc().strides;
-        conf_.src1_stride
-                = get_different_layout_stride(strides0, strides1, ndims);
+        conf_.src1_stride = into<int>(
+                get_different_layout_stride(strides0, strides1, ndims));
         conf_.outer_dims
                 = get_outer_dims_product(strides0, src0_md_.dims(), ndims);
     }
@@ -781,12 +781,15 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
-    const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
-            : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int src0_type_size
+            = into<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = into<int>(types::data_type_size(src1_d.data_type()));
+    const int src2_type_size = into<int>(pd()->is_ternary_op()
+                    ? types::data_type_size(src2_d.data_type())
+                    : 0);
+    const int dst_type_size
+            = into<int>(types::data_type_size(dst_d.data_type()));
 
     const auto &conf = pd()->get_conf();
     const bool is_src_different_layouts = conf.is_src_different_layouts;
@@ -796,7 +799,8 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
 
         const dim_t src1_different_layout_stride = conf.src1_stride;
         for (size_t i = 0; i < simd_w; i++)
-            indices[i] = i * src1_different_layout_stride * src1_type_size;
+            indices[i] = into<unsigned>(
+                    i * src1_different_layout_stride * src1_type_size);
 
         const dim_t batch = src0_d.dims()[0];
         const dim_t batch_stride = src1_d.blocking_desc().strides[0];
@@ -902,12 +906,15 @@ void jit_uni_binary_t::execute_bcast_per_batch_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
-    const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
-            : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int src0_type_size
+            = into<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = into<int>(types::data_type_size(src1_d.data_type()));
+    const int src2_type_size = into<int>(pd()->is_ternary_op()
+                    ? types::data_type_size(src2_d.data_type())
+                    : 0);
+    const int dst_type_size
+            = into<int>(types::data_type_size(dst_d.data_type()));
 
     const dim_t MB = src0_d.dims()[0];
     const dim_t nelems0_per_b = src0_d.nelems(true) / MB;
@@ -957,12 +964,15 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
-    const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
-            : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int src0_type_size
+            = into<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = into<int>(types::data_type_size(src1_d.data_type()));
+    const int src2_type_size = into<int>(pd()->is_ternary_op()
+                    ? types::data_type_size(src2_d.data_type())
+                    : 0);
+    const int dst_type_size
+            = into<int>(types::data_type_size(dst_d.data_type()));
 
     const auto ndims = src0_d.ndims();
     const auto &dims = src0_d.dims();
@@ -982,8 +992,8 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
                               : 0);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = into<dim_t>(
+                std::ceil(into<float>(src0_d.padded_dims()[1]) / simd_w));
         // Compute strategy:
         // Each block is individual - parallel over MB and C_blocks safely.
 
@@ -1081,12 +1091,15 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
-    const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
-            : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int src0_type_size
+            = into<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = into<int>(types::data_type_size(src1_d.data_type()));
+    const int src2_type_size = into<int>(pd()->is_ternary_op()
+                    ? types::data_type_size(src2_d.data_type())
+                    : 0);
+    const int dst_type_size
+            = into<int>(types::data_type_size(dst_d.data_type()));
 
     const auto ndims = src0_d.ndims();
     const auto &dims = src0_d.dims();
@@ -1108,8 +1121,8 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
             = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = into<dim_t>(
+                std::ceil(into<float>(src0_d.padded_dims()[1]) / simd_w));
         // Compute strategy:
         // Each line of channels is individual, parallel over MB, C_blocks
         // and spatial (broadcasted and not broadcasted spatial dims

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -163,7 +163,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::apply_postops(int unroll, bool tail) {
         const Vmm vmm_aux = vreg_saturation_ubound_;
         for (int i = 0; i < unroll; i += 2) {
             const bool can_load_two_simdw = unroll - i >= 2;
-            const int offt_base = simd_w_ * i;
+            const int offt_base = into<int>(simd_w_ * i);
             const Vmm vreg_tmp_even_src0 = Vmm(i + vmm_start_idx_);
             const Vmm vreg_tmp_odd_src0 = Vmm(i + 1 + vmm_start_idx_);
             if (can_load_two_simdw) {
@@ -190,7 +190,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::apply_postops(int unroll, bool tail) {
 
     const auto sum_injector = [&]() {
         for (int i = 0; i < unroll; i++) {
-            const int offt = simd_w_ * i;
+            const int offt = into<int>(simd_w_ * i);
             const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
             const Vmm vreg_tmp = conf_.is_src_different_layouts
                     ? vmm_gathered_src_
@@ -281,8 +281,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::load_kernel_params() {
 template <cpu_isa_t isa, typename Vmm>
 Address jit_uni_binary_kernel_t<isa, Vmm>::src0_ptr(size_t offt) {
     const auto src0_type_size = types::data_type_size(conf_.src0_type);
-    return vmmword[reg_src0_ + reg_offt_src0_ * src0_type_size
-            + offt * src0_type_size];
+    return vmmword[reg_src0_ + reg_offt_src0_ * into<int>(src0_type_size)
+            + into<int>(offt * src0_type_size)];
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -293,15 +293,16 @@ Address jit_uni_binary_kernel_t<isa, Vmm>::src1_ptr(size_t offt) {
 template <cpu_isa_t isa, typename Vmm>
 Address jit_uni_binary_kernel_t<isa, Vmm>::src2_ptr(size_t offt) {
     const auto src2_type_size = types::data_type_size(conf_.src2_type);
-    return vmmword[reg_src2_ + reg_offt_src0_ * src2_type_size
-            + offt * src2_type_size];
+    return vmmword[reg_src2_ + reg_offt_src0_ * into<int>(src2_type_size)
+            + into<int>(offt * src2_type_size)];
 }
 
 template <cpu_isa_t isa, typename Vmm>
 Address jit_uni_binary_kernel_t<isa, Vmm>::dst_ptr(size_t offt) {
     const auto src0_type_size = types::data_type_size(conf_.src0_type);
-    const auto &reg_offt_dst
-            = conf_.is_i8 ? reg_offt_dst_ : (reg_offt_src0_ * src0_type_size);
+    const auto &reg_offt_dst = conf_.is_i8
+            ? reg_offt_dst_
+            : (reg_offt_src0_ * into<int>(src0_type_size));
     return vmmword[reg_dst_ + reg_offt_dst + offt];
 }
 
@@ -347,7 +348,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::perform_op(
     else if (cmp_op) {
         const unsigned int predicate = cmp_predicate(alg);
         if (is_avx512) {
-            vcmpps(cmp_mask, v0, v1, predicate);
+            vcmpps(cmp_mask, v0, v1, into<uint8_t>(predicate));
             vmovups(v0 | cmp_mask | T_z, vreg_one_);
         } else {
             uni_vcmpps(v0, v0, v1, predicate);
@@ -444,11 +445,11 @@ void jit_uni_binary_kernel_t<isa, Vmm>::load_src1(
         // use reg_src1_ directly, without offset stored in second
         // register
         add(reg_src1_,
-                types::data_type_size(conf_.src1_type) * conf_.src1_stride
-                        * simd_w_);
+                into<uint32_t>(types::data_type_size(conf_.src1_type)
+                        * conf_.src1_stride * simd_w_));
         sub(reg_reverse_src1_stride_range_,
-                types::data_type_size(conf_.src1_type) * conf_.src1_stride
-                        * simd_w_);
+                into<uint32_t>(types::data_type_size(conf_.src1_type)
+                        * conf_.src1_stride * simd_w_));
 
         Label src1_stride_range_not_exceed, src1_C_tail_end;
 
@@ -456,7 +457,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::load_src1(
         jg(src1_stride_range_not_exceed, T_NEAR);
         {
             pop(reg_src1_);
-            add(reg_src1_, types::data_type_size(conf_.src1_type));
+            add(reg_src1_,
+                    into<uint32_t>(types::data_type_size(conf_.src1_type)));
             push(reg_src1_);
             mov(reg_reverse_src1_stride_range_, reg_src1_stride_range_);
         }
@@ -471,7 +473,7 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_kernel_t<isa, Vmm>::store(int unroll, bool tail) {
     for (int i = 0; i < unroll; i++) {
         const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
-        const int offt = simd_w_ * i;
+        const int offt = into<int>(simd_w_ * i);
         const auto dt_size = types::data_type_size(conf_.dst_type);
 
         if (is_tail_kernel_ && padding_tail_size_) {
@@ -488,12 +490,12 @@ void jit_uni_binary_kernel_t<isa, Vmm>::store(int unroll, bool tail) {
                             vmm_tail_vmask_);
                 io_.at(conf_.dst_type)
                         ->store(vreg_zero_, dst_ptr(offt * dt_size), false);
-                off_base = simd_w_ * dt_size;
+                off_base = into<int>(simd_w_ * dt_size);
                 zero_pad_left -= simd_w_ - tail_size_;
             } else {
                 io_.at(conf_.dst_type)
                         ->store(vreg_tmp_src0, dst_ptr(offt * dt_size), true);
-                off_base = tail_size_ * dt_size;
+                off_base = into<int>(tail_size_ * dt_size);
             }
 
             if (zero_pad_left) {
@@ -536,7 +538,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::compute_ne_xf16_dst_body(
                 && !conf_.is_src_different_layouts;
         const Vmm vreg_tmp_even_src0 = Vmm(i + vmm_start_idx_);
         const Vmm vreg_tmp_odd_src0 = Vmm(i + 1 + vmm_start_idx_);
-        const int offt_base = simd_w_ * i;
+        const int offt_base = into<int>(simd_w_ * i);
 
         if (can_load_two_simdw_src0) {
             io_.at(conf_.src0_type)
@@ -564,7 +566,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::compute_ne_xf16_dst_body(
             const Vmm vreg_tmp_src1 = j == 0 || !can_load_two_simdw_src1
                     ? vreg_tmp_even_src1
                     : vreg_tmp_odd_src1;
-            const int offt = simd_w_ * j + offt_base;
+            const int offt = into<int>(simd_w_ * j + offt_base);
             if (!can_load_two_simdw_src0)
                 io_.at(conf_.src0_type)
                         ->load(src0_ptr(offt), vreg_tmp_src0, tail);
@@ -590,7 +592,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::compute_dst_body(
                 ? vmm_gathered_src_
                 : Vmm(unroll + i + vmm_start_idx_);
         const Vmm vreg_tmp_src1 = offt_src1_ ? vreg_tmp : vreg_bcast_src1_;
-        const int offt = simd_w_ * i;
+        const int offt = into<int>(simd_w_ * i);
         io_.at(conf_.src0_type)->load(src0_ptr(offt), vreg_tmp_src0, tail);
         if (offt_src1_) load_src1(vreg_tmp_src1, offt, tail);
 
@@ -682,42 +684,43 @@ void jit_uni_binary_kernel_t<isa, Vmm>::forward() {
     L(unroll_loop);
     {
         const size_t offt = unroll_regs_ * simd_w_;
-        cmp(reg_reverse_spat_offt_, offt * dst_type_size);
+        cmp(reg_reverse_spat_offt_, into<uint32_t>(offt * dst_type_size));
         jl(unroll_loop_tail, T_NEAR);
 
-        compute_dst(unroll_regs_, treat_each_compute_step_as_tail);
-        sub(reg_reverse_spat_offt_, offt * dst_type_size);
-        add(reg_offt_src0_, offt);
+        compute_dst(into<int>(unroll_regs_), treat_each_compute_step_as_tail);
+        sub(reg_reverse_spat_offt_, into<uint32_t>(offt * dst_type_size));
+        add(reg_offt_src0_, into<uint32_t>(offt));
 
         if (conf_.is_i8) {
             if (!conf_.broadcast_src1_value && !conf_.is_src_different_layouts)
-                add(reg_offt_src1_, offt * src1_type_size);
-            add(reg_offt_dst_, offt);
+                add(reg_offt_src1_, into<uint32_t>(offt * src1_type_size));
+            add(reg_offt_dst_, into<uint32_t>(offt));
         } else {
             if (conf_.use_stride_src1 && !conf_.is_src_different_layouts)
-                add(reg_offt_src1_, offt * src1_type_size);
-            if (conf_.use_stride_rhs_postops) add(reg_off_rhs_postops_, offt);
+                add(reg_offt_src1_, into<uint32_t>(offt * src1_type_size));
+            if (conf_.use_stride_rhs_postops)
+                add(reg_off_rhs_postops_, into<uint32_t>(offt));
         }
         jmp(unroll_loop);
     }
 
     L(unroll_loop_tail);
     {
-        cmp(reg_reverse_spat_offt_, simd_w_ * dst_type_size);
+        cmp(reg_reverse_spat_offt_, into<uint32_t>(simd_w_ * dst_type_size));
         jl(nelems_tail, T_NEAR);
 
         compute_dst(1, treat_each_compute_step_as_tail);
-        sub(reg_reverse_spat_offt_, simd_w_ * dst_type_size);
-        add(reg_offt_src0_, simd_w_);
+        sub(reg_reverse_spat_offt_, into<uint32_t>(simd_w_ * dst_type_size));
+        add(reg_offt_src0_, into<uint32_t>(simd_w_));
         if (conf_.is_i8) {
             if (!conf_.broadcast_src1_value && !conf_.is_src_different_layouts)
-                add(reg_offt_src1_, simd_w_ * src1_type_size);
-            add(reg_offt_dst_, simd_w_);
+                add(reg_offt_src1_, into<uint32_t>(simd_w_ * src1_type_size));
+            add(reg_offt_dst_, into<uint32_t>(simd_w_));
         } else {
             if (conf_.use_stride_src1 && !conf_.is_src_different_layouts)
-                add(reg_offt_src1_, simd_w_ * src1_type_size);
+                add(reg_offt_src1_, into<uint32_t>(simd_w_ * src1_type_size));
             if (conf_.use_stride_rhs_postops)
-                add(reg_off_rhs_postops_, simd_w_);
+                add(reg_off_rhs_postops_, into<uint32_t>(simd_w_));
         }
 
         jmp(unroll_loop_tail);
@@ -731,12 +734,12 @@ void jit_uni_binary_kernel_t<isa, Vmm>::forward() {
         compute_dst(1, true);
         // need to increase if forward over outer dims
         if (is_src1_outer_dims_tail_) {
-            add(reg_offt_src0_, tail_size_);
+            add(reg_offt_src0_, into<uint32_t>(tail_size_));
             if (conf_.is_i8)
-                add(reg_offt_dst_, tail_size_);
+                add(reg_offt_dst_, into<uint32_t>(tail_size_));
             else {
                 if (conf_.use_stride_rhs_postops)
-                    add(reg_off_rhs_postops_, tail_size_);
+                    add(reg_off_rhs_postops_, into<uint32_t>(tail_size_));
             }
         }
     }
@@ -766,7 +769,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::forward_over_outer_dims() {
     {
         mov(reg_reverse_spat_offt_, outer_dims_size);
         forward();
-        sub(reg_outer_dims_range_, outer_dims_size);
+        sub(reg_outer_dims_range_, into<uint32_t>(outer_dims_size));
         cmp(reg_outer_dims_range_, 0);
         jg(c_loop);
     }

--- a/src/cpu/x64/jit_uni_convert_xf16.cpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.cpp
@@ -82,7 +82,7 @@ void jit_uni_cvt_ps_to_xf16_t<isa>::generate() {
             mov(reg_nelems, number_of_loops);
             L(l_number_of_loops);
             for (size_t i = 0; i < unroll_length; i += simd_w_)
-                cvt_ps_to_xf16(i, false);
+                cvt_ps_to_xf16(into<int>(i), false);
             add(reg_input, sizeof(float) * unroll_length);
             add(reg_output, sizeof(float16_t) * unroll_length);
 
@@ -92,9 +92,9 @@ void jit_uni_cvt_ps_to_xf16_t<isa>::generate() {
         }
         if (loop_tail > 0) {
             for (size_t i = 0; i < loop_tail; i += simd_w_)
-                cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * loop_tail);
-            add(reg_output, sizeof(float16_t) * loop_tail);
+                cvt_ps_to_xf16(into<int>(i), false);
+            add(reg_input, into<uint32_t>(sizeof(float) * loop_tail));
+            add(reg_output, into<uint32_t>(sizeof(float16_t) * loop_tail));
         }
         if (tail_size_ != 0) {
             setup_mask();

--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -325,8 +325,8 @@ void compute_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp,
             : 1;
 
     parallel(nthrs, [=](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start {0}, end {0};
+        balance211(into<dim_t>(work_amount), nthr, ithr, start, end);
 
         int ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
         if (jcp.loop_order == loop_ngc)

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -483,10 +483,10 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking, false);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, into<uint32_t>(wei_ch_stride));
+                add(reg_input, into<uint32_t>(inp_ch_stride));
+                add(reg_output, into<uint32_t>(out_ch_stride));
+                if (jcp.with_bias) add(reg_bias, into<uint32_t>(bias_stride));
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -546,7 +546,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
         if (n_oi == 0) {
             compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, into<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
@@ -554,7 +554,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
             if (l_pad > 0) {
                 compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, into<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -562,8 +562,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, into<uint32_t>(inp_shift));
+                    add(reg_output, into<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -572,8 +572,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, into<uint32_t>(inp_shift));
+                add(reg_output, into<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -781,7 +781,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
             }
 
             add(aux1_reg_kernel, ch_blk * stride_w * sizeof(float));
-            sub(aux1_reg_ddst, sp_step * sizeof(float));
+            sub(aux1_reg_ddst, into<uint32_t>(sp_step * sizeof(float)));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
@@ -789,7 +789,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
         }
 
         add(aux_reg_kernel, kw * ch_blk * stride_h * sizeof(float));
-        sub(aux_reg_ddst, ow * sp_step * sizeof(float));
+        sub(aux_reg_ddst, into<uint32_t>(ow * sp_step * sizeof(float)));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -879,9 +879,9 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
             {
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
-                add(reg_kernel, wei_ch_stride);
-                add(reg_dsrc, data_ch_stride);
-                add(reg_ddst, data_ch_stride);
+                add(reg_kernel, into<uint32_t>(wei_ch_stride));
+                add(reg_dsrc, into<uint32_t>(data_ch_stride));
+                add(reg_ddst, into<uint32_t>(data_ch_stride));
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -923,8 +923,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, unroll_w * jcp.stride_w * ch_step);
-            add(reg_ddst, unroll_w * ch_step);
+            add(reg_dsrc, into<uint32_t>(unroll_w * jcp.stride_w * ch_step));
+            add(reg_ddst, into<uint32_t>(unroll_w * ch_step));
 
             sub(reg_ur_str_w, unroll_w);
             jmp(unroll_w_label);
@@ -955,7 +955,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
             const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
-            cmp(reg_ch_blocks, channel_step);
+            cmp(reg_ch_blocks, into<uint32_t>(channel_step));
             je(masking_done, T_NEAR);
             // Prepare masks for tail
             Reg32 reg_tmp_32 = reg_tmp.cvt32();
@@ -1165,11 +1165,11 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
     for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-        int output_sp_offset = i_ur * ch_step;
+        dim_t output_sp_offset = i_ur * ch_step;
         if (i_ur == 0) {
             for (int c = 0; c < input_overlap; ++c) {
                 int input_sp = c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
 
                 const bool over_steps_bdry = true && is_last_block
@@ -1190,7 +1190,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
             for (int c = 0; c < cascade_input; ++c) {
                 int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
                 int input_sp = overlap + c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -1267,9 +1267,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         bool masked_load
                 = IMPLICATION(isa == sse41, tail_in_first_simd) && is_last_ch;
         for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-            int output_sp_offset = nxc_sse41_offset
-                    ? i_ur * ch_step + r * simd_w_
-                    : (i_ur * reg_repeats_ + r) * ch_step;
+            int output_sp_offset = into<int>(nxc_sse41_offset
+                            ? i_ur * ch_step + r * simd_w_
+                            : (i_ur * reg_repeats_ + r) * ch_step);
             size_t output_offset
                     = static_cast<size_t>(output_sp_offset * sizeof(float));
             Vmm vmm_output = get_output_reg(r);
@@ -1278,9 +1278,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
             if (i_ur == 0) {
                 for (int c = 0; c < input_overlap; ++c) {
                     int input_sp = c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
-                            ? input_sp * ch_step + r * simd_w_
-                            : (input_sp * reg_repeats_ + r) * ch_step;
+                    int input_sp_offset = into<int>(nxc_sse41_offset
+                                    ? input_sp * ch_step + r * simd_w_
+                                    : (input_sp * reg_repeats_ + r) * ch_step);
                     if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
 
                     const bool over_steps_bdry = true && is_last_block
@@ -1298,9 +1298,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                 for (int c = 0; c < cascade_input; ++c) {
                     int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
                     int input_sp = overlap + c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
-                            ? input_sp * ch_step + r * simd_w_
-                            : (input_sp * reg_repeats_ + r) * ch_step;
+                    int input_sp_offset = into<int>(nxc_sse41_offset
+                                    ? input_sp * ch_step + r * simd_w_
+                                    : (input_sp * reg_repeats_ + r) * ch_step);
                     if (input_sp_offset < 0
                             || overlap + c + l_pad > right_border)
                         continue;
@@ -1487,7 +1487,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
         L(ow_blk_label);
         {
             compute_bias_step_unroll(unroll_w, nb_ch_blocking, is_last_ch);
-            add(reg_tmp_output, unroll_w * ch_offset);
+            add(reg_tmp_output, into<uint32_t>(unroll_w * ch_offset));
 
             dec(reg_iter_ow_blk);
             cmp(reg_iter_ow_blk, 0);
@@ -1496,7 +1496,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
 
         if (tail_w > 0) {
             compute_bias_step_unroll(tail_w, nb_ch_blocking, is_last_ch);
-            add(reg_tmp_output, tail_w * ch_offset);
+            add(reg_tmp_output, into<uint32_t>(tail_w * ch_offset));
         }
 
         inc(reg_oh);
@@ -1646,14 +1646,14 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter_kh_loop(
     {
         store_filter(nb_ch_blocking);
 
-        add(reg_tmp_filter, filter_offset_kw);
+        add(reg_tmp_filter, into<uint32_t>(filter_offset_kw));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
     }
 
     /* Comeback pointers */
-    sub(reg_tmp_filter, filter_offset_kh);
+    sub(reg_tmp_filter, into<uint32_t>(filter_offset_kh));
 }
 
 template <cpu_isa_t isa>
@@ -1729,8 +1729,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
                 nb_ch_blocking, is_last_ch);
         store_filter(nb_ch_blocking, is_last_ch);
 
-        add(reg_tmp_filter, filter_offset);
-        add(reg_tmp_input, input_offset);
+        add(reg_tmp_filter, into<uint32_t>(filter_offset));
+        add(reg_tmp_input, into<uint32_t>(input_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
@@ -1741,8 +1741,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
     mov(reg_kh_aux, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_tmp_input, input_offset);
-        sub(reg_tmp_filter, filter_offset);
+        sub(reg_tmp_input, into<uint32_t>(input_offset));
+        sub(reg_tmp_filter, into<uint32_t>(filter_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -1836,7 +1836,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_tmp_filter, filter_shift * jcp.stride_h);
+        sub(reg_tmp_filter, into<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
@@ -1849,13 +1849,14 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
                 int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_tmp_filter, filter_shift * inp_corr);
-                add(reg_tmp_input, input_shift * inp_corr);
+                add(reg_tmp_filter, into<uint32_t>(filter_shift * inp_corr));
+                add(reg_tmp_input, into<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
             sub(reg_tmp_filter,
-                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+                    into<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Apply correction */
@@ -1889,11 +1890,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     }
 
     /* Compute middle block */
-    add(reg_tmp_input, input_shift * jcp.stride_h);
+    add(reg_tmp_input, into<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_tmp_output, output_shift);
+    add(reg_tmp_output, into<uint32_t>(output_shift));
     inc(reg_oh);
     cmp(reg_oh, reg_oh_worksize);
     jl(loop_begin_label, T_NEAR);
@@ -1955,8 +1956,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (l_pad && do_unroll_w) {
         compute_h_loop(unroll_w, l_pad, 0, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, into<uint32_t>(data_offset));
+        add(reg_input_baddr, into<uint32_t>(data_offset * jcp.stride_w));
         unroll_trips--;
         pad_offset = l_pad;
         l_pad = 0;
@@ -1971,8 +1972,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     }
     if (unroll_trips > 0) {
         compute_h_loop(unroll_w, l_pad, pad_offset, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, into<uint32_t>(data_offset));
+        add(reg_input_baddr, into<uint32_t>(data_offset * jcp.stride_w));
     }
     if (do_ow_blk_loop) {
         dec(reg_iter_ow_blk);

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -110,29 +110,29 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
             "skipping non-grouped convolution in depthwise convolution "
             "implementation");
 
-    jcp.ngroups = weights_d.dims()[0];
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = into<int>(weights_d.dims()[0]);
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1];
+    jcp.oc = into<int>(dst_d.dims()[1]);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1];
+    jcp.ic = into<int>(src_d.dims()[1]);
 
-    jcp.ih = src_d.dims()[2];
-    jcp.iw = src_d.dims()[3];
-    jcp.oh = dst_d.dims()[2];
-    jcp.ow = dst_d.dims()[3];
+    jcp.ih = into<int>(src_d.dims()[2]);
+    jcp.iw = into<int>(src_d.dims()[3]);
+    jcp.oh = into<int>(dst_d.dims()[2]);
+    jcp.ow = into<int>(dst_d.dims()[3]);
 
-    jcp.kh = weights_d.dims()[3];
-    jcp.kw = weights_d.dims()[4];
+    jcp.kh = into<int>(weights_d.dims()[3]);
+    jcp.kw = into<int>(weights_d.dims()[4]);
 
-    jcp.t_pad = cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][1];
+    jcp.t_pad = into<int>(cd.padding[0][0]);
+    jcp.l_pad = into<int>(cd.padding[0][1]);
 
-    jcp.stride_h = cd.strides[0];
-    jcp.stride_w = cd.strides[1];
+    jcp.stride_h = into<int>(cd.strides[0]);
+    jcp.stride_w = into<int>(cd.strides[1]);
 
-    jcp.dilate_h = cd.dilates[0];
-    jcp.dilate_w = cd.dilates[1];
+    jcp.dilate_h = into<int>(cd.dilates[0]);
+    jcp.dilate_w = into<int>(cd.dilates[1]);
 
     int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -146,8 +146,8 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
 
     jcp.loop_order = loop_ngcw;
 
@@ -310,29 +310,29 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
             "non-grouped convolution in depthwise implementation");
 
     const int ndims = diff_src_d.ndims();
-    jcp.ngroups = weights_d.dims()[0];
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = into<int>(weights_d.dims()[0]);
+    jcp.mb = into<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1];
+    jcp.oc = into<int>(diff_dst_d.dims()[1]);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1];
+    jcp.ic = into<int>(diff_src_d.dims()[1]);
 
-    jcp.ih = diff_src_d.dims()[2];
-    jcp.iw = diff_src_d.dims()[3];
-    jcp.oh = diff_dst_d.dims()[2];
-    jcp.ow = diff_dst_d.dims()[3];
+    jcp.ih = into<int>(diff_src_d.dims()[2]);
+    jcp.iw = into<int>(diff_src_d.dims()[3]);
+    jcp.oh = into<int>(diff_dst_d.dims()[2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[3]);
 
-    jcp.kh = weights_d.dims()[3];
-    jcp.kw = weights_d.dims()[4];
+    jcp.kh = into<int>(weights_d.dims()[3]);
+    jcp.kw = into<int>(weights_d.dims()[4]);
 
-    jcp.t_pad = cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][1];
+    jcp.t_pad = into<int>(cd.padding[0][0]);
+    jcp.l_pad = into<int>(cd.padding[0][1]);
 
-    jcp.stride_h = cd.strides[0];
-    jcp.stride_w = cd.strides[1];
+    jcp.stride_h = into<int>(cd.strides[0]);
+    jcp.stride_w = into<int>(cd.strides[1]);
 
-    jcp.dilate_h = cd.dilates[0];
-    jcp.dilate_w = cd.dilates[1];
+    jcp.dilate_h = into<int>(cd.dilates[0]);
+    jcp.dilate_w = into<int>(cd.dilates[1]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -408,8 +408,8 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
             && jcp.ngroups <= weights_d.padded_dims()[0];
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BAD_PARAM, "");
 
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_out = into<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_in = into<int>(types::data_type_size(diff_dst_d.data_type()));
 
     jcp.ur_w = is_bf16           ? (isa_has_bf16(jcp.isa) ? 6 : 4)
             : isa == avx512_core ? 6
@@ -484,10 +484,10 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(!(!mayiuse(isa) || (is_bf16 && !mayiuse(avx512_core))),
             VERBOSE_UNSUPPORTED_ISA);
 
-    jcp.ngroups = diff_weights_d.dims()[0];
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
-    jcp.oc_without_padding = diff_dst_d.dims()[1];
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(diff_weights_d.dims()[0]);
+    jcp.oc = into<int>(diff_dst_d.dims()[1] / jcp.ngroups);
+    jcp.oc_without_padding = into<int>(diff_dst_d.dims()[1]);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
 
     const bool with_groups = diff_weights_d.ndims() == src_d.ndims() + 1;
 
@@ -496,24 +496,24 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(jcp.is_depthwise, VERBOSE_UNSUPPORTED_FEATURE,
             "non-grouped convolution in depthwise implementation");
 
-    jcp.mb = src_d.dims()[0];
+    jcp.mb = into<int>(src_d.dims()[0]);
 
-    jcp.ih = src_d.dims()[2];
-    jcp.iw = src_d.dims()[3];
-    jcp.oh = diff_dst_d.dims()[2];
-    jcp.ow = diff_dst_d.dims()[3];
+    jcp.ih = into<int>(src_d.dims()[2]);
+    jcp.iw = into<int>(src_d.dims()[3]);
+    jcp.oh = into<int>(diff_dst_d.dims()[2]);
+    jcp.ow = into<int>(diff_dst_d.dims()[3]);
 
-    jcp.kh = diff_weights_d.dims()[3];
-    jcp.kw = diff_weights_d.dims()[4];
+    jcp.kh = into<int>(diff_weights_d.dims()[3]);
+    jcp.kw = into<int>(diff_weights_d.dims()[4]);
 
-    jcp.stride_h = cd.strides[0];
-    jcp.stride_w = cd.strides[1];
+    jcp.stride_h = into<int>(cd.strides[0]);
+    jcp.stride_w = into<int>(cd.strides[1]);
 
-    jcp.t_pad = cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][1];
+    jcp.t_pad = into<int>(cd.padding[0][0]);
+    jcp.l_pad = into<int>(cd.padding[0][1]);
 
-    jcp.dilate_h = cd.dilates[0];
-    jcp.dilate_w = cd.dilates[1];
+    jcp.dilate_h = into<int>(cd.dilates[0]);
+    jcp.dilate_w = into<int>(cd.dilates[1]);
 
     jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
 
@@ -633,7 +633,7 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     /* BF16: accumulation of output happens in f32, down-conversion to bf16
      * happens during the reduction phase. */
     jcp.typesize_out = sizeof(float);
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
     jcp.bia_dt = jcp.with_bias ? cd.diff_bias_desc.data_type : data_type::undef;
 
     jcp.harness = is_data_layout_nxc ? harness_nxc : harness_mb_reduction;

--- a/src/cpu/x64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.cpp
@@ -386,8 +386,8 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         balance211(ch_outer_blocks, jcp.nthr_g, ithr_g, g_start, g_end);
 
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
-        int mb_start {0}, mb_end {0};
-        balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
+        dim_t mb_start {0}, mb_end {0};
+        balance211(into<dim_t>(jcp.mb), jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         const int ithr_oh = (ithr / (jcp.nthr_mb * jcp.nthr_g)) % jcp.nthr_oh;
         const int nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
@@ -548,8 +548,9 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         int g_start {0}, g_end {0};
         balance211(nb_ch, jcp.nthr_g, ithr_g, g_start, g_end);
 
-        int mb_start {0}, mb_end {0};
-        balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
+        dim_t mb_start {0}, mb_end {0};
+        balance211(into<dim_t>(jcp.mb), jcp.nthr_mb, ithr_mb, mb_start,
+                mb_end);
 
         auto i_mb = diff_weights_type == bf16 ? ithr_mb : ithr_mb - 1;
         f32_data_t *diff_wei = (ithr_mb == 0 && diff_weights_type == f32)

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -64,7 +64,9 @@ protected:
         return utils::one_of(
                 data_type(), data_type::f8_e5m2, data_type::f8_e4m3);
     }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    int dtype_size() const {
+        return into<int>(types::data_type_size(data_type()));
+    }
     cpu_isa_t get_io_isa(cpu_isa_t isa) const {
         // reusing avx512_core instantiation for bf16
         return is_bf16() && is_superset(isa, avx512_core)

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -50,7 +50,9 @@ struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
 
 protected:
     data_type_t data_type() const { return pd_->src_md()->data_type; }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    int dtype_size() const {
+        return into<int>(types::data_type_size(data_type()));
+    }
 
     const eltwise_desc_t &desc() const { return *pd_->desc(); }
 
@@ -114,16 +116,16 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
 
         for (int id = 0; id < 2; id++) {
             L(loop_label[id]);
-            cmp(reg_work_amount, uf[id] * loop_dec[id] - 1);
+            cmp(reg_work_amount, into<uint32_t>(uf[id] * loop_dec[id] - 1));
             jle(loop_label[id + 1], T_NEAR);
 
             compute_step(
                     loop_vectorize[id], uf[id], shift[id], desc().alg_kind);
 
-            add(reg_from, uf[id] * shift[id]);
-            add(reg_to, uf[id] * shift[id]);
+            add(reg_from, into<uint32_t>(uf[id] * shift[id]));
+            add(reg_to, into<uint32_t>(uf[id] * shift[id]));
 
-            sub(reg_work_amount, uf[id] * loop_dec[id]);
+            sub(reg_work_amount, into<uint32_t>(uf[id] * loop_dec[id]));
             jmp(loop_label[id]);
         }
 
@@ -235,8 +237,11 @@ private:
     void compute_step(bool vectorize, const size_t uf, const size_t shift,
             const alg_kind_t alg) {
 
-        auto vreg_from = [&](const size_t i) -> Vmm { return Vmm(i + 1); };
-        auto vreg_to = [&](const size_t i) -> Vmm { return Vmm(uf + i + 1); };
+        auto vreg_from
+                = [&](const size_t i) -> Vmm { return Vmm(into<int>(i + 1)); };
+        auto vreg_to = [&](const size_t i) -> Vmm {
+            return Vmm(into<int>(uf + i + 1));
+        };
 
         // 1. Load (vregs <- mem)
         for (size_t i = 0; i < uf; i++)

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -187,8 +187,8 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
             // calculate dst
             compute_dst();
 
-            add(reg_src, c_src_size);
-            add(reg_dst, c_dst_size);
+            add(reg_src, into<uint32_t>(c_src_size));
+            add(reg_dst, into<uint32_t>(c_dst_size));
 
             jmp(unroll_loop);
         }
@@ -476,14 +476,15 @@ struct kernel_stat_t
             L(c_blk_loop);
             {
 
-                cmp(reg_nc_block, nc_blocks_);
+                cmp(reg_nc_block, into<uint32_t>(nc_blocks_));
                 je(c_blk_loop_end, T_NEAR);
 
                 // calculate mean
                 compute_stat_block(unroll_c_);
 
                 add(reg_src_start,
-                        c_block_ * types::data_type_size(src_d_.data_type()));
+                        into<uint32_t>(c_block_
+                                * types::data_type_size(src_d_.data_type())));
                 add(reg_nc_block, 1);
 
                 jmp(c_blk_loop);
@@ -494,7 +495,8 @@ struct kernel_stat_t
         if (unroll_c_tail_) {
             compute_stat_block(unroll_c_tail_);
             add(reg_src_start,
-                    c_block_tail_ * types::data_type_size(src_d_.data_type()));
+                    into<uint32_t>(c_block_tail_
+                            * types::data_type_size(src_d_.data_type())));
         }
 
         if (axis_simd_tail_) compute_stat_block(1, true);
@@ -648,7 +650,7 @@ protected:
                 uni_vaddps(Vmm_mean(ur), Vmm_mean(ur), Vmm_src(ur));
             }
 
-            add(reg_src, c_src_size);
+            add(reg_src, into<uint32_t>(c_src_size));
             jmp(sp_blk_loop);
         }
         L(sp_blk_loop_end);
@@ -704,7 +706,7 @@ protected:
                 uni_vfmadd231ps(Vmm_var(ur), Vmm_src(ur), Vmm_src(ur));
             }
 
-            add(reg_src, c_src_size);
+            add(reg_src, into<uint32_t>(c_src_size));
             jmp(sp_blk_loop);
         }
         L(sp_blk_loop_end);
@@ -716,9 +718,15 @@ protected:
             compute_mean_block(unroll, tail);
     }
 
-    Vmm Vmm_mean(size_t ur = 0) { return Vmm(1 + 0 * unroll_c_ + ur); }
-    Vmm Vmm_var(size_t ur = 0) { return Vmm(1 + 1 * unroll_c_ + ur); }
-    Vmm Vmm_src(size_t ur = 0) { return Vmm(1 + 2 * unroll_c_ + ur); }
+    Vmm Vmm_mean(size_t ur = 0) {
+        return Vmm(into<int>(1 + 0 * unroll_c_ + ur));
+    }
+    Vmm Vmm_var(size_t ur = 0) {
+        return Vmm(into<int>(1 + 1 * unroll_c_ + ur));
+    }
+    Vmm Vmm_src(size_t ur = 0) {
+        return Vmm(into<int>(1 + 2 * unroll_c_ + ur));
+    }
 
     Xbyak::Address src_ptr(size_t offt = 0) {
         return vmmword[reg_src + offt * src_d_.data_type_size()];

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -279,10 +279,10 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(int ll) {
 
     // extract ll-th part of mask (ll-th QWORD)
     vpblendd(vreg_mask_q, vreg_zeros, vreg_mask,
-            0x3 << 2 * ll); // 0x3 - mask for 2 x DWORD
+            into<uint8_t>(0x3 << 2 * ll)); // 0x3 - mask for 2 x DWORD
 
     // Move mask from ll-th pos to 0-th pos
-    if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, ll);
+    if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, into<uint8_t>(ll));
 }
 
 template <>
@@ -295,10 +295,11 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
             for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
                 pinsrd(vreg_src(jj),
                         ptr[aux_reg_src_w + offset + i * data_type_size(s32)],
-                        i);
+                        into<uint8_t>(i));
         else
             for (int i = 0; i < jpp.c_tail; i++)
-                pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i], i);
+                pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i],
+                        into<uint8_t>(i));
     } else
         movups(vreg_src(jj), ptr[aux_reg_src_w + offset]);
 }
@@ -318,7 +319,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
             // Example:  idx=[31..0]
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
-            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+            const uint8_t shift
+                    = into<uint8_t>(cpu_isa_traits_t<avx2>::vlen - jpp.c_tail);
 
             if (jpp.safe_c_tail) {
 
@@ -331,7 +333,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
 
             } else {
                 Label load_data_safely, done;
-                add(aux_reg_src_w, offset);
+                add(aux_reg_src_w, into<uint32_t>(offset));
 
                 // Check if mask crosses page boundary
                 cmp(aux_reg_src_w, reg_src_safe_access);
@@ -351,7 +353,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
                 vpalignr(vreg_src(jj), vreg_tmp, vreg_src(jj), shift);
 
                 L(done);
-                sub(aux_reg_src_w, offset);
+                sub(aux_reg_src_w, into<uint32_t>(offset));
             }
         }
 
@@ -385,14 +387,15 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
             for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
                 pinsrd(vr_src,
                         ptr[aux_reg_src_w + offset + i * data_type_size(s32)],
-                        i);
+                        into<uint8_t>(i));
         else
             movups(vr_src, ptr[aux_reg_src_w + offset]);
     } else if (utils::one_of(jpp.src_dt, s8, u8)) {
         if (masked) {
             const int copy_range = math::ilog2q(jpp.tail[ll] + 1);
             for (int i = 0; i < copy_range; i++)
-                pinsrb(vr_src, ptr[aux_reg_src_w + offset + i], i);
+                pinsrb(vr_src, ptr[aux_reg_src_w + offset + i],
+                        into<uint8_t>(i));
 
             if (jpp.src_dt == s8)
                 pmovsxbd(vr_src, vr_src);
@@ -430,10 +433,10 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
             const int msk_gran = cpu_isa_traits_t<avx2>::vlen
                     / data_type_size(avg_proc_dt);
 
-            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen
+            const uint8_t shift = into<uint8_t>(cpu_isa_traits_t<avx2>::vlen
                     - (jpp.c_tail > (ll + 1) * msk_gran
                                     ? msk_gran
-                                    : jpp.c_tail - (ll * msk_gran));
+                                    : jpp.c_tail - (ll * msk_gran)));
             if (jpp.safe_c_tail) {
                 /* load src_tail at 'src_address - shift' so that it does not
                  * spill over the memory boundary */
@@ -446,7 +449,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
                 Label load_data_safely, done;
                 // assume that it is not safe to load the src_tail
 
-                add(aux_reg_src_w, offset);
+                add(aux_reg_src_w, into<uint32_t>(offset));
 
                 // Check if load crosses the memory boundary
                 cmp(aux_reg_src_w, reg_src_safe_access);
@@ -466,7 +469,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
                 uni_vpxor(vreg_zeros, vreg_zeros, vreg_zeros);
 
                 L(done);
-                sub(aux_reg_src_w, offset);
+                sub(aux_reg_src_w, into<uint32_t>(offset));
             }
 
             // Conversion s8/u8 -> s32
@@ -549,10 +552,11 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
         if (jpp.src_dt == s32)
             for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
-                        vreg_dst(jj), i);
+                        vreg_dst(jj), into<uint8_t>(i));
         else if (utils::one_of(jpp.src_dt, u8, s8))
             for (int i = 0; i < jpp.c_tail; i++)
-                pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj), i);
+                pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj),
+                        into<uint8_t>(i));
         else
             assert(!"unsupported src data type");
     } else
@@ -569,7 +573,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
     int c_block = jpp.c_block;
 
     const uint64_t low_mask = (1ULL << (c_block / 2)) - 1;
-    const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+    const uint8_t shift
+            = into<uint8_t>(cpu_isa_traits_t<avx2>::vlen - jpp.c_tail);
 
     if (masked) {
         switch (jpp.src_dt) {
@@ -665,7 +670,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
         if (masked)
             for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
-                        vr_dst, i);
+                        vr_dst, into<uint8_t>(i));
         else
             movups(ptr[reg_ptr_dst_i8 + offset], vr_dst);
     } else if (utils::one_of(jpp.src_dt, s8, u8)) {
@@ -679,7 +684,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
                 ? math::ilog2q(jpp.tail[ll] + 1)
                 : cpu_isa_traits_t<sse41>::vlen / data_type_size(avg_proc_dt);
         for (int i = 0; i < copy_range; i++)
-            pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, i);
+            pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, into<uint8_t>(i));
     } else
         assert(!"unsupported src data type");
 }
@@ -742,7 +747,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
 
         if (is_masked && (ll_end > jpp.c_tail)) { //implies this tail not full.
             Label store_data_safely, done;
-            const uint8_t shift = msk_gran - jpp.c_tail % msk_gran;
+            const uint8_t shift
+                    = into<uint8_t>(msk_gran - jpp.c_tail % msk_gran);
 
             if (!jpp.safe_c_tail) {
                 cmp(reg_ptr_maskmovdqu_dst, reg_dst_safe_access);
@@ -905,17 +911,17 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
                     load_src(jj, 0, c_tail);
                     compute_max_op(jj);
                 }
-                add(aux_reg_src_w, c * sizeof_src_dt());
+                add(aux_reg_src_w, into<uint32_t>(c * sizeof_src_dt()));
                 inc(reg_kw_index);
                 cmp(reg_kw_index, reg_kw);
                 jl(l_kw, T_NEAR);
             }
-            add(aux_reg_src_h, iw * c * sizeof_src_dt());
+            add(aux_reg_src_h, into<uint32_t>(iw * c * sizeof_src_dt()));
             inc(reg_kh_index);
             cmp(reg_kh_index, reg_kh);
             jl(l_kh, T_NEAR);
         }
-        add(aux_reg_src_d, ih * iw * c * sizeof_src_dt());
+        add(aux_reg_src_d, into<uint32_t>(ih * iw * c * sizeof_src_dt()));
         inc(reg_kd_index);
         cmp(reg_kd_index, reg_kd);
         jl(l_kd, T_NEAR);
@@ -936,7 +942,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
     int iw = jpp.iw;
     int c = jpp.c;
 
-    const int num_ll = data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt);
+    const int num_ll = into<int>(
+            data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt));
 
     for (int jj = 0; jj < ur_c; jj++) {
         for (int ll = 0; ll < num_ll; ll++) {
@@ -973,17 +980,17 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
                         }
                     }
                 }
-                add(aux_reg_src_w, c * sizeof_src_dt());
+                add(aux_reg_src_w, into<uint32_t>(c * sizeof_src_dt()));
                 inc(reg_kw_index);
                 cmp(reg_kw_index, reg_kw);
                 jl(l_kw, T_NEAR);
             }
-            add(aux_reg_src_h, iw * c * sizeof_src_dt());
+            add(aux_reg_src_h, into<uint32_t>(iw * c * sizeof_src_dt()));
             inc(reg_kh_index);
             cmp(reg_kh_index, reg_kh);
             jl(l_kh, T_NEAR);
         }
-        add(aux_reg_src_d, ih * iw * c * sizeof_src_dt());
+        add(aux_reg_src_d, into<uint32_t>(ih * iw * c * sizeof_src_dt()));
         inc(reg_kd_index);
         cmp(reg_kd_index, reg_kd);
         jl(l_kd, T_NEAR);
@@ -1053,8 +1060,10 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_c_block() {
         L(l_main_loop);
         {
             compute_step(ur_c, 0);
-            add(reg_ptr_src_i8, ur_c * c_block * sizeof_src_dt());
-            add(reg_ptr_dst_i8, ur_c * c_block * sizeof_dst_dt());
+            add(reg_ptr_src_i8,
+                    into<uint32_t>(ur_c * c_block * sizeof_src_dt()));
+            add(reg_ptr_dst_i8,
+                    into<uint32_t>(ur_c * c_block * sizeof_dst_dt()));
             inc(c_iter);
             cmp(c_iter, c_steps);
             jl(l_main_loop, T_NEAR);
@@ -1113,7 +1122,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
 
                 // Need mask in MMX regs also?
                 if (need_mmx_mask)
-                    movq(mmx_mask(i), reg_mask); // reuse value in reg_mask
+                    movq(mmx_mask(into<int>(i)),
+                            reg_mask); // reuse value in reg_mask
             }
 
             // Merge Low (xreg_mask_lo alias for vreg_mask.xreg)
@@ -1122,7 +1132,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
             vinserti128(vreg_mask, vreg_mask, xreg_mask_hi, 1);
 
             // Compute mask algned to left from vreg_mask and store it in vreg_mask_2 to be use for tail processing.
-            const uint8_t shift = 32 - jpp.c_tail;
+            const uint8_t shift = into<uint8_t>(32 - jpp.c_tail);
             vperm2i128(vreg_mask_2, vreg_mask, vreg_mask, 0x08);
             if (shift <= 16) {
                 vpalignr(vreg_mask_2, vreg_mask, vreg_mask_2, 16 - shift);
@@ -1139,7 +1149,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
             if (!need_ymm_mask)
                 for (size_t i = 0; i < QW_PER_VREG; i++) {
                     mov(reg_mask, vmask[i]);
-                    movq(mmx_mask(i), reg_mask);
+                    movq(mmx_mask(into<int>(i)), reg_mask);
                 }
 
             // Form full mask for one QWORD
@@ -1279,28 +1289,28 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
     const bool is_1d = ndims == 3;
     const bool is_3d = ndims == 5;
 
-    jpp.mb = src_d.dims()[0];
-    jpp.c = src_d.dims()[1];
+    jpp.mb = into<int>(src_d.dims()[0]);
+    jpp.c = into<int>(src_d.dims()[1]);
 
-    jpp.id = is_3d ? src_d.dims()[ndims - 3] : 1;
-    jpp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jpp.iw = src_d.dims()[ndims - 1];
+    jpp.id = into<int>(is_3d ? src_d.dims()[ndims - 3] : 1);
+    jpp.ih = into<int>(is_1d ? 1 : src_d.dims()[ndims - 2]);
+    jpp.iw = into<int>(src_d.dims()[ndims - 1]);
 
-    jpp.od = is_3d ? dst_d.dims()[ndims - 3] : 1;
-    jpp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jpp.ow = dst_d.dims()[ndims - 1];
+    jpp.od = into<int>(is_3d ? dst_d.dims()[ndims - 3] : 1);
+    jpp.oh = into<int>(is_1d ? 1 : dst_d.dims()[ndims - 2]);
+    jpp.ow = into<int>(dst_d.dims()[ndims - 1]);
 
-    jpp.stride_d = is_3d ? pd.strides[ndims - 5] : 1;
-    jpp.stride_h = is_1d ? 1 : pd.strides[ndims - 4];
-    jpp.stride_w = pd.strides[ndims - 3];
+    jpp.stride_d = into<int>(is_3d ? pd.strides[ndims - 5] : 1);
+    jpp.stride_h = into<int>(is_1d ? 1 : pd.strides[ndims - 4]);
+    jpp.stride_w = into<int>(pd.strides[ndims - 3]);
 
-    jpp.kd = is_3d ? pd.kernel[ndims - 5] : 1;
-    jpp.kh = is_1d ? 1 : pd.kernel[ndims - 4];
-    jpp.kw = pd.kernel[ndims - 3];
+    jpp.kd = into<int>(is_3d ? pd.kernel[ndims - 5] : 1);
+    jpp.kh = into<int>(is_1d ? 1 : pd.kernel[ndims - 4]);
+    jpp.kw = into<int>(pd.kernel[ndims - 3]);
 
-    jpp.f_pad = is_3d ? pd.padding[0][ndims - 5] : 0;
-    jpp.t_pad = is_1d ? 0 : pd.padding[0][ndims - 4];
-    jpp.l_pad = pd.padding[0][ndims - 3];
+    jpp.f_pad = into<int>(is_3d ? pd.padding[0][ndims - 5] : 0);
+    jpp.t_pad = into<int>(is_1d ? 0 : pd.padding[0][ndims - 4]);
+    jpp.l_pad = into<int>(pd.padding[0][ndims - 3]);
 
     int back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
@@ -1474,9 +1484,11 @@ status_t jit_uni_i8i8_pooling_fwd_t<isa>::execute_forward(
                 dim_t(jpp.kw), jpp.iw + jpp.l_pad - ow * jpp.stride_w);
 
         auto p = jit_uni_i8i8_pool_call_params_t();
-        p.src_i8 = &src_i8[get_offset(src_d, n, 0, id, ih, iw)
+        p.src_i8 = &src_i8[get_offset(src_d, into<int>(n), 0, into<int>(id),
+                                   into<int>(ih), into<int>(iw))
                 * src_d.data_type_size()];
-        p.dst_i8 = &dst_i8[get_offset(dst_d, n, 0, od, oh, ow)
+        p.dst_i8 = &dst_i8[get_offset(dst_d, into<int>(n), 0, into<int>(od),
+                                   into<int>(oh), into<int>(ow))
                 * dst_d.data_type_size()];
         p.dst_orig = dst_i8;
         p.kd_range = kd_end - kd_start;

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -177,8 +177,8 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
             // calculate dst
             compute_dst();
 
-            add(reg_src, c_src_size);
-            add(reg_dst, c_dst_size);
+            add(reg_src, into<uint32_t>(c_src_size));
+            add(reg_dst, into<uint32_t>(c_dst_size));
 
             jmp(unroll_loop);
         }
@@ -428,16 +428,18 @@ struct kernel_stat_t
             L(c_blk_loop);
             {
 
-                cmp(reg_nc_block, nc_blocks_);
+                cmp(reg_nc_block, into<uint32_t>(nc_blocks_));
                 je(c_blk_loop_end, T_NEAR);
 
                 // calculate mean
                 compute_stat_block(unroll_c_);
 
                 add(reg_src_start,
-                        c_block_ * types::data_type_size(src_d_.data_type()));
-                add_mean(c_block_);
-                if (compute_var_) add(reg_var, c_block_ * sizeof(float));
+                        into<uint32_t>(c_block_
+                                * types::data_type_size(src_d_.data_type())));
+                add_mean(into<int>(c_block_));
+                if (compute_var_)
+                    add(reg_var, into<uint32_t>(c_block_ * sizeof(float)));
                 add(reg_nc_block, 1);
 
                 jmp(c_blk_loop);
@@ -448,9 +450,11 @@ struct kernel_stat_t
         if (unroll_c_tail_) {
             compute_stat_block(unroll_c_tail_);
             add(reg_src_start,
-                    c_block_tail_ * types::data_type_size(src_d_.data_type()));
-            add_mean(c_block_tail_);
-            if (compute_var_) add(reg_var, c_block_tail_ * sizeof(float));
+                    into<uint32_t>(c_block_tail_
+                            * types::data_type_size(src_d_.data_type())));
+            add_mean(into<int>(c_block_tail_));
+            if (compute_var_)
+                add(reg_var, into<uint32_t>(c_block_tail_ * sizeof(float)));
         }
 
         if (axis_simd_tail_) compute_stat_block(1, true);
@@ -533,7 +537,7 @@ protected:
                 uni_vaddps(Vmm_mean(ur), Vmm_mean(ur), vmm_src);
             }
 
-            add(reg_src, c_src_size);
+            add(reg_src, into<uint32_t>(c_src_size));
             jmp(sp_blk_loop);
         }
         L(sp_blk_loop_end);
@@ -573,7 +577,7 @@ protected:
                 uni_vfmadd231ps(Vmm_var(ur), vmm_src, vmm_src);
             }
 
-            add(reg_src, c_src_size);
+            add(reg_src, into<uint32_t>(c_src_size));
             jmp(sp_blk_loop);
         }
         L(sp_blk_loop_end);
@@ -591,8 +595,8 @@ protected:
     }
     void add_mean(int c_block) { add(reg_mean, c_block * sizeof(float)); }
 
-    Vmm Vmm_mean(size_t ur = 0) { return Vmm(3 + ur); }
-    Vmm Vmm_var(size_t ur = 0) { return Vmm(9 + ur); }
+    Vmm Vmm_mean(size_t ur = 0) { return Vmm(into<int>(3 + ur)); }
+    Vmm Vmm_var(size_t ur = 0) { return Vmm(into<int>(9 + ur)); }
 
     Xbyak::Address src_ptr(size_t offt = 0) {
         return vmmword[reg_src + offt * src_d_.data_type_size()];
@@ -812,7 +816,7 @@ status_t jit_uni_instance_normalization_fwd_t::execute_forward(
         parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
             dim_t SP_start = 0, SP_end = 0;
             balance211(SP, nthr, ithr, SP_start, SP_end);
-            const int block_size = SP_end - SP_start;
+            const dim_t block_size = SP_end - SP_start;
             for (int n = 0; n < N; ++n) {
                 float *local_mean = stat_reduction + n * nthr * C + ithr * C;
                 const size_t s_off

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -318,7 +318,7 @@ protected:
             }
 
             // unrolled loop remainder
-            for (int i = utils::rnd_dn(axis_simd_full_, unroll);
+            for (int i = into<int>(utils::rnd_dn(axis_simd_full_, unroll));
                     i < axis_simd_full_; i += 2) {
                 const bool can_load_two_simdw = axis_simd_full_ - i >= 2;
                 if (!can_load_two_simdw)
@@ -379,7 +379,7 @@ protected:
             }
 
             // unrolled loop remainder
-            for (int i = utils::rnd_dn(axis_simd_full_, unroll);
+            for (int i = into<int>(utils::rnd_dn(axis_simd_full_, unroll));
                     i < axis_simd_full_; i++) {
                 io_[src_d_.data_type()]->load(
                         src_ptr(i * simd_w_), Vmm(base_idx + 1), need_tail);
@@ -632,10 +632,10 @@ protected:
             // calculate dst
             calculate_dst();
 
-            add(reg_src, c_src_size);
-            add(reg_dst, c_dst_size);
-            add(reg_mean, float_size);
-            add(reg_var, float_size);
+            add(reg_src, into<uint32_t>(c_src_size));
+            add(reg_dst, into<uint32_t>(c_dst_size));
+            add(reg_mean, into<uint32_t>(float_size));
+            add(reg_var, into<uint32_t>(float_size));
             jmp(unroll_loop);
         }
         L(end);
@@ -898,10 +898,10 @@ protected:
             if (axis_simd_tail_)
                 calculate_diff_scale_shift(axis_simd_full_ * simd_w_, true);
 
-            add(reg_src, c_src_size);
-            add(reg_diff_dst, c_ddst_size);
-            add(reg_mean, float_size);
-            add(reg_inv_sqrtvar, float_size);
+            add(reg_src, into<uint32_t>(c_src_size));
+            add(reg_diff_dst, into<uint32_t>(c_ddst_size));
+            add(reg_mean, into<uint32_t>(float_size));
+            add(reg_inv_sqrtvar, into<uint32_t>(float_size));
             jmp(unroll_loop);
         }
         L(end);
@@ -1154,11 +1154,12 @@ protected:
             if (axis_simd_tail_)
                 compute_diff_src(axis_simd_full_ * simd_w_, true);
 
-            add(reg_src, c_src_size);
-            add(reg_diff_dst, c_ddst_size);
-            add(reg_diff_src, c_dsrc_size);
-            if (calculate_diff_stats_ && !skip_mean_) add(reg_mean, float_size);
-            add(reg_inv_sqrtvar, float_size);
+            add(reg_src, into<uint32_t>(c_src_size));
+            add(reg_diff_dst, into<uint32_t>(c_ddst_size));
+            add(reg_diff_src, into<uint32_t>(c_dsrc_size));
+            if (calculate_diff_stats_ && !skip_mean_)
+                add(reg_mean, into<uint32_t>(float_size));
+            add(reg_inv_sqrtvar, into<uint32_t>(float_size));
             jmp(unroll_loop);
         }
         L(end);
@@ -1331,7 +1332,7 @@ status_t jit_uni_layer_normalization_fwd_t::execute_forward(
                 + N_start * C_padded * src_d.data_type_size();
         char *const __restrict dst_ptr = reinterpret_cast<char *>(dst)
                 + N_start * C_padded * dst_d.data_type_size();
-        const int block_size = N_end - N_start;
+        const dim_t block_size = N_end - N_start;
         float *mean_ptr = skip_mean ? nullptr : &mean[N_start];
         float *dst_scales_inv_ptr = nullptr;
         if (!pd()->attr()->scales_.has_default_values(DNNL_ARG_DST)) {
@@ -1400,7 +1401,7 @@ status_t jit_uni_layer_normalization_bwd_t::execute_backward(
     parallel(max_nthr, [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         dim_t N_start = 0, N_end = 0;
         balance211(N, nthr, ithr, N_start, N_end);
-        const int block_size = N_end - N_start;
+        const dim_t block_size = N_end - N_start;
         const char *const __restrict src_ptr
                 = reinterpret_cast<const char *>(src)
                 + N_start * C_padded * src_d.data_type_size();
@@ -1433,7 +1434,7 @@ status_t jit_uni_layer_normalization_bwd_t::execute_backward(
     parallel(max_nthr, [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         dim_t N_start = 0, N_end = 0;
         balance211(N, nthr, ithr, N_start, N_end);
-        const int block_size = N_end - N_start;
+        const dim_t block_size = N_end - N_start;
         const char *const __restrict src_ptr
                 = reinterpret_cast<const char *>(src)
                 + N_start * C_padded * src_d.data_type_size();

--- a/src/cpu/x64/jit_uni_ncsp_convolution.cpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.cpp
@@ -91,10 +91,10 @@ status_t reduction_helper_t::reshape_weights(
         // matmul to conv: remove batch, restore spatial
         for (int d = 0; d < ndims_ch; ++d)
             reduce[d] = i_md->dims[d + 1]; // g, o, i
-        for (int d = ndims_ch; d < ndims_out; ++d)
+        for (dim_t d = ndims_ch; d < ndims_out; ++d)
             reduce[d] = 1; // d, h, w
     }
-    return memory_desc_reshape(*o_md, *i_md, ndims_out, reduce);
+    return memory_desc_reshape(*o_md, *i_md, into<int>(ndims_out), reduce);
 }
 
 status_t reduction_helper_t::reshape_for_transpose(

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -197,17 +197,17 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
     jpp.is_training = pd.prop_kind == prop_kind::forward_training;
     jpp.is_backward = pd.prop_kind == prop_kind::backward_data;
 
-    jpp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jpp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jpp.iw = src_d.dims()[ndims - 1];
-    jpp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jpp.ow = dst_d.dims()[ndims - 1];
-    jpp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
+    jpp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jpp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jpp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jpp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jpp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jpp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
 
     const bool is_avx512 = is_superset(isa, avx512_core);
     jpp.ndims = ndims;
-    jpp.mb = src_d.dims()[0];
-    jpp.c_without_padding = src_d.dims()[1];
+    jpp.mb = into<int>(src_d.dims()[0]);
+    jpp.c_without_padding = into<int>(src_d.dims()[1]);
     jpp.c_block = is_avx512 ? 16 : 8;
 
     jpp.alg = pd.alg_kind;
@@ -284,7 +284,7 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         jpp.is_f16 = false;
         jpp.is_fp8 = false;
         jpp.src_dt = jpp.dst_dt = data_type::f32;
-        jpp.dt_size = types::data_type_size(jpp.src_dt);
+        jpp.dt_size = into<int>(types::data_type_size(jpp.src_dt));
         jpp.tag_kind = jit_memory_tag_kind_t::ncsp;
 
         // used to initialize binary post-ops
@@ -293,7 +293,7 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
                     data_type::f32, blocked_fmt_tag));
         }
     } else {
-        jpp.dt_size = types::data_type_size(src_d.data_type());
+        jpp.dt_size = into<int>(types::data_type_size(src_d.data_type()));
         jpp.tag_kind = (fmt_tag == nspc_fmt_tag)
                 ? jit_memory_tag_kind_t::nspc
                 : jit_memory_tag_kind_t::blocked;
@@ -356,16 +356,16 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
     jpp.is_c_padded = jpp.tag_kind == jit_memory_tag_kind_t::blocked
             && src_d.padded_dims()[1] != jpp.c_without_padding;
 
-    jpp.stride_d = (ndims == 5) ? pd.strides[0] : 1;
-    jpp.stride_h = (ndims == 3) ? 1 : pd.strides[ndims - 4];
-    jpp.stride_w = pd.strides[ndims - 3];
-    jpp.kd = (ndims == 5) ? pd.kernel[0] : 1;
-    jpp.kh = (ndims == 3) ? 1 : pd.kernel[ndims - 4];
-    jpp.kw = pd.kernel[ndims - 3];
+    jpp.stride_d = into<int>((ndims == 5) ? pd.strides[0] : 1);
+    jpp.stride_h = into<int>((ndims == 3) ? 1 : pd.strides[ndims - 4]);
+    jpp.stride_w = into<int>(pd.strides[ndims - 3]);
+    jpp.kd = into<int>((ndims == 5) ? pd.kernel[0] : 1);
+    jpp.kh = into<int>((ndims == 3) ? 1 : pd.kernel[ndims - 4]);
+    jpp.kw = into<int>(pd.kernel[ndims - 3]);
 
-    jpp.f_pad = (ndims == 5) ? pd.padding[0][0] : 0;
-    jpp.t_pad = (ndims == 3) ? 0 : pd.padding[0][ndims - 4];
-    jpp.l_pad = pd.padding[0][ndims - 3];
+    jpp.f_pad = into<int>((ndims == 5) ? pd.padding[0][0] : 0);
+    jpp.t_pad = into<int>((ndims == 3) ? 0 : pd.padding[0][ndims - 4]);
+    jpp.l_pad = into<int>(pd.padding[0][ndims - 3]);
 
     const int back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
@@ -566,7 +566,8 @@ inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const int idx) {
             const auto c_tail = jpp.c_tail % sse41_single_block_size;
             std::bitset<8> tail_mask((1 << c_tail) - 1);
             tail_mask.flip();
-            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1, tail_mask.to_ulong());
+            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1,
+                    into<int>(tail_mask.to_ulong()));
         }
     } else if (isa == avx || isa == avx2) {
         uni_vxorps(ymm_tmp_1, ymm_tmp_1, ymm_tmp_1);
@@ -584,7 +585,8 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
         if (isa == sse41) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
                 for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-                    pinsrb(indxr, ptr[reg_index + step_index + i], i);
+                    pinsrb(indxr, ptr[reg_index + step_index + i],
+                            into<uint8_t>(i));
             } else {
                 movd(indxr, ptr[reg_index + step_index]);
             }
@@ -592,7 +594,8 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
         } else if (isa == avx || isa == avx2) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
                 for (int i = 0; i < jpp.c_tail; i++)
-                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i], i);
+                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i],
+                            into<uint8_t>(i));
             } else {
                 vmovq(indxr, ptr[reg_index + step_index]);
             }
@@ -639,7 +642,8 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                    pextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                    pextrb(ptr[reg_index + step_index + i], xr,
+                            into<uint8_t>(4 * i));
                 }
             }
         } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
@@ -652,7 +656,8 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                    vpextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                    vpextrb(ptr[reg_index + step_index + i], xr,
+                            into<uint8_t>(4 * i));
                 }
 
                 if (jpp.c_tail > (jpp.c_block / 2)) {
@@ -664,7 +669,7 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                         // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
                         vpextrb(ptr[reg_index + step_index + (jpp.c_block / 2)
                                         + i],
-                                higher_128bits, 4 * i);
+                                higher_128bits, into<uint8_t>(4 * i));
                     }
                 }
             } else {
@@ -1097,8 +1102,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
 
             const auto indr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
             const bool is_first_w_block = jj == 0;
-            store_indices(
-                    indr_i, step_index, is_c_tail_processing, is_first_w_block);
+            store_indices(indr_i, into<int>(step_index), is_c_tail_processing,
+                    is_first_w_block);
         }
     }
 }
@@ -1113,9 +1118,9 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
     int c_block = jpp.c_block;
     const int output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
-            ? jpp.f32_accum_block_size
-            : output_c_off;
+    const int input_c_off
+            = into<int>(jpp.needs_f32_accum_for_bf16 ? jpp.f32_accum_block_size
+                                                     : output_c_off);
     const auto input_dt
             = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
     const size_t input_dt_size = types::data_type_size(input_dt);
@@ -1141,13 +1146,13 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
         const auto outr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
         auto out_offset = output_dt_size * (jj * output_c_off + bci * c_block);
         const bool is_c_tail_processing = is_tail_processing(bci);
-        load(jpp.dst_dt, reg_idx(outr_i), reg_output, out_offset,
+        load(jpp.dst_dt, reg_idx(outr_i), reg_output, into<int>(out_offset),
                 is_c_tail_processing);
         const size_t step_index = (jj * output_c_off + bci * c_block)
                 * types::data_type_size(jpp.ind_dt);
 
         const auto indr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
-        load_indices(indr_i, step_index, is_c_tail_processing);
+        load_indices(indr_i, into<int>(step_index), is_c_tail_processing);
     }
     uni_vmovq(xmm_tmp, reg_k_shift);
     uni_vpbroadcastd(vmm_k_offset, xmm_tmp);
@@ -1182,7 +1187,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
                 int aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
                         + bci * c_block;
                 if (aux_inp_offset >= iw * input_c_off) continue;
-                int inp_offset = input_dt_size * aux_inp_offset;
+                int inp_offset = into<int>(input_dt_size * aux_inp_offset);
                 load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1226,13 +1231,14 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
             if (with_c_tail_proccessing && (isa == avx || isa == avx2))
                 pop_vmm_val(vmm_c_tail_mask.getIdx());
         }
-        add(aux_reg_input, input_dt_size * iw * input_c_off);
+        add(aux_reg_input, into<uint32_t>(input_dt_size * iw * input_c_off));
         inc(kj);
         cmp(kj, reg_kh);
         jl(kh_label, T_NEAR);
     }
     if (jpp.simple_alg && jpp.ndims == 5) {
-        add(aux_reg_input_d, input_dt_size * jpp.ih * iw * input_c_off);
+        add(aux_reg_input_d,
+                into<uint32_t>(input_dt_size * jpp.ih * iw * input_c_off));
 
         mov(tmp_gpr, reg_kd_pad_shift);
         uni_vmovq(xmm_tmp, tmp_gpr);
@@ -1255,10 +1261,11 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
 template <cpu_isa_t isa>
 void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         int ur_bc, bool with_c_tail_proccessing) {
-    const int c_off = jpp.needs_f32_accum_for_bf16
-            ? jpp.f32_accum_block_size
-            : ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c
-                                                             : jpp.c_block);
+    const int c_off = into<int>(jpp.needs_f32_accum_for_bf16
+                    ? jpp.f32_accum_block_size
+                    : ((jpp.tag_kind == jit_memory_tag_kind_t::nspc)
+                                      ? jpp.c
+                                      : jpp.c_block));
 
     Label l_skip, l_ih_loop, l_id_loop;
 
@@ -1282,7 +1289,7 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
     const auto src_dt
             = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
     const auto dt_size = types::data_type_size(src_dt);
-    const int width_size = jpp.iw * c_off * dt_size;
+    const int width_size = into<int>(jpp.iw * c_off * dt_size);
 
     auto aux_reg_zero_ptr = tmp_gpr;
 
@@ -1293,12 +1300,12 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         L(l_ih_loop);
         {
             const auto vlen = cpu_isa_traits_t<isa>::vlen;
-            const int step = c_off * dt_size;
+            const int step = into<int>(c_off * dt_size);
 
             // TODO: maybe a big code generated here
             for_(int i = 0; i < width_size; i += step)
             for (int bci = 0; bci < ur_bc; bci++) {
-                const int offs = i + bci * jpp.c_block * dt_size;
+                const int offs = into<int>(i + bci * jpp.c_block * dt_size);
                 if (isa == sse41) {
                     bool is_needed_c_tail_processing = false;
                     if (is_tail_processing(bci)
@@ -1347,9 +1354,9 @@ void jit_uni_pool_kernel_t<isa>::generate() {
     int l_pad = jpp.l_pad;
     const int output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
-            ? jpp.f32_accum_block_size
-            : output_c_off;
+    const int input_c_off
+            = into<int>(jpp.needs_f32_accum_for_bf16 ? jpp.f32_accum_block_size
+                                                     : output_c_off);
 
     int vlen = cpu_isa_traits_t<isa>::vlen;
 
@@ -1400,14 +1407,17 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         auto output_dt_size = jpp.dt_size;
         auto shift = (isa == sse41) ? vlen : 0;
         add(reg_input,
-                input_dt_size * nstl::max(0, ur_w * stride_w - lpad)
+                into<uint32_t>(input_dt_size
+                                * nstl::max(0, ur_w * stride_w - lpad)
                                 * input_c_off
-                        - shift);
+                        - shift));
         add(reg_output, output_dt_size * ur_w * output_c_off - shift);
         if (jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward)) {
             auto ishift = (isa == sse41) ? jpp.c_block / 2 : 0;
             auto ind_dt_size = types::data_type_size(jpp.ind_dt);
-            add(reg_index, (ur_w * output_c_off - ishift) * ind_dt_size);
+            add(reg_index,
+                    into<uint32_t>(
+                            (ur_w * output_c_off - ishift) * ind_dt_size));
         }
     };
 

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -186,7 +186,8 @@ private:
                 assert(!"Unknown data type for indices");
                 return;
             }
-            add(reg_index, types::data_type_size(jpp.ind_dt) * 4);
+            add(reg_index,
+                    into<uint32_t>(types::data_type_size(jpp.ind_dt) * 4));
         }
 
         step(ur_w, ur_bc, pad_l, pad_r, with_c_tail_processing);

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -783,7 +783,8 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         parallel_nd(jpp.mb, jpp.oh, nb2_c, [=](dim_t n, dim_t oh, dim_t b2_c) {
             const auto b_c = b2_c * jpp.ur_bc;
             const auto ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-            ker(0, n, b_c, oh, ur_bc);
+            ker(0, into<int>(n), into<int>(b_c), into<int>(oh),
+                    into<int>(ur_bc));
         });
     } else {
         if (trans_src || trans_dst) {
@@ -791,11 +792,13 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
             parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
                     [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
                 if (trans_src)
-                    transpose_facade->execute_transpose_input(ithr, n, b_c);
+                    transpose_facade->execute_transpose_input(
+                            ithr, into<int>(n), into<int>(b_c));
                 for (dim_t oh = 0; oh < jpp.oh; ++oh)
-                    ker(ithr, n, b_c, oh, 1);
+                    ker(ithr, into<int>(n), into<int>(b_c), into<int>(oh), 1);
                 if (trans_dst)
-                    transpose_facade->execute_transpose_output(ithr, n, b_c);
+                    transpose_facade->execute_transpose_output(
+                            ithr, into<int>(n), into<int>(b_c));
             });
         } else {
             // nChw16c, nChw8c format
@@ -812,7 +815,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
                         start, n, jpp.mb, b_c, jpp.nb_c, oh, jpp.oh);
 
                 for (dim_t iwork = start; iwork < end; ++iwork) {
-                    ker(ithr, n, b_c, oh, 1);
+                    ker(ithr, into<int>(n), into<int>(b_c), into<int>(oh), 1);
                     utils::nd_iterator_step(
                             n, jpp.mb, b_c, jpp.nb_c, oh, jpp.oh);
                 }
@@ -931,8 +934,9 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
                     - jpp.id;
             const dim_t id = nstl::max(ik - jpp.f_pad, dim_t(0));
             for (dim_t oh = 0; oh < jpp.oh; ++oh) {
-                ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, ur_bc,
-                        first_ithr);
+                ker(into<int>(n), into<int>(b_c), into<int>(od), into<int>(oh),
+                        into<int>(id), into<int>(d_t_overflow),
+                        into<int>(d_b_overflow), into<int>(ur_bc), first_ithr);
             }
         });
     } else {
@@ -940,7 +944,8 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
             parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
                     [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
                 if (trans_src)
-                    transpose_facade->execute_transpose_input(ithr, n, b_c);
+                    transpose_facade->execute_transpose_input(
+                            ithr, into<int>(n), into<int>(b_c));
 
                 for (int od = 0; od < jpp.od; ++od) {
                     const int ik = od * jpp.stride_d;
@@ -950,25 +955,26 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
                             - jpp.id;
                     const int id = nstl::max(ik - jpp.f_pad, 0);
                     for (int oh = 0; oh < jpp.oh; ++oh) {
-                        ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
-                                ithr);
+                        ker(into<int>(n), into<int>(b_c), od, oh, id,
+                                d_t_overflow, d_b_overflow, 1, into<int>(ithr));
                     }
                 }
 
                 if (trans_dst)
-                    transpose_facade->execute_transpose_output(ithr, n, b_c);
+                    transpose_facade->execute_transpose_output(
+                            ithr, into<int>(n), into<int>(b_c));
             });
         } else {
             parallel_nd(jpp.mb, jpp.nb_c, jpp.od,
                     [=](dim_t n, dim_t b_c, dim_t od) {
-                const int ik = od * jpp.stride_d;
+                const int ik = into<int>(od * jpp.stride_d);
                 const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
                 const int d_b_overflow
                         = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
                 const int id = nstl::max(ik - jpp.f_pad, 0);
                 for (int oh = 0; oh < jpp.oh; ++oh) {
-                    ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
-                            first_ithr);
+                    ker(into<int>(n), into<int>(b_c), into<int>(od), oh, id,
+                            d_t_overflow, d_b_overflow, 1, first_ithr);
                 }
             });
         }
@@ -1314,7 +1320,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                     const dim_t b_c = b2_c * jpp.ur_bc;
                     const dim_t ur_bc
                             = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    process_simple(n, b_c, od, ur_bc, first_ithr);
+                    process_simple(into<int>(n), into<int>(b_c), into<int>(od),
+                            into<int>(ur_bc), first_ithr);
                 });
             } else {
                 parallel_nd_ext(nthr, jpp.mb, nb2_c,
@@ -1323,9 +1330,10 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                     const dim_t ur_bc
                             = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
                     for (int od = 0; od < jpp.od; ++od) {
-                        process_simple(n, b_c, od, ur_bc, ithr);
+                        process_simple(into<int>(n), into<int>(b_c), od,
+                                into<int>(ur_bc), into<int>(ithr));
                     }
-                    f32_accum->cvt_to_bf16_slice_3d(ithr,
+                    f32_accum->cvt_to_bf16_slice_3d(into<int>(ithr),
                             (bfloat16_t *)diff_src, diff_src_d, n, b_c, ur_bc);
                 });
             }
@@ -1335,21 +1343,24 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                 parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
                         [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
                     if (trans_src)
-                        transpose_facade->execute_transpose_input(ithr, n, b_c);
+                        transpose_facade->execute_transpose_input(
+                                ithr, into<int>(n), into<int>(b_c));
                     for (int od = 0; od < jpp.od; ++od) {
-                        process_simple(n, b_c, od, 1, ithr);
+                        process_simple(into<int>(n), into<int>(b_c), od, 1,
+                                into<int>(ithr));
                     }
                     if (trans_dst)
                         transpose_facade->execute_transpose_output(
-                                ithr, n, b_c);
+                                ithr, into<int>(n), into<int>(b_c));
                     if (jpp.needs_f32_accum_for_bf16)
-                        f32_accum->cvt_to_bf16_slice_3d(ithr,
+                        f32_accum->cvt_to_bf16_slice_3d(into<int>(ithr),
                                 (bfloat16_t *)diff_src, diff_src_d, n, b_c, 1);
                 });
             } else {
                 parallel_nd(jpp.mb, jpp.nb_c, jpp.od,
                         [=](dim_t n, dim_t b_c, dim_t od) {
-                    process_simple(n, b_c, od, 1, first_ithr);
+                    process_simple(into<int>(n), into<int>(b_c), into<int>(od),
+                            1, first_ithr);
                 });
             }
         }
@@ -1388,17 +1399,19 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                 const dim_t b_c = b2_c * jpp.ur_bc;
 
                 if (trans_dst) {
-                    transpose_facade->execute_transpose_input(ithr, n, b_c);
+                    transpose_facade->execute_transpose_input(
+                            ithr, into<int>(n), into<int>(b_c));
 
                     size_t block_size = jpp.c_block * jpp.id * jpp.ih * jpp.iw
                             * input_dt_size;
 
                     const void *src = transpose_facade->get_src_addr_3d(
                             ithr, 0, 0, jpp);
-                    std::memset((void *)src, zero_val, block_size);
+                    std::memset((void *)src, into<int>(zero_val), block_size);
                 }
 
-                if (jpp.needs_f32_accum_for_bf16) f32_accum->zero_data(ithr);
+                if (jpp.needs_f32_accum_for_bf16)
+                    f32_accum->zero_data(into<int>(ithr));
 
                 const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
                 for (dim_t kd = 0; kd < jpp.kd; ++kd) {
@@ -1414,17 +1427,21 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                             continue;
                         const dim_t id = nstl::max(ik - jpp.f_pad, dim_t(0));
                         for (dim_t oh = 0; oh < jpp.oh; ++oh) {
-                            ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow,
-                                    false, kd, ur_bc, ithr);
+                            ker(into<int>(n), into<int>(b_c), od, into<int>(oh),
+                                    into<int>(id), into<int>(d_t_overflow),
+                                    into<int>(d_b_overflow), false,
+                                    into<int>(kd), into<int>(ur_bc),
+                                    into<int>(ithr));
                         }
                     }
                 }
 
                 if (trans_src)
-                    transpose_facade->execute_transpose_output(ithr, n, b_c);
+                    transpose_facade->execute_transpose_output(
+                            ithr, into<int>(n), into<int>(b_c));
 
                 if (jpp.needs_f32_accum_for_bf16)
-                    f32_accum->cvt_to_bf16_slice_3d(ithr,
+                    f32_accum->cvt_to_bf16_slice_3d(into<int>(ithr),
                             (bfloat16_t *)diff_src, diff_src_d, n, b_c, ur_bc);
             });
         } else {
@@ -1445,8 +1462,11 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                             continue;
                         const dim_t id = nstl::max(ik - jpp.f_pad, dim_t(0));
                         for (dim_t oh = 0; oh < jpp.oh; ++oh) {
-                            ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow,
-                                    false, kd, ur_bc, first_ithr);
+                            ker(into<int>(n), into<int>(b_c), od, into<int>(oh),
+                                    into<int>(id), into<int>(d_t_overflow),
+                                    into<int>(d_b_overflow), false,
+                                    into<int>(kd), into<int>(ur_bc),
+                                    first_ithr);
                         }
                     }
                 });

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -275,7 +275,7 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::reduce_ne_convert_xf16() {
         compute_op_(vmm_acc_, vmm_tmp1_);
         compute_op_(vmm_acc_, vmm_tmp2_);
 
-        add(reg_src_, 2 * simd_w_ * conf_.src_dt_size);
+        add(reg_src_, into<uint32_t>(2 * simd_w_ * conf_.src_dt_size));
 
         sub(reg_work_, 2);
         jmp(label_work_begin);
@@ -288,7 +288,7 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::reduce_ne_convert_xf16() {
         io_load_.load(ptr[reg_src_], vmm_tmp1_, false);
         compute_op_(vmm_acc_, vmm_tmp1_);
 
-        add(reg_src_, simd_w_ * conf_.src_dt_size);
+        add(reg_src_, into<uint32_t>(simd_w_ * conf_.src_dt_size));
 
         dec(reg_work_);
         jmp(label_work_tail_begin);
@@ -314,7 +314,7 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::reduce_base() {
         io_load_.load(ptr[reg_src_], vmm_tmp1_, false);
         compute_op_(vmm_acc_, vmm_tmp1_);
 
-        add(reg_src_, simd_w_ * conf_.src_dt_size);
+        add(reg_src_, into<uint32_t>(simd_w_ * conf_.src_dt_size));
 
         dec(reg_work_);
         jmp(label_work_begin);

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -142,7 +142,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         // be unrolled.
         if (prb.is_tail_present) {
             ndims_full_unroll = 1;
-            len_unroll = prb.nodes[0].n;
+            len_unroll = into<int>(prb.nodes[0].n);
             tail_len_unroll = prb.nodes[0].is_zero_pad_needed
                     ? 0
                     : static_cast<int>(prb.nodes[0].tail_size);
@@ -509,7 +509,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 = (utils::one_of(prb_.otype, u8, s8, s32) && interim_f32);
 
         for (int i = 0; i < unroll; i++) {
-            const int node_0_input_stride = prb_.is(0);
+            const int node_0_input_stride = into<int>(prb_.is(0));
             load(Ymm(i), i_addr(i_off + i * node_0_input_stride),
                     unroll * itype_sz_);
 
@@ -548,7 +548,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
 
         for (int i = 0; i < unroll; i++) {
-            const int node_1_output_stride = prb_.os(1);
+            const int node_1_output_stride = into<int>(prb_.os(1));
             if (prb_.otype != f32)
                 cvt2odt(Ymm(i), prb_.otype,
                         need_saturation       ? s32
@@ -585,7 +585,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     bool process_unroll_tr8x8(const int ndims, const int len) {
         if (!can_do_tr8x8()) return false;
 
-        const int step_size = prb_.n(0) * prb_.n(1);
+        const int step_size = into<int>(prb_.n(0) * prb_.n(1));
         int i_off = 0, o_off = 0;
         for (int off = 0; off < len; off += step_size) {
             step(off, i_off, o_off, i_off, o_off, step_size);
@@ -927,14 +927,15 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             if (itype_sz_ == 4 || interim_f32) {
                 for (int ur = 0; ur < reg_unroll; ur += load_step)
                     for (int r = 1; r < load_step; ++r) {
-                        uni_vshufps(Xmm(ur + r), Xmm(ur), Xmm(ur), r);
+                        uni_vshufps(Xmm(ur + r), Xmm(ur), Xmm(ur),
+                                into<Xbyak::uint8>(r));
                     }
             } else {
                 for (int ur = 0; ur < reg_unroll; ur += load_step)
                     for (int r = 1; r < load_step; ++r) {
                         if (mayiuse(avx))
                             vpalignr(Xmm(ur + r), Xmm(ur), Xmm(ur),
-                                    itype_sz_ * r);
+                                    into<uint8_t>(itype_sz_ * r));
                         else {
                             movups(Xmm(ur + r), Xmm(ur));
                             palignr(Xmm(ur + r), Xmm(ur), itype_sz_ * r);
@@ -1202,7 +1203,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                     for (int r = ur; r < ur + ur_step; ++r) {
                         if (zero_padding[r] == 0 || !tail_processing) {
                             uni_vshufps(xmm_tmp_, xmm_compensation,
-                                    xmm_compensation, r);
+                                    xmm_compensation, into<Xbyak::uint8>(r));
                             const Reg32 reg_tmp_32 = reg_tmp_.cvt32();
                             uni_vmovd(reg_tmp_32, xmm_tmp_);
                             const auto comp_addr = c_addr(c_off[r]);
@@ -1367,8 +1368,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         mov(reg_tmp_, empty_chunk_info);
         mov(data_chunk_addr(curr_node_id), reg_tmp_);
 
-        const int padded_area = prb_.nodes[curr_node_id].n
-                - prb_.nodes[curr_node_id].tail_size;
+        const int padded_area = into<int>(prb_.nodes[curr_node_id].n
+                - prb_.nodes[curr_node_id].tail_size);
 
         if (prb_.nodes[curr_node_id].is_zero_pad_needed) {
             int num_of_zero_padded_values = padded_area;
@@ -1468,7 +1469,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                     = jit_loop == 1 ? desc.len_last_dim_unroll : 1;
             const int curr_node_id = nfu + (jit_loop - 1);
             const int parent_node_id = prb_.nodes[curr_node_id].parent_node_id;
-            const int tail_size = prb_.tail(curr_node_id) / unroll_factor;
+            const int tail_size
+                    = into<int>(prb_.tail(curr_node_id) / unroll_factor);
             const auto node_size = prb_.n(curr_node_id) / unroll_factor;
             const Reg64 reg_loop_cnt = reg_cnt[jit_loop - 1];
             const bool curr_node_has_tail = prb_.tail(curr_node_id) != 0;
@@ -1518,16 +1520,17 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             } else if (curr_node_has_tail) {
                 L(loop);
             } else {
-                loop_begin(loop, reg_loop_cnt, node_size);
+                loop_begin(loop, reg_loop_cnt, into<int>(node_size));
             }
 
             create_loops(desc, reg_cnt, jit_loop - 1);
 
-            loop_end(loop, reg_loop_cnt, node_size,
-                    prb_.is(curr_node_id) * unroll_factor,
-                    prb_.os(curr_node_id) * unroll_factor,
-                    prb_.ss(curr_node_id) * unroll_factor,
-                    prb_.cs(curr_node_id) * unroll_factor, curr_node_id);
+            loop_end(loop, reg_loop_cnt, into<int>(node_size),
+                    into<int>(prb_.is(curr_node_id) * unroll_factor),
+                    into<int>(prb_.os(curr_node_id) * unroll_factor),
+                    into<int>(prb_.ss(curr_node_id) * unroll_factor),
+                    into<int>(prb_.cs(curr_node_id) * unroll_factor),
+                    curr_node_id);
         } else {
             compute_blk_ker(desc);
         }
@@ -1565,8 +1568,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         , f8_e5m2_cvt_(nullptr)
         , f8_e4m3_cvt_(nullptr) {
         assert(!utils::one_of(isa_, isa_undef, isa_all));
-        itype_sz_ = data_type_size(prb_.itype);
-        otype_sz_ = data_type_size(prb_.otype);
+        itype_sz_ = into<int>(data_type_size(prb_.itype));
+        otype_sz_ = into<int>(data_type_size(prb_.otype));
         stype_sz_ = sizeof(float);
         if (prb_.otype == data_type::bf16 && !mayiuse(avx512_core_bf16)
                 && !mayiuse(avx2_vnni_2)) {
@@ -1822,9 +1825,9 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
     jit_single_blk_kernel_t(const tr::prb_t &prb)
         : jit_generator_t(jit_name())
         , prb_(prb)
-        , itype_sz_(data_type_size(prb_.itype))
-        , otype_sz_(data_type_size(prb_.otype))
-        , block_sz(prb.nodes[0].n) {}
+        , itype_sz_(into<int>(data_type_size(prb_.itype)))
+        , otype_sz_(into<int>(data_type_size(prb_.otype)))
+        , block_sz(into<int>(prb.nodes[0].n)) {}
 
     void generate() override {
         auto input_stride
@@ -1840,10 +1843,12 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
         je(tail_processing, T_NEAR);
 
         if (block_sz == 8) {
-            gen_ker8x8(0, 0, input_stride, output_stride, 8, 8);
+            gen_ker8x8(0, 0, into<int>(input_stride), into<int>(output_stride),
+                    8, 8);
             block_sz = 8;
         } else if (block_sz == 16) {
-            gen_ker16x16_in_8x8(input_stride, output_stride);
+            gen_ker16x16_in_8x8(
+                    into<int>(input_stride), into<int>(output_stride));
             block_sz = 16;
         } else {
             assert(!"unimplemented");
@@ -1858,8 +1863,10 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
             auto o_tail = output_stride % 8 != 0 ? output_stride % 8 : 8;
             if (i_tail != o_tail) {
                 auto t_mask = i_tail == 8 ? o_tail : i_tail;
-                gen_setmask(t_mask);
-                gen_ker8x8(0, 0, input_stride, output_stride, i_tail, o_tail);
+                gen_setmask(into<int>(t_mask));
+                gen_ker8x8(0, 0, into<int>(input_stride),
+                        into<int>(output_stride), into<int>(i_tail),
+                        into<int>(o_tail));
             }
         } else if (block_sz == 16) {
             auto i_tail = input_stride % 16 != 0 ? input_stride % 16 : 16;
@@ -1867,9 +1874,10 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
             if (i_tail != o_tail) {
                 auto t_mask = i_tail == 16 ? o_tail : i_tail;
                 t_mask %= 8;
-                if (t_mask != 0) gen_setmask(t_mask);
-                gen_ker16x16_in_8x8(
-                        input_stride, output_stride, i_tail, o_tail);
+                if (t_mask != 0) gen_setmask(into<int>(t_mask));
+                gen_ker16x16_in_8x8(into<int>(input_stride),
+                        into<int>(output_stride), into<int>(i_tail),
+                        into<int>(o_tail));
             }
         } else {
             assert(!"unimplemented");
@@ -1950,7 +1958,7 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
         vxorps(ymm_tmp, ymm_tmp, ymm_tmp);
         vpcmpeqd(ymm_mask, ymm_mask, ymm_mask);
         // shift by mask to have tail nelems in ymm_mask
-        const uint8_t in_mask = 0xFF << mask;
+        const uint8_t in_mask = into<uint8_t>(0xFF << mask);
         vpblendd(ymm_mask, ymm_mask, ymm_tmp, in_mask);
     }
 
@@ -2207,7 +2215,7 @@ static void prb_block_for_cache(tr::prb_t &prb) {
             // is currently unsupported (i.e. tail processing can only be handled
             // at the inner-most dimension)
             bool inner_block_has_tail = false;
-            for (int idx = min_idx - 1; idx >= new_position; idx--) {
+            for (int idx = into<int>(min_idx - 1); idx >= new_position; idx--) {
                 if (prb.nodes[idx].parent_node_id == min_idx) {
                     inner_block_has_tail = true;
                     break;
@@ -2215,7 +2223,7 @@ static void prb_block_for_cache(tr::prb_t &prb) {
             }
 
             if (min_idx > new_position && (!inner_block_has_tail))
-                prb_node_move(prb, min_idx, new_position);
+                prb_node_move(prb, into<int>(min_idx), new_position);
         }
     }
 }

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
@@ -98,8 +98,8 @@ struct direct_copy_kernel_t
                 && (utils::one_of(src_dt_, data_type::bf16, data_type::f16))
                 && (unroll % 2 == 0)) {
             for (size_t i = 0; i < static_cast<size_t>(unroll) / 2; i++) {
-                const Vmm &vmm_src_even = vmm_src(2 * i);
-                const Vmm &vmm_src_odd = vmm_src(2 * i + 1);
+                const Vmm &vmm_src_even = vmm_src(into<int>(2 * i));
+                const Vmm &vmm_src_odd = vmm_src(into<int>(2 * i + 1));
                 Vmm vmm_tmp(vmm_tmp_idx_);
                 io_[src_dt_]->load_two_simdw_xf16(
                         src_ptr(2 * i * types::data_type_size(src_dt_)
@@ -131,8 +131,12 @@ struct direct_copy_kernel_t
 
         if (tail) return;
 
-        add(reg_src, unroll * types::data_type_size(src_dt_) * simd_w_);
-        add(reg_dst, unroll * types::data_type_size(dst_dt_) * simd_w_);
+        add(reg_src,
+                into<uint32_t>(
+                        unroll * types::data_type_size(src_dt_) * simd_w_));
+        add(reg_dst,
+                into<uint32_t>(
+                        unroll * types::data_type_size(dst_dt_) * simd_w_));
         sub(reg_work_amount, unroll * simd_w_);
     }
 

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -370,7 +370,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
         if (ild.dims[i_pos] == old.dims[o_pos]) {
             p.nodes[ndims].n = ild.dims[i_pos];
-            p.nodes[ndims].dim_id = old.id[o_pos];
+            p.nodes[ndims].dim_id = into<int>(old.id[o_pos]);
             p.nodes[ndims].tail_size = old.tails[o_pos];
             p.nodes[ndims].is_zero_pad_needed
                     = old.is_blk[o_pos] && old.tails[o_pos] > 0;
@@ -396,7 +396,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
             const size_t tail_of_lower_dim = old.tails[o_pos] % factor;
 
             p.nodes[ndims].n = ild.dims[i_pos];
-            p.nodes[ndims].dim_id = old.id[o_pos];
+            p.nodes[ndims].dim_id = into<int>(old.id[o_pos]);
             p.nodes[ndims].tail_size = tail_of_upper_dim;
             p.nodes[ndims].is_zero_pad_needed
                     = old.is_blk[o_pos] && tail_of_upper_dim > 0;
@@ -416,7 +416,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
             dim_t factor = ild.dims[i_pos] / old.dims[o_pos];
             p.nodes[ndims].n = old.dims[o_pos];
-            p.nodes[ndims].dim_id = old.id[o_pos];
+            p.nodes[ndims].dim_id = into<int>(old.id[o_pos]);
             p.nodes[ndims].tail_size = old.tails[o_pos];
             p.nodes[ndims].is_zero_pad_needed
                     = old.is_blk[o_pos] && old.tails[o_pos] > 0;

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -99,17 +99,17 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_SPARSE_CFG);
 
     conf_.alg = desc()->alg_kind;
-    conf_.c = C();
-    conf_.od = OD();
-    conf_.oh = OH();
-    conf_.ow = OW();
-    conf_.id = ID();
-    conf_.ih = IH();
-    conf_.iw = IW();
+    conf_.c = into<unsigned int>(C());
+    conf_.od = into<unsigned int>(OD());
+    conf_.oh = into<unsigned int>(OH());
+    conf_.ow = into<unsigned int>(OW());
+    conf_.id = into<unsigned int>(ID());
+    conf_.ih = into<unsigned int>(IH());
+    conf_.iw = into<unsigned int>(IW());
     conf_.ndims = ndims();
 
     if (conf_.alg == alg_kind::resampling_linear)
-        conf_.number_of_corners = pow(2, conf_.ndims - 2);
+        conf_.number_of_corners = into<unsigned int>(pow(2, conf_.ndims - 2));
 
     conf_.src_dt_size = types::data_type_size(conf_.src_data_type);
     conf_.dst_dt_size = types::data_type_size(conf_.dst_data_type);
@@ -128,10 +128,13 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(engine_t *engine) {
 
     conf_.el_size_of_indices = sizeof(unsigned);
 
-    conf_.inner_stride = src_d.blocking_desc().strides[ndims() - 1];
-    conf_.stride_d = IH() * IW() * conf_.inner_stride * conf_.src_dt_size;
-    conf_.stride_h = IW() * conf_.inner_stride * conf_.src_dt_size;
-    conf_.stride_w = conf_.inner_stride * conf_.src_dt_size;
+    conf_.inner_stride
+            = into<unsigned int>(src_d.blocking_desc().strides[ndims() - 1]);
+    conf_.stride_d = into<unsigned int>(
+            IH() * IW() * conf_.inner_stride * conf_.src_dt_size);
+    conf_.stride_h
+            = into<unsigned int>(IW() * conf_.inner_stride * conf_.src_dt_size);
+    conf_.stride_w = into<unsigned int>(conf_.inner_stride * conf_.src_dt_size);
 
     const std::vector<injector::post_op_type> accepted_post_ops
             = {injector::sum, injector::eltwise, injector::binary};
@@ -301,18 +304,18 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_nearest() {
             + utils::rnd_up(pd()->OW(), kernel_->get_simd_w()));
 
     for (dim_t od = 0; od < pd()->OD(); od++) {
-        const int offset_id = nearest_idx(od, pd()->OD(), pd()->ID())
-                * pd()->get_conf().stride_d;
+        const int offset_id = into<int>(nearest_idx(od, pd()->OD(), pd()->ID())
+                * pd()->get_conf().stride_d);
         indices_.emplace_back(offset_id);
     }
     for (dim_t oh = 0; oh < pd()->OH(); oh++) {
-        const int offset_ih = nearest_idx(oh, pd()->OH(), pd()->IH())
-                * pd()->get_conf().stride_h;
+        const int offset_ih = into<int>(nearest_idx(oh, pd()->OH(), pd()->IH())
+                * pd()->get_conf().stride_h);
         indices_.emplace_back(offset_ih);
     }
     for (dim_t ow = 0; ow < pd()->OW(); ow++) {
-        const int offset_iw = nearest_idx(ow, pd()->OW(), pd()->IW())
-                * pd()->get_conf().stride_w;
+        const int offset_iw = into<int>(nearest_idx(ow, pd()->OW(), pd()->IW())
+                * pd()->get_conf().stride_w);
         indices_.emplace_back(offset_iw);
     }
 
@@ -333,9 +336,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
         // tail processing possibilities on sse41 and avx. To avoid problems
         // with that, number of spatial points is aligned to simd width, because
         // all of them are read in the kernel.
-        num_of_elements = number_of_corners
+        num_of_elements = into<unsigned int>(number_of_corners
                 * utils::rnd_up(pd()->OD() * pd()->OH() * pd()->OW(),
-                        kernel_->get_simd_w());
+                        kernel_->get_simd_w()));
 
         indices_.resize(num_of_elements);
         weights_.resize(num_of_elements);
@@ -356,10 +359,10 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
                 for (unsigned i = 0; i < number_of_corners; i++) {
                     std::bitset<3> corners(i);
-                    indices_[i * indices_stride + offset]
-                            = coeffs_id.idx[corners.test(2)] * stride_d
+                    indices_[i * indices_stride + offset] = into<unsigned>(
+                            coeffs_id.idx[corners.test(2)] * stride_d
                             + coeffs_ih.idx[corners.test(1)] * stride_h
-                            + coeffs_iw.idx[corners.test(0)] * stride_w;
+                            + coeffs_iw.idx[corners.test(0)] * stride_w);
                     weights_[i * weights_stride + offset]
                             = coeffs_id.wei[corners.test(2)]
                             * coeffs_ih.wei[corners.test(1)]
@@ -369,7 +372,8 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
         });
     } else if (pd()->get_conf().tag_kind == jit_memory_tag_kind_t::nspc
             || pd()->get_conf().tag_kind == jit_memory_tag_kind_t::blocked) {
-        num_of_elements = 2 * (pd()->OD() + pd()->OH() + pd()->OW());
+        num_of_elements = into<unsigned int>(
+                2 * (pd()->OD() + pd()->OH() + pd()->OW()));
 
         indices_.resize(num_of_elements);
         weights_.resize(num_of_elements);
@@ -390,8 +394,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
             // to read and makes the operation faster.
             weights_w[2 * ow] = coeffs_iw.wei[0];
             weights_w[2 * ow + 1] = coeffs_iw.wei[1];
-            indices_w[2 * ow] = coeffs_iw.idx[0] * stride_w;
-            indices_w[2 * ow + 1] = coeffs_iw.idx[1] * stride_w;
+            indices_w[2 * ow] = into<unsigned int>(coeffs_iw.idx[0] * stride_w);
+            indices_w[2 * ow + 1]
+                    = into<unsigned int>(coeffs_iw.idx[1] * stride_w);
         }
 
         for (dim_t oh = 0; oh < pd()->OH(); oh++) {
@@ -399,8 +404,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_h[oh] = coeffs_ih.wei[0];
             weights_h[pd()->OH() + oh] = coeffs_ih.wei[1];
-            indices_h[oh] = coeffs_ih.idx[0] * stride_h;
-            indices_h[pd()->OH() + oh] = coeffs_ih.idx[1] * stride_h;
+            indices_h[oh] = into<unsigned int>(coeffs_ih.idx[0] * stride_h);
+            indices_h[pd()->OH() + oh]
+                    = into<unsigned int>(coeffs_ih.idx[1] * stride_h);
         }
 
         for (dim_t od = 0; od < pd()->OD(); od++) {
@@ -408,8 +414,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_d[od] = coeffs_id.wei[0];
             weights_d[pd()->OD() + od] = coeffs_id.wei[1];
-            indices_d[od] = coeffs_id.idx[0] * stride_d;
-            indices_d[pd()->OD() + od] = coeffs_id.idx[1] * stride_d;
+            indices_d[od] = into<unsigned int>(coeffs_id.idx[0] * stride_d);
+            indices_d[pd()->OD() + od]
+                    = into<unsigned int>(coeffs_id.idx[1] * stride_d);
         }
     } else {
         assert(!"Invalid memory format kind.");

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -225,7 +225,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding_in_post_ops(
     else {
         std::bitset<8> tail_mask((1 << tail_size_) - 1);
         tail_mask.flip();
-        uni_vblendps(vmm_data, vmm_data, vmm_zeros, tail_mask.to_ulong());
+        uni_vblendps(
+                vmm_data, vmm_data, vmm_zeros, into<int>(tail_mask.to_ulong()));
     }
 }
 
@@ -303,7 +304,7 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
         const int c_to_compute_without_tail, const bool is_tail) {
     const int c_to_compute_with_tail
-            = is_tail ? utils::rnd_up(tail_size_, simd_w_) : 0;
+            = into<int>(is_tail ? utils::rnd_up(tail_size_, simd_w_) : 0);
     const int c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
             - c_to_compute_with_tail;
 
@@ -317,7 +318,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
             io_.at(conf_.dst_data_type)->store(vmm_zeros, dst_address, false);
         }
 
-        add(reg_dst_, c_to_zeroing * conf_.dst_dt_size);
+        add(reg_dst_, into<uint32_t>(c_to_zeroing * conf_.dst_dt_size));
     }
 }
 
@@ -359,7 +360,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_ncsp_format() {
 
     mov(reg_indices_h, reg_indices_);
     mov(reg_indices_w, reg_indices_);
-    add(reg_indices_w, conf_.oh * conf_.el_size_of_indices);
+    add(reg_indices_w, into<uint32_t>(conf_.oh * conf_.el_size_of_indices));
 
     Label oh_loop_begin, oh_loop_end;
     Label ow_loop_begin, ow_loop_end;
@@ -386,8 +387,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_ncsp_format() {
 
             nearest_interpolation(false);
 
-            add(reg_dst_, simd_w_ * conf_.dst_dt_size);
-            add(reg_indices_w, simd_w_ * conf_.el_size_of_indices);
+            add(reg_dst_, into<uint32_t>(simd_w_ * conf_.dst_dt_size));
+            add(reg_indices_w,
+                    into<uint32_t>(simd_w_ * conf_.el_size_of_indices));
             sub(reg_work_, simd_w_);
 
             jmp(ow_loop_begin, T_NEAR);
@@ -396,10 +398,10 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_ncsp_format() {
 
         if (tail_size_ > 0) {
             nearest_interpolation(true);
-            add(reg_dst_, tail_size_ * conf_.dst_dt_size);
+            add(reg_dst_, into<uint32_t>(tail_size_ * conf_.dst_dt_size));
         }
 
-        add(reg_indices_h, conf_.el_size_of_indices);
+        add(reg_indices_h, into<uint32_t>(conf_.el_size_of_indices));
         pop(reg_indices_w);
         pop(reg_oh);
         add(reg_oh, 1);
@@ -435,8 +437,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
 
         nearest_interpolation(false);
 
-        add(reg_src_shifted, simd_w_ * conf_.src_dt_size);
-        add(reg_dst_, simd_w_ * conf_.dst_dt_size);
+        add(reg_src_shifted, into<uint32_t>(simd_w_ * conf_.src_dt_size));
+        add(reg_dst_, into<uint32_t>(simd_w_ * conf_.dst_dt_size));
 
         add(reg_c, simd_w_);
         jmp(c_loop_begin, T_NEAR);
@@ -446,9 +448,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
     if (is_tail) {
         nearest_interpolation(true);
         if (conf_.tag_kind == tag_kind::nspc)
-            add(reg_dst_, tail_size_ * conf_.dst_dt_size);
+            add(reg_dst_, into<uint32_t>(tail_size_ * conf_.dst_dt_size));
         else if (conf_.tag_kind == tag_kind::blocked)
-            add(reg_dst_, simd_w_ * conf_.dst_dt_size);
+            add(reg_dst_, into<uint32_t>(simd_w_ * conf_.dst_dt_size));
     }
 }
 
@@ -486,8 +488,8 @@ void jit_uni_resampling_kernel_t<isa,
 
         nearest_ne_xf16_interpolation(false);
 
-        add(reg_src_shifted, 2 * simd_w_ * conf_.src_dt_size);
-        add(reg_dst_, 2 * simd_w_ * conf_.dst_dt_size);
+        add(reg_src_shifted, into<uint32_t>(2 * simd_w_ * conf_.src_dt_size));
+        add(reg_dst_, into<uint32_t>(2 * simd_w_ * conf_.dst_dt_size));
 
         add(reg_c, 2 * simd_w_);
         jmp(c_loop_begin, T_NEAR);
@@ -539,7 +541,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
                         is_tail_in_blocked_format);
         }
 
-        add(reg_indices_, conf_.el_size_of_indices);
+        add(reg_indices_, into<uint32_t>(conf_.el_size_of_indices));
 
         dec(reg_work_);
         jmp(loop_begin, T_NEAR);
@@ -549,8 +551,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
-    const unsigned indices_stride
-            = conf_.ow * conf_.oh * conf_.od * conf_.el_size_of_indices;
+    const unsigned indices_stride = into<unsigned int>(
+            conf_.ow * conf_.oh * conf_.od * conf_.el_size_of_indices);
     const unsigned weights_stride
             = conf_.ow * conf_.oh * conf_.od * sizeof(float);
 
@@ -594,9 +596,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
 
         linear_interpolation(false);
 
-        add(reg_dst_, simd_w_ * conf_.dst_dt_size);
+        add(reg_dst_, into<uint32_t>(simd_w_ * conf_.dst_dt_size));
         add(reg_weights, simd_w_ * sizeof(float));
-        add(reg_indices_, simd_w_ * conf_.el_size_of_indices);
+        add(reg_indices_, into<uint32_t>(simd_w_ * conf_.el_size_of_indices));
         sub(reg_work_, simd_w_);
 
         jmp(loop_begin, T_NEAR);
@@ -679,10 +681,10 @@ void jit_uni_resampling_kernel_t<isa,
         je(c_loop_end, T_NEAR);
 
         linear_interpolation(reg_c, false);
-        add(reg_dst_, 2 * simd_w_ * conf_.dst_dt_size);
+        add(reg_dst_, into<uint32_t>(2 * simd_w_ * conf_.dst_dt_size));
 
         for (unsigned i = 0; i < conf_.number_of_corners; i++)
-            add(src_regs_[i], 2 * simd_w_ * conf_.src_dt_size);
+            add(src_regs_[i], into<uint32_t>(2 * simd_w_ * conf_.src_dt_size));
 
         add(reg_c, 2 * simd_w_);
         jmp(c_loop_begin, T_NEAR);
@@ -759,10 +761,10 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_linear_c_interpolate(
         je(c_loop_end, T_NEAR);
 
         linear_interpolation(reg_c, false);
-        add(reg_dst_, simd_w_ * conf_.dst_dt_size);
+        add(reg_dst_, into<uint32_t>(simd_w_ * conf_.dst_dt_size));
 
         for (unsigned i = 0; i < conf_.number_of_corners; i++)
-            add(src_regs_[i], simd_w_ * conf_.src_dt_size);
+            add(src_regs_[i], into<uint32_t>(simd_w_ * conf_.src_dt_size));
 
         add(reg_c, simd_w_);
         jmp(c_loop_begin, T_NEAR);
@@ -772,9 +774,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_linear_c_interpolate(
     if (is_tail) {
         linear_interpolation(reg_c, true);
         if (conf_.tag_kind == tag_kind::nspc)
-            add(reg_dst_, tail_size_ * conf_.dst_dt_size);
+            add(reg_dst_, into<uint32_t>(tail_size_ * conf_.dst_dt_size));
         else if (conf_.tag_kind == tag_kind::blocked)
-            add(reg_dst_, simd_w_ * conf_.dst_dt_size);
+            add(reg_dst_, into<uint32_t>(simd_w_ * conf_.dst_dt_size));
     }
 }
 
@@ -845,7 +847,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_c_oriented_format(
         // right corners from both the weights and indices tables.
         // These two values occurs one after the other in memory,
         // so the address should be shifted by two elements.
-        add(reg_indices_, 2 * conf_.el_size_of_indices);
+        add(reg_indices_, into<uint32_t>(2 * conf_.el_size_of_indices));
         add(reg_weights, 2 * sizeof(float));
 
         for (unsigned i = 0; i < conf_.number_of_corners; i++) {

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -284,24 +284,31 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         const auto max_body_unroll = n_loops_ ? unroll_regs_
                 : loop_tail_                  ? loop_tail_
                                               : 1;
-        pre_body(max_body_unroll);
+        pre_body(into<int>(max_body_unroll));
 
         L(body_unroll_loop);
         {
             if (n_loops_) {
-                cmp(reg_reverse_n_elems, unroll_regs_ * process_n_elems_);
+                cmp(reg_reverse_n_elems,
+                        into<uint32_t>(unroll_regs_ * process_n_elems_));
                 jl(body_unroll_tail_loop, T_NEAR);
 
-                body(unroll_regs_, max_body_unroll, false);
-                sub(reg_reverse_n_elems, unroll_regs_ * process_n_elems_);
-                add(reg_src_spat_offt, unroll_regs_ * src_next_vreg_stride_);
-                add(reg_dst_spat_offt, unroll_regs_ * dst_next_vreg_stride_);
+                body(into<int>(unroll_regs_), into<int>(max_body_unroll),
+                        false);
+                sub(reg_reverse_n_elems,
+                        into<uint32_t>(unroll_regs_ * process_n_elems_));
+                add(reg_src_spat_offt,
+                        into<uint32_t>(unroll_regs_ * src_next_vreg_stride_));
+                add(reg_dst_spat_offt,
+                        into<uint32_t>(unroll_regs_ * dst_next_vreg_stride_));
                 if (need_scratchpad_)
                     add(reg_interim_spat_offt,
-                            unroll_regs_ * interim_next_vreg_stride_);
+                            into<uint32_t>(
+                                    unroll_regs_ * interim_next_vreg_stride_));
                 if (!pd_->is_fwd())
                     add(reg_diff_dst_spat_offt,
-                            unroll_regs_ * diff_dst_next_vreg_stride_);
+                            into<uint32_t>(
+                                    unroll_regs_ * diff_dst_next_vreg_stride_));
                 jmp(body_unroll_loop);
             }
         }
@@ -309,19 +316,25 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         L(body_unroll_tail_loop);
         {
             if (loop_tail_) {
-                cmp(reg_reverse_n_elems, loop_tail_ * process_n_elems_);
+                cmp(reg_reverse_n_elems,
+                        into<uint32_t>(loop_tail_ * process_n_elems_));
                 jl(tail_axis, T_NEAR);
 
-                body(loop_tail_, max_body_unroll, false);
-                sub(reg_reverse_n_elems, loop_tail_ * process_n_elems_);
-                add(reg_src_spat_offt, loop_tail_ * src_next_vreg_stride_);
-                add(reg_dst_spat_offt, loop_tail_ * dst_next_vreg_stride_);
+                body(into<int>(loop_tail_), into<int>(max_body_unroll), false);
+                sub(reg_reverse_n_elems,
+                        into<uint32_t>(loop_tail_ * process_n_elems_));
+                add(reg_src_spat_offt,
+                        into<uint32_t>(loop_tail_ * src_next_vreg_stride_));
+                add(reg_dst_spat_offt,
+                        into<uint32_t>(loop_tail_ * dst_next_vreg_stride_));
                 if (need_scratchpad_)
                     add(reg_interim_spat_offt,
-                            loop_tail_ * interim_next_vreg_stride_);
+                            into<uint32_t>(
+                                    loop_tail_ * interim_next_vreg_stride_));
                 if (!pd_->is_fwd())
                     add(reg_diff_dst_spat_offt,
-                            loop_tail_ * diff_dst_next_vreg_stride_);
+                            into<uint32_t>(
+                                    loop_tail_ * diff_dst_next_vreg_stride_));
             }
         }
 
@@ -331,13 +344,13 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                 cmp(reg_reverse_n_elems, 1);
                 jl(loop_end, T_NEAR);
 
-                body(1, max_body_unroll, true);
+                body(1, into<int>(max_body_unroll), true);
             }
         }
 
         L(loop_end);
 
-        post_body(max_body_unroll);
+        post_body(into<int>(max_body_unroll));
     }
 
     void uni_vaddps_maybe_tail(
@@ -639,9 +652,9 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                                     alg_kind::eltwise_exp, pd_->is_fwd(), 0.f);
                     for (size_t j = 0; j < exp_vmm_aux_count; j++) {
                         // Insert the next idx starting after `vreg_tmp_sum`.
-                        exp_aux_indices.insert(static_cast<size_t>(
-                                get_aux_vmm(vreg_tmp_sum, (j + 1) * max_unroll)
-                                        .getIdx()));
+                        exp_aux_indices.insert(into<size_t>(get_aux_vmm(
+                                vreg_tmp_sum, into<int>((j + 1) * max_unroll))
+                                                                    .getIdx()));
                     }
                     exp_injector_->compute_vector(
                             vreg_tmp_src.getIdx(), exp_aux_indices);
@@ -1251,19 +1264,22 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         L(axis_size_body);
         {
             if (axis_size_ >= unroll_axis_size_) {
-                cmp(reg_reverse_axis_elems, unroll_axis_size_);
+                cmp(reg_reverse_axis_elems, into<uint32_t>(unroll_axis_size_));
                 jl(axis_size_tail, T_NEAR);
 
-                body(unroll_axis_size_, inner_unroll, tail);
+                body(into<int>(unroll_axis_size_), inner_unroll, tail);
 
                 add(reg_src_spat_offt,
-                        unroll_axis_size_ * src_next_vreg_stride_);
+                        into<uint32_t>(
+                                unroll_axis_size_ * src_next_vreg_stride_));
                 add(reg_interim_spat_offt,
-                        unroll_axis_size_ * interim_next_vreg_stride_);
+                        into<uint32_t>(
+                                unroll_axis_size_ * interim_next_vreg_stride_));
                 add(reg_dst_spat_offt,
-                        unroll_axis_size_ * dst_next_vreg_stride_);
+                        into<uint32_t>(
+                                unroll_axis_size_ * dst_next_vreg_stride_));
 
-                sub(reg_reverse_axis_elems, unroll_axis_size_);
+                sub(reg_reverse_axis_elems, into<uint32_t>(unroll_axis_size_));
                 jmp(axis_size_body);
             }
         }
@@ -1271,20 +1287,26 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         L(axis_size_tail);
         {
             if (axis_size_unroll_tail_) {
-                body(axis_size_unroll_tail_, inner_unroll, tail);
+                body(into<int>(axis_size_unroll_tail_), inner_unroll, tail);
 
                 add(reg_src_spat_offt,
-                        axis_size_unroll_tail_ * src_next_vreg_stride_);
+                        into<uint32_t>(axis_size_unroll_tail_
+                                * src_next_vreg_stride_));
                 add(reg_interim_spat_offt,
-                        axis_size_unroll_tail_ * interim_next_vreg_stride_);
+                        into<uint32_t>(axis_size_unroll_tail_
+                                * interim_next_vreg_stride_));
                 add(reg_dst_spat_offt,
-                        axis_size_unroll_tail_ * dst_next_vreg_stride_);
+                        into<uint32_t>(axis_size_unroll_tail_
+                                * dst_next_vreg_stride_));
             }
         }
         // Restore initial offsets for the next round.
-        sub(reg_src_spat_offt, axis_size_ * src_next_vreg_stride_);
-        sub(reg_interim_spat_offt, axis_size_ * interim_next_vreg_stride_);
-        sub(reg_dst_spat_offt, axis_size_ * dst_next_vreg_stride_);
+        sub(reg_src_spat_offt,
+                into<uint32_t>(axis_size_ * src_next_vreg_stride_));
+        sub(reg_interim_spat_offt,
+                into<uint32_t>(axis_size_ * interim_next_vreg_stride_));
+        sub(reg_dst_spat_offt,
+                into<uint32_t>(axis_size_ * dst_next_vreg_stride_));
     }
 
     // The function provides complete softmax algorithm over axis_size_. Stages:
@@ -1442,9 +1464,11 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         axis_size_loop_unroll(store_body, unroll_inner, tail);
 
         add(reg_src_spat_offt,
-                unroll_inner * simd_w_ * src_d_.data_type_size());
+                into<uint32_t>(
+                        unroll_inner * simd_w_ * src_d_.data_type_size()));
         add(reg_dst_spat_offt,
-                unroll_inner * simd_w_ * dst_d_.data_type_size());
+                into<uint32_t>(
+                        unroll_inner * simd_w_ * dst_d_.data_type_size()));
     }
 
     // The function provides unrolling over inner size. A single compute block
@@ -1462,12 +1486,14 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         L(unroll_loop);
         {
             if (n_loops_) {
-                cmp(reg_reverse_n_elems, unroll_inner_size_ * simd_w_);
+                cmp(reg_reverse_n_elems,
+                        into<uint32_t>(unroll_inner_size_ * simd_w_));
                 jl(unroll_tail_loop, T_NEAR);
 
-                axis_full_cycle(unroll_inner_size_, false);
+                axis_full_cycle(into<int>(unroll_inner_size_), false);
 
-                sub(reg_reverse_n_elems, unroll_inner_size_ * simd_w_);
+                sub(reg_reverse_n_elems,
+                        into<uint32_t>(unroll_inner_size_ * simd_w_));
                 jmp(unroll_loop);
             }
         }
@@ -1475,12 +1501,12 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         L(unroll_tail_loop);
         {
             if (loop_tail_) {
-                cmp(reg_reverse_n_elems, loop_tail_ * simd_w_);
+                cmp(reg_reverse_n_elems, into<uint32_t>(loop_tail_ * simd_w_));
                 jl(tail_loop, T_NEAR);
 
-                axis_full_cycle(loop_tail_, false);
+                axis_full_cycle(into<int>(loop_tail_), false);
 
-                sub(reg_reverse_n_elems, loop_tail_ * simd_w_);
+                sub(reg_reverse_n_elems, into<uint32_t>(loop_tail_ * simd_w_));
                 // No jump, unroll_tail run once.
             }
         }

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -548,7 +548,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
                 jit_tail_.uni_vmovups_maybe_tail(
                         vmmword[reg_ptr_stat_ + reg_off_c_ + vlen / 2], vzero_);
             }
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
             dec(reg_C_);
             jnz(label_zeroise);
         }
@@ -557,7 +557,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
     void load_stat(bool compute_mean, const int c_blks_to_unroll = 1) {
         int start_idx = min_idx_to_unroll_;
         int end_idx = c_blks_to_unroll + min_idx_to_unroll_;
-        const int step = simd_w * acc_type_size_;
+        const dim_t step = simd_w * acc_type_size_;
 
         // load mean or variance
         for (int idx = start_idx, off = 0; idx < end_idx; idx++, off += step) {
@@ -583,7 +583,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
     void compute_stat(bool compute_mean, const int c_blks_to_unroll = 1) {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = c_blks_to_unroll + min_idx_to_unroll_;
-        const int step = simd_w * data_type_size_;
+        const dim_t step = simd_w * data_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx; idx++, off += step) {
             const Vmm vstat = Vmm(idx);
@@ -606,7 +606,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
             bool compute_mean, const int c_blks_to_unroll = 1) {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = c_blks_to_unroll + min_idx_to_unroll_;
-        const int step = simd_w * data_type_size_;
+        const dim_t step = simd_w * data_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx;
                 idx += 2, off += 2 * step) {
@@ -636,7 +636,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
     void store_stat(const int c_blks_to_unroll = 1) {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = c_blks_to_unroll + min_idx_to_unroll_;
-        const int step = simd_w * acc_type_size_;
+        const dim_t step = simd_w * acc_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx; idx++, off += step) {
             const Vmm vstat = Vmm(idx);
@@ -660,7 +660,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
             {
                 compute_stat(compute_mean);
 
-                add(reg_off_dat_, stride_S_ * data_type_size_);
+                add(reg_off_dat_, into<uint32_t>(stride_S_ * data_type_size_));
 
                 dec(reg_S_);
                 jnz(label_S);
@@ -668,8 +668,8 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
 
             store_stat();
 
-            add(reg_off_dat_save_, stride_C_ * data_type_size_);
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_dat_save_, into<uint32_t>(stride_C_ * data_type_size_));
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
 
             dec(reg_C_);
             jnz(label_C);
@@ -706,7 +706,8 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
                                       compute_mean, c_blks_to_unroll)
                             : compute_stat(compute_mean, c_blks_to_unroll);
 
-                    add(reg_off_dat_, stride_S_ * data_type_size_);
+                    add(reg_off_dat_,
+                            into<uint32_t>(stride_S_ * data_type_size_));
 
                     dec(reg_S_);
                     jnz(label_S);
@@ -714,9 +715,12 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
 
                 store_stat(c_blks_to_unroll);
 
-                add(reg_off_c_, c_blks_to_unroll * simd_w * acc_type_size_);
+                add(reg_off_c_,
+                        into<uint32_t>(
+                                c_blks_to_unroll * simd_w * acc_type_size_));
                 add(reg_off_dat_save_,
-                        c_blks_to_unroll * stride_C_ * data_type_size_);
+                        into<uint32_t>(c_blks_to_unroll * stride_C_
+                                * data_type_size_));
 
                 sub(reg_C_, c_blks_to_unroll);
                 jmp(c_unroll_label[c_blks_to_unroll], T_NEAR);
@@ -746,7 +750,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
                 compute_blocked(compute_mean);
             }
 
-            add(reg_ptr_src_, stride_N_ * data_type_size_);
+            add(reg_ptr_src_, into<uint32_t>(stride_N_ * data_type_size_));
             dec(reg_N_);
             jnz(label_N);
         }
@@ -757,7 +761,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
         cmp(reg_do_normalise_, 0);
         jz(label_ret);
 
-        const int S = pd_->D() * pd_->H() * pd_->W();
+        const int S = into<int>(pd_->D() * pd_->H() * pd_->W());
         mov(reg_tmp_, float2int(pd_->MB() * S));
         Xmm xtmp = Xmm(vtmp_.getIdx());
         uni_vmovq(xtmp, reg_tmp_);
@@ -781,7 +785,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
                         vmmword[reg_ptr_stat_ + reg_off_c_ + vlen / 2], v_);
             }
 
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
             dec(reg_C_);
             jnz(label_normalise);
         }
@@ -1012,7 +1016,7 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
     }
 
     void load_two_c_mean_sqrtvar() {
-        const int offt = simd_w * acc_type_size_;
+        const dim_t offt = simd_w * acc_type_size_;
         jit_tail_.uni_vmovups_maybe_tail(
                 vmean_even_, vmmword[reg_ptr_mean_ + reg_off_c_]);
         jit_tail_.uni_vmovups_maybe_tail(
@@ -1056,9 +1060,10 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
             compute_bnorm(vsrc_even, vmean_even_, vsqrtvar_even_,
                     stream_store_allowed, true);
 
-            load_c_specifics(true, simd_w * acc_type_size_);
+            load_c_specifics(true, into<int>(simd_w * acc_type_size_));
             compute_bnorm(vsrc_odd, vmean_odd_, vsqrtvar_odd_,
-                    stream_store_allowed, true, stride_C_ * data_type_size_);
+                    stream_store_allowed, true,
+                    into<int>(stride_C_ * data_type_size_));
         }
     }
 
@@ -1078,12 +1083,13 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
             {
                 compute_bnorm_avx2_ne_xf16(false, stream_store_allowed);
 
-                add(reg_off_dat_, stride_S_ * data_type_size_);
+                add(reg_off_dat_, into<uint32_t>(stride_S_ * data_type_size_));
                 dec(reg_S_);
                 jnz(label_S, T_NEAR);
             }
-            add(reg_off_dat_save_, 2 * stride_C_ * data_type_size_);
-            add(reg_off_c_, 2 * simd_w * acc_type_size_);
+            add(reg_off_dat_save_,
+                    into<uint32_t>(2 * stride_C_ * data_type_size_));
+            add(reg_off_c_, into<uint32_t>(2 * simd_w * acc_type_size_));
 
             sub(reg_C_, 2);
             jnz(label_C, T_NEAR);
@@ -1102,7 +1108,7 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
             {
                 compute_bnorm_avx2_ne_xf16(true, stream_store_allowed);
 
-                add(reg_off_dat_, stride_S_ * data_type_size_);
+                add(reg_off_dat_, into<uint32_t>(stride_S_ * data_type_size_));
                 dec(reg_S_);
                 jnz(label_S_C_tail, T_NEAR);
             }
@@ -1125,14 +1131,14 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
                 compute_bnorm(
                         v_, vmean_, vsqrtvar_, stream_store_allowed, false);
 
-                add(reg_off_dat_, stride_S_ * data_type_size_);
+                add(reg_off_dat_, into<uint32_t>(stride_S_ * data_type_size_));
 
                 dec(reg_S_);
                 jnz(label_S);
             }
 
-            add(reg_off_dat_save_, stride_C_ * data_type_size_);
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_dat_save_, into<uint32_t>(stride_C_ * data_type_size_));
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
 
             dec(reg_C_);
             jnz(label_C);
@@ -1163,8 +1169,8 @@ struct jit_bnorm_fwd_t : public jit_generator_t {
                 compute_blocked(stream_store_allowed);
             }
 
-            add(reg_ptr_src_, stride_N_ * data_type_size_);
-            add(reg_ptr_dst_, stride_N_ * data_type_size_);
+            add(reg_ptr_src_, into<uint32_t>(stride_N_ * data_type_size_));
+            add(reg_ptr_dst_, into<uint32_t>(stride_N_ * data_type_size_));
             if (jit_relu_.with_relu_ && !jit_relu_.with_relu_inf_only_)
                 add(reg_ptr_ws_, stride_N_ / bits_per_byte);
 
@@ -1306,7 +1312,7 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vone_, x);
 
-        const int S = pd_->D() * pd_->H() * pd_->W();
+        const int S = into<int>(pd_->D() * pd_->H() * pd_->W());
         mov(reg_tmp_, float2int(pd_->MB() * S));
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vNS_, x);
@@ -1387,14 +1393,14 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
             {
                 compute_bnorm(stream_store_allowed);
 
-                add(reg_off_dat_, stride_S_ * data_type_size_);
+                add(reg_off_dat_, into<uint32_t>(stride_S_ * data_type_size_));
 
                 dec(reg_S_);
                 jnz(label_S);
             }
 
-            add(reg_off_dat_save_, stride_C_ * data_type_size_);
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_dat_save_, into<uint32_t>(stride_C_ * data_type_size_));
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
 
             dec(reg_C_);
             jnz(label_C);
@@ -1416,14 +1422,14 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
 
                 compute_bnorm(stream_store_allowed);
 
-                add(reg_off_c_, simd_w * acc_type_size_);
-                add(reg_off_dat_, stride_C_ * data_type_size_);
+                add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
+                add(reg_off_dat_, into<uint32_t>(stride_C_ * data_type_size_));
 
                 dec(reg_C_);
                 jnz(label_C);
             }
 
-            add(reg_off_dat_save_, stride_S_ * data_type_size_);
+            add(reg_off_dat_save_, into<uint32_t>(stride_S_ * data_type_size_));
 
             dec(reg_S_);
             jnz(label_S);
@@ -1451,9 +1457,9 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
                 compute_blocked(stream_store_allowed);
             }
 
-            add(reg_ptr_src_, stride_N_ * data_type_size_);
-            add(reg_ptr_diff_src_, stride_N_ * data_type_size_);
-            add(reg_ptr_diff_dst_, stride_N_ * data_type_size_);
+            add(reg_ptr_src_, into<uint32_t>(stride_N_ * data_type_size_));
+            add(reg_ptr_diff_src_, into<uint32_t>(stride_N_ * data_type_size_));
+            add(reg_ptr_diff_dst_, into<uint32_t>(stride_N_ * data_type_size_));
             add(reg_ptr_ws_, stride_N_ / bits_per_byte);
 
             dec(reg_N_);
@@ -1624,7 +1630,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
                         vmmword[reg_ptr_diff_beta_ + reg_off_c_ + vlen / 2],
                         vzero_);
             }
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
             dec(reg_C_);
             jnz(label_zeroise);
         }
@@ -1636,7 +1642,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = number_of_unrolled_variables_ * c_blks_to_unroll
                 + min_idx_to_unroll_;
-        const int step = simd_w * acc_type_size_;
+        const dim_t step = simd_w * acc_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx;
                 idx += number_of_unrolled_variables_, off += step) {
@@ -1668,7 +1674,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = number_of_unrolled_variables_ * c_blks_to_unroll
                 + min_idx_to_unroll_;
-        const int step = simd_w * acc_type_size_;
+        const dim_t step = simd_w * acc_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx;
                 idx += number_of_unrolled_variables_, off += step) {
@@ -1694,7 +1700,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = number_of_unrolled_variables_ * c_blks_to_unroll
                 + min_idx_to_unroll_;
-        const int step = simd_w * data_type_size_;
+        const dim_t step = simd_w * data_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx;
                 idx += number_of_unrolled_variables_, off += step) {
@@ -1724,7 +1730,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
         const int start_idx = min_idx_to_unroll_;
         const int end_idx = number_of_unrolled_variables_ * c_blks_to_unroll
                 + min_idx_to_unroll_;
-        const int step = simd_w * acc_type_size_;
+        const dim_t step = simd_w * acc_type_size_;
 
         for (int idx = start_idx, off = 0; idx < end_idx;
                 idx += number_of_unrolled_variables_, off += step) {
@@ -1769,7 +1775,7 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
             {
                 compute_diff_beta_and_diff_gamma();
 
-                add(reg_off_dat_, stride_S_ * data_type_size_);
+                add(reg_off_dat_, into<uint32_t>(stride_S_ * data_type_size_));
 
                 dec(reg_S_);
                 jnz(label_S);
@@ -1778,8 +1784,8 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
             load_and_prepare_sqrtvar();
             store_diff_beta_and_diff_gamma();
 
-            add(reg_off_dat_save_, stride_C_ * data_type_size_);
-            add(reg_off_c_, simd_w * acc_type_size_);
+            add(reg_off_dat_save_, into<uint32_t>(stride_C_ * data_type_size_));
+            add(reg_off_c_, into<uint32_t>(simd_w * acc_type_size_));
 
             dec(reg_C_);
             jnz(label_C);
@@ -1812,7 +1818,8 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
                 {
                     compute_diff_beta_and_diff_gamma(c_blks_to_unroll);
 
-                    add(reg_off_dat_, stride_S_ * data_type_size_);
+                    add(reg_off_dat_,
+                            into<uint32_t>(stride_S_ * data_type_size_));
 
                     dec(reg_S_);
                     jnz(label_S);
@@ -1821,9 +1828,12 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
                 load_and_prepare_sqrtvar(c_blks_to_unroll);
                 store_diff_beta_and_diff_gamma(c_blks_to_unroll);
 
-                add(reg_off_c_, c_blks_to_unroll * simd_w * acc_type_size_);
+                add(reg_off_c_,
+                        into<uint32_t>(
+                                c_blks_to_unroll * simd_w * acc_type_size_));
                 add(reg_off_dat_save_,
-                        c_blks_to_unroll * stride_C_ * data_type_size_);
+                        into<uint32_t>(c_blks_to_unroll * stride_C_
+                                * data_type_size_));
 
                 sub(reg_C_, c_blks_to_unroll);
                 jmp(c_unroll_label[c_blks_to_unroll], T_NEAR);
@@ -1852,8 +1862,8 @@ struct jit_bnorm_bwd_diff_ss_t : public jit_generator_t {
                 compute_blocked();
             }
 
-            add(reg_ptr_src_, stride_N_ * data_type_size_);
-            add(reg_ptr_diff_dst_, stride_N_ * data_type_size_);
+            add(reg_ptr_src_, into<uint32_t>(stride_N_ * data_type_size_));
+            add(reg_ptr_diff_dst_, into<uint32_t>(stride_N_ * data_type_size_));
             add(reg_ptr_ws_, stride_N_ / bits_per_byte);
 
             dec(reg_N_);
@@ -1973,7 +1983,7 @@ public:
             const batch_normalization_pd_t *pd) {
 
         int nthrs = dnnl_get_max_threads();
-        int C_PADDED = get_c_padded(pd);
+        dim_t C_PADDED = get_c_padded(pd);
 
         auto sbuf_sz = use_tmp_stats(pd) * 2 * C_PADDED;
         auto pbuf_sz
@@ -1992,7 +2002,7 @@ public:
         std::tie(stride_N, stride_S, stride_C)
                 = get_data_strides<isa>(pd_, tag_kind_);
 
-        const int nthr_NS = nthr.N * nthr.S;
+        const dim_t nthr_NS = nthr.N * nthr.S;
         const bool need_reduction = nthr_NS > 1;
         const dim_t tail_size = blk_has_tail ? C_ % simd_w : simd_w;
 
@@ -2020,7 +2030,7 @@ public:
 
         // find local mean
         acc_data_t *r_mean = need_reduction ? rbuf : mean;
-        parallel(nthr.glob,
+        parallel(into<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2035,7 +2045,7 @@ public:
             const size_t d_off = start.N * stride_N + start.C * stride_C
                     + start.S * stride_S;
             c.src = (void *)((char *)src + d_off * dt_size_);
-            const int ithr_NS = ithr.N * nthr.S + ithr.S;
+            const dim_t ithr_NS = ithr.N * nthr.S + ithr.S;
             c.mean = &r_mean[ithr_NS * size_C_stat + start.C * simd_w];
             c.blk_has_tail = blk_has_tail && stop.C == C_blks;
             c.do_normalise = !need_reduction;
@@ -2047,7 +2057,7 @@ public:
 
         // find local var
         acc_data_t *r_var = need_reduction ? rbuf : var;
-        parallel(nthr.glob,
+        parallel(into<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2062,7 +2072,7 @@ public:
             const size_t d_off = start.N * stride_N + start.C * stride_C
                     + start.S * stride_S;
             c.src = (void *)((char *)src + d_off * dt_size_);
-            const int ithr_NS = ithr.N * nthr.S + ithr.S;
+            const dim_t ithr_NS = ithr.N * nthr.S + ithr.S;
             c.mean = &mean[start.C * simd_w];
             c.var = &r_var[ithr_NS * size_C_stat + start.C * simd_w];
             c.blk_has_tail = blk_has_tail && stop.C == C_blks;
@@ -2083,7 +2093,7 @@ public:
         std::tie(stride_N, stride_S, stride_C)
                 = get_data_strides<isa>(pd_, tag_kind_);
 
-        parallel(nthr.glob,
+        parallel(into<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2161,7 +2171,7 @@ public:
         const dim_t tail_size = blk_has_tail ? C_ % simd_w : simd_w;
         const dim_t size_C_stat = (C_blks - 1) * simd_w + tail_size;
 
-        const int nthr_NS = nthr.N * nthr.S;
+        const dim_t nthr_NS = nthr.N * nthr.S;
         const bool need_reduction = nthr_NS > 1;
 
         acc_data_t *diff_gamma = diff_scale;
@@ -2197,14 +2207,14 @@ public:
             });
         };
 
-        parallel(nthr.glob,
+        parallel(into<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
             bnorm_dims_t start, stop;
             work_distribution(C_blks, ithr, nthr, start, stop);
 
-            const int ithr_NS = ithr.N * nthr.S + ithr.S;
+            const dim_t ithr_NS = ithr.N * nthr.S + ithr.S;
             acc_data_t *loc_diff_gamma = &r_diff_gamma[ithr_NS * size_C_stat];
             acc_data_t *loc_diff_beta = &r_diff_beta[ithr_NS * size_C_stat];
 
@@ -2240,7 +2250,7 @@ public:
         std::tie(stride_N, stride_S, stride_C)
                 = get_data_strides<isa>(pd_, tag_kind_);
 
-        parallel(nthr.glob,
+        parallel(into<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2409,7 +2419,7 @@ private:
     bnorm_dims_t map_thread(int ithr_glob, const bnorm_dims_t &nthr) {
         auto ithr = bnorm_dims_t();
         ithr.glob = ithr_glob;
-        ithr.C = map_thread_c(ithr.glob, nthr);
+        ithr.C = map_thread_c(into<int>(ithr.glob), nthr);
         ithr.N = ithr.glob / nthr.S % nthr.N;
         ithr.S = ithr.glob % nthr.S;
         return ithr;
@@ -2422,7 +2432,8 @@ private:
 
     void work_distribution(dim_t C_blks, const bnorm_dims_t &ithr,
             const bnorm_dims_t &nthr, bnorm_dims_t &start, bnorm_dims_t &stop) {
-        work_distribution_c(C_blks, ithr.C, nthr.C, start.C, stop.C);
+        work_distribution_c(
+                C_blks, into<int>(ithr.C), into<int>(nthr.C), start.C, stop.C);
         balance211(N_, nthr.N, ithr.N, start.N, stop.N);
         balance211(S_, nthr.S, ithr.S, start.S, stop.S);
     }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -121,7 +121,7 @@ int jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * i_ur;
 
-    return jcp.typesize_out * (ur_stride + i_load * jcp.load_block);
+    return into<int>(jcp.typesize_out * (ur_stride + i_load * jcp.load_block));
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -275,7 +275,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        int offt = into<int>((i_load * jcp.reduce_dim + u0) * jcp.load_block);
 
         return ptr[aux_reg_load_data + u1 * jcp.reduce_loop_load_step
                 + jcp.typesize_in * offt];
@@ -530,7 +530,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
     L(reduce_loop);
     {
         fma_block(false);
-        add(aux_reg_bcast_data, jcp.reduce_loop_bcast_step);
+        add(aux_reg_bcast_data, into<uint32_t>(jcp.reduce_loop_bcast_step));
         add(aux_reg_load_data, jcp.reduce_loop_load_step);
         sub(reg_reduce_loop_iter, jcp.reduce_loop_unroll);
         jg(reduce_loop, T_NEAR);
@@ -719,27 +719,28 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     const int ndims = src_d.ndims();
     jcp.nthr = nthreads;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = into<int>((ndims == 5) ? src_d.dims()[2] : 1);
+    jcp.ih = into<int>((ndims == 3) ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>((ndims == 5) ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>((ndims == 3) ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>((ndims == 5) ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(
+            (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>((ndims == 5) ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>((ndims == 3) ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>((ndims == 5) ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>((ndims == 3) ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     jcp.signed_input = (src_d.data_type() == data_type::s8);
@@ -815,10 +816,10 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 512;
@@ -844,7 +845,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             && (jcp.oh <= size_threshold && jcp.ow <= size_threshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs = 3;
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = into<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
         const int spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
@@ -856,7 +857,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = into<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -891,14 +892,15 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     jcp.bcast_loop_bcast_step
             = jcp.ur * jcp.ic_without_padding * jcp.typesize_in;
 
-    jcp.load_loop_load_step = jcp.reduce_dim * jcp.load_block * jcp.typesize_in;
+    jcp.load_loop_load_step
+            = into<int>(jcp.reduce_dim * jcp.load_block * jcp.typesize_in);
 
     jcp.load_loop_iter_step = jcp.load_block;
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    int nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    int nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -929,7 +931,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
                              div_up(jcp.nthr, jcp.load_grp_count))
             * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+    bcast_blocking = into<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
     bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
     int space_for_bcast = (L2_capacity - /* kernel_size - */
@@ -970,9 +972,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     jcp.nb_reduce_blocking = reduce_blocking / jcp.reduce_block;
     jcp.nb_reduce_blocking_max = reduce_blocking_max / jcp.reduce_block;
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = into<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = into<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     // miniumum size of load dim chunk for work distribution within threads
     jcp.nb_load_chunk = 1;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -142,7 +142,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = typename rtus_driver_t<isa>::call_params_t();
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     // override some constants for fused dw_conv
     const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
     const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
@@ -431,9 +431,10 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr, into<dim_t>(jcp.mb * jcp.ngroups * jcp_dw->oh),
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                dim_t(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
             int load_step;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -443,7 +443,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](int ii, int ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -429,11 +429,11 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
+        int gb = into<int>(gg * jcp.nb_ch_blocking);
         int g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
+        int ih_s = into<int>(-jcp.t_pad + oh_s * jcp.stride_h);
+        int ow_s = into<int>(owb * jcp.ow_block);
         int iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -78,12 +78,12 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     const bool is_3d = ndims == 5;
     const bool is_avx2 = isa == avx2;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = into<int>(with_groups ? weights_d.dims()[0] : 1);
+    jcp.oc = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic = into<int>(src_d.dims()[1] / jcp.ngroups);
+    jcp.id = into<int>(is_3d ? src_d.dims()[2] : 1);
+    jcp.oc_without_padding = into<int>(dst_d.dims()[1] / jcp.ngroups);
+    jcp.ic_without_padding = into<int>(src_d.dims()[1] / jcp.ngroups);
     jcp.is_depthwise = true && with_groups
             && utils::everyone_is(
                     1, jcp.ic_without_padding, jcp.oc_without_padding);
@@ -183,21 +183,21 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     }
 
     jcp.prop_kind = cd.prop_kind;
-    jcp.mb = src_d.dims()[0];
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.mb = into<int>(src_d.dims()[0]);
+    jcp.ih = into<int>(is_1d ? 1 : src_d.dims()[ndims - 2]);
+    jcp.iw = into<int>(src_d.dims()[ndims - 1]);
+    jcp.od = into<int>(is_3d ? dst_d.dims()[2] : 1);
+    jcp.oh = into<int>(is_1d ? 1 : dst_d.dims()[ndims - 2]);
+    jcp.ow = into<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = into<int>(is_3d ? weights_d.dims()[with_groups + 2] : 1);
+    jcp.kh = into<int>(is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = into<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = into<int>(is_3d ? cd.padding[0][0] : 0);
+    jcp.t_pad = into<int>(is_1d ? 0 : cd.padding[0][ndims - 4]);
+    jcp.l_pad = into<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = into<int>(is_3d ? cd.strides[0] : 1);
+    jcp.stride_h = into<int>(is_1d ? 1 : cd.strides[ndims - 4]);
+    jcp.stride_w = into<int>(cd.strides[ndims - 3]);
 
     if (jcp.is_depthwise) {
         jcp.ch_block = is_avx2 ? 8 : 4;
@@ -228,9 +228,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     VDISPATCH_DECONVOLUTION_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_TAG_S, "weights");
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = into<int>(is_3d ? cd.dilates[0] : 0);
+    jcp.dilate_h = into<int>(is_1d ? 0 : cd.dilates[ndims - 4]);
+    jcp.dilate_w = into<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_DECONVOLUTION_IC(
             !(!IMPLICATION(jcp.dilate_d, jcp.stride_d == 1)
@@ -280,10 +280,10 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = into<int>(
+            jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0);
+    jcp.typesize_in = into<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out = into<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -656,7 +656,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
         const auto kh_offset = jcp_.kw * jcp_.oc_without_padding * jcp_.ngroups
                 * sizeof(int32_t);
 
-        add(reg_zp_src_pad_comp, kh_offset);
+        add(reg_zp_src_pad_comp, into<uint32_t>(kh_offset));
         mov(zp_src_pad_comp_addr_, reg_zp_src_pad_comp);
     }
 
@@ -756,7 +756,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                 }
             }
             for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-                const int aux_filt_off = kernel_offset(ocb, icb1, ki);
+                const int aux_filt_off
+                        = into<int>(kernel_offset(ocb, icb1, ki));
 
                 if (_end - _start > 0) {
                     if (jcp_.is_depthwise) {
@@ -1798,9 +1799,9 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                 }
 
                 const int wei_stride
-                        = (!jcp.signed_input && !jcp.src_zero_point)
-                        ? kh_lo * wht_kh_stride
-                        : 0;
+                        = into<int>((!jcp.signed_input && !jcp.src_zero_point)
+                                        ? kh_lo * wht_kh_stride
+                                        : 0);
                 p.src = src_w + ih_max * src_h_stride;
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
                 p.filt = wht_w + wei_stride;
@@ -2029,9 +2030,9 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 }
 
                 const int wei_stride
-                        = (!jcp.signed_input && !jcp.src_zero_point)
-                        ? kh_lo * wht_kh_stride
-                        : 0;
+                        = into<int>((!jcp.signed_input && !jcp.src_zero_point)
+                                        ? kh_lo * wht_kh_stride
+                                        : 0);
                 p.src = src_w + ih_max * src_h_stride;
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
                 p.filt = wht_w + wei_stride;

--- a/src/cpu/x64/jit_uni_xf16_sum.cpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.cpp
@@ -202,7 +202,7 @@ status_t jit_avx512_core_bf16_sum_kernel_t::init_conf(
     jsp.is_bf16_dst = data_type::bf16 == o_d.data_type();
 
     jsp.typesize_in = sizeof(bfloat16_t);
-    jsp.typesize_out = types::data_type_size(o_d.data_type());
+    jsp.typesize_out = into<int>(types::data_type_size(o_d.data_type()));
 
     return status::success;
 }
@@ -259,14 +259,14 @@ void jit_avx2_vnni_2_xf16_sum_kernel_t::tail_iteration() {
     cmp(reg_sz, 0);
     jle(exit_label, T_NEAR);
     for (int unroll = 3; unroll >= 0; unroll--) {
-        const unsigned char process_elems = 1 << unroll;
+        const unsigned char process_elems = into<unsigned char>(1 << unroll);
         mov(rsi, process_elems);
         cmp(reg_sz, rsi);
         jge(tail_unroll_labels[unroll], T_NEAR);
     }
 
     for (int unroll = 3; unroll >= 0; unroll--) {
-        const unsigned char process_elems = 1 << unroll;
+        const unsigned char process_elems = into<unsigned char>(1 << unroll);
         L(tail_unroll_labels[unroll]);
         if (process_elems == 8) {
             Xmm vacc0l = Xmm(acc_vreg_idx(unroll, 0));
@@ -338,8 +338,8 @@ status_t jit_avx2_vnni_2_xf16_sum_kernel_t::init_conf(jit_sum_conf_t &jsp,
     jsp.src_dt = i_d.data_type();
     jsp.dst_dt = o_d.data_type();
 
-    jsp.typesize_in = types::data_type_size(i_d.data_type());
-    jsp.typesize_out = types::data_type_size(o_d.data_type());
+    jsp.typesize_in = into<int>(types::data_type_size(i_d.data_type()));
+    jsp.typesize_out = into<int>(types::data_type_size(o_d.data_type()));
 
     return status::success;
 }
@@ -360,15 +360,15 @@ void jit_uni_xf16_sum_kernel_t<Vmm>::loop_iteration(int current_unroll) {
         uni_vpxor(vacc0, vacc0, vacc0);
         uni_vpxor(vacc1, vacc1, vacc1);
         for (int acc_iter = 0; acc_iter < num_acc_iters; acc_iter++) {
-            read_iter(acc_iter, u_idx, src_shift);
+            read_iter(acc_iter, u_idx, into<int>(src_shift));
             add_iter(acc_iter, u_idx);
         }
-        write_iter(u_idx, dst_shift);
+        write_iter(u_idx, into<int>(dst_shift));
     }
     sub(reg_sz, num_compute_elements);
     for (int s = 0; s < jsp.num_srcs; s++)
-        add(reg_src[s], current_unroll * src_shift);
-    add(reg_dst, 2 * current_unroll * dst_shift);
+        add(reg_src[s], into<uint32_t>(current_unroll * src_shift));
+    add(reg_dst, into<uint32_t>(2 * current_unroll * dst_shift));
     jge(loop_label, T_NEAR);
     L(loop_exit_label);
 }

--- a/src/cpu/x64/jit_uni_xf16_sum.hpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.hpp
@@ -298,9 +298,9 @@ struct jit_xf16_sum_t : public primitive_t {
 
             return is_superset(isa, avx512_core)
                     ? jit_avx512_core_bf16_sum_kernel_t::init_conf(
-                              jsp_, src_mds_.size(), dst_md_)
-                    : jit_avx2_vnni_2_xf16_sum_kernel_t::init_conf(
-                              jsp_, src_mds_.size(), src_mds_, dst_md_);
+                              jsp_, into<int>(src_mds_.size()), dst_md_)
+                    : jit_avx2_vnni_2_xf16_sum_kernel_t::init_conf(jsp_,
+                              into<int>(src_mds_.size()), src_mds_, dst_md_);
         }
         jit_sum_conf_t jsp_;
     };

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_bwd_nhwc.cpp
@@ -66,8 +66,8 @@ void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::generate() {
 template <data_type_t d_type>
 void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::reserve_stack_space(
         std::size_t space) {
-    const unsigned maxCounter = (space / zmm_size_) - 1;
-    this->sub(rsp, space);
+    const unsigned maxCounter = into<unsigned int>((space / zmm_size_) - 1);
+    this->sub(rsp, into<uint32_t>(space));
     this->uni_vpxor(zmm4, zmm4, zmm4);
     for (unsigned i = 0; i < maxCounter; ++i)
         this->vmovups(ptr[rsp + i * zmm_size_], zmm4);
@@ -76,7 +76,7 @@ void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::reserve_stack_space(
 template <data_type_t d_type>
 void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::unreserve_stack_space(
         std::size_t space) {
-    this->add(rsp, space);
+    this->add(rsp, into<uint32_t>(space));
 }
 
 template <data_type_t d_type>
@@ -285,11 +285,11 @@ void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::compute(
 template <data_type_t d_type>
 void jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>::increment_loop_params(
         std::size_t offset) {
-    this->add(this->src_, offset);
-    this->add(this->diffsrc_, offset);
-    this->add(this->diffdst_, offset);
-    this->add(this->workspace0_, offset);
-    this->add(this->workspace1_, offset);
+    this->add(this->src_, into<uint32_t>(offset));
+    this->add(this->diffsrc_, into<uint32_t>(offset));
+    this->add(this->diffdst_, into<uint32_t>(offset));
+    this->add(this->workspace0_, into<uint32_t>(offset));
+    this->add(this->workspace1_, into<uint32_t>(offset));
 }
 
 template <data_type_t d_type>

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_nhwc.cpp
@@ -62,7 +62,7 @@ void jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>::generate() {
 template <data_type_t d_type>
 void jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>::reserve_stack_space(
         std::size_t space) {
-    this->sub(rsp, space);
+    this->sub(rsp, into<uint32_t>(space));
     this->uni_vpxor(zmm4, zmm4, zmm4);
     for (unsigned i = 0; i < 2u; ++i)
         this->vmovups(ptr[rsp + i * zmm_size], zmm4);
@@ -71,7 +71,7 @@ void jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>::reserve_stack_space(
 template <data_type_t d_type>
 void jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>::unreserve_stack_space(
         std::size_t space) {
-    this->add(rsp, space);
+    this->add(rsp, into<uint32_t>(space));
 }
 
 template <data_type_t d_type>
@@ -166,11 +166,11 @@ template <data_type_t d_type>
 void jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>::increment_loop_params(
         std::size_t offset) {
 
-    this->add(this->src_, offset);
-    this->add(this->dst_, offset);
+    this->add(this->src_, into<uint32_t>(offset));
+    this->add(this->dst_, into<uint32_t>(offset));
     if (this->pk_ != prop_kind::forward_inference) {
-        this->add(this->ws0_, offset);
-        this->add(this->ws1_, offset);
+        this->add(this->ws0_, into<uint32_t>(offset));
+        this->add(this->ws1_, into<uint32_t>(offset));
     }
 }
 

--- a/src/cpu/x64/lrn/jit_uni_lrn.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn.cpp
@@ -37,7 +37,7 @@ static dnnl_dim_t compute_n_summands(
         dnnl_dim_t size, int ndims, const dnnl_alg_kind_t &alg_kind) {
     return alg_kind == alg_kind::lrn_across_channels
             ? size
-            : std::pow(size, ndims - 2);
+            : into<dnnl_dim_t>(std::pow(size, ndims - 2));
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
@@ -54,11 +54,11 @@ template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_lrn_fwd_t<isa, d_type>::init(engine_t *engine) {
     using namespace alg_kind;
 
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
+    const int C = into<int>(pd()->C());
+    const int H = into<int>(pd()->H());
+    const int W = into<int>(pd()->W());
     const int ndims = memory_desc_wrapper(pd()->src_md()).ndims();
-    const int ls = pd()->desc()->local_size;
+    const int ls = into<int>(pd()->desc()->local_size);
     const float K = pd()->desc()->lrn_k;
     const auto pk = pd()->desc()->prop_kind;
     const auto ak = pd()->desc()->alg_kind;
@@ -109,10 +109,10 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::execute_forward(
     auto ws = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_WORKSPACE, status);
     CHECK(status);
 
-    const int N = pd()->MB();
-    const int C = pd()->C();
-    const int HW = pd()->H() * pd()->W();
-    const int ls = pd()->desc()->local_size;
+    const int N = into<int>(pd()->MB());
+    const int C = into<int>(pd()->C());
+    const int HW = into<int>(pd()->H() * pd()->W());
+    const int ls = into<int>(pd()->desc()->local_size);
 
     const auto ak = pd()->desc()->alg_kind;
     const auto dat_tag = pd()->dat_tag_;
@@ -196,7 +196,7 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     dat_tag_ = memory_desc_matches_one_of_tag(
             *src_md(), nChw16c, nChw8c, nchw, nhwc);
 
-    const int HW = src_d.dims()[2] * src_d.dims()[3];
+    const dim_t HW = src_d.dims()[2] * src_d.dims()[3];
 
     const bool args_ok_across = true && desc()->alg_kind == lrn_across_channels
             && desc()->local_size == 5 && one_of(dat_tag_, nChw8c, nchw, nhwc)
@@ -245,10 +245,10 @@ jit_uni_lrn_bwd_t<isa, d_type>::~jit_uni_lrn_bwd_t() = default;
 template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_lrn_bwd_t<isa, d_type>::init(engine_t *engine) {
     using namespace alg_kind;
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
-    const int &ls = pd()->desc()->local_size;
+    const int C = into<int>(pd()->C());
+    const int H = into<int>(pd()->H());
+    const int W = into<int>(pd()->W());
+    const int &ls = into<int>(pd()->desc()->local_size);
     const auto &ak = pd()->desc()->alg_kind;
     const int ndims = memory_desc_wrapper(pd()->src_md()).ndims();
     const float A = pd()->desc()->lrn_alpha / compute_n_summands(ls, ndims, ak);
@@ -290,10 +290,10 @@ status_t jit_uni_lrn_bwd_t<isa, d_type>::execute_backward(
     auto diff_src = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_DIFF_SRC, status);
     CHECK(status);
 
-    const int N = pd()->MB();
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
+    const int N = into<int>(pd()->MB());
+    const int C = into<int>(pd()->C());
+    const int H = into<int>(pd()->H());
+    const int W = into<int>(pd()->W());
     const auto ak = pd()->desc()->alg_kind;
     const auto &dat_tag = pd()->dat_tag_;
 

--- a/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn_kernel.cpp
@@ -1361,14 +1361,14 @@ void jit_uni_lrn_fwd_kernel_t<sse41, data_type::f32>::generate(
     if (load_lo) this->movups(xc_lo, this->ptr[src_ + J.HW * 0]);
     this->movups(xc_hi, this->ptr[src_ + J.HW * 0 + h_offset * sizeof(float)]);
     if (compute_tail) {
-        this->pslldq(xc_lo, l_shift * sizeof(float));
+        this->pslldq(xc_lo, into<int>(l_shift * sizeof(float)));
         this->andps(xc_hi, xmask_hi);
     }
 
     if (load_lo) this->movups(xd_lo, this->ptr[src_ + J.HW * 4]);
     this->movups(xd_hi, this->ptr[src_ + J.HW * 4 + h_offset * sizeof(float)]);
     if (compute_tail) {
-        this->pslldq(xd_lo, l_shift * sizeof(float));
+        this->pslldq(xd_lo, into<int>(l_shift * sizeof(float)));
         this->andps(xd_hi, xmask_hi);
     }
 
@@ -1400,7 +1400,7 @@ void jit_uni_lrn_fwd_kernel_t<sse41, data_type::f32>::generate(
     if (load_lo) this->movups(xe_lo, this->ptr[src_ + J.HW * 8]);
     this->movups(xe_hi, this->ptr[src_ + J.HW * 8 + h_offset * sizeof(float)]);
     if (compute_tail) {
-        this->pslldq(xe_lo, l_shift * sizeof(float));
+        this->pslldq(xe_lo, into<int>(l_shift * sizeof(float)));
         this->andps(xe_hi, xmask_hi);
     }
 

--- a/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
@@ -34,13 +34,13 @@ public:
         : ker_(nullptr)
         , ker_first_(nullptr)
         , ker_last_(nullptr)
-        , N_(pd->MB())
-        , C_(pd->C())
-        , H_(pd->H())
-        , W_(pd->W())
+        , N_(into<int>(pd->MB()))
+        , C_(into<int>(pd->C()))
+        , H_(into<int>(pd->H()))
+        , W_(into<int>(pd->W()))
         , use_h_parallelism_(H_ > 28 ? 1 : 0) {
 
-        const int local_size = pd->desc()->local_size;
+        const int local_size = into<int>(pd->desc()->local_size);
         const float alpha = pd->desc()->lrn_alpha / local_size;
         const float beta = pd->desc()->lrn_beta;
         const auto pk = pd->desc()->prop_kind;
@@ -174,13 +174,13 @@ public:
         : ker_(nullptr)
         , ker_first_(nullptr)
         , ker_last_(nullptr)
-        , N_(pd->MB())
-        , C_(pd->C())
-        , H_(pd->H())
-        , W_(pd->W())
+        , N_(into<int>(pd->MB()))
+        , C_(into<int>(pd->C()))
+        , H_(into<int>(pd->H()))
+        , W_(into<int>(pd->W()))
         , use_h_parallelism_(H_ > 28 ? 1 : 0) {
 
-        const int local_size = pd->desc()->local_size;
+        const int local_size = into<int>(pd->desc()->local_size);
         const float alpha = pd->desc()->lrn_alpha / local_size;
         const float beta = pd->desc()->lrn_beta;
 

--- a/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
@@ -32,11 +32,11 @@ class lrn_avx512_nhwc_executor_fwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_fwd_t(const PD_T *pd)
         : ker_(utils::make_unique<
-                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(pd->C(),
-                  pd->desc()->prop_kind,
+                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(
+                  into<unsigned>(pd->C()), pd->desc()->prop_kind,
                   pd->desc()->lrn_alpha / pd->desc()->local_size,
                   pd->desc()->lrn_beta, pd->desc()->lrn_k,
-                  pd->desc()->local_size))
+                  into<int>(pd->desc()->local_size)))
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())
@@ -88,9 +88,10 @@ class lrn_avx512_nhwc_executor_bwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_bwd_t(const PD_T *pd)
         : ker_ {utils::make_unique<
-                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(pd->C(),
+                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(
+                  into<unsigned>(pd->C()),
                   pd->desc()->lrn_alpha / pd->desc()->local_size,
-                  pd->desc()->lrn_beta, pd->desc()->local_size)}
+                  pd->desc()->lrn_beta, into<int>(pd->desc()->local_size))}
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -32,19 +32,19 @@ using namespace data_type;
 using namespace format_tag;
 void matmul_amx_blocking_params_t::update_configuration(
         brgemm_matmul_conf_t &bgmmc) const {
-    bgmmc.nthr_k = nthr_k_;
-    bgmmc.nthr_m = nthr_m_;
-    bgmmc.nthr_n = nthr_n_;
-    bgmmc.nthr_b = nthr_b_;
+    bgmmc.nthr_k = into<int>(nthr_k_);
+    bgmmc.nthr_m = into<int>(nthr_m_);
+    bgmmc.nthr_n = into<int>(nthr_n_);
+    bgmmc.nthr_b = into<int>(nthr_b_);
     bgmmc.nthr = nthr_;
     bgmmc.M_blk = m_blk_;
-    bgmmc.M_chunk_size = m_chunk_size_;
+    bgmmc.M_chunk_size = into<int>(m_chunk_size_);
     bgmmc.N_blk = n_blk_;
-    bgmmc.N_chunk_size = n_chunk_size_;
+    bgmmc.N_chunk_size = into<int>(n_chunk_size_);
 
     bgmmc.K_blk = k_blk_;
-    bgmmc.K_chunk_size = k_chunk_size_;
-    bgmmc.brgemm_batch_size = brgemm_batch_size_;
+    bgmmc.K_chunk_size = into<int>(k_chunk_size_);
+    bgmmc.brgemm_batch_size = into<int>(brgemm_batch_size_);
 
     bgmmc.use_buffer_c = need_buf_c_;
     bgmmc.use_buffer_a = need_buf_a_;
@@ -197,9 +197,10 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         best_blocking.n_decomposition
                 = nstl::min(bgmmc.N, (dim_t)bgmmc.wei_n_blk);
         best_blocking.m_decomposition = bgmmc.M;
-        uint32_t n_per_core = div_up(bgmmc.N, bgmmc.nthr);
+        uint32_t n_per_core = into<uint32_t>(div_up(bgmmc.N, bgmmc.nthr));
         n_per_core = rnd_up(n_per_core, best_blocking.n_decomposition);
-        best_blocking.set_core_divs(1, 1, 1, div_up(bgmmc.N, n_per_core));
+        best_blocking.set_core_divs(
+                1, 1, 1, into<int>(div_up(bgmmc.N, n_per_core)));
 
         if (best_blocking.nthr_n_
                 < core_utilization_threshold * best_blocking.nthr) {
@@ -230,8 +231,9 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.K <= best_blocking.wei_k_blk && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
-        best_blocking.set_core_divs(1, div_up(bgmmc.M, m_per_core), 1, 1);
+        const uint32_t m_per_core = into<uint32_t>(div_up(bgmmc.M, bgmmc.nthr));
+        best_blocking.set_core_divs(
+                1, into<int>(div_up(bgmmc.M, m_per_core)), 1, 1);
         best_blocking.set_tmul_sizes();
         best_blocking.set_decomposition();
 
@@ -265,7 +267,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.N <= 32 && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        const uint32_t m_per_core = into<uint32_t>(div_up(bgmmc.M, bgmmc.nthr));
 
         best_blocking.m_per_thread = m_per_core;
         // in this case 2 full are preferable
@@ -279,7 +281,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         const size_t m_per_core_actual = rnd_up(
                 best_blocking.m_per_thread, best_blocking.m_decomposition);
         best_blocking.set_core_divs(
-                1, div_up(bgmmc.M, m_per_core_actual), 1, 1);
+                1, into<int>(div_up(bgmmc.M, m_per_core_actual)), 1, 1);
 
         if (best_blocking.nthr_m_
                 < core_utilization_threshold * best_blocking.nthr) {
@@ -324,7 +326,7 @@ bool matmul_amx_blocking_params_macro_t::find_best_blocking(
 
     for (size_t nthr_to_check = bgmmc.nthr; nthr_to_check > 0;
             nthr_to_check--) {
-        current_blocking.nthr_ = nthr_to_check;
+        current_blocking.nthr_ = into<int>(nthr_to_check);
 
         for (int b_div = 1; b_div <= current_blocking.nthr_; ++b_div) {
             if (current_blocking.nthr_ % b_div != 0) continue;
@@ -354,11 +356,13 @@ bool matmul_amx_blocking_params_macro_t::find_best_blocking(
 
     if (best_blocking.use_buffer_b && !best_blocking.transposed_B
             && !best_blocking.is_horizontal) {
-        current_blocking.nthr_ = best_blocking.nthr_b_ * best_blocking.nthr_m_
-                * best_blocking.nthr_n_ * best_blocking.nthr_k_;
-        current_blocking.set_core_divs(best_blocking.nthr_b_,
-                best_blocking.nthr_m_, best_blocking.nthr_k_,
-                best_blocking.nthr_n_);
+        current_blocking.nthr_
+                = into<int>(best_blocking.nthr_b_ * best_blocking.nthr_m_
+                        * best_blocking.nthr_n_ * best_blocking.nthr_k_);
+        current_blocking.set_core_divs(into<int>(best_blocking.nthr_b_),
+                into<int>(best_blocking.nthr_m_),
+                into<int>(best_blocking.nthr_k_),
+                into<int>(best_blocking.nthr_n_));
         if (current_blocking.set_blocking_parameters(true)
                 && current_blocking > best_blocking) {
             best_blocking = current_blocking;
@@ -402,7 +406,7 @@ void matmul_amx_blocking_params_macro_t::calculate_layer_sizes(
     // Reducing k-tmul or n-tmul does not shorten the cycles.
     // However, reducing mtmul reduces the number of cycles required to execute a single tmul instruction.
     layer_perf_characteristics.num_cycles_per_tmul
-            = m_tmul * max_k_tmul * max_n_tmul / macs_per_cycle_base;
+            = into<int>(m_tmul * max_k_tmul * max_n_tmul / macs_per_cycle_base);
 
     layer_perf_characteristics.a_size
             = m_per_thread * k_per_thread * gemm_dt_sz;
@@ -549,8 +553,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
                 / bw_interpolator.llc_bw;
     } else {
         strip_mid_dram = layer_perf_characteristics.strip_mid_size_shared
-                        / bw_interpolator.get_bw(
-                                layer_perf_characteristics.strip_mid_share_coef)
+                        / bw_interpolator.get_bw(into<int>(
+                                layer_perf_characteristics.strip_mid_share_coef))
                 + layer_perf_characteristics.strip_mid_size_private
                         / bw_interpolator.get_bw(1);
 
@@ -580,8 +584,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_1_cycles(
             && !layer_perf_characteristics.strip1_a_read_v) {
         // default for vertical and horizontal without b transform
         strip_1_cycles = layer_perf_characteristics.strip_1_size_shared
-                        / bw_interpolator.get_bw(
-                                layer_perf_characteristics.strip_1_share_coef)
+                        / bw_interpolator.get_bw(into<int>(
+                                layer_perf_characteristics.strip_1_share_coef))
                 + layer_perf_characteristics.strip_1_size_private
                         / bw_interpolator.get_bw(1);
     } else if (layer_perf_characteristics.strip1_b_in_mlc_h
@@ -795,7 +799,8 @@ std::set<dim_t> matmul_amx_blocking_params_macro_t::blk_candidates(
 size_t matmul_amx_blocking_params_macro_t::l2_matrix_usage(size_t k_chunk_size,
         size_t m_or_n_blk, size_t k_blk, bool is_horizontal,
         bool force_transform_matrix_to_l2) const {
-    int decomposition = is_horizontal ? m_decomposition : n_decomposition;
+    int decomposition
+            = into<int>(is_horizontal ? m_decomposition : n_decomposition);
     size_t l1_matrix_size = 2 * decomposition
             * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz; // 2 for prefetch
@@ -843,10 +848,12 @@ size_t matmul_amx_blocking_params_macro_t::l2_matrix_and_c_usage(
 
 int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
         size_t k_blk, size_t n_blk, bool is_horizontal) const {
-    int a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * gemm_dt_sz;
-    int b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * gemm_dt_sz;
+    int a_bw = into<int>(m_blk
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz);
+    int b_bw = into<int>(n_blk
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+            * gemm_dt_sz);
     int c_bw;
 
     if ((l2_matrix_and_c_usage(k_chunk_size, is_horizontal ? n_blk : m_blk,
@@ -857,15 +864,15 @@ int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
             && nthr_k_ == 1) {
         c_bw = 0;
     } else {
-        c_bw = m_blk * n_blk * acc_dt_sz;
+        c_bw = into<int>(m_blk * n_blk * acc_dt_sz);
     }
     return a_bw + b_bw + c_bw;
 }
 
 int matmul_amx_blocking_params_macro_t::compute(
         size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk) const {
-    return m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
-            * n_blk;
+    return into<int>(m_blk
+            * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread) * n_blk);
 }
 
 float matmul_amx_blocking_params_macro_t::ratio(size_t m_blk,
@@ -1274,28 +1281,31 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
     for (int nthr_k = 1; nthr_k <= max_nthr_k; nthr_k++) {
         int nthr_bmn = bgmmc.nthr / nthr_k;
 
-        int num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
-        int num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
+        int num_M_blk = into<int>(
+                bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk));
+        int num_N_blk = into<int>(
+                bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk));
         int k_parallel_work = nstl::min(max_k_parallel_work, nthr_k);
-        int num_parallel_work
-                = bgmmc.batch * num_M_blk * num_N_blk * k_parallel_work;
+        int num_parallel_work = into<int>(
+                bgmmc.batch * num_M_blk * num_N_blk * k_parallel_work);
         const bool a_lot_of_parallel_work_lvl2
                 = num_parallel_work > 16 * bgmmc.nthr;
         const bool low_parallelism
                 = static_cast<float>(num_parallel_work) < 1.5f * bgmmc.nthr;
         const bool maybe_low_blocking
                 = is_amx_int8 && bm_conf_utils.maybe_low_brg_blocking();
-        const int min_M_blk = !bgmmc.is_runtime_M
-                        && (maybe_low_blocking || low_parallelism)
-                        && bgmmc.M_blk > 32
-                ? div_up(bgmmc.M_blk, 2)
-                : bgmmc.M_blk;
-        const int min_N_blk = !bgmmc.is_runtime_N && low_parallelism
-                        && is_amx_xf16 && !bm_conf_utils.check_n_blk_fixed()
-                        && bgmmc.N_blk > 32 && !runtime_dims
-                        && !bgmmc.transposed_B // Transposed copy B kernel doesn't support adjusting N_blk
-                ? 32
-                : bgmmc.N_blk;
+        const int min_M_blk = into<int>(!bgmmc.is_runtime_M
+                                && (maybe_low_blocking || low_parallelism)
+                                && bgmmc.M_blk > 32
+                        ? div_up(bgmmc.M_blk, 2)
+                        : bgmmc.M_blk);
+        const int min_N_blk = into<int>(!bgmmc.is_runtime_N && low_parallelism
+                                && is_amx_xf16
+                                && !bm_conf_utils.check_n_blk_fixed()
+                                && bgmmc.N_blk > 32 && !runtime_dims
+                                && !bgmmc.transposed_B // Transposed copy B kernel doesn't support adjusting N_blk
+                        ? 32
+                        : bgmmc.N_blk);
         const int desired_M_chunk = bgmmc.is_runtime_M
                 ? runtime_M_chunk
                 : nstl::min(4, num_M_blk);
@@ -1304,7 +1314,7 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
                 : nstl::min(a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
 
         std::unordered_set<int> mblk_candidates;
-        for (int m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
+        for (int m_blk = into<int>(bgmmc.M_blk); m_blk >= min_M_blk;
                 m_blk = m_blk > 1 ? div_up(m_blk, 2) : m_blk - 1) {
             if (IMPLICATION(maybe_low_blocking, m_blk != bgmmc.M_blk))
                 mblk_candidates.insert(m_blk);
@@ -1322,7 +1332,8 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
         }
 
         bool found_best_blocking = false;
-        for_(int n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
+        for_(int n_blk = into<int>(bgmmc.N_blk); n_blk >= min_N_blk;
+                n_blk -= 16)
         for_(int m_blk : mblk_candidates)
         for_(int n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
         for (int m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
@@ -1335,11 +1346,11 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
             // TODO: Verify whether using a chunk count of 1 for runtime M and N is optimal for
             // this heuristic. The previous implementation inadvertently used DNNL_RUNTIME_DIM_VAL
             // for M and N in arithmetic, producing incorrect work_amount values.
-            int m_chunks
-                    = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, m_blk * m_ch_sz);
-            int n_chunks
-                    = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, n_blk * n_ch_sz);
-            int work_amount = bgmmc.batch * m_chunks * n_chunks;
+            int m_chunks = into<int>(
+                    bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, m_blk * m_ch_sz));
+            int n_chunks = into<int>(
+                    bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, n_blk * n_ch_sz));
+            int work_amount = into<int>(bgmmc.batch * m_chunks * n_chunks);
 
             bool skip_config = work_amount < nthr_bmn * 3
                     && work_amount % nthr_bmn != 0 && max_nthr_k == 1;
@@ -1372,7 +1383,7 @@ void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
         int nthr_k, int n_blk, int n_chunk_size, int m_blk, int m_chunk_size) {
     nthr_k_ = nstl::max(1, nthr_k);
     nthr_mnb_ = nthr / nthr_k_;
-    nthr_ = nthr_mnb_ * nthr_k_;
+    nthr_ = into<int>(nthr_mnb_ * nthr_k_);
     n_blk_ = n_blk;
     n_chunk_size_ = n_chunk_size;
     m_blk_ = m_blk;

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -73,7 +73,7 @@ private:
     float linear_interpolation(
             const std::map<int, float> &points, float x) const {
         // Find the interval [x0, x1] where x0 <= x <= x1
-        auto it = points.lower_bound(x);
+        auto it = points.lower_bound(into<int>(x));
         if (it == points.end()) {
             return points.rbegin()
                     ->second; // x is greater than the largest x in the map
@@ -104,7 +104,7 @@ public:
         , nthr_k_(nstl::max(nthr_k, 1))
         , nthr_b_(nstl::max(nthr_b, 1))
         , nthr_mnb_(nthr / nthr_k_)
-        , nthr_(nthr_mnb_ * nthr_k_)
+        , nthr_(into<int>(nthr_mnb_ * nthr_k_))
         , n_blk_(N_blk)
         , n_chunk_size_(N_chunk_size)
         , n_chunk_elems_(n_blk_ * n_chunk_size_)

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -493,9 +493,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
             brgattr.hint_expected_A_size = vM * vK * bs;
             brgattr.hint_expected_B_size = vN * vK * bs;
             brgattr.hint_expected_C_size = vM * vN * bs;
-            if (bgmmc_.LDB2 != 0) brgattr.LDB2 = bgmmc_.LDB2;
+            if (bgmmc_.LDB2 != 0) brgattr.LDB2 = into<int>(bgmmc_.LDB2);
 
-            brgattr.LDC2_N = bgmmc_.M_blk * bgmmc_.LDC;
+            brgattr.LDC2_N = into<int>(bgmmc_.M_blk * bgmmc_.LDC);
 
             brgattr.hint_innermost_loop = brgemm_innermost_undef;
             brgattr.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
@@ -558,8 +558,10 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
                 if (i_N == 0 && i_init == i_init_start) {
                     reducers_[i_M][i_K] = nullptr;
                     auto db_desc = pd()->get_brg_desc(idx);
-                    db_desc.reduce_dim = i_K ? bgmmc.K_tail : bgmmc.K_blk;
-                    db_desc.load_dim = i_M ? bgmmc.M_tail : bgmmc.M_blk;
+                    db_desc.reduce_dim
+                            = into<int>(i_K ? bgmmc.K_tail : bgmmc.K_blk);
+                    db_desc.load_dim
+                            = into<int>(i_M ? bgmmc.M_tail : bgmmc.M_blk);
 
                     if (db_desc.reduce_dim > 0 && db_desc.load_dim > 0) {
                         CHECK(safe_ptr_assign(reducers_[i_M][i_K],
@@ -685,7 +687,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                 bt {0}, mt {0}, nt {0};
         int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
         int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
-        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        int batch_per_thread = into<int>(div_up(bgmmc.batch, bgmmc.nthr_b));
         if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
@@ -816,10 +818,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
     const bool is_last_K_blk = brgmm_ctx.is_last_K_blk(k_blk_idx);
 
     const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
-    const int remaining_k_blks
-            = (bgmmc.use_buffer_a ? utils::rnd_up(bgmmc.K, bgmmc.K_blk)
-                                  : bgmmc.K)
-            - k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
+    const int remaining_k_blks = into<int>(
+            (bgmmc.use_buffer_a ? utils::rnd_up(bgmmc.K, bgmmc.K_blk) : bgmmc.K)
+            - k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size);
     const bool is_K_tail
             = is_last_K_blk && (gemm_batch * bgmmc.K_blk) != remaining_k_blks;
 
@@ -1125,13 +1126,13 @@ void brgemm_matmul_t<isa>::maybe_reduce_A(
         const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
 
         auto *reduce_ptr = bgmmc.use_buffer_reduce
-                ? brgmm_ctx.get_buf_reduce_ptr(ithr, m)
-                : brgmm_ctx.get_data_reduce_ptr(m);
+                ? brgmm_ctx.get_buf_reduce_ptr(ithr, into<int>(m))
+                : brgmm_ctx.get_data_reduce_ptr(into<int>(m));
 
         brgemm_kernel_diff_bias_t p;
 
         p.ptr_diff_bias_acc = (void *)reduce_ptr;
-        p.ptr_diff_bias = (void *)brgmm_ctx.get_data_reduce_ptr(m);
+        p.ptr_diff_bias = (void *)brgmm_ctx.get_data_reduce_ptr(into<int>(m));
 
         const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(m_blk_idx);
 
@@ -1238,30 +1239,33 @@ void brgemm_matmul_t<isa>::maybe_reduce_and_convert_partial_results_A(
             const bool is_reduce_f32 = bgmmc.reduce_dt == f32;
 
             float *reduce_acc = is_reduce_f32
-                    ? (float *)brgmm_ctx.get_data_reduce_ptr(m)
-                    : (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(0, m);
+                    ? (float *)brgmm_ctx.get_data_reduce_ptr(into<int>(m))
+                    : (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(
+                              0, into<int>(m));
 
             int ibuf = !is_reduce_f32;
             for (; ibuf < bgmmc.nthr_k - 1; ibuf++) {
                 float *reduce_buf
                         = (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(
-                                ibuf, m);
+                                ibuf, into<int>(m));
                 acc_ker_f32_->accumulate(reduce_acc, reduce_buf, acc_size);
             }
 
             if (!is_reduce_f32) {
                 float *reduce_buf
                         = (float *)brgmm_ctx.get_buf_reduce_ptr_by_index(
-                                ibuf, m);
+                                ibuf, into<int>(m));
                 switch (bgmmc.reduce_dt) {
                     case data_type::bf16:
                         add_floats_and_cvt_to_bfloat16(
-                                (bfloat16_t *)brgmm_ctx.get_data_reduce_ptr(m),
+                                (bfloat16_t *)brgmm_ctx.get_data_reduce_ptr(
+                                        into<int>(m)),
                                 reduce_acc, reduce_buf, acc_size);
                         break;
                     case data_type::f16:
                         add_floats_and_cvt_to_float16(
-                                (float16_t *)brgmm_ctx.get_data_reduce_ptr(m),
+                                (float16_t *)brgmm_ctx.get_data_reduce_ptr(
+                                        into<int>(m)),
                                 reduce_acc, reduce_buf, acc_size);
                         break;
                     default: assert(!"invalid data type");
@@ -1305,7 +1309,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                 bt {0}, mt {0}, nt {0};
         int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
         int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
-        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        int batch_per_thread = into<int>(div_up(bgmmc.batch, bgmmc.nthr_b));
         if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
@@ -1474,8 +1478,8 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     const bool use_legacy_zp_a_path
             = !bgmmc.with_wei_decompression && !bgmmc.with_per_mn_compensation;
     int32_t neg_zp_b = use_legacy_zp_a_path ? brgmm_ctx.get_neg_zp_b() : 0;
-    int32_t neg_zp_ab_comp
-            = use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0;
+    int32_t neg_zp_ab_comp = into<int32_t>(
+            use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0);
     ctx.zp_b_neg_val_ptr = &neg_zp_b;
     ctx.zp_ab_comp_ptr = &neg_zp_ab_comp;
 
@@ -1596,29 +1600,31 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         // Handle first block
         if (k_start % adj_k_blk > 0) {
             const auto first_blk_size = adj_k_blk - (k_start % adj_k_blk);
-            call_copy_kernel(k_start, first_blk_size, 0);
+            call_copy_kernel(k_start, into<int>(first_blk_size), 0);
             k += first_blk_size;
         }
         // Handle full blocks
         for (; (k + adj_k_blk) <= k_end; k += adj_k_blk) {
             const auto gb = (k - k_start) / bgmmc.K_blk;
-            call_copy_kernel(k, adj_k_blk, gb);
+            call_copy_kernel(k, into<int>(adj_k_blk), into<int>(gb));
         }
         // Handle last block
         if (k_end > k) {
             const auto gb = (k - k_start) / bgmmc.K_blk;
-            call_copy_kernel(k, k_end - k, gb);
+            call_copy_kernel(k, into<int>(k_end - k), into<int>(gb));
         }
     } else { // Default case with k_blk blocking
         for (int gb = 0; gb < gemm_batch; ++gb) {
             const auto k = k_start + gb * bgmmc.K_blk;
             const auto k_iters = nstl::min(bgmmc.K_blk, bgmmc.K);
-            call_copy_kernel(k, k_iters, gb, /*aligned_blocks=*/true);
+            call_copy_kernel(
+                    k, into<int>(k_iters), gb, /*aligned_blocks=*/true);
         }
         if (is_K_tail) {
             const auto k = k_start + gemm_batch * bgmmc.K_blk;
             const auto k_iters = bgmmc.K % bgmmc.K_blk;
-            call_copy_kernel(k, k_iters, gemm_batch, /*aligned_blocks=*/true);
+            call_copy_kernel(k, into<int>(k_iters), gemm_batch,
+                    /*aligned_blocks=*/true);
         }
     }
 }
@@ -1655,7 +1661,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             data_B_offsets_ptr_
                     = CTX_IN_MEM(const int64_t *, DNNL_ARG_WEIGHTS, 1);
             data_B_bitmask_ptr_ = CTX_IN_MEM(const char *, DNNL_ARG_WEIGHTS, 2);
-            B_packed_sparse_block_size_ = weights_d.blk_size();
+            B_packed_sparse_block_size_ = into<int>(weights_d.blk_size());
         }
 
         bias_ptr_ = CTX_IN_MEM(const char *, DNNL_ARG_BIAS);
@@ -1743,7 +1749,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 pd->attr()->post_ops_, ctx);
         base_brg_ker_idx_
                 = pd->get_brg_kernel_idx(false, true, 0, 0, false, false);
-        vnni_factor = data_type_vnni_granularity(bgmmc.wei_dt);
+        vnni_factor = into<int>(data_type_vnni_granularity(bgmmc.wei_dt));
 
         reorder_zp_a_comp_ptr_ = nullptr;
         if (bgmmc_.has_zero_point_a && bgmmc_.blocked_B) {
@@ -1754,8 +1760,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             // multitreaded execution mode
             const size_t reorder_zp_a_comp_offset
                     = weights_d.size() - weights_d.additional_buffer_size();
-            const size_t b_batch
-                    = get_bb_idx(bgmmc.batch - 1, bgmmc_.bcast_B_desc) + 1;
+            const size_t b_batch = get_bb_idx(into<int>(bgmmc.batch - 1),
+                                           bgmmc_.bcast_B_desc)
+                    + 1;
             assert(IMPLICATION(bgmmc.s8s8_compensation_required,
                     !is_runtime_value(bgmmc.s8s8_comp_b_str)));
             const size_t s8s8_buffer_sz = bgmmc.s8s8_compensation_required
@@ -1784,15 +1791,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         K_ = bgmmc.K;
         K_chunks_ = bgmmc.K_chunks;
         K_chunk_tail_ = bgmmc.num_K_blocks % get_K_chunk_size();
-        K_chunk_tail_elements_ = K_ % bgmmc.K_chunk_elems;
+        K_chunk_tail_elements_ = into<int>(K_ % bgmmc.K_chunk_elems);
 
         const bool avoid_overlap_of_tail_and_non_tail_kernels
                 = bgmmc.nthr > 1 && bgmmc.with_sum;
 
         if (bgmmc.is_runtime_M) {
             M_ = helper.M();
-            M_chunks_ = M_ / bgmmc.M_chunk_elems;
-            M_chunk_tail_elements_ = M_ % bgmmc.M_chunk_elems;
+            M_chunks_ = into<int>(M_ / bgmmc.M_chunk_elems);
+            M_chunk_tail_elements_ = into<int>(M_ % bgmmc.M_chunk_elems);
             int tail = M_chunk_tail_elements_;
             dim_t m_idx = M_ - tail;
             int tail_idx = 0;
@@ -1830,7 +1837,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             }
 
             M_tail_block_start_ = M_chunks_ * get_M_chunk_size();
-            M_chunk_tail_ = m_tail_processing_.size();
+            M_chunk_tail_ = into<int>(m_tail_processing_.size());
             if (M_chunk_tail_ > 0) M_chunks_++;
             for (int dim_idx = 0; dim_idx < 3; dim_idx++)
                 A_strides_[dim_idx] = bgmmc.a_dt_sz
@@ -1848,7 +1855,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             M_ = bgmmc.M;
             M_chunks_ = bgmmc.M_chunks;
             M_chunk_tail_ = bgmmc.num_M_blocks % get_M_chunk_size();
-            M_chunk_tail_elements_ = M_ % bgmmc.M_chunk_elems;
+            M_chunk_tail_elements_ = into<int>(M_ % bgmmc.M_chunk_elems);
             M_tail_block_start_ = bgmmc.num_M_blocks - (bgmmc.M_tail > 0);
             for (int dim_idx = 0; dim_idx < 3; dim_idx++)
                 A_strides_[dim_idx] = bgmmc.A_strides[dim_idx];
@@ -1857,8 +1864,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         if (bgmmc.is_runtime_N) {
             N_ = helper.N();
-            N_chunks_ = N_ / bgmmc.N_chunk_elems;
-            N_chunk_tail_elems_ = N_ % bgmmc.N_chunk_elems;
+            N_chunks_ = into<int>(N_ / bgmmc.N_chunk_elems);
+            N_chunk_tail_elems_ = into<int>(N_ % bgmmc.N_chunk_elems);
             int tail = N_chunk_tail_elems_;
             dim_t n_idx = N_ - tail;
             int tail_idx = 0;
@@ -1896,7 +1903,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             }
 
             N_tail_block_start_ = N_chunks_ * bgmmc.N_chunk_size;
-            N_chunk_tail_ = n_tail_processing_.size();
+            N_chunk_tail_ = into<int>(n_tail_processing_.size());
             if (N_chunk_tail_ > 0) N_chunks_++;
 
             for (int dim_idx = 0; dim_idx < 3; dim_idx++)
@@ -1911,7 +1918,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             N_ = bgmmc.N;
             N_chunks_ = bgmmc.N_chunks;
             N_chunk_tail_ = bgmmc.num_N_blocks % bgmmc.N_chunk_size;
-            N_chunk_tail_elems_ = N_ % bgmmc.N_chunk_elems;
+            N_chunk_tail_elems_ = into<int>(N_ % bgmmc.N_chunk_elems);
             N_tail_block_start_ = bgmmc.num_N_blocks - (bgmmc.N_tail > 0);
             for (int dim_idx = 0; dim_idx < 3; dim_idx++)
                 B_strides_[dim_idx] = bgmmc.B_strides[dim_idx];
@@ -1936,12 +1943,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         // In case of micro heuristics, nthr_m==nthr_n==nthr_b==1 (round up has no effect)
         int m_chunks_per_thread = rnd_up(M_chunks_, bgmmc.nthr_m);
         int n_chunks_per_thread = rnd_up(N_chunks_, bgmmc.nthr_n);
-        int b_per_thread = rnd_up(bgmmc.batch, bgmmc.nthr_b);
+        int b_per_thread = into<int>(rnd_up(bgmmc.batch, bgmmc.nthr_b));
         parallel_work_amount_gemm_
                 = b_per_thread * m_chunks_per_thread * n_chunks_per_thread;
 
         // parallelization
-        parallel_work_amount_ = bgmmc.batch * M_chunks_ * N_chunks_;
+        parallel_work_amount_ = into<int>(bgmmc.batch * M_chunks_ * N_chunks_);
 
         // The number of threads available during primitive execution may
         // increase (ex. Eigen threadpool implementation) or decrease
@@ -2051,8 +2058,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         const int wei_k_blk = bgmmc_.is_bf32 || bgmmc_.is_xf16_fp8
                 ? get_wei_k_blk(bgmmc_.orig_wei_dt)
                 : bgmmc_.wei_k_blk;
-        const int k_idx = bgmmc_.blocked_B ? k / wei_k_blk : k;
-        const int n_idx = bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n;
+        const int k_idx
+                = into<int>(into<int>(bgmmc_.blocked_B ? k / wei_k_blk : k));
+        const int n_idx = into<int>(
+                into<int>(bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n));
         const int int4_fac = bgmmc_.is_int4_weights ? 2 : 1;
         return (B_strides_[1] * k_idx + B_strides_[0] * n_idx
                        + get_data_B_off_within_block(k, n))
@@ -2287,9 +2296,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 : bgmmc_.wei_k_blk;
         dim_t x0 = k % orig_wei_k_blk;
         dim_t x1 = n % bgmmc_.wei_n_blk;
-        const int orig_vnni_factor = bgmmc_.is_xf16_fp8
-                ? data_type_vnni_granularity(bgmmc_.orig_wei_dt)
-                : vnni_factor;
+        const int orig_vnni_factor = into<int>(bgmmc_.is_xf16_fp8
+                        ? data_type_vnni_granularity(bgmmc_.orig_wei_dt)
+                        : vnni_factor);
         dim_t offset
                 = (x0 / orig_vnni_factor) * orig_vnni_factor * bgmmc_.wei_n_blk
                 + x1 * orig_vnni_factor + x0 % orig_vnni_factor;
@@ -2500,11 +2509,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             // locally just before usage. Using the single global scaling before
             // parallel section might produce significant overhead for small
             // problems running in multitreaded execution mode
-            const int base_offset = get_bb_idx(b_idx, bgmmc_.bcast_B_desc)
-                            * rnd_up(bgmmc_.N, bgmmc_.wei_n_blk)
-                    + n_blk_idx * bgmmc_.N_blk;
+            const int base_offset
+                    = into<int>(get_bb_idx(b_idx, bgmmc_.bcast_B_desc)
+                                    * rnd_up(bgmmc_.N, bgmmc_.wei_n_blk)
+                            + n_blk_idx * bgmmc_.N_blk);
             PRAGMA_OMP_SIMD()
-            for (int b = 0; b < bgmmc_.N_blk; b++)
+            for (int b = 0; b < into<int>(bgmmc_.N_blk); b++)
                 zp_comp[b] = -get_neg_zp_a()
                         * reorder_zp_a_comp_ptr_[base_offset + b];
         }
@@ -2618,9 +2628,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     int get_M_kernel_size(int m_block_idx) const {
         if (!is_M_tail_processing(m_block_idx))
-            return bgmmc_.M_blk;
+            return into<int>(bgmmc_.M_blk);
         else if (!bgmmc_.is_runtime_M)
-            return bgmmc_.M_tail;
+            return into<int>(bgmmc_.M_tail);
 
         assert(is_runtime_M_tail_chunk(m_block_idx)
                 && !m_tail_processing_.empty());
@@ -2658,9 +2668,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     int get_N_kernel_size(int n_block_idx) const {
         if (!is_N_tail_processing(n_block_idx))
-            return bgmmc_.N_blk;
+            return into<int>(bgmmc_.N_blk);
         else if (!bgmmc_.is_runtime_N)
-            return bgmmc_.N_tail;
+            return into<int>(bgmmc_.N_tail);
 
         assert(is_runtime_N_tail_chunk(n_block_idx)
                 && !n_tail_processing_.empty());

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -43,9 +43,10 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
     jit_brgemm_matmul_copy_a_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
         , jit_generator_t(jit_name())
-        , typesize_(conf_->a_dt_sz)
-        , tr_typesize_(conf_->tr_a_dt_sz)
-        , vnni_granularity_(data_type_vnni_granularity(conf_->src_dt))
+        , typesize_(into<int>(conf_->a_dt_sz))
+        , tr_typesize_(into<int>(conf_->tr_a_dt_sz))
+        , vnni_granularity_(
+                  into<int>(data_type_vnni_granularity(conf_->src_dt)))
         , k_step_(vlen_ / nstl::max(typesize_, tr_typesize_))
         , src_stride_(conf_->copy_A_src_stride)
         , tr_src_stride_((conf_->use_buffer_a_tail_only
@@ -265,8 +266,8 @@ void jit_brgemm_matmul_copy_a_impl_t<
 template <typename Vmm>
 void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
         bool is_K_tail, bool is_first_K_iter, bool is_last_K_iter) {
-    const int K_blk = is_K_tail ? conf_->K % conf_->K_blk
-                                : nstl::min(conf_->K, conf_->K_blk);
+    const int K_blk = into<int>(is_K_tail ? conf_->K % conf_->K_blk
+                                          : nstl::min(conf_->K, conf_->K_blk));
     const int k_tail = K_blk % k_step_;
     const int num_k_iters = K_blk / k_step_;
     const int num_acc = utils::saturate(1, (int)num_comp_acc_, num_k_iters);
@@ -295,7 +296,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
             const int k_idx = kb * k_loop_unroll_ + k;
             const size_t offset
                     = static_cast<size_t>(k_idx) * k_step_ * typesize_;
-            load_vmm(k, offset);
+            load_vmm(k, into<int>(offset));
             maybe_compute_compensation(k_idx, get_vmm_copy(k));
         }
         if (allow_input_shift_for_s8s8 && conf_->s8s8_compensation_required) {
@@ -330,7 +331,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
                 const size_t offset
                         = (static_cast<size_t>(kb) * k_loop_unroll_ + k)
                         * k_step_ * tr_typesize_;
-                store_vmm(k, offset);
+                store_vmm(k, into<int>(offset));
             }
         }
     }
@@ -438,8 +439,8 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_M_loop(
 
     copy_K_loop(is_K_tail, is_first_K_iter, is_last_K_iter);
 
-    add(reg_src, src_stride_);
-    add(reg_tr_src, tr_src_stride_);
+    add(reg_src, into<uint32_t>(src_stride_));
+    add(reg_tr_src, into<uint32_t>(tr_src_stride_));
     if (do_compute_compensation_) {
         // shift comp pointers
         if (!(is_first_K_iter && is_last_K_iter))
@@ -477,7 +478,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::generate() {
                 = conf_->K_tail > 0 ? conf_->K % conf_->K_blk : 0;
         if (K_blk_tail > 0) {
             Label not_K_tail;
-            cmp(reg_K_blk, K_blk_tail);
+            cmp(reg_K_blk, into<uint32_t>(K_blk_tail));
             jne(not_K_tail, T_NEAR);
             copy_M_loop(true, is_first_K_iter, is_last_K_iter);
             jmp(copy_body_done, T_NEAR);
@@ -502,7 +503,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::generate() {
         {
             // first K iteration
             Label first_not_last;
-            cmp(reg_K_start, last_K_threshold);
+            cmp(reg_K_start, into<uint32_t>(last_K_threshold));
             jl(first_not_last, T_NEAR);
             copy_body(true, true);
             jmp(done, T_NEAR);
@@ -513,7 +514,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::generate() {
         }
 
         L(not_first);
-        cmp(reg_K_start, last_K_threshold);
+        cmp(reg_K_start, into<uint32_t>(last_K_threshold));
         jl(not_first_not_last, T_NEAR);
 
         copy_body(false, true);
@@ -1136,8 +1137,8 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::transpose_common_ymm(
     const dim_t dst_B_offset = dst_stride * avx2_transpose_size;
     const int B_rows = nstl::min(avx2_transpose_size, nrows);
     const int B_columns = nstl::max(ncolumns - avx2_transpose_size, 0);
-    add(src, src_B_offset);
-    add(dst, dst_B_offset);
+    add(src, into<uint32_t>(src_B_offset));
+    add(dst, into<uint32_t>(dst_B_offset));
     jit_generator_t::transpose(src, dst, src_stride, dst_stride, B_rows,
             B_columns, dt, ymm_tmp, ymm_tail_mask, xmm_upper_tail_mask);
 
@@ -1145,8 +1146,8 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::transpose_common_ymm(
     const dim_t dst_C_offset = dt_size * avx2_transpose_size;
     const int C_rows = nstl::max(nrows - avx2_transpose_size, 0);
     const int C_columns = nstl::min(avx2_transpose_size, ncolumns);
-    add(src, -src_B_offset + src_C_offset);
-    add(dst, -dst_B_offset + dst_C_offset);
+    add(src, into<uint32_t>(-src_B_offset + src_C_offset));
+    add(dst, into<uint32_t>(-dst_B_offset + dst_C_offset));
     jit_generator_t::transpose(src, dst, src_stride, dst_stride, C_rows,
             C_columns, dt, ymm_tmp, ymm_tail_mask, xmm_upper_tail_mask);
 
@@ -1156,12 +1157,12 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::transpose_common_ymm(
             = dst_stride * avx2_transpose_size + dt_size * avx2_transpose_size;
     const int D_rows = nstl::max(nrows - avx2_transpose_size, 0);
     const int D_columns = nstl::max(ncolumns - avx2_transpose_size, 0);
-    add(src, -src_C_offset + src_D_offset);
-    add(dst, -dst_C_offset + dst_D_offset);
+    add(src, into<uint32_t>(-src_C_offset + src_D_offset));
+    add(dst, into<uint32_t>(-dst_C_offset + dst_D_offset));
     jit_generator_t::transpose(src, dst, src_stride, dst_stride, D_rows,
             D_columns, dt, ymm_tmp, ymm_tail_mask, xmm_upper_tail_mask);
-    sub(src, src_D_offset);
-    sub(dst, dst_D_offset);
+    sub(src, into<uint32_t>(src_D_offset));
+    sub(dst, into<uint32_t>(dst_D_offset));
 }
 
 template <>
@@ -1466,8 +1467,8 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::generate() {
         L(m_loop);
         {
             deploy_transpose(reg_m_dst, reg_m_src, nrows, columns_step);
-            add(reg_m_src, m_loop_src_shift);
-            add(reg_m_dst, m_loop_dst_shift);
+            add(reg_m_src, into<uint32_t>(m_loop_src_shift));
+            add(reg_m_dst, into<uint32_t>(m_loop_dst_shift));
         }
         sub(reg_loop_m, columns_step);
         cmp(reg_loop_m, columns_step);
@@ -1519,8 +1520,8 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::generate() {
             if (is_dynamic_src_ld)
                 add(reg_k_src, ptr[rsp + dynamic_src_ld_x_kstep_offt_]);
             else
-                add(reg_k_src, k_loop_src_shift);
-            add(reg_k_dst, k_loop_dst_shift);
+                add(reg_k_src, into<uint32_t>(k_loop_src_shift));
+            add(reg_k_dst, into<uint32_t>(k_loop_dst_shift));
         }
         sub(reg_loop_k, rows_step);
         cmp(reg_loop_k, rows_step);
@@ -2059,8 +2060,8 @@ void jit_brgemm_matmul_copy_a_transposed_int8_impl_t::compute_m_loop(
     L(m_loop);
     {
         deploy_transpose(reg_m_dst_, reg_m_src_, nrows, columns_step_);
-        add(reg_m_src_, m_loop_src_shift_);
-        add(reg_m_dst_, m_loop_dst_shift_);
+        add(reg_m_src_, into<uint32_t>(m_loop_src_shift_));
+        add(reg_m_dst_, into<uint32_t>(m_loop_dst_shift_));
     }
     sub(reg_loop_m_, columns_step_);
     cmp(reg_loop_m_, columns_step_);
@@ -2121,8 +2122,8 @@ void jit_brgemm_matmul_copy_a_transposed_int8_impl_t::compute_k_loop(
         if (is_dynamic_src_ld_)
             add(reg_k_src_, ptr[rsp + dynamic_src_ld_x_kstep_offt_]);
         else
-            add(reg_k_src_, k_loop_src_shift_);
-        add(reg_k_dst_, k_loop_dst_shift_);
+            add(reg_k_src_, into<uint32_t>(k_loop_src_shift_));
+        add(reg_k_dst_, into<uint32_t>(k_loop_dst_shift_));
     }
     sub(reg_loop_k_, rows_step_);
     cmp(reg_loop_k_, rows_step_);
@@ -2317,7 +2318,7 @@ void jit_brgemm_matmul_copy_a_transposed_int8_impl_t::generate() {
         jne(not_first, T_NEAR);
         {
             Label first_not_last;
-            cmp(reg_tmp_, last_K_threshold);
+            cmp(reg_tmp_, into<uint32_t>(last_K_threshold));
             jl(first_not_last, T_NEAR);
             compute_k_loop(true, true);
             jmp(done, T_NEAR);
@@ -2328,7 +2329,7 @@ void jit_brgemm_matmul_copy_a_transposed_int8_impl_t::generate() {
         }
 
         L(not_first);
-        cmp(reg_tmp_, last_K_threshold);
+        cmp(reg_tmp_, into<uint32_t>(last_K_threshold));
         jl(not_first_not_last, T_NEAR);
 
         compute_k_loop(false, true);
@@ -3550,7 +3551,7 @@ private:
     void load_ymm(int ymm_idx, size_t offset, bool is_tail, size_t tail_sz) {
         Xbyak::Ymm vmm_src = Xbyak::Ymm(ymm_idx);
         if (is_tail) {
-            load_bytes(vmm_src, reg_src, offset, tail_sz);
+            load_bytes(vmm_src, reg_src, offset, into<int>(tail_sz));
         } else if (is_src_int4_) {
             load_bytes(vmm_src, reg_src, offset, simd_w_ / src_elems_per_byte_);
         } else
@@ -3567,7 +3568,7 @@ private:
             assert(one_of(pass, 0, 1));
             const dim_t tr_src_off_base = k * tr_src_stride_;
             const int set_1_tr_src_offset
-                    = tr_src_off_base + pass * 2 * n_blk_step_;
+                    = into<int>(tr_src_off_base + pass * 2 * n_blk_step_);
             const int row_start = k * k_blk_step_;
             const int row_end = nstl::min(row_start + k_blk_step_, nrows);
             if (!zeropad) {
@@ -3681,8 +3682,9 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         copy_block(k_unroll * k_blk_step_, ncolumns, is_N_rem, zeropad);
         if (!zeropad && !is_dynamic_stride_)
             add(reg_src,
-                    k_unroll * k_blk_step_ * src_stride_ / src_elems_per_byte_);
-        add(reg_tr_src, k_unroll * tr_src_stride_);
+                    into<uint32_t>(k_unroll * k_blk_step_ * src_stride_
+                            / src_elems_per_byte_));
+        add(reg_tr_src, into<uint32_t>(k_unroll * tr_src_stride_));
 
         sub(reg_K, k_unroll * k_blk_step_);
         cmp(reg_K, k_unroll * k_blk_step_);
@@ -3694,8 +3696,10 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
 
         copy_block(k_blk_step_, ncolumns, is_N_rem, zeropad);
         if (!zeropad && !is_dynamic_stride_)
-            add(reg_src, k_blk_step_ * src_stride_ / src_elems_per_byte_);
-        add(reg_tr_src, tr_src_stride_);
+            add(reg_src,
+                    into<uint32_t>(
+                            k_blk_step_ * src_stride_ / src_elems_per_byte_));
+        add(reg_tr_src, into<uint32_t>(tr_src_stride_));
 
         sub(reg_K, k_blk_step_);
         jmp(K_loop_single, T_NEAR);
@@ -3709,7 +3713,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
             jle(K_loop_done, T_NEAR);
 
             copy_block(k_blk_tail, ncolumns, is_N_rem, zeropad);
-            add(reg_tr_src, tr_src_stride_);
+            add(reg_tr_src, into<uint32_t>(tr_src_stride_));
             sub(reg_K, k_blk_tail);
             L(K_loop_done);
         }
@@ -3757,7 +3761,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
 
         if (is_dynamic_N_) {
             Label main_N_blk;
-            cmp(reg_N_blk, conf_->N_blk);
+            cmp(reg_N_blk, into<uint32_t>(conf_->N_blk));
             je(main_N_blk, T_NEAR);
             compute_K_loop(true, ncolumns);
             jmp(done, T_NEAR);
@@ -3840,7 +3844,9 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
                 }
 
                 L(skip_acc);
-                cmp(reg_K_start, rnd_up(conf_->K, conf_->K_blk) - conf_->K_blk);
+                cmp(reg_K_start,
+                        into<uint32_t>(
+                                rnd_up(conf_->K, conf_->K_blk) - conf_->K_blk));
                 jl(store, T_NEAR);
 
                 if (req_s8s8_comp) {
@@ -3965,9 +3971,9 @@ struct jit_brgemm_matmul_copy_b_bf16_t
 
     jit_brgemm_matmul_copy_b_bf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize(conf->b_dt_sz)
-        , tr_typesize(conf->tr_b_dt_sz)
-        , wei_scales_typesize(conf->wei_scales_dt_sz)
+        , typesize(into<int>(conf->b_dt_sz))
+        , tr_typesize(into<int>(conf->tr_b_dt_sz))
+        , wei_scales_typesize(into<int>(conf->wei_scales_dt_sz))
         , src_stride(conf->copy_B_wei_stride)
         , tr_src_stride(conf_->LDB * k_blk_step * tr_typesize)
         , is_src_int4(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
@@ -4315,7 +4321,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
     mov(ptr[rsp + reg_tr_src_offs], reg_tr_src);
     xor_(reg_copy_block_n_shift, reg_copy_block_n_shift);
 
-    int current_n_blk_step = do_N_loop ? conf_->LDB : n_blk_step;
+    int current_n_blk_step = into<int>(do_N_loop ? conf_->LDB : n_blk_step);
 
     Label loop_row_start, loop_row_tail, loop_row_done;
     cmp(reg_dynamic_tail, current_n_blk_step);
@@ -4328,16 +4334,16 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
 
         if (do_N_loop) {
             add(reg_tr_src,
-                    (current_n_blk_step / conf_->LDB) * conf_->LDB2
-                            * tr_typesize);
+                    into<uint32_t>((current_n_blk_step / conf_->LDB)
+                            * conf_->LDB2 * tr_typesize));
             add(reg_src,
-                    conf_->B_strides[0] == typesize
-                            ? current_n_blk_step * typesize
-                            : conf_->B_strides[0]);
+                    into<uint32_t>(conf_->B_strides[0] == typesize
+                                    ? current_n_blk_step * typesize
+                                    : conf_->B_strides[0]));
             add(reg_copy_block_n_shift,
-                    conf_->B_strides[0] == typesize
-                            ? current_n_blk_step * typesize
-                            : conf_->B_strides[0]);
+                    into<uint32_t>(conf_->B_strides[0] == typesize
+                                    ? current_n_blk_step * typesize
+                                    : conf_->B_strides[0]));
 
         } else {
             add(reg_src, current_n_blk_step * typesize);
@@ -4416,9 +4422,9 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
         // Only when k_group_size < k_blk_step
         // Otherwise default K-loop is used
         if (is_wei_grouped_over_k) {
-            const int k_group_size = conf_->is_wei_zp_per_k
-                    ? conf_->wei_zp_k_gsize
-                    : conf_->wei_scales_k_gsize;
+            const int k_group_size = into<int>(conf_->is_wei_zp_per_k
+                            ? conf_->wei_zp_k_gsize
+                            : conf_->wei_scales_k_gsize);
             if (k_group_size < k_blk_step) {
                 if (zeropad) return;
                 copy_block(
@@ -4437,8 +4443,10 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
         copy_block(k_unroll * k_blk_step, ncolumns, is_N_tail, zeropad);
 
         if (!zeropad && !is_dynamic_stride)
-            add(reg_src, (k_unroll * k_blk_step * src_stride) / elems_per_byte);
-        add(reg_tr_src, k_unroll * tr_src_stride);
+            add(reg_src,
+                    into<uint32_t>((k_unroll * k_blk_step * src_stride)
+                            / elems_per_byte));
+        add(reg_tr_src, into<uint32_t>(k_unroll * tr_src_stride));
 
         sub(reg_K, k_unroll * k_blk_step);
         cmp(reg_K, k_unroll * k_blk_step);
@@ -4450,8 +4458,9 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
 
         copy_block(k_blk_step, ncolumns, is_N_tail, zeropad);
         if (!zeropad && !is_dynamic_stride)
-            add(reg_src, (k_blk_step * src_stride) / elems_per_byte);
-        add(reg_tr_src, tr_src_stride);
+            add(reg_src,
+                    into<uint32_t>((k_blk_step * src_stride) / elems_per_byte));
+        add(reg_tr_src, into<uint32_t>(tr_src_stride));
 
         sub(reg_K, k_blk_step);
         jmp(K_loop_single, T_NEAR);
@@ -4465,14 +4474,15 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
             jle(K_loop_done, T_NEAR);
 
             copy_block(k_blk_tail, ncolumns, is_N_tail, zeropad);
-            add(reg_tr_src, tr_src_stride);
+            add(reg_tr_src, into<uint32_t>(tr_src_stride));
             sub(reg_K, k_blk_tail);
             L(K_loop_done);
         }
     };
 
     auto compute_K_loop = [&](bool is_N_tail) {
-        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        int ncolumns = into<int>(
+                into<int>(is_N_tail ? conf_->N_tail : conf_->N_blk));
         // 'param1' register (rcx on Windows) re-written in compute_K_loop_body
         // so we need to read and keep 'current_K_pad' parameter in stack before
         // the call
@@ -4488,7 +4498,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
 
     if (conf_->N_tail > 0 || is_dynamic_N) {
         Label main_N_blk;
-        cmp(reg_N_blk, conf_->N_blk);
+        cmp(reg_N_blk, into<uint32_t>(conf_->N_blk));
         je(main_N_blk, T_NEAR);
         compute_K_loop(true);
         jmp(done, T_NEAR);
@@ -4600,7 +4610,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
                 (k * src_stride_ + n * typesize_in_) / src_elems_per_byte_);
         if (is_tail && !isa_has_masks(conf_->isa)) {
             load_bytes(src_vmm, addr,
-                    (ncolumns % simd_w_) * typesize_in_ / src_elems_per_byte_);
+                    into<int>((ncolumns % simd_w_) * typesize_in_
+                            / src_elems_per_byte_));
             load_value(src_vmm, src_vmm, vmm_permd, conf_->orig_wei_dt, false);
         } else
             load_value(src_vmm, addr, vmm_permd, conf_->orig_wei_dt, is_tail);
@@ -4624,7 +4635,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto addr = maybe_EVEX_compress_addr(reg_zp_ptr, offset);
         if (is_tail && !isa_has_masks(conf_->isa)) {
             load_bytes(vmm_zp_b_shift, addr,
-                    (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte);
+                    into<int>(
+                            (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte));
             load_value(vmm_zp_b_shift, vmm_zp_b_shift, vmm_permd, zp_dt, false);
         } else
             load_value(vmm_zp_b_shift, addr, vmm_permd, zp_dt, is_tail);
@@ -4643,8 +4655,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto offset = n * scales_dt_sz;
         const auto addr = maybe_EVEX_compress_addr(reg_wei_scales, offset);
         if (is_tail && !isa_has_masks(conf_->isa)) {
-            load_bytes(
-                    vmm_wei_scales, addr, (ncolumns % simd_w_) * scales_dt_sz);
+            load_bytes(vmm_wei_scales, addr,
+                    into<int>((ncolumns % simd_w_) * scales_dt_sz));
             load_scale_value(vmm_wei_scales, vmm_wei_scales, scales_dt, false);
         } else
             load_scale_value(vmm_wei_scales, addr, scales_dt, is_tail);
@@ -4698,8 +4710,9 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::compute_k_loop(int ncolumns) {
         jl(K_end_label, T_NEAR);
 
         copy_16_x_n_block(unroll, ncolumns);
-        add(reg_src, (unroll * src_stride_) / src_elems_per_byte_);
-        add(reg_tr_src, unroll * tr_src_stride_);
+        add(reg_src,
+                into<uint32_t>((unroll * src_stride_) / src_elems_per_byte_));
+        add(reg_tr_src, into<uint32_t>(unroll * tr_src_stride_));
 
         sub(reg_K_iters, unroll);
         jmp(K_start_label, T_NEAR);
@@ -4767,15 +4780,15 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::generate() {
     Label done;
     if (conf_->N_tail > 0) {
         Label not_N_tail;
-        cmp(reg_N_blk, conf_->N_tail);
+        cmp(reg_N_blk, into<uint32_t>(conf_->N_tail));
         jne(not_N_tail, T_NEAR);
-        compute_k_loop(conf_->N_tail);
+        compute_k_loop(into<int>(conf_->N_tail));
         jmp(done, T_NEAR);
 
         L(not_N_tail);
     }
 
-    compute_k_loop(conf_->N_blk);
+    compute_k_loop(into<int>(conf_->N_blk));
     L(done);
 
     postamble();
@@ -4791,10 +4804,11 @@ struct jit_brgemm_matmul_copy_b_transposed_t
 
     jit_brgemm_matmul_copy_b_transposed_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize_(conf_->b_dt_sz)
-        , tr_typesize_(conf_->tr_b_dt_sz)
-        , wei_scales_typesize_(conf_->wei_scales_dt_sz)
-        , vnni_granularity_(data_type_vnni_granularity(conf_->wei_dt))
+        , typesize_(into<int>(conf_->b_dt_sz))
+        , tr_typesize_(into<int>(conf_->tr_b_dt_sz))
+        , wei_scales_typesize_(into<int>(conf_->wei_scales_dt_sz))
+        , vnni_granularity_(
+                  into<int>(data_type_vnni_granularity(conf_->wei_dt)))
         , k_blk_step_(vlen_ / tr_typesize_)
         , is_wei_grouped_over_k_(
                   conf_->is_wei_zp_per_k || conf_->is_wei_scale_per_k)
@@ -5354,7 +5368,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::init_tail_mask(
                 ? size_t(((size_t)1 << div_up(dt_step * columns_tail, 2)) - 1)
                 : size_t(((size_t)1 << dt_step * columns_tail) - 1);
         if (req_cvtps2xf16_)
-            kmovw(kTail, tail_mask);
+            kmovw(kTail, into<unsigned int>(tail_mask));
         else
             kmovq(kTail, tail_mask);
     }
@@ -5956,7 +5970,8 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_K_loop(bool is_N_tail,
     L(K_loop);
     copy_row_x_col(nrows, k_blk_step_);
     add(reg_src, (k_blk_step_ * typesize_) / src_elems_per_byte_);
-    add(reg_tr_src, k_blk_step_ / vnni_granularity_ * tr_src_stride_);
+    add(reg_tr_src,
+            into<uint32_t>(k_blk_step_ / vnni_granularity_ * tr_src_stride_));
     if (req_int8_zp_b_shift_ && conf_->is_wei_zp_per_k)
         add(qword[rsp + reg_cur_k_offs_], k_blk_step_);
 
@@ -6019,19 +6034,20 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
     L(N_loop);
     compute_K_loop(false, curr_K_tail, is_first_K_iter, is_last_K_iter);
 
-    add(reg_src_base, (n_blk_step_ * src_stride_) / src_elems_per_byte_);
+    add(reg_src_base,
+            into<uint32_t>((n_blk_step_ * src_stride_) / src_elems_per_byte_));
     if (conf_->LDB2 > 0) {
         Label small_increment, ldb_off_done;
         mov(regq_tmp, ptr[rsp + ldb_step_idx_offs]);
         add(regq_tmp, n_blk_step_);
 
-        cmp(regq_tmp, conf_->LDB);
+        cmp(regq_tmp, into<uint32_t>(conf_->LDB));
         jne(small_increment, T_NEAR);
 
         add(reg_tr_src_base,
-                -conf_->LDB * vnni_granularity_ * tr_typesize_
+                into<uint32_t>(-conf_->LDB * vnni_granularity_ * tr_typesize_
                         + n_blk_step_ * vnni_granularity_ * tr_typesize_
-                        + conf_->LDB2 * tr_typesize_);
+                        + conf_->LDB2 * tr_typesize_));
         mov(regq_tmp, 0);
         mov(ptr[rsp + ldb_step_idx_offs], regq_tmp);
         jmp(ldb_off_done, T_NEAR);
@@ -6046,7 +6062,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
     if (conf_->is_wei_scale_per_n) {
         const auto &scales_dt_sz = conf_->wei_scales_dt_sz;
         const auto offset = n_blk_step_ * scales_dt_sz;
-        add(reg_wei_scales, offset);
+        add(reg_wei_scales, into<uint32_t>(offset));
     }
 
     if (conf_->is_wei_zp_per_n) {
@@ -6062,9 +6078,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
         // compensation pointer. Only the stack-saved ZP pointer needs to
         // advance per N-block in that case.
         if (req_int8_zp_b_shift_)
-            add(qword[rsp + reg_zp_b_ptr_offs_], offset);
+            add(qword[rsp + reg_zp_b_ptr_offs_], into<uint32_t>(offset));
         else
-            add(reg_zp_ptr, offset);
+            add(reg_zp_ptr, into<uint32_t>(offset));
     }
 
     if (req_zp_comp_) add(reg_zp_comp_ptr, comp_shift_);
@@ -6212,22 +6228,24 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         }
 
         if (is_wei_grouped_over_k_ && grouped_k < k_blk_step_) {
-            compute_N_loop(grouped_k, is_first_K_iter, is_last_K_iter);
+            compute_N_loop(
+                    into<int>(grouped_k), is_first_K_iter, is_last_K_iter);
             return;
         }
 
         Label compute_body_done;
         if (conf_->K_tail > 0 && K_blk_tail != K_tail_tail) {
             Label not_K_tail;
-            cmp(reg_K_iters, k_blk);
+            cmp(reg_K_iters, into<uint32_t>(k_blk));
             je(not_K_tail, T_NEAR);
-            compute_N_loop(K_tail_tail, is_first_K_iter, is_last_K_iter);
+            compute_N_loop(
+                    into<int>(K_tail_tail), is_first_K_iter, is_last_K_iter);
             jmp(compute_body_done, T_NEAR);
 
             L(not_K_tail);
         }
 
-        compute_N_loop(K_blk_tail, is_first_K_iter, is_last_K_iter);
+        compute_N_loop(into<int>(K_blk_tail), is_first_K_iter, is_last_K_iter);
         L(compute_body_done);
     };
 
@@ -6252,7 +6270,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         {
             // first K iteration
             Label first_not_last;
-            cmp(reg_K_start, last_K_threshold);
+            cmp(reg_K_start, into<uint32_t>(last_K_threshold));
             jl(first_not_last, T_NEAR);
             compute_body(true, true);
             jmp(done, T_NEAR);
@@ -6263,7 +6281,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         }
 
         L(not_first);
-        cmp(reg_K_start, last_K_threshold);
+        cmp(reg_K_start, into<uint32_t>(last_K_threshold));
         jl(not_first_not_last, T_NEAR);
 
         compute_body(false, true);
@@ -6288,9 +6306,9 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
 
     jit_brgemm_matmul_copy_b_cvt_bf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize_(conf->b_dt_sz)
-        , tr_typesize_(conf->tr_b_dt_sz)
-        , wei_scales_typesize_(conf_->wei_scales_dt_sz)
+        , typesize_(into<int>(conf->b_dt_sz))
+        , tr_typesize_(into<int>(conf->tr_b_dt_sz))
+        , wei_scales_typesize_(into<int>(conf_->wei_scales_dt_sz))
         , is_src_int4_(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
         , src_elems_per_byte_(is_src_int4_ ? 2 : 1)
         , src_stride_(
@@ -6581,9 +6599,9 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         // Only when k_group_size < k_blk_step
         // Otherwise default K-loop is used
         if (is_wei_grouped_over_k_) {
-            const int k_group_size = conf_->is_wei_zp_per_k
-                    ? conf_->wei_zp_k_gsize
-                    : conf_->wei_scales_k_gsize;
+            const int k_group_size = into<int>(conf_->is_wei_zp_per_k
+                            ? conf_->wei_zp_k_gsize
+                            : conf_->wei_scales_k_gsize);
             if (k_group_size == 1) {
                 if (zeropad) return;
                 copy_block(k_group_size, ncolumns, /*zeropad= */ false);
@@ -6598,8 +6616,8 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
 
         L(K_loop_unrolled);
         copy_block(k_unroll * k_blk_step, ncolumns, zeropad);
-        add(reg_src, k_unroll * src_stride_);
-        add(reg_tr_src, k_unroll * tr_src_stride_);
+        add(reg_src, into<uint32_t>(k_unroll * src_stride_));
+        add(reg_tr_src, into<uint32_t>(k_unroll * tr_src_stride_));
 
         sub(reg_K, k_unroll * k_blk_step);
         cmp(reg_K, k_unroll * k_blk_step);
@@ -6610,8 +6628,8 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         jl(K_loop_tail_or_done, T_NEAR);
 
         copy_block(k_blk_step, ncolumns, zeropad);
-        add(reg_src, src_stride_);
-        add(reg_tr_src, tr_src_stride_);
+        add(reg_src, into<uint32_t>(src_stride_));
+        add(reg_tr_src, into<uint32_t>(tr_src_stride_));
 
         sub(reg_K, k_blk_step);
         jmp(K_loop_single, T_NEAR);
@@ -6624,7 +6642,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
             cmp(reg_K, 0);
             jle(K_loop_done, T_NEAR);
             copy_block(k_blk_tail, ncolumns, zeropad);
-            add(reg_tr_src, tr_src_stride_);
+            add(reg_tr_src, into<uint32_t>(tr_src_stride_));
             sub(reg_K, k_blk_tail);
             L(K_loop_done);
         }
@@ -6649,20 +6667,20 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
 
     if (conf_->LDB2 != 0) {
         Label main_N_loop, main_N_loop_tail;
-        int tail = conf_->N % conf_->LDB;
+        int tail = into<int>(conf_->N % conf_->LDB);
 
         if (tail != 0) {
-            cmp(reg_N_blk, conf_->LDB);
+            cmp(reg_N_blk, into<uint32_t>(conf_->LDB));
             jl(main_N_loop_tail, T_NEAR);
         }
 
         L(main_N_loop);
-        compute_K_loop(conf_->LDB);
-        add(reg_src, conf_->LDB2 * typesize_);
-        add(reg_tr_src, conf_->LDB2 * tr_typesize_);
+        compute_K_loop(into<int>(conf_->LDB));
+        add(reg_src, into<uint32_t>(conf_->LDB2 * typesize_));
+        add(reg_tr_src, into<uint32_t>(conf_->LDB2 * tr_typesize_));
 
-        sub(reg_N_blk, conf_->LDB);
-        cmp(reg_N_blk, conf_->LDB);
+        sub(reg_N_blk, into<uint32_t>(conf_->LDB));
+        cmp(reg_N_blk, into<uint32_t>(conf_->LDB));
         jge(main_N_loop, T_NEAR);
 
         if (tail != 0) {
@@ -6675,15 +6693,15 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
     } else {
         if (conf_->N_tail > 0) {
             Label main_N_blk;
-            cmp(reg_N_blk, conf_->N_blk);
+            cmp(reg_N_blk, into<uint32_t>(conf_->N_blk));
             je(main_N_blk, T_NEAR);
-            compute_K_loop(conf_->N_tail);
+            compute_K_loop(into<int>(conf_->N_tail));
             jmp(done, T_NEAR);
 
             L(main_N_blk);
         }
 
-        compute_K_loop(conf_->N_blk);
+        compute_K_loop(into<int>(conf_->N_blk));
     }
     L(done);
     postamble();
@@ -6751,8 +6769,8 @@ struct jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t
     jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
         , jit_generator_t(jit_name())
-        , typesize_(conf->b_dt_sz)
-        , tr_typesize_(conf->tr_b_dt_sz)
+        , typesize_(into<int>(conf->b_dt_sz))
+        , tr_typesize_(into<int>(conf->tr_b_dt_sz))
         , src_stride_(conf->LDB * k_blk_step * typesize_)
         , tr_src_stride_(conf->LDB * tr_k_blk_step * tr_typesize_)
         , cvt_helper_(this, conf) {}
@@ -6868,9 +6886,12 @@ private:
 
                 L(K_loop_unrolled);
                 copy_block(k_unroll_rows, ncolumns, zeropad);
-                add(reg_src, (k_unroll_rows / k_blk_step) * src_stride_);
+                add(reg_src,
+                        into<uint32_t>(
+                                (k_unroll_rows / k_blk_step) * src_stride_));
                 add(reg_tr_src,
-                        (k_unroll_rows / tr_k_blk_step) * tr_src_stride_);
+                        into<uint32_t>((k_unroll_rows / tr_k_blk_step)
+                                * tr_src_stride_));
 
                 sub(reg_K, k_unroll_rows);
                 cmp(reg_K, k_unroll_rows);
@@ -6882,8 +6903,9 @@ private:
             jl(K_loop_tail_or_done, T_NEAR);
 
             copy_block(k_step, ncolumns, zeropad);
-            add(reg_src, (k_step / k_blk_step) * src_stride_);
-            add(reg_tr_src, (k_step / tr_k_blk_step) * tr_src_stride_);
+            add(reg_src, into<uint32_t>((k_step / k_blk_step) * src_stride_));
+            add(reg_tr_src,
+                    into<uint32_t>((k_step / tr_k_blk_step) * tr_src_stride_));
 
             sub(reg_K, k_step);
             jmp(K_loop_single, T_NEAR);
@@ -6902,12 +6924,14 @@ private:
             cmp(reg_K, tr_k_blk_step);
             jle(tail_one_pack, T_NEAR);
             copy_block(k_blk_step, ncolumns, zeropad);
-            add(reg_tr_src, (k_blk_step / tr_k_blk_step) * tr_src_stride_);
+            add(reg_tr_src,
+                    into<uint32_t>(
+                            (k_blk_step / tr_k_blk_step) * tr_src_stride_));
             jmp(K_loop_done, T_NEAR);
 
             L(tail_one_pack);
             copy_block(tr_k_blk_step, ncolumns, zeropad);
-            add(reg_tr_src, tr_src_stride_);
+            add(reg_tr_src, into<uint32_t>(tr_src_stride_));
 
             L(K_loop_done);
         };
@@ -6946,20 +6970,20 @@ private:
         assert(conf_->LDB2 != 0);
 
         Label main_N_loop, main_N_loop_tail;
-        int tail = conf_->N % conf_->LDB;
+        int tail = into<int>(conf_->N % conf_->LDB);
 
         if (tail != 0) {
-            cmp(reg_N_blk, conf_->LDB);
+            cmp(reg_N_blk, into<uint32_t>(conf_->LDB));
             jl(main_N_loop_tail, T_NEAR);
         }
 
         L(main_N_loop);
-        compute_K_loop(conf_->LDB);
-        add(reg_src, conf_->B_strides[0]);
-        add(reg_tr_src, conf_->LDB2 * tr_typesize_);
+        compute_K_loop(into<int>(conf_->LDB));
+        add(reg_src, into<uint32_t>(conf_->B_strides[0]));
+        add(reg_tr_src, into<uint32_t>(conf_->LDB2 * tr_typesize_));
 
-        sub(reg_N_blk, conf_->LDB);
-        cmp(reg_N_blk, conf_->LDB);
+        sub(reg_N_blk, into<uint32_t>(conf_->LDB));
+        cmp(reg_N_blk, into<uint32_t>(conf_->LDB));
         jge(main_N_loop, T_NEAR);
 
         if (tail != 0) {

--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -80,11 +80,11 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
 
     memory_desc_t src_md_reduced, dst_md_reduced;
     VDISPATCH_REORDER_IC(memory_desc_reshape(src_md_reduced, src_md,
-                                 non_unit_dim, non_unit_dims)
+                                 into<int>(non_unit_dim), non_unit_dims)
                     == status::success,
             VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "src");
     VDISPATCH_REORDER_IC(memory_desc_reshape(dst_md_reduced, dst_md,
-                                 non_unit_dim, non_unit_dims)
+                                 into<int>(non_unit_dim), non_unit_dims)
                     == status::success,
             VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "dst");
 
@@ -147,8 +147,8 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
 
     // find first umatching stride by division
     dim_t lm_idx = -1;
-    int prev_M_src = src_over_dst[l_idx],
-        prev_1_over_M_dst = dst_over_src[l_idx];
+    int prev_M_src = into<int>(src_over_dst[l_idx]),
+        prev_1_over_M_dst = into<int>(dst_over_src[l_idx]);
     // here we are checking to make sure all indexes are the same in src/dst
     // and dst/src arrays (comparing with prev_h_src and prev_h_dst). If its
     // different, then both src/dst and dst/src arrays should be different. In
@@ -175,8 +175,8 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     // Only case this might be possible is unit strides after batch.
     VDISPATCH_REORDER_IC(lm_idx != -1, VERBOSE_UNSUPPORTED_MEM_STRIDE);
 
-    int prev_1_over_K_src = src_over_dst[lm_idx],
-        prev_K_dst = dst_over_src[lm_idx];
+    int prev_1_over_K_src = into<int>(src_over_dst[lm_idx]),
+        prev_K_dst = into<int>(dst_over_src[lm_idx]);
     // Here we make sure the last strides divs are the same. If not, then this
     // means that one of the l+m, l+m+1, ..., l+m+n indexes is not in the same
     // order as in src. For example in src, looking at memory view, it can be

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -88,7 +88,7 @@ int get_wei_k_blk(data_type_t wei_dt) {
     const int k_outer_block = 16;
 
     // VNNI granularity determines the inner block size along K.
-    const int k_inner_block = data_type_vnni_granularity(wei_dt);
+    const int k_inner_block = into<int>(data_type_vnni_granularity(wei_dt));
 
     return k_outer_block * k_inner_block;
 }
@@ -625,9 +625,9 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             VCONDCHECK_BG(
                     IMPLICATION(bgmmc.is_xf16_fp8, blocked_B_layouts_allowed),
                     VERBOSE_UNSUPPORTED_TAG)
-            const int default_n_block = init_n_tag
-                    ? get_default_n_block(format_tag::undef)
-                    : bgmmc.N_blk;
+            const int default_n_block = into<int>(init_n_tag
+                            ? get_default_n_block(format_tag::undef)
+                            : bgmmc.N_blk);
             bgmmc.wei_tag = blocked_B_layouts_allowed && !bgmmc.is_runtime_N
                             && !bgmmc.is_int4_weights
                     ? this->pick_blocked_B_layout(default_n_block)
@@ -1190,7 +1190,7 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
 
     dim_t min_m_chunks = div_up(matmul.M, max_m_blk);
 
-    int n_blk = bgmmc.N_blk;
+    int n_blk = into<int>(bgmmc.N_blk);
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1267,7 +1267,7 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
                 return n;
             };
 
-            int nthr_bmn = max_div(max_bmn_parallel, nthr);
+            int nthr_bmn = into<int>(max_div(max_bmn_parallel, nthr));
             int nthr_k = nstl::max(nthr / nthr_bmn, 1);
             int nthr_remainder = nthr % nthr_bmn;
 
@@ -1372,7 +1372,7 @@ float compute_blocking_heuristic_avx2(brgemm_matmul_conf_t &bgmmc,
     int min_m_blk
             = static_cast<int>(nstl::min((dim_t)32, matmul.M)); // max_m_blk
 
-    int n_blk = bgmmc.N_blk;
+    int n_blk = into<int>(bgmmc.N_blk);
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1429,7 +1429,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     dim_t max_m_blk = nstl::min((dim_t)256, matmul.M);
     dim_t min_m_blk = nstl::min((dim_t)32, matmul.M);
 
-    int n_blk = bgmmc.N_blk;
+    int n_blk = into<int>(bgmmc.N_blk);
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1447,7 +1447,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     const float req_additional_parallel = nthr / max_parallel;
     if (req_additional_parallel > 1) {
         min_m_blk = saturate<dim_t>(nstl::min((dim_t)16, max_m_blk), max_m_blk,
-                matmul.M / req_additional_parallel);
+                into<long>(matmul.M / req_additional_parallel));
         max_parallel *= div_up(matmul.M, min_m_blk);
     } else if (bm_conf_utils.check_is_transposed(bgmmc.src_tag)
             && matmul.K >= 4096) {
@@ -1469,7 +1469,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     max_m_blk = nstl::max(max_m_blk, min_m_blk);
     for_(int nthr_k = start_nthr_k; nthr_k >= 1; --nthr_k)
     for_(int n_chunk_size = n_chunks_start; n_chunk_size >= 1; --n_chunk_size)
-    for (int m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
+    for (int m_blk = into<int>(max_m_blk); m_blk >= min_m_blk; --m_blk) {
         matmul_avx512_blocking_params_t cur_params(matmul, nthr);
         cur_params.update_params(
                 1, m_blk, n_chunk_size, n_blk, brgemm_bs, k_blk, nthr_k);
@@ -1561,7 +1561,7 @@ status_t compute_blocking_heuristic(brgemm_matmul_conf_t &bgmmc,
                 : fixed_K_tail_size ? bgmmc.wei_k_blk
                                     : bgmmc.K;
         bgmmc.brgemm_batch_size
-                = nstl::max(bgmmc.K / bgmmc.K_blk, static_cast<dim_t>(1));
+                = into<int>(nstl::max(bgmmc.K / bgmmc.K_blk, into<dim_t>(1)));
 
         matmul_amx_blocking_params_micro_t best_blocking(bgmmc);
 
@@ -2004,8 +2004,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             weights_d.dims(), dst_d.dims(), bgmmc.batch_ndims, bgmmc.batch);
 
     // required granularity for k dimension
-    bgmmc.required_k_granularity
-            = bgmmc.is_amx ? data_type_vnni_granularity(bgmmc.wei_dt) : 1;
+    bgmmc.required_k_granularity = into<int>(
+            bgmmc.is_amx ? data_type_vnni_granularity(bgmmc.wei_dt) : 1);
 
     VCONDCHECK_BG(bgmmc.required_k_granularity > 0, VERBOSE_BLOCKING_FAIL, "");
 
@@ -2220,7 +2220,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             } else {
                 const dim_t max_bs = nstl::max<dim_t>(1, k_group / bgmmc.K_blk);
                 if (bgmmc.brgemm_batch_size > max_bs)
-                    bgmmc.brgemm_batch_size = max_bs;
+                    bgmmc.brgemm_batch_size = into<int>(max_bs);
             }
 
             const dim_t new_chunk_K = bgmmc.K_blk * bgmmc.brgemm_batch_size;
@@ -2240,9 +2240,10 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             size_t n_elements_in_wei_zmm = platform::get_cache_line_size()
                     / (data_type_vnni_granularity(bgmmc.wei_dt)
                             * bgmmc.tr_b_dt_sz);
-            bgmmc.wei_n_blk = rnd_up(bgmmc.N_blk, n_elements_in_wei_zmm);
+            bgmmc.wei_n_blk
+                    = into<int>(rnd_up(bgmmc.N_blk, n_elements_in_wei_zmm));
         } else {
-            bgmmc.wei_n_blk = bgmmc.N_blk;
+            bgmmc.wei_n_blk = into<int>(bgmmc.N_blk);
         }
 
         VCHECK_BG(bm_conf_utils.update_and_check_B_tag(
@@ -2455,7 +2456,7 @@ status_t init_conf(brgemm_matmul_conf_t &conf, dim_t batch, dim_t M, dim_t K,
         conf.is_bf16_with_int_wei = is_bf16_with_int_wei;
         conf.with_wei_decompression = with_wei_decompression;
         conf.wei_tag = in_tag;
-        conf.wei_n_blk = conf.N_blk = conf.LDB = n_blk;
+        conf.wei_n_blk = into<int>(conf.N_blk = conf.LDB = n_blk);
         conf.N_tail = conf.N % conf.N_blk;
         conf.b_dt_sz = types::data_type_size(in_type);
         conf.tr_b_dt_sz = types::data_type_size(conf.wei_dt);
@@ -2498,26 +2499,29 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
     bgmmc.N_chunk_elems = bgmmc.N_blk * bgmmc.N_chunk_size;
     bgmmc.K_chunk_elems
             = bgmmc.K_blk * bgmmc.K_chunk_size * bgmmc.brgemm_batch_size;
-    bgmmc.M_chunks = bgmmc.is_runtime_M ? runtime_value_for(bgmmc.M_chunks)
-                                        : div_up(bgmmc.M, bgmmc.M_chunk_elems);
-    bgmmc.N_chunks = bgmmc.is_runtime_N ? runtime_value_for(bgmmc.N_chunks)
-                                        : div_up(bgmmc.N, bgmmc.N_chunk_elems);
-    bgmmc.K_chunks = bgmmc.is_runtime_K ? runtime_value_for(bgmmc.K_chunks)
-                                        : div_up(bgmmc.K, bgmmc.K_chunk_elems);
-    bgmmc.num_M_blocks = bgmmc.is_runtime_M
-            ? runtime_value_for(bgmmc.num_M_blocks)
-            : div_up(bgmmc.M, bgmmc.M_blk);
-    bgmmc.num_N_blocks = bgmmc.is_runtime_N
-            ? runtime_value_for(bgmmc.num_N_blocks)
-            : div_up(bgmmc.N, bgmmc.N_blk);
-    bgmmc.num_K_blocks = bgmmc.is_runtime_K
-            ? runtime_value_for(bgmmc.num_K_blocks)
-            : div_up(bgmmc.K, bgmmc.K_blk * bgmmc.brgemm_batch_size);
+    bgmmc.M_chunks = into<int>(bgmmc.is_runtime_M
+                    ? runtime_value_for(bgmmc.M_chunks)
+                    : div_up(bgmmc.M, bgmmc.M_chunk_elems));
+    bgmmc.N_chunks = into<int>(bgmmc.is_runtime_N
+                    ? runtime_value_for(bgmmc.N_chunks)
+                    : div_up(bgmmc.N, bgmmc.N_chunk_elems));
+    bgmmc.K_chunks = into<int>(bgmmc.is_runtime_K
+                    ? runtime_value_for(bgmmc.K_chunks)
+                    : div_up(bgmmc.K, bgmmc.K_chunk_elems));
+    bgmmc.num_M_blocks = into<int>(bgmmc.is_runtime_M
+                    ? runtime_value_for(bgmmc.num_M_blocks)
+                    : div_up(bgmmc.M, bgmmc.M_blk));
+    bgmmc.num_N_blocks = into<int>(bgmmc.is_runtime_N
+                    ? runtime_value_for(bgmmc.num_N_blocks)
+                    : div_up(bgmmc.N, bgmmc.N_blk));
+    bgmmc.num_K_blocks = into<int>(bgmmc.is_runtime_K
+                    ? runtime_value_for(bgmmc.num_K_blocks)
+                    : div_up(bgmmc.K, bgmmc.K_blk * bgmmc.brgemm_batch_size));
 
     const int last_chunck_batch_size
-            = (nstl::max(bgmmc.K, bgmmc.K_blk)
-                      - (bgmmc.K_chunks - 1) * bgmmc.K_chunk_elems)
-            / bgmmc.K_blk;
+            = into<int>((nstl::max(bgmmc.K, bgmmc.K_blk)
+                                - (bgmmc.K_chunks - 1) * bgmmc.K_chunk_elems)
+                    / bgmmc.K_blk);
 
     bgmmc.brgemm_batch_tail_size
             = last_chunck_batch_size % bgmmc.brgemm_batch_size;

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -445,7 +445,7 @@ private:
             vpaddd(vmm_S(c), vmm_S(c), vmm_data_sr());
             L(skip_chunk);
         }
-        add(reg_a, wei_k_stride_bytes_);
+        add(reg_a, into<uint32_t>(wei_k_stride_bytes_));
         dec(reg_k_iter);
         jmp(k_loop, T_NEAR);
         L(k_done);
@@ -500,7 +500,7 @@ private:
             vpaddd(vmm_S(c), vmm_S(c), vmm_t1_sr());
             L(skip_chunk);
         }
-        add(reg_a, wei_k_stride_bytes_);
+        add(reg_a, into<uint32_t>(wei_k_stride_bytes_));
         dec(reg_k_iter);
         jmp(k_loop, T_NEAR);
         L(k_done);
@@ -606,14 +606,14 @@ private:
             load_param(reg_a, GET_OFF(src_batch_ptr));
             load_param(reg_tmp, GET_OFF(m_base));
             add(reg_tmp, reg_m);
-            imul(reg_tmp, reg_tmp, src_m_stride_bytes_);
+            imul(reg_tmp, reg_tmp, into<int>(src_m_stride_bytes_));
             add(reg_a, reg_tmp);
             emit_t_reduce_into_T_bc(subtract_Gzs);
         }
 
         // delta row base = delta + m * LDC * 4.
         push(reg_m);
-        imul(reg_m, reg_m, LDC_ * f32_sz);
+        imul(reg_m, reg_m, into<int>(LDC_ * f32_sz));
         add(reg_m, reg_delta);
 
         for (int c = 0; c < chunks_; ++c) {
@@ -645,9 +645,9 @@ private:
                     const bool has_tail = rem > 0 && rem < simd_w;
                     const dim_t off
                             = c * simd_w * types::data_type_size(wei_zp_dt_);
-                    const int tail_bytes = has_tail
-                            ? rem * types::data_type_size(wei_zp_dt_)
-                            : 0;
+                    const int tail_bytes = into<int>(has_tail
+                                    ? rem * types::data_type_size(wei_zp_dt_)
+                                    : 0);
                     load_vec_zps_f32(vmm_zw(), wei_zp_dt_, ptr[reg_tmp + off],
                             has_tail, tail_bytes);
                 }

--- a/src/cpu/x64/matmul/jit_uni_sparse_matmul.cpp
+++ b/src/cpu/x64/matmul/jit_uni_sparse_matmul.cpp
@@ -68,11 +68,11 @@ struct sparse_matmul_kernel_t : public jit_generator_t {
     int data_type_size() const { return sizeof(float); }
     int index_type_size() const { return sizeof(int32_t); }
 
-    int block_size() const { return vlen(); }
+    int block_size() const { return into<int>(vlen()); }
 
     int unroll_factor() const { return 2; }
 
-    int N() const { return N_; }
+    int N() const { return into<int>(N_); }
 
 protected:
     size_t N_;
@@ -173,17 +173,17 @@ struct jit_uni_sparse_matmul_kernel_t : public sparse_matmul_kernel_t {
 
     Vmm get_wei_reg(int index, bool is_tail_block) {
         // Vmm(0) is reserved for mask.
-        const int nloads = is_tail_block
-                ? utils::div_up(tail_block_size(), simd_w())
-                : block_size() / simd_w();
+        const int nloads = into<int>(is_tail_block
+                        ? utils::div_up(tail_block_size(), simd_w())
+                        : block_size() / simd_w());
         return Vmm(nloads + index + 1);
     }
 
     void loop_within_block_row(
             Vmm vreg_src_val, Reg64 reg_src_col_idx, bool is_tail_block) {
-        const int nloads = is_tail_block
-                ? utils::div_up(tail_block_size(), simd_w())
-                : block_size() / simd_w();
+        const int nloads = into<int>(is_tail_block
+                        ? utils::div_up(tail_block_size(), simd_w())
+                        : block_size() / simd_w());
         for (int i_load = 0; i_load < nloads; i_load++) {
             Vmm vreg_tmp_wei = get_wei_reg(i_load, is_tail_block);
             // Load a row of weights.
@@ -254,15 +254,15 @@ struct jit_uni_sparse_matmul_kernel_t : public sparse_matmul_kernel_t {
         Label loop_over_blocks_begin, loop_over_blocks_end;
         L(loop_over_blocks_begin);
         {
-            cmp(reg_blocks_count, nblocks);
+            cmp(reg_blocks_count, into<uint32_t>(nblocks));
             je(loop_over_blocks_end, T_NEAR);
 
             mov(reg_block_offset, reg_blocks_count);
             shl(reg_block_offset, math::ilog2q(block_size()));
 
-            const int nloads = is_tail_block
-                    ? utils::div_up(tail_block_size(), simd_w())
-                    : block_size() / simd_w();
+            const int nloads = into<int>(is_tail_block
+                            ? utils::div_up(tail_block_size(), simd_w())
+                            : block_size() / simd_w());
             std::vector<Vmm> vregs_dst(nloads);
             for (int i_load = 0; i_load < nloads; i_load++) {
                 vregs_dst[i_load] = get_dst_reg(i_load);

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -46,7 +46,8 @@ public:
         size_t code_size = post_ops_gen.getSize();
         size_t estimated_vec_code_size = (size_t)nstl::max(
                 (int)code_size - (int)mean_none_vec_code_bytes, 0);
-        estimated_vec_insts = estimated_vec_code_size / mean_vec_inst_bytes;
+        estimated_vec_insts
+                = into<int>(estimated_vec_code_size / mean_vec_inst_bytes);
         return status::success;
     }
 

--- a/src/cpu/x64/prelu/jit_prelu_backward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_backward.cpp
@@ -217,7 +217,8 @@ status_t jit_prelu_bwd_t::execute(const exec_ctx_t &ctx) const {
                 weights_diff_scratchpad, C_cache_line_aligned, nthr);
 
         if (bcast == prelu::bcast::per_oc_blocked) {
-            const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+            const dim_t C_blocks
+                    = into<dim_t>(std::ceil(into<float>(C) / simd_w));
             work_amount = MB * C_blocks;
             parallel_nd_ext(nthr, MB, C_blocks,
                     [=](int ithr, int, dim_t mb, dim_t c_blk) {
@@ -283,7 +284,7 @@ void jit_prelu_bwd_t::scratchpad_to_diff_weights_reduction(float *scratchpad,
     const auto reduction_kernel = reduction_kernel_.get();
     const auto &simd_w = reduction_kernel_->simd_w();
     const bool tail_exists = C % simd_w;
-    const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+    const dim_t C_blocks = into<dim_t>(std::ceil(into<float>(C) / simd_w));
 
     parallel_nd(C_blocks, [=](dim_t c_blk) {
         const auto blk_offset = c_blk * simd_w;

--- a/src/cpu/x64/prelu/jit_prelu_base_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_base_kernel.cpp
@@ -53,24 +53,24 @@ void jit_prelu_base_kernel_t::generate() {
     L(unroll_loop);
     {
         const size_t offt = unrolling_factor * simd_w_;
-        cmp(reg_data_size_, offt);
+        cmp(reg_data_size_, into<uint32_t>(offt));
         jl(unroll_loop_tail, T_NEAR);
 
         compute_dst(unrolling_factor, false /*tail*/);
-        sub(reg_data_size_, offt);
-        add(reg_offset_, offt);
+        sub(reg_data_size_, into<uint32_t>(offt));
+        add(reg_offset_, into<uint32_t>(offt));
         jmp(unroll_loop);
     }
 
     static constexpr size_t single_unrolling = 1u;
     L(unroll_loop_tail);
     {
-        cmp(reg_data_size_, simd_w_);
+        cmp(reg_data_size_, into<uint32_t>(simd_w_));
         jl(nelems_tail, T_NEAR);
 
         compute_dst(single_unrolling, false /*tail*/);
-        sub(reg_data_size_, simd_w_);
-        add(reg_offset_, simd_w_);
+        sub(reg_data_size_, into<uint32_t>(simd_w_));
+        add(reg_offset_, into<uint32_t>(simd_w_));
         jmp(unroll_loop_tail);
     }
 
@@ -104,7 +104,7 @@ size_t jit_prelu_base_kernel_t::calc_tail_size(
 }
 
 int jit_prelu_base_kernel_t::reserve_vmm() {
-    return number_reserved_vmms_++;
+    return into<int>(number_reserved_vmms_++);
 }
 
 size_t jit_prelu_base_kernel_t::get_number_reserved_vmms() const noexcept {
@@ -118,8 +118,8 @@ size_t jit_prelu_base_kernel_t::get_number_reserved_vmms() const noexcept {
 
 int jit_prelu_base_kernel_t::get_compute_vmm(
         size_t base_idx, size_t unroll_group) const {
-    return number_reserved_vmms_ + base_idx
-            + unroll_group * number_vmm_single_compute_;
+    return into<int>(number_reserved_vmms_ + base_idx
+            + unroll_group * number_vmm_single_compute_);
 }
 
 size_t jit_prelu_base_kernel_t::calc_unrolling_factor() const noexcept {

--- a/src/cpu/x64/prelu/jit_prelu_forward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_forward.cpp
@@ -181,7 +181,8 @@ status_t jit_prelu_fwd_t::execute(const exec_ctx_t &ctx) const {
             });
         } else if (bcast == prelu::bcast::per_oc_blocked) {
             const auto simd_w = kernel->simd_w();
-            const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+            const dim_t C_blocks
+                    = into<dim_t>(std::ceil(into<float>(C) / simd_w));
 
             parallel_nd(MB, C_blocks, [=](dim_t mb, dim_t c_blk) {
                 jit_prelu_forward_kernel_t::call_params_t params;

--- a/src/cpu/x64/prelu/jit_prelu_reduction_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_reduction_kernel.cpp
@@ -92,11 +92,11 @@ void jit_prelu_reduction_kernel_t::generate(bool tail) {
     L(unroll_loop);
     {
         const size_t offt = unrolling_factor * scratchpad_c_block_offset_;
-        cmp(reg_reduction_blocks_, unrolling_factor);
+        cmp(reg_reduction_blocks_, into<uint32_t>(unrolling_factor));
         jl(unroll_loop_tail, T_NEAR);
-        compute_dst(unrolling_factor, tail);
-        sub(reg_reduction_blocks_, unrolling_factor);
-        add(reg_offset_, offt);
+        compute_dst(into<int>(unrolling_factor), tail);
+        sub(reg_reduction_blocks_, into<uint32_t>(unrolling_factor));
+        add(reg_offset_, into<uint32_t>(offt));
         jmp(unroll_loop);
     }
 
@@ -106,7 +106,7 @@ void jit_prelu_reduction_kernel_t::generate(bool tail) {
         jle(end, T_NEAR);
         compute_dst(1, tail);
         sub(reg_reduction_blocks_, 1);
-        add(reg_offset_, scratchpad_c_block_offset_);
+        add(reg_offset_, into<uint32_t>(scratchpad_c_block_offset_));
         jmp(unroll_loop_tail);
     }
 
@@ -116,7 +116,7 @@ void jit_prelu_reduction_kernel_t::generate(bool tail) {
 }
 
 int jit_prelu_reduction_kernel_t::reserve_vmm() {
-    return number_reserved_vmms_++;
+    return into<int>(number_reserved_vmms_++);
 }
 
 Xbyak::Address jit_prelu_reduction_kernel_t::diff_scratch_ptr(
@@ -187,7 +187,7 @@ template <typename Vmm>
 void jit_uni_prelu_reduction_kernel_t<Vmm>::compute_dst(
         int unrolling_factor, bool tail) {
 
-    const int vmm_begin = number_reserved_vmms_;
+    const int vmm_begin = into<int>(number_reserved_vmms_);
 
     for (int unrolling_group = 0; unrolling_group < unrolling_factor;
             ++unrolling_group) {

--- a/src/cpu/x64/prelu/jit_prelu_utils.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_utils.cpp
@@ -222,7 +222,8 @@ void apply_zero_padding(jit_generator_t *host, const size_t tail_size,
     if (reg_offset == nullptr)
         host->lea(reg_ptr, ptr[reg_dst + off_start]);
     else
-        host->lea(reg_ptr, ptr[reg_dst + (*reg_offset * dt_size) + off_start]);
+        host->lea(reg_ptr,
+                ptr[reg_dst + (*reg_offset * into<int>(dt_size)) + off_start]);
     host->mov(reg_counter, off_end - off_start);
     host->rep();
     host->stosb();

--- a/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_backward_kernel.cpp
@@ -59,7 +59,8 @@ Xbyak::Address jit_prelu_backward_kernel_t::data_ptr(int arg_num, size_t offt) {
     const auto get_addr
             = [&](const Xbyak::Reg64 &reg_base, const data_type_t dt) {
         const auto dt_size = types::data_type_size(dt);
-        return ptr[reg_base + reg_offset_ * dt_size + offt * dt_size];
+        return ptr[reg_base + reg_offset_ * into<int>(dt_size)
+                + into<int>(offt) * into<int>(dt_size)];
     };
 
     switch (arg_num) {
@@ -212,7 +213,7 @@ void jit_uni_prelu_backward_kernel_t<Xbyak::Zmm>::compute_dst(
     auto get_next_opmask = [opmask_counter]() mutable {
         static constexpr size_t opmask_range_begin = 2;
         static constexpr size_t opmask_range_end = 8;
-        const auto opmask = Xbyak::Opmask(opmask_counter++);
+        const auto opmask = Xbyak::Opmask(into<int>(opmask_counter++));
         if (opmask_counter == opmask_range_end)
             opmask_counter = opmask_range_begin;
         return opmask;

--- a/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_uni_prelu_forward_kernel.cpp
@@ -52,7 +52,8 @@ Xbyak::Address jit_prelu_forward_kernel_t::data_ptr(int arg_num, size_t offt) {
     const auto get_addr
             = [&](const Xbyak::Reg64 &reg_base, const data_type_t dt) {
         const auto dt_size = types::data_type_size(dt);
-        return ptr[reg_base + reg_offset_ * dt_size + offt * dt_size];
+        return ptr[reg_base + reg_offset_ * into<int>(dt_size)
+                + into<int>(offt) * into<int>(dt_size)];
     };
 
     switch (arg_num) {

--- a/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
@@ -148,10 +148,12 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
     const auto &conf = pd()->get_conf();
     assert(conf.tag_kind == jit_memory_tag_kind_t::blocked);
 
-    const int transpose_row = pd()->is_fwd() ? conf.group_size
-                                             : conf.axis_size / conf.group_size;
-    const int transpose_col = pd()->is_fwd() ? conf.axis_size / conf.group_size
-                                             : conf.group_size;
+    const int transpose_row
+            = into<int>(pd()->is_fwd() ? conf.group_size
+                                       : conf.axis_size / conf.group_size);
+    const int transpose_col
+            = into<int>(pd()->is_fwd() ? conf.axis_size / conf.group_size
+                                       : conf.group_size);
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
     auto scratchpad_ptr = scratchpad.template get<int>(
@@ -159,7 +161,8 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
 
     // Precompute transposed axis helper array
     parallel_nd(transpose_col, transpose_row, [=](dim_t i, dim_t j) {
-        scratchpad_ptr[j * transpose_col + i] = i * transpose_row + j;
+        scratchpad_ptr[j * transpose_col + i]
+                = into<int>(i * transpose_row + j);
     });
 
     const dim_t CB = utils::div_up(conf.c, conf.blk_size);
@@ -167,17 +170,17 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
 
     // Precompute input offsets using transposed axis
     parallel_nd(CB, [=](dim_t cb) {
-        const int blk_end
-                = nstl::min(conf.blk_size, conf.c - cb * conf.blk_size);
+        const int blk_end = into<int>(
+                nstl::min(conf.blk_size, conf.c - cb * conf.blk_size));
         PRAGMA_OMP_SIMD()
         for (int cc = 0; cc < blk_end; ++cc) {
-            const int off = cb * conf.blk_size + cc;
+            const dim_t off = cb * conf.blk_size + cc;
             int input_c = scratchpad_ptr[off];
             // Re-write transposed axis data.
-            scratchpad_ptr[off]
-                    = (input_c / conf.blk_size * conf.sp * conf.blk_size
-                              + input_c % conf.blk_size)
-                    * conf.dt_size;
+            scratchpad_ptr[off] = into<int>(
+                    (input_c / conf.blk_size * conf.sp * conf.blk_size
+                            + input_c % conf.blk_size)
+                    * conf.dt_size);
         }
     });
 

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -78,15 +78,16 @@ void jit_uni_shuffle_kernel_t<avx512_core>::emu_gather_data(
     constexpr unsigned xmm_size_elem = 8; //bf16
     constexpr unsigned xmm_size_elem_half = xmm_size_elem / 2;
 
-    const unsigned number_of_xmms = is_tail
-            ? utils::div_up(conf_.simd_tail, xmm_size_elem)
-            : utils::div_up(conf_.simd_w, xmm_size_elem);
+    const unsigned number_of_xmms = into<unsigned int>(is_tail
+                    ? utils::div_up(conf_.simd_tail, xmm_size_elem)
+                    : utils::div_up(conf_.simd_w, xmm_size_elem));
 
     for (unsigned i = 0; i < number_of_xmms; i++) {
-        const unsigned number_of_xmm_halfs = is_tail && i == number_of_xmms - 1
-                ? utils::div_up(conf_.simd_tail,
-                          xmm_size_elem_half + i * xmm_size_elem)
-                : 2;
+        const unsigned number_of_xmm_halfs = into<unsigned int>(
+                is_tail && i == number_of_xmms - 1
+                        ? utils::div_up(conf_.simd_tail,
+                                  xmm_size_elem_half + i * xmm_size_elem)
+                        : 2);
 
         for (unsigned j = 0; j < number_of_xmm_halfs; j++) {
             const unsigned rem = conf_.simd_tail % xmm_size_elem_half;
@@ -96,16 +97,17 @@ void jit_uni_shuffle_kernel_t<avx512_core>::emu_gather_data(
                     ? rem
                     : xmm_size_elem_half;
 
-            vextractf32x4(xmm_tmp, Zmm(indices_idx), j + i * 2);
+            vextractf32x4(xmm_tmp, Zmm(indices_idx), into<uint8_t>(j + i * 2));
             for (unsigned k = 0; k < number_of_values_to_load; k++) {
-                vpextrd(reg_tmp_.cvt32(), xmm_tmp, k + j * xmm_size_elem_half);
+                vpextrd(reg_tmp_.cvt32(), xmm_tmp,
+                        into<uint8_t>(k + j * xmm_size_elem_half));
                 add(reg_src_addr, reg_tmp_);
                 vpinsrw(xmm_dst, xmm_dst, ptr[reg_src_addr],
-                        k + j * xmm_size_elem_half);
+                        into<uint8_t>(k + j * xmm_size_elem_half));
                 mov(reg_src_addr, reg_tmp1_);
             }
         }
-        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, i);
+        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, into<uint8_t>(i));
     }
 }
 
@@ -120,24 +122,24 @@ void jit_uni_shuffle_kernel_t<avx>::emu_gather_data(const Reg64 &reg_src_addr,
 
     constexpr unsigned xmm_size_elem = 4;
 
-    const unsigned number_of_xmms = is_tail
-            ? utils::div_up(conf_.simd_tail, xmm_size_elem)
-            : utils::div_up(conf_.simd_w, xmm_size_elem);
+    const unsigned number_of_xmms = into<unsigned int>(is_tail
+                    ? utils::div_up(conf_.simd_tail, xmm_size_elem)
+                    : utils::div_up(conf_.simd_w, xmm_size_elem));
     for (unsigned i = 0; i < number_of_xmms; i++) {
-        vextractf128(xmm_tmp, Ymm(indices_idx), i);
+        vextractf128(xmm_tmp, Ymm(indices_idx), into<uint8_t>(i));
 
         const unsigned number_of_values_to_load = i == number_of_xmms - 1
                         && is_tail && conf_.simd_tail % xmm_size_elem != 0
                 ? conf_.simd_tail % xmm_size_elem
                 : xmm_size_elem;
         for (unsigned j = 0; j < number_of_values_to_load; j++) {
-            vpextrd(reg_tmp_.cvt32(), xmm_tmp, j);
+            vpextrd(reg_tmp_.cvt32(), xmm_tmp, into<uint8_t>(j));
             add(reg_src_addr, reg_tmp_);
-            vpinsrd(xmm_dst, xmm_dst, ptr[reg_src_addr], j);
+            vpinsrd(xmm_dst, xmm_dst, ptr[reg_src_addr], into<uint8_t>(j));
             mov(reg_src_addr, reg_tmp1_);
         }
 
-        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, i);
+        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, into<uint8_t>(i));
     }
 }
 
@@ -150,11 +152,11 @@ void jit_uni_shuffle_kernel_t<sse41>::emu_gather_data(const Reg64 &reg_src_addr,
     constexpr unsigned xmm_size_elem = 4;
 
     const unsigned number_of_values_to_load
-            = is_tail ? conf_.simd_tail : xmm_size_elem;
+            = into<unsigned int>(is_tail ? conf_.simd_tail : xmm_size_elem);
     for (unsigned j = 0; j < number_of_values_to_load; j++) {
-        pextrd(reg_tmp_.cvt32(), Xmm(indices_idx), j);
+        pextrd(reg_tmp_.cvt32(), Xmm(indices_idx), into<uint8_t>(j));
         add(reg_src_addr, reg_tmp_);
-        pinsrd(Xmm(data_idx), ptr[reg_src_addr], j);
+        pinsrd(Xmm(data_idx), ptr[reg_src_addr], into<uint8_t>(j));
         mov(reg_src_addr, reg_tmp1_);
     }
 }
@@ -276,7 +278,7 @@ void jit_uni_shuffle_kernel_t<sse41>::store_data(const int data_idx,
     if (is_tail)
         for (unsigned i = 0; i < conf_.simd_tail; i++) {
             pextrd(ptr[reg_dst_addr + offset + i * conf_.dt_size],
-                    Xmm(data_idx), i);
+                    Xmm(data_idx), into<uint8_t>(i));
         }
     else
         movups(ptr[reg_dst_addr + offset], Vmm(data_idx));
@@ -291,9 +293,9 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
     const Reg64 &reg_cb_loop_size = reg_tmp4_;
     const Reg64 &reg_blk_tail = reg_tmp5_;
     const Reg64 &reg_src_save = reg_tmp6_;
-    const int simd_in_blk = conf_.blk_size / conf_.simd_w;
+    const int simd_in_blk = into<int>(conf_.blk_size / conf_.simd_w);
     const int simd_in_tail_blk
-            = utils::div_up(conf_.c % conf_.blk_size, conf_.simd_w);
+            = into<int>(utils::div_up(conf_.c % conf_.blk_size, conf_.simd_w));
     const Vmm vmm_tmp[4] = {Vmm(5), Vmm(6), Vmm(7), Vmm(8)};
 
     auto load_indices = ([&](bool is_blk_tail) {
@@ -316,7 +318,8 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
                     simd_tail_condition);
 
             store_data(vmm_src_.getIdx(), reg_dst_,
-                    i * conf_.simd_w * conf_.dt_size, simd_tail_condition);
+                    into<int>(i * conf_.simd_w * conf_.dt_size),
+                    simd_tail_condition);
         }
     });
 
@@ -332,7 +335,7 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
 
     xor_(reg_blk_tail, reg_blk_tail);
 
-    cmp(reg_cb_loop_size, conf_.blk_size);
+    cmp(reg_cb_loop_size, into<uint32_t>(conf_.blk_size));
     je(no_tail, T_NEAR);
 
     mov(reg_blk_tail, reg_cb_loop_size);
@@ -353,14 +356,14 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
         xor_(reg_sp, reg_sp);
         L(sp_loop_begin);
         {
-            cmp(reg_sp, conf_.sp_split_size);
+            cmp(reg_sp, into<uint32_t>(conf_.sp_split_size));
             jge(sp_loop_end, T_NEAR);
 
             shuffle(false);
 
             inc(reg_sp);
-            add(reg_src_, conf_.blk_size * conf_.dt_size);
-            add(reg_dst_, conf_.blk_size * conf_.dt_size);
+            add(reg_src_, into<uint32_t>(conf_.blk_size * conf_.dt_size));
+            add(reg_dst_, into<uint32_t>(conf_.blk_size * conf_.dt_size));
 
             jmp(sp_loop_begin);
         }
@@ -368,11 +371,12 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
 
         mov(reg_src_, reg_src_save);
 
-        add(reg_cb, conf_.blk_size);
+        add(reg_cb, into<uint32_t>(conf_.blk_size));
         add(reg_dst_,
-                conf_.blk_size * (conf_.sp - conf_.sp_split_size)
-                        * conf_.dt_size);
-        add(reg_indices_, conf_.blk_size * conf_.el_size_of_indices);
+                into<uint32_t>(conf_.blk_size * (conf_.sp - conf_.sp_split_size)
+                        * conf_.dt_size));
+        add(reg_indices_,
+                into<uint32_t>(conf_.blk_size * conf_.el_size_of_indices));
 
         jmp(cb_loop_begin);
     }
@@ -386,14 +390,14 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
     xor_(reg_sp, reg_sp);
     L(sp_tail_loop_begin);
     {
-        cmp(reg_sp, conf_.sp_split_size);
+        cmp(reg_sp, into<uint32_t>(conf_.sp_split_size));
         jge(sp_tail_loop_end, T_NEAR);
 
         shuffle(true);
 
         inc(reg_sp);
-        add(reg_src_, conf_.blk_size * conf_.dt_size);
-        add(reg_dst_, conf_.blk_size * conf_.dt_size);
+        add(reg_src_, into<uint32_t>(conf_.blk_size * conf_.dt_size));
+        add(reg_dst_, into<uint32_t>(conf_.blk_size * conf_.dt_size));
 
         jmp(sp_tail_loop_begin);
     }

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -309,9 +309,9 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
     // and in convert_to_f32, they are shifted-left to finally convert to f32
     // For f16 we do not need such interleaving.
     const int xmm_size_elem = (data_type_ == data_type::f16) ? 8 : 4;
-    const int number_of_xmms = tail
-            ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
-            : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
+    const int number_of_xmms = into<int>(tail
+                    ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
+                    : utils::div_up(gather_conf_->simd_w_, xmm_size_elem));
     const int num_indices_in_xmm = 16 / sizeof(int);
     for (int i = 0, idx = 0; i < number_of_xmms; i++) {
 
@@ -322,18 +322,21 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
         for (int j = 0; j < number_of_values_to_load; j++) {
 
             if (j % num_indices_in_xmm == 0)
-                host_->vextractf32x4(xmm_tmp, indices_vmm, idx++);
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+                host_->vextractf32x4(
+                        xmm_tmp, indices_vmm, into<uint8_t>(idx++));
+            host_->vpextrd(
+                    gather_conf_->reg_tmp_.cvt32(), xmm_tmp, into<uint8_t>(j));
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            into<uint8_t>(j));
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
-                            xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            into<uint8_t>(j * 2));
                     break;
                 case data_type::s8:
                 case data_type::u8:
@@ -345,7 +348,7 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                    fp8_supported_)
                             && "Unsupported data type.");
                     host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            into<uint8_t>(i * xmm_size_elem + j));
                     break;
                 }
                 default: assert(!"Unsupported data type.");
@@ -353,10 +356,10 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
             host_->mov(src_reg, gather_conf_->reg_tmp1_);
         }
         if (data_type_ == data_type::bf16) {
-            host_->vinsertf32x4(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf32x4(dst_vmm, dst_vmm, xmm_dst, into<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         } else if (data_type_ == data_type::f16) {
-            host_->vinsertf32x4(dst_ymm, dst_ymm, xmm_dst, i);
+            host_->vinsertf32x4(dst_ymm, dst_ymm, xmm_dst, into<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         }
     }
@@ -391,34 +394,36 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
     // and in convert_to_f32, they are shifted-left to finally convert to f32
     // For f16 we do not need such interleaving.
     const int xmm_size_elem = 4;
-    const int number_of_xmms = tail
-            ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
-            : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
+    const int number_of_xmms = into<int>(tail
+                    ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
+                    : utils::div_up(gather_conf_->simd_w_, xmm_size_elem));
     for (int i = 0; i < number_of_xmms; i++) {
-        host_->vextractf128(xmm_tmp, indices_vmm, i);
+        host_->vextractf128(xmm_tmp, indices_vmm, into<uint8_t>(i));
 
         const int number_of_values_to_load = i == number_of_xmms - 1 && tail
                         && tail_conf_->tail_size_ % xmm_size_elem != 0
                 ? tail_conf_->tail_size_ % xmm_size_elem
                 : xmm_size_elem;
         for (int j = 0; j < number_of_values_to_load; j++) {
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+            host_->vpextrd(
+                    gather_conf_->reg_tmp_.cvt32(), xmm_tmp, into<uint8_t>(j));
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f32:
                 case data_type::s32: {
-                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            into<uint8_t>(j));
                     break;
                 }
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
                     host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            into<uint8_t>(i * xmm_size_elem + j));
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
-                            xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            into<uint8_t>(j * 2));
                     break;
                 case data_type::s8:
                 case data_type::u8:
@@ -430,7 +435,7 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                    fp8_supported_)
                             && "Unsupported data type.");
                     host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            into<uint8_t>(i * xmm_size_elem + j));
                     break;
                 }
                 default: assert(!"Unsupported data type.");
@@ -440,7 +445,7 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
 
         if (utils::one_of(data_type_, data_type::f32, data_type::s32,
                     data_type::bf16))
-            host_->vinsertf128(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf128(dst_vmm, dst_vmm, xmm_dst, into<uint8_t>(i));
     }
 
     if (data_type_ == data_type::s32 || data_type_ == data_type::bf16)
@@ -463,14 +468,15 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
 
     const unsigned xmm_size_elem = 4;
     const unsigned number_of_values_to_load
-            = tail ? tail_conf_->tail_size_ : xmm_size_elem;
+            = into<unsigned int>(tail ? tail_conf_->tail_size_ : xmm_size_elem);
     for (unsigned j = 0; j < number_of_values_to_load; j++) {
-        host_->pextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm, j);
+        host_->pextrd(
+                gather_conf_->reg_tmp_.cvt32(), indices_vmm, into<uint8_t>(j));
         host_->add(src_reg, gather_conf_->reg_tmp_);
         switch (data_type_) {
             case data_type::f32:
             case data_type::s32: {
-                host_->pinsrd(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrd(dst_vmm, host_->ptr[src_reg], into<uint8_t>(j));
                 break;
             }
             case data_type::f16:
@@ -489,7 +495,7 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                            data_type::f8_e5m2),
                                fp8_supported_)
                         && "Unsupported data type.");
-                host_->pinsrb(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrb(dst_vmm, host_->ptr[src_reg], into<uint8_t>(j));
                 break;
             }
             default: assert(!"Unsupported data type.");
@@ -626,7 +632,7 @@ void jit_io_helper_t<Vmm>::load(const Xbyak::Address &src_addr,
                     || (!is_tail_load_supported && (is_i8 || is_xf16)));
 
     if (can_load_byte_by_byte) {
-        load_byte_by_byte(src_addr, dst_vmm, tail_conf_->tail_size_);
+        load_byte_by_byte(src_addr, dst_vmm, into<int>(tail_conf_->tail_size_));
     } else {
         switch (data_type_) {
             case data_type::f32: load_f32(src_addr, dst_vmm, tail); break;
@@ -785,7 +791,7 @@ void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
                 = vreg_traits_t<Xbyak::Xmm>::vlen / sizeof(int32_t);
         const size_t store_size = (tail ? tail_conf_->tail_size_ : xmm_length)
                 * types::data_type_size(data_type_);
-        store_byte_by_byte(src_vmm, dst_addr, store_size);
+        store_byte_by_byte(src_vmm, dst_addr, into<int>(store_size));
     } else {
         switch (data_type_) {
             case data_type::f32:

--- a/third_party/xbyak/xbyak/xbyak_util.h
+++ b/third_party/xbyak/xbyak/xbyak_util.h
@@ -1591,7 +1591,7 @@ inline CoreType setAffinityAndGetCoreType(uint32_t cpu)
 
 inline bool initCpuTopology(CpuTopology& cpuTopo)
 {
-	const uint32_t logicalCpuNum = sysconf(_SC_NPROCESSORS_ONLN);
+	const uint32_t logicalCpuNum = static_cast<uint32_t>(sysconf(_SC_NPROCESSORS_ONLN));
 
 	if (logicalCpuNum == 0) return false;
 	if (logicalCpuNum >= (1u << XBYAK_CPUMASK_BITN)) return false;


### PR DESCRIPTION
PR converted to draft after gathering feedback from comments below.

Resolves the BinSkim C4244 warnings tracked in [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).

## Changes

Ports the existing GPU-side `into<T>()` pattern (`src/gpu/intel/utils.hpp`)
into `src/common/utils.hpp` so the CPU backend can share it, and adds one
CPU-specific variant:

- `into<T>()` - behaves like `static_cast` in release builds, but asserts
  the value fits the target type in dev mode.
- `relaxed_into<T>()` - for the few cases where wrap-around is intentional
  (signed/unsigned reinterpretation in compensation).

Applies these casts across the x64 backend wherever implicit conversions
were firing C4244: JIT immediates, register indices, loop counters, and
offsets.

## Coverage

**Primitives:** brgemm, convolution, matmul, inner_product, pooling,
normalization, eltwise, reorder, prelu, lrn, reduction, shuffle, softmax,
binary, resampling, sum, gemm

**Infrastructure:** jit_generator, nstl, jit_io_helper, injectors