### PR TITLE
x64: pooling: fix implicit narrowing conversions

### DIFF
--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -82,9 +82,10 @@ status_t nchw_pooling_fwd_t<data_type::f32>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset]
+                        = static_cast<int>(value);
         }
     };
 
@@ -284,9 +285,10 @@ status_t nchw_pooling_fwd_t<d_type>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset]
+                        = static_cast<int>(value);
         }
     };
 

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -183,7 +183,7 @@ struct nchw_pooling_bwd_t : public primitive_t {
 
         dim_t channel_block_size_ {1};
         int nthr_; // To not exceed the limit in execute used for set up.
-        int nbuf_ {0};
+        dim_t nbuf_ {0};
 
     private:
         void init_scratchpad() {

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -82,7 +82,7 @@ void nhwc_pooling_fwd_t<d_type>::array_add(
 template <data_type_t d_type>
 void nhwc_pooling_fwd_t<d_type>::array_nhwc_max(const dim_t n, ker_data_t *dst,
         const ker_data_t *src, unsigned char *ws, const size_t ws_offset,
-        const data_type_t ws_dt, const int index) const {
+        const data_type_t ws_dt, const dim_t index) const {
     assert(ws);
 #if SAFE_TO_USE_OMP_SIMD
     PRAGMA_OMP_SIMD()
@@ -98,9 +98,10 @@ void nhwc_pooling_fwd_t<d_type>::array_nhwc_max(const dim_t n, ker_data_t *dst,
             assert(ws_dt == data_type::u8 || ws_dt == data_type::s32);
             if (ws_dt == data_type::u8) {
                 assert(0 <= index && index <= 255);
-                ws[ws_offset + oc] = index;
+                ws[ws_offset + oc] = static_cast<unsigned char>(index);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset + oc] = index;
+                reinterpret_cast<int *>(ws)[ws_offset + oc]
+                        = static_cast<int>(index);
         }
 #else
         // Need to add explicit predicates for GCC to vectorize this.

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -140,7 +140,7 @@ private:
     void array_add(const dim_t n, const ker_data_t *src, ker_data_t *dst) const;
     void array_nhwc_max(const dim_t n, ker_data_t *dst, const ker_data_t *src,
             unsigned char *ws, const size_t ws_offset, const data_type_t ws_dt,
-            const int index) const;
+            const dim_t index) const;
     void array_nhwc_initialize(const dim_t n, ker_data_t *dst,
             unsigned char *ws, const size_t ws_offset,
             const data_type_t ws_dt) const;

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -90,9 +90,9 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[off] = value;
+                ws[off] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[off] = value;
+                reinterpret_cast<int *>(ws)[off] = static_cast<int>(value);
         }
     };
 
@@ -137,7 +137,7 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 }
             }
         }
-        int num_summands;
+        dim_t num_summands;
         if (alg == alg_kind::pooling_avg_include_padding)
             num_summands = KW * KH * KD;
         else {
@@ -165,7 +165,7 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                     * (KH - ih_start_excluded - ih_end_excluded)
                     * (KW - iw_start_excluded - iw_end_excluded);
         }
-        d /= num_summands;
+        d /= static_cast<float>(num_summands);
     };
 
     const bool is_max_pool = alg == alg_kind::pooling_max;
@@ -340,7 +340,7 @@ status_t ref_pooling_bwd_t::execute(const exec_ctx_t &ctx) const {
         balance211(diff_src_d.nelems(true), nthr, ithr, start, end);
         if (start == end) return;
 
-        for (int i = start; i < end; i++)
+        for (dim_t i = start; i < end; i++)
             io::store_float_value(data_type::f32, 0, diff_src, i);
     });
 

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -634,7 +634,7 @@ status_t brgemm_desc_set_attr(
 status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (brg == nullptr) return status::invalid_arguments;
 
-    const int max_vpad = nstl::max(
+    const dim_t max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
     if (brg->is_dgmm)
@@ -645,7 +645,7 @@ status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (!brg->is_dgmm) {
         // virtual padding is restricted by bd_block size due to
         // brgemm_kernel implementation. TODO: remove this restriction
-        const int min_bd_block
+        const dim_t min_bd_block
                 = brg->bdb_tail > 0 ? brg->bdb_tail : brg->bd_block;
         if ((max_vpad > min_bd_block)) return status::unimplemented;
     }
@@ -728,12 +728,12 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
     for (int i = 0; i < max_palette_size_in_bytes; i++)
         _tc[i] = 0;
 
-    const int typesize_A
+    const dim_t typesize_A
             = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_A;
-    const int typesize_B
+    const dim_t typesize_B
             = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_B;
 
-    const int rd_step = 4 / typesize_A;
+    const dim_t rd_step = 4 / typesize_A;
 
     const auto Ac = typesize_A * rd_block;
 

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -79,7 +79,7 @@ void brgemm_desc_t::cleanup_dst_md() {
     dst_md_ = nullptr;
 }
 
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
     brgemm_kernel_params_t brgemm_p;
@@ -107,7 +107,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -135,7 +135,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -178,7 +178,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -213,7 +213,7 @@ status_t DNNL_API brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel);
 ///     * In rest scenarios is not used.
 /// @param dynamic_values TODO: missing doc
 ///
-void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C,
         void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
@@ -240,7 +240,7 @@ void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
 ///     * In rest scenarios is not used.
 /// @param dynamic_values TODO: missing doc
 ///
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C,
         void *scratch = nullptr,
@@ -269,7 +269,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
 /// @param dynamic_values TODO: missing doc
 ///
 void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
-        int bs, const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
+        dim_t bs, const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
 
@@ -299,7 +299,7 @@ void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
 /// @param dynamic_values TODO: missing doc
 ///
 void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
-        int bs, const void *addr_A, const void *addr_B,
+        dim_t bs, const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -39,7 +39,7 @@ brgemm_kernel_container_t::get_set() {
     return set_;
 }
 
-bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
+bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
         const std::vector<char> &bd_mask,
         const std::vector<brgemm_batch_element_t> &static_offsets) {
     bd_mask_list_.push_back(bd_mask);
@@ -100,7 +100,7 @@ bool brgemm_kernel_container_t::brgemm_kernel_cmp(
     return (std::memcmp(lcode, rcode, lsz) < 0);
 }
 
-status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
+status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
     // Use two level hashing of brgemm kernels:
     // 1. Try to find entry in local brgemm_map_ using brgemm descriptor as a
     // key (we can check if brgemm descriptor is unique inside brgemm primitive)
@@ -123,7 +123,7 @@ status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
     return status::success;
 }
 
-bool brgemm_palette_container_t::insert(int idx, const brgemm_desc_t *brg) {
+bool brgemm_palette_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
     S_t kernel_palette;
     auto status = brgemm_init_tiles(*brg, kernel_palette.data());
     if (status != status::success) return false;

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -49,7 +49,7 @@ bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
-    const int ref_size = refs_.size();
+    const dim_t ref_size = refs_.size();
     if (idx > ref_size - 1) { refs_.resize(idx + 1); }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
@@ -60,7 +60,7 @@ bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
     return ret.second;
 }
 
-int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
+dim_t brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         const std::vector<char> &bd_mask,
         const std::vector<brgemm_batch_element_t> &static_offsets) {
     bd_mask_list_.push_back(bd_mask);
@@ -68,7 +68,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
 
     static_offsets_list_.push_back(static_offsets);
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
-    const int ref_size = refs_.size();
+    const dim_t ref_size = refs_.size();
     const auto ret = map_.insert({brg, -1});
     if (!ret.second) {
         // if there was no insertion then clean bd_mask and static_offsets
@@ -77,7 +77,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         return ret.first->second;
     }
 
-    int idx = map_.size() - 1;
+    const dim_t idx = map_.size() - 1;
     if (idx > ref_size - 1) {
         if (ref_size == 0)
             refs_.resize(1);
@@ -100,7 +100,8 @@ bool brgemm_kernel_container_t::brgemm_kernel_cmp(
     return (std::memcmp(lcode, rcode, lsz) < 0);
 }
 
-status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
+status_t brgemm_kernel_container_t::insert(
+        dim_t idx, const brgemm_desc_t *brg) {
     // Use two level hashing of brgemm kernels:
     // 1. Try to find entry in local brgemm_map_ using brgemm descriptor as a
     // key (we can check if brgemm descriptor is unique inside brgemm primitive)

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -39,13 +39,13 @@ public:
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
 
-    bool insert(int idx, brgemm_desc_t &brg) {
+    bool insert(dim_t idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
         std::vector<brgemm_batch_element_t> dummy_static_offsets;
         return insert(idx, brg, dummy_bd_mask, dummy_static_offsets);
     }
 
-    bool insert(int idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
+    bool insert(dim_t idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
     int insert(brgemm_desc_t &brg) {
@@ -78,7 +78,7 @@ struct brgemm_kernel_container_t {
         return refs_[idx];
     }
 
-    status_t insert(int idx, const brgemm_desc_t *brg);
+    status_t insert(dim_t idx, const brgemm_desc_t *brg);
     static bool brgemm_kernel_cmp(const std::shared_ptr<brgemm_kernel_t> &lhs,
             const std::shared_ptr<brgemm_kernel_t> &rhs);
 
@@ -117,12 +117,12 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](int idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](dim_t idx) const { return refs_[idx]->data(); }
 
-    bool insert(int idx, const brgemm_desc_t *brg);
-    bool insert(int idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
+    bool insert(dim_t idx, const brgemm_desc_t *brg);
+    bool insert(dim_t idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
 
-    inline void maybe_tile_configure(bool is_amx, int &idx, int new_idx) const {
+    inline void maybe_tile_configure(bool is_amx, dim_t &idx, dim_t new_idx) const {
         if (idx == new_idx) return;
         if (is_amx && (idx < 0 || refs_[idx] != refs_[new_idx]))
             amx_tile_configure(refs_[new_idx]->data());

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -37,7 +37,10 @@ public:
     brgemm_desc_container_t() = default;
     brgemm_desc_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
-    inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
+    inline const brgemm_desc_t *operator[](dim_t idx) const {
+        assert(idx >= 0);
+        return refs_[idx];
+    }
 
     bool insert(dim_t idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
@@ -48,13 +51,13 @@ public:
     bool insert(dim_t idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
-    int insert(brgemm_desc_t &brg) {
+    dim_t insert(brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
         std::vector<brgemm_batch_element_t> dummy_static_offsets;
         return insert(brg, dummy_bd_mask, dummy_static_offsets);
     }
 
-    int insert(brgemm_desc_t &brg, const std::vector<char> &bd_mask,
+    dim_t insert(brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
     size_t refs_size() { return refs_.size(); }
@@ -62,7 +65,7 @@ public:
 private:
     std::vector<const brgemm_desc_t *> refs_;
 
-    std::map<brgemm_desc_t, int> map_;
+    std::map<brgemm_desc_t, dim_t> map_;
     std::vector<std::vector<char>> bd_mask_list_;
     std::vector<std::vector<brgemm_batch_element_t>> static_offsets_list_;
 };
@@ -74,7 +77,8 @@ struct brgemm_kernel_container_t {
     brgemm_kernel_container_t() = default;
     brgemm_kernel_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
-    inline const brgemm_kernel_t *operator[](int idx) const {
+    inline const brgemm_kernel_t *operator[](dim_t idx) const {
+        assert(idx >= 0);
         return refs_[idx];
     }
 
@@ -117,12 +121,18 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](dim_t idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](dim_t idx) const {
+        assert(idx >= 0);
+        return refs_[idx]->data();
+    }
 
     bool insert(dim_t idx, const brgemm_desc_t *brg);
-    bool insert(dim_t idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
+    bool insert(dim_t idx, const brgemm_desc_t &brg) {
+        return insert(idx, &brg);
+    }
 
-    inline void maybe_tile_configure(bool is_amx, dim_t &idx, dim_t new_idx) const {
+    inline void maybe_tile_configure(
+            bool is_amx, dim_t &idx, dim_t new_idx) const {
         if (idx == new_idx) return;
         if (is_amx && (idx < 0 || refs_[idx] != refs_[new_idx]))
             amx_tile_configure(refs_[new_idx]->data());

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -168,8 +168,8 @@ struct DNNL_API brgemm_attr_t {
     // then "max_bs" is the the only batch size that can be used on kernel call
     // else "max_bs" is the maximum batch size that can be used
     dim_t max_bs;
-    int max_top_vpad, max_bottom_vpad;
-    int max_top_bpad, max_bottom_bpad;
+    dim_t max_top_vpad, max_bottom_vpad;
+    dim_t max_top_bpad, max_bottom_bpad;
     dim_t hint_expected_A_size, hint_expected_B_size, hint_expected_C_size;
     brgemm_kernel_innermost_loop_t hint_innermost_loop
             = brgemm_ld_loop_innermost;
@@ -201,7 +201,7 @@ struct DNNL_API brgemm_attr_t {
     // 0 – bd_mask is not used
     // 1 – bd_mask is used on storing stage only
     // 2 – bd_mask used both on reading and storing stages
-    int bd_mask_level;
+    dim_t bd_mask_level;
     // use_uker is a boolean value that determines whether to use the unrolled
     // kernel or not
     bool use_uker;
@@ -221,12 +221,12 @@ struct DNNL_API brgemm_attr_t {
     bool var_bs {false};
     bool postops_only {false};
     // Hint for bs_group value in brgemm_desc_t
-    int hint_bs_group {0};
+    dim_t hint_bs_group {0};
 
-    int hint_bd_block {0};
-    int hint_ld_block {0};
-    int hint_bd_block2 {0};
-    int hint_ld_block2 {0};
+    dim_t hint_bd_block {0};
+    dim_t hint_ld_block {0};
+    dim_t hint_bd_block2 {0};
+    dim_t hint_ld_block2 {0};
     bool hint_ununroll_bd_loop {false};
 
     brgemm_kernel_hint_mem_advice_t mem_advice {brgemm_hint_mem_advice_undef};
@@ -260,10 +260,10 @@ struct brgemm_desc_t {
     dim_t bcast_dim = 0; // M;
     dim_t load_dim = 0; // N;
     dim_t reduce_dim = 0; // K;
-    int LDA = 0;
-    int LDB = 0;
-    int LDC = 0;
-    int LDD = 0;
+    dim_t LDA = 0;
+    dim_t LDB = 0;
+    dim_t LDC = 0;
+    dim_t LDD = 0;
 
     bool fused_copy_a = false;
     // we use two isa_ variables
@@ -329,7 +329,7 @@ struct brgemm_desc_t {
     bool with_dst_scales = false;
     data_type_t dt_wei_scales = data_type::undef;
     // Grouping in batch used by brdgmm kernel
-    int bs_group {0};
+    dim_t bs_group {0};
 
     brgemm_attr_t brgattr;
 
@@ -337,18 +337,18 @@ struct brgemm_desc_t {
     dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     bool is_blocked = false;
 
-    int bdb = 0, bd_block = 0, bdb_tail = 0;
-    int bdb2 = 0, bd_block2 = 0, bdb2_tail = 0;
-    int ldb = 0, ld_block = 0, ldb_tail = 0;
-    int ldb2 = 0, ld_block2 = 0, ldb2_tail = 0;
-    int rdb = 0, rd_block = 0, rdb_tail = 0;
-    int rd_step = 0, ld_step = 0;
+    dim_t bdb = 0, bd_block = 0, bdb_tail = 0;
+    dim_t bdb2 = 0, bd_block2 = 0, bdb2_tail = 0;
+    dim_t ldb = 0, ld_block = 0, ldb_tail = 0;
+    dim_t ldb2 = 0, ld_block2 = 0, ldb2_tail = 0;
+    dim_t rdb = 0, rd_block = 0, rdb_tail = 0;
+    dim_t rd_step = 0, ld_step = 0;
 
-    int typesize_A = 0;
-    int typesize_B = 0;
-    int typesize_C = 0;
-    int typesize_D = 0;
-    int typesize_bias = 0;
+    dim_t typesize_A = 0;
+    dim_t typesize_B = 0;
+    dim_t typesize_C = 0;
+    dim_t typesize_D = 0;
+    dim_t typesize_bias = 0;
 
     bool is_ymm = false;
     bool is_zmm = false;
@@ -373,7 +373,7 @@ struct brgemm_desc_t {
     // by kernel API.
     bool with_weights_scale_adjust = false;
     brgemm_kernel_innermost_loop_t innermost_loop = brgemm_ld_loop_innermost;
-    int is_M_tail = false;
+    dim_t is_M_tail = false;
     bool interleave_tilestores_ = false;
     brgemm_prf_t prfA, prfB, prfC;
     bool is_runtime_lda = false;
@@ -390,10 +390,10 @@ struct brgemm_desc_t {
     // Controls whether y is treated as a row in GEMV-specific code paths.
     bool treat_y_as_row = false;
     // GEMV transA register-blocking unroll factor.
-    int gemv_transa_bd_unroll = 0;
+    dim_t gemv_transa_bd_unroll = 0;
     // non-transA: tail along the reduction dimension.
     // transA:     number of valid elements in the final vector accumulator.
-    int gemv_tail = 0;
+    dim_t gemv_tail = 0;
 
     static constexpr int MAX_VPAD = 100;
     static constexpr int AMX_TILES_NUM = 8;
@@ -430,7 +430,7 @@ struct brgemm_desc_t {
     dim_t gemv_bdb_tail() const {
         assert(is_gemv);
         if (!is_gemv) return 0;
-        const int gemv_transa_simd_w
+        const dim_t gemv_transa_simd_w
                 = transA ? bd_block / gemv_transa_bd_unroll : 1;
         assert(IMPLICATION(transA, gemv_transa_simd_w != 1));
         return transA ? bdb_tail / gemv_transa_simd_w : bdb_tail;
@@ -519,67 +519,65 @@ struct brgemm_desc_t {
     }
 
     // Tile register decomposition
-    int get_bd_block2() const noexcept {
-        auto res = (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0));
-        return res;
+    dim_t get_bd_block2() const noexcept {
+        return (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0));
     }
 
-    int get_ld_block2() const noexcept {
-        auto res = (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0));
-        return res;
+    dim_t get_ld_block2() const noexcept {
+        return (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0));
     }
 
-    int get_num_C_tiles() const noexcept {
+    dim_t get_num_C_tiles() const noexcept {
         return get_bd_block2() * get_ld_block2();
     }
-    int get_C_tensor(int m, int n, bool m_tail = false,
+    dim_t get_C_tensor(dim_t m, dim_t n, bool m_tail = false,
             bool n_tail = false) const noexcept {
         auto M = m_tail ? get_bd_block2() - 1 : m;
         auto N = n_tail ? get_ld_block2() - 1 : n;
         return (M * get_ld_block2() + N);
     }
 
-    int get_num_A_tiles() const noexcept {
+    dim_t get_num_A_tiles() const noexcept {
         const auto req_tiles = (bdb_tail && bdb > 1) ? 2 : 1;
         const auto max_tiles = AMX_TILES_NUM - get_num_C_tiles() - 1;
         const auto n_tiles = nstl::min(get_bd_block2(), max_tiles);
         assert(n_tiles >= req_tiles);
-        return nstl::max(req_tiles, n_tiles);
+        return nstl::max<dim_t>(req_tiles, n_tiles);
     }
 
-    int get_A_tensor(int m, bool m_tail = false) const noexcept {
+    dim_t get_A_tensor(dim_t m, bool m_tail = false) const noexcept {
         const auto full_A_tiles = get_num_A_tiles() - (bdb_tail ? 1 : 0);
         auto M = (m_tail || full_A_tiles == 0) ? get_num_A_tiles() - 1
                                                : m % full_A_tiles;
         return (get_num_C_tiles() + M);
     }
 
-    int get_num_B_tiles() const noexcept {
+    dim_t get_num_B_tiles() const noexcept {
         const auto req_tiles = (ldb_tail && ldb > 1) ? 2 : 1;
         const auto max_tiles
                 = AMX_TILES_NUM - get_num_C_tiles() - get_num_A_tiles();
         const auto n_tiles = nstl::min(get_ld_block2(), max_tiles);
         assert(n_tiles >= req_tiles);
-        return nstl::max(req_tiles, n_tiles);
+        return nstl::max<dim_t>(req_tiles, n_tiles);
     }
 
-    int get_B_tensor(int n, bool n_tail = false) const noexcept {
+    dim_t get_B_tensor(dim_t n, bool n_tail = false) const noexcept {
         const auto full_B_tiles = get_num_B_tiles() - (ldb_tail ? 1 : 0);
         auto N = (n_tail || full_B_tiles == 0) ? get_num_B_tiles() - 1
                                                : n % full_B_tiles;
         return (get_num_C_tiles() + get_num_A_tiles() + N);
     }
 
-    int get_convert_wsp_buffer_size() const noexcept {
+    dim_t get_convert_wsp_buffer_size() const noexcept {
         if (!is_input_convert()) return 0;
-        const int n_bdb = bd_block2;
-        const int n_rdb = rdb + (rdb_tail != 0);
-        const int n_ldb = ldb + (ldb_tail != 0);
-        const int downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
+        const dim_t n_bdb = bd_block2;
+        const dim_t n_rdb = rdb + (rdb_tail != 0);
+        const dim_t n_ldb = ldb + (ldb_tail != 0);
+        const dim_t downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
         return downcvt_tiles * tilesize;
     }
 
-    int get_fused_copy_a_wsp_buffer_size() const noexcept {
+    dim_t get_fused_copy_a_wsp_buffer_size() const noexcept {
         if (fused_copy_a)
             return brgattr.max_bs * bcast_dim
                     * dnnl::impl::utils::rnd_up(reduce_dim, max_rd_block())
@@ -587,8 +585,8 @@ struct brgemm_desc_t {
         return 0;
     }
 
-    int get_wsp_buffer_size() const noexcept {
-        int sz = 0;
+    dim_t get_wsp_buffer_size() const noexcept {
+        dim_t sz = 0;
         if (is_tmm) {
             sz = get_num_C_tiles() * tilesize; // postops buffer
             sz += get_convert_wsp_buffer_size();

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -167,7 +167,7 @@ struct DNNL_API brgemm_attr_t {
     // if unrolled kernel is used (use_uker == true)
     // then "max_bs" is the the only batch size that can be used on kernel call
     // else "max_bs" is the maximum batch size that can be used
-    int max_bs;
+    dim_t max_bs;
     int max_top_vpad, max_bottom_vpad;
     int max_top_bpad, max_bottom_bpad;
     dim_t hint_expected_A_size, hint_expected_B_size, hint_expected_C_size;
@@ -215,7 +215,7 @@ struct DNNL_API brgemm_attr_t {
     // bd block. By default are equal to regular leading dimension parameters
     // specified on brgemm creation.
     // Supported by brgemm unrolled kernel for now.
-    int LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
+    dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     // If "true" then batchsize is allowed to change on each kernel call
     // and there is no unrolling by batchsize in kernel
     bool var_bs {false};
@@ -257,9 +257,9 @@ struct brgemm_desc_t {
 
     // Note: new added parameters must be taken into account in the brgemm
     // comparison function
-    int bcast_dim = 0; // M;
-    int load_dim = 0; // N;
-    int reduce_dim = 0; // K;
+    dim_t bcast_dim = 0; // M;
+    dim_t load_dim = 0; // N;
+    dim_t reduce_dim = 0; // K;
     int LDA = 0;
     int LDB = 0;
     int LDC = 0;
@@ -334,7 +334,7 @@ struct brgemm_desc_t {
     brgemm_attr_t brgattr;
 
     // Derived  parameters
-    int LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
+    dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     bool is_blocked = false;
 
     int bdb = 0, bd_block = 0, bdb_tail = 0;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -346,7 +346,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) return false;
 
         auto min_bdb = INT_MAX;
-        const auto start_bd_block = nstl::min(max_width, BD);
+        const auto start_bd_block = nstl::min<dim_t>(max_width, BD);
         auto best_bd_block = start_bd_block;
         for (auto bd_block = start_bd_block; bd_block > 0; bd_block--) {
             int bdb = 0;
@@ -419,7 +419,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 }
             }
             if (brg->bd_block == 1) {
-                brg->bd_block = nstl::min(max_width, BD);
+                brg->bd_block = nstl::min<dim_t>(max_width, BD);
                 brg->bdb_tail = BD % max_width;
                 for (int i = max_width; i >= min_width; i--) {
                     const auto i_tail = BD % i;
@@ -595,7 +595,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         } else if (BD <= 16) {
             // Have to call recalc_blocking twice to calculate ldb
             recalc_blocking(BD, 16, 0, 0);
-            const auto ld_block2 = nstl::min(
+            const auto ld_block2 = nstl::min<dim_t>(
                     ldb_tail_16 ? ((brg->ldb > 4) ? 3 : 4) : 5, div_up(LD, 16));
             recalc_blocking(0, 0, 1, ld_block2);
         } else if (bdb_tail_only && weak_bdb && BD > 64) {
@@ -611,7 +611,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
             // Have to call recalc_blocking twice to calculate bdb
             // we can't use ld_block other than 16
             recalc_blocking(16, 16, 0, 0);
-            const auto bd_block2 = nstl::min(
+            const auto bd_block2 = nstl::min<dim_t>(
                     brg->bdb_tail ? (brg->bdb > 4 ? 3 : 4) : 5, div_up(BD, 16));
             recalc_blocking(0, 0, bd_block2, 1);
         } else if (bdb_block_tail && ldb_tail_16 && BD_R16 == 32 && LD_R16 == 32
@@ -660,7 +660,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     const auto rd_block_step = brg->rd_block_step();
     const auto max_rd_block = brg->max_rd_block();
     if (brg->amx_may_extend_k()) {
-        brg->rd_block = nstl::min(
+        brg->rd_block = nstl::min<dim_t>(
                 rnd_up(brg->reduce_dim, brg->rd_step), max_rd_block);
     } else if (brg->fused_copy_a) {
         brg->rd_block = max_rd_block;
@@ -1117,9 +1117,9 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     CHECK(safe_dim_to_int(brg->LDD, LDC));
     brg->is_runtime_ldc = brg->is_runtime_ldd = is_runtime_value(LDC);
 
-    CHECK(safe_dim_to_int(brg->bcast_dim, (brg->is_row_major()) ? M : N));
-    CHECK(safe_dim_to_int(brg->load_dim, (brg->is_row_major()) ? N : M));
-    CHECK(safe_dim_to_int(brg->reduce_dim, K));
+    brg->bcast_dim = (brg->is_row_major()) ? M : N;
+    brg->load_dim = (brg->is_row_major()) ? N : M;
+    brg->reduce_dim = K;
 
     brg->bd_block2 = 0;
     brg->bdb2 = 0;
@@ -1182,8 +1182,8 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     CHECK(safe_dim_to_int(brg->LDC, LDC));
     CHECK(safe_dim_to_int(brg->LDD, LDC));
 
-    CHECK(safe_dim_to_int(brg->bcast_dim, M));
-    CHECK(safe_dim_to_int(brg->load_dim, N));
+    brg->bcast_dim = M;
+    brg->load_dim = N;
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -209,30 +209,30 @@ void set_brg_vmm(brgemm_desc_t *brg) {
             = !brg->is_zmm && mayiuse(avx2) && is_superset(brg->isa_impl, avx2);
 }
 
-int calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
+dim_t calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
     brg->ld_block2 = try_ld_block2;
     brg->ldb2 = brg->ldb / brg->ld_block2;
     brg->ldb2_tail = brg->ldb % brg->ld_block2;
 
-    if (brg->ldb2 == 0) brg->ld_block2 = nstl::max(1, brg->ldb2_tail);
+    if (brg->ldb2 == 0) brg->ld_block2 = nstl::max<dim_t>(1, brg->ldb2_tail);
     brg->embd_bcst = brg->is_f32
             && (brg->ldb2_tail <= 1 && brg->ldb2 == 0)
             /*only avx512 or more can bcast*/
             && is_superset(brg->isa_impl, avx512_core);
 
-    const int adj_ld_block2
+    const dim_t adj_ld_block2
             = (brg->ldb2 != 0) ? brg->ld_block2 : brg->ldb2_tail;
-    return nstl::max(1, adj_ld_block2);
+    return nstl::max<dim_t>(1, adj_ld_block2);
 }
 
-int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
+dim_t calculate_max_bcast_block(brgemm_desc_t *brg, const dim_t adj_ld_block2) {
 
     // TODO: Calculating the number of available registers should be re-factored
     // to use one code here and in brgemm kernel generator on
     // "max_effective_vregs" calculation
     int max_isa_regs = isa_num_vregs(brg->isa_impl);
-    const int max_bcst_regs = brg->n_bcast_1_load ? 0 : 1;
-    const int load_regs = brg->n_bcast_1_load ? 1 : adj_ld_block2;
+    const dim_t max_bcst_regs = brg->n_bcast_1_load ? 0 : 1;
+    const dim_t load_regs = brg->n_bcast_1_load ? 1 : adj_ld_block2;
     const bool req_zp_a_comp_pads
             = (brg->req_cal_comp_pads || brg->brgattr.max_top_vpad > 0
                       || brg->brgattr.max_bottom_vpad > 0)
@@ -258,15 +258,15 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
     // --------------- microkernel ---------------
     // see vmm_inp_shift() in brgemm kernel
-    const int compensation_regs = brg->req_s8s8_compensation
+    const dim_t compensation_regs = brg->req_s8s8_compensation
                     || brg->zp_type_a != brgemm_broadcast_t::none
             ? 1
             : 0;
 
     // see vmm_zp_a_shift(), vmm_one_bytes() in brgemm kernel
-    const int zp_a_comp_pads_regs = req_zp_a_comp_pads ? 2 : 0;
+    const dim_t zp_a_comp_pads_regs = req_zp_a_comp_pads ? 2 : 0;
 
-    const int microkernel_regs = zp_a_comp_pads_regs + compensation_regs;
+    const dim_t microkernel_regs = zp_a_comp_pads_regs + compensation_regs;
 
     const auto microkernel_max_reg_count
             = max_isa_regs - microkernel_regs - load_regs - max_bcst_regs;
@@ -275,9 +275,9 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
             = microkernel_max_reg_count / (adj_ld_block2 + brg->n_bcast_1_load);
 
     // ----- post-ops and store accumulators -----
-    const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
+    const dim_t beta_regs = !one_of(brg->beta, 1.f, 0.f);
 
-    const int postops_regs = brg->attr()
+    const dim_t postops_regs = brg->attr()
             ? injector::aux_vec_count(
                       brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
@@ -287,7 +287,7 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     // registers related to 'max_bcast_block'
     assert(IMPLICATION(
             brg->is_bf16_emu, is_superset(brg->isa_impl, avx512_core)));
-    const int bf16_emu_regs = brg->is_bf16_emu ? 4 : 0;
+    const dim_t bf16_emu_regs = brg->is_bf16_emu ? 4 : 0;
 
     const auto store_regs = nstl::max(beta_regs,
             nstl::max(
@@ -313,12 +313,12 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     const auto LD = brg->load_dim;
     const auto LD_R16 = rnd_up(LD, 16);
 
-    const int max_width = 16, min_width = 1;
+    const dim_t max_width = 16, min_width = 1;
     brg->ld_block = 16;
     brg->ldb = LD / brg->ld_block;
     brg->ldb_tail = LD % brg->ld_block;
 
-    auto find_bdb_bd_mask = [&](int bd_block, int &bdb, int &bdb_tail) {
+    auto find_bdb_bd_mask = [&](dim_t bd_block, dim_t &bdb, dim_t &bdb_tail) {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) {
             bdb = div_up(BD, bd_block);
             bdb_tail = BD % bd_block;
@@ -345,12 +345,12 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     auto find_bd_block_for_bd_mask = [&]() {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) return false;
 
-        auto min_bdb = INT_MAX;
+        dim_t min_bdb = INT_MAX;
         const auto start_bd_block = nstl::min<dim_t>(max_width, BD);
         auto best_bd_block = start_bd_block;
         for (auto bd_block = start_bd_block; bd_block > 0; bd_block--) {
-            int bdb = 0;
-            int bdb_tail = 0;
+            dim_t bdb = 0;
+            dim_t bdb_tail = 0;
             find_bdb_bd_mask(bd_block, bdb, bdb_tail);
             // bcast_dim should be divided by bd_block
             if (bdb < min_bdb && bdb_tail == 0) {
@@ -447,8 +447,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 || brg->bd_block < 8);
     };
 
-    auto recalc_blocking = [&](int new_bd_block, int new_ld_block,
-                                   int new_bd_block2, int new_ld_block2) {
+    auto recalc_blocking = [&](dim_t new_bd_block, dim_t new_ld_block,
+                                   dim_t new_bd_block2, dim_t new_ld_block2) {
         if (new_bd_block != 0) {
             brg->bd_block = new_bd_block;
             find_bdb_bd_mask(brg->bd_block, brg->bdb, brg->bdb_tail);
@@ -853,12 +853,12 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     brg->ldb = brg->load_dim / brg->ld_block;
     brg->ldb_tail = brg->load_dim % brg->ld_block;
 
-    const int max_vpad = nstl::max(
+    const dim_t max_vpad = nstl::max<dim_t>(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
     // iterate ld_block2 starting from 4 to allow bd_block larger than
     // virtual padding
-    int max_bcast_block {0}, min_bcast_block {0}, adj_ld_block2 {0};
+    dim_t max_bcast_block {0}, min_bcast_block {0}, adj_ld_block2 {0};
     bool few_regs = utils::one_of(brg->isa_impl, avx2, avx2_vnni, avx2_vnni_2);
     bool hint_n_bcast_1_load
             = brg->brgattr.hint_loop_order == brgemm_lo_bl_1load;
@@ -875,11 +875,11 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     // padding to avoid possible functional issues
     if (min_bcast_block < max_vpad) return status::unimplemented;
 
-    const int min_block = nstl::max(1, max_vpad);
+    const dim_t min_block = nstl::max<dim_t>(1, max_vpad);
 
     float best_bd_block_eff = 0.f;
     brg->bd_block = max_bcast_block;
-    for (int bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
+    for (dim_t bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
         // avoid msvc warning 'potential divide by zero'
         const auto bd_block_disb = (brg->bcast_dim <= 0 || bd_block == 0)
                 ? 0.f
@@ -905,7 +905,7 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     const data_type_t rd_block_dt = get_mac_emu_data_type(
             brg->dt_a, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
     if (rd_block_dt == dnnl_data_type_undef) return status::unimplemented;
-    const int vnni_granularity = data_type_vnni_granularity(rd_block_dt);
+    const dim_t vnni_granularity = data_type_vnni_granularity(rd_block_dt);
     brg->rd_block = rd_unroll * vnni_granularity;
     brg->rdb = brg->reduce_dim / brg->rd_block;
     brg->rdb_tail = brg->reduce_dim % brg->rd_block;
@@ -965,7 +965,7 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     if (brg->isa_impl == isa_undef) return status::unimplemented;
 
     set_brg_vmm(brg); // Needed to dispatch into the right kernel later.
-    const int max_vregs = isa_num_vregs(brg->isa_impl);
+    const dim_t max_vregs = isa_num_vregs(brg->isa_impl);
 
     const int simd_w = isa_max_vlen(brg->isa_impl) / brg->typesize_C;
     const bool is_avx2_vnni_2_xf16
@@ -999,19 +999,19 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
 
     const int max_n_block2_vmms = 4;
     const int max_n_block2 = max_n_block2_vmms / n_block1_num_steps;
-    n_block2 = nstl::min(max_n_block2, nb_n_block1);
+    n_block2 = nstl::min<dim_t>(max_n_block2, nb_n_block1);
 
-    const int aux_vregs
+    const dim_t aux_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_aux_vmm_count(*brg);
-    const int compute_vregs
+    const dim_t compute_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_compute_vmm_count(*brg);
-    const int bf16_emu_vregs = brg->is_bf16_emu * 4;
-    const int postops_regs = brg->attr()
+    const dim_t bf16_emu_vregs = brg->is_bf16_emu * 4;
+    const dim_t postops_regs = brg->attr()
             ? injector::aux_vec_count(
                       brg->attr()->post_ops_, brg->isa_impl, true)
             : 0;
 
-    const int max_acc_vmms = max_vregs
+    const dim_t max_acc_vmms = max_vregs
             - nstl::max(postops_regs,
                     nstl::max(compute_vregs + aux_vregs, bf16_emu_vregs));
 
@@ -1107,14 +1107,14 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->req_s8s8_compensation = brg->is_int8 && brg->dt_a == data_type::s8
             && !isa_has_s8s8(brg->isa_impl) && !brg->with_per_mn_compensation;
 
-    CHECK(safe_dim_to_int(brg->LDA, (brg->is_row_major()) ? LDA : LDB));
+    brg->LDA = (brg->is_row_major()) ? LDA : LDB;
     brg->is_runtime_lda = (brg->is_row_major()) ? is_runtime_value(LDA)
                                                 : is_runtime_value(LDB);
-    CHECK(safe_dim_to_int(brg->LDB, (brg->is_row_major()) ? LDB : LDA));
+    brg->LDB = (brg->is_row_major()) ? LDB : LDA;
     brg->is_runtime_ldb = (brg->is_row_major()) ? is_runtime_value(LDB)
                                                 : is_runtime_value(LDA);
-    CHECK(safe_dim_to_int(brg->LDC, LDC));
-    CHECK(safe_dim_to_int(brg->LDD, LDC));
+    brg->LDC = LDC;
+    brg->LDD = LDC;
     brg->is_runtime_ldc = brg->is_runtime_ldd = is_runtime_value(LDC);
 
     brg->bcast_dim = (brg->is_row_major()) ? M : N;
@@ -1178,9 +1178,9 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
 
     brg->is_dgmm = true;
 
-    CHECK(safe_dim_to_int(brg->LDA, LDA));
-    CHECK(safe_dim_to_int(brg->LDC, LDC));
-    CHECK(safe_dim_to_int(brg->LDD, LDC));
+    brg->LDA = LDA;
+    brg->LDC = LDC;
+    brg->LDD = LDC;
 
     brg->bcast_dim = M;
     brg->load_dim = N;

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -173,7 +173,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_permute_vmm() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::load_accumulators(
-        int m_blocks, int n_blocks) {
+        dim_t m_blocks, dim_t n_blocks) {
     const int v_substep = vnni_substep();
     for_(int v = 0; v < v_substep; ++v)
     for_(int m = 0; m < m_blocks; ++m)
@@ -228,7 +228,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::set_A_B_matrices() {
     }
 
     add(reg_aux_A, reg_a_offset);
-    lea(reg_aux_B, ptr[reg_aux_B + reg_aux_N * brg.typesize_B]);
+    lea(reg_aux_B,
+            ptr[reg_aux_B + reg_aux_N * xbyak_address_scale(brg.typesize_B)]);
 }
 
 template <typename Wmm>
@@ -242,7 +243,7 @@ template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::cvt2ps(data_type_t type_in,
         const Vmm vmm_in, const Xbyak::Operand &op, bool mask_flag,
         bool store) {
-    const int tail_size = tail_length();
+    const int tail_size = xbyak_register_index(tail_length());
     const bool is_load_tail = op.isMEM() && mask_flag && tail_size > 0
             && (tail_size < static_cast<int>(
                         vreg_traits_t<Vmm>::vlen / sizeof(float)));
@@ -268,7 +269,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::cvt2ps(data_type_t type_in,
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     injector_utils::vmm_index_set_t vmm_idxs_param;
@@ -367,7 +368,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     const bool dq2ps_required = brg.is_int8;
     const int v_substep = vnni_substep();
@@ -459,7 +460,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_bias) {
         reg_aux_bias.restore();
-        lea(reg_aux_bias, ptr[reg_aux_bias + reg_aux_N * brg.typesize_bias]);
+        lea(reg_aux_bias,
+                ptr[reg_aux_bias
+                        + reg_aux_N * xbyak_address_scale(brg.typesize_bias)]);
     }
 
     for_(int v_i = 0; v_i < v_substep; ++v_i)
@@ -615,7 +618,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_without_post_ops(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     const bool dt_requires_saturation
             = brg.is_int8 && brg.dt_c != data_type::s32;
@@ -654,13 +657,13 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_without_post_ops(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::maybe_transpose_interleaved_vnni_to_plain(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     if (vnni_substep() == 1) return;
 
     // The tail block is always processed as plain.
     // No need to transpose it here.
-    const int n_blocks_e = n_blocks - has_n_tail;
+    const dim_t n_blocks_e = n_blocks - has_n_tail;
 
     auto ymm_aux0 = vmm_tmp(0);
     for_(int m_i = 0; m_i < m_blocks; m_i++)
@@ -690,7 +693,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_src_zp() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     const int v_substep = vnni_substep();
 
@@ -710,7 +713,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
     for (int n = 0; n < n_blocks; n++) {
         const int substep_simd = get_substep_simd(n, v_i, has_n_tail);
         if (substep_simd <= 0) continue;
-        const size_t offset = comp_offset(n);
+        const dim_t offset = comp_offset(n);
         if (brg.req_s8s8_compensation) {
             const Vmm vmm_comp = vmm_s8s8_comp();
             uni_vmovups(vmm_comp,
@@ -737,7 +740,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
                     vpmulld(vmm_zp, vmm_zp,
                             maybe_EVEX_compress_addr(reg_aux_src_zp, offset));
             } else {
-                const int tail_size = tail_length();
+                const int tail_size = xbyak_register_index(tail_length());
                 const Vmm ymm_tmp
                         = vmm_bcast(); // used for bcast or tail processing in avx2
                 load_data(data_type::s32, vmm_zp, ptr[reg_aux_zp_comp + offset],
@@ -758,7 +761,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators(
-        int m_blocks, int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     maybe_transpose_interleaved_vnni_to_plain(m_blocks, n_blocks, has_n_tail);
 
@@ -788,10 +791,10 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::load_a(
-        Vmm vmma, int m_i, int n_i, int v_i, bool has_n_tail) {
-    const int n_blocks
+        Vmm vmma, dim_t m_i, dim_t n_i, dim_t v_i, bool has_n_tail) {
+    const dim_t n_blocks
             = has_n_tail && n_block2_tail() > 0 ? n_block2_tail() : n_block2();
-    const int substep_simd = get_substep_simd(n_i, v_i, has_n_tail);
+    const dim_t substep_simd = get_substep_simd(n_i, v_i, has_n_tail);
     const bool is_tail_block = has_n_tail && n_i + 1 == n_blocks;
     const bool mask_flag = substep_simd < simd_w_;
     const auto addr = ptr[reg_aux_A + A_offset(m_i, n_i)
@@ -840,11 +843,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_a(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::load_b(
-        Vmm vmmb, int n_i, int v_i, bool has_n_tail, bool wei_zp) {
+        Vmm vmmb, dim_t n_i, dim_t v_i, bool has_n_tail, bool wei_zp) {
     assert(IMPLICATION(wei_zp, brg.is_int8 && compute_src_zp_));
     // for B matrix we assume memory is padded and it is safe to load simd
     // elements. is_tail only used during avx_ne_convert tail optimization.
-    const int n_blocks
+    const dim_t n_blocks
             = has_n_tail && n_block2_tail() > 0 ? n_block2_tail() : n_block2();
     const bool is_tail_block = has_n_tail && (n_i + 1 == n_blocks);
     const auto addr = ptr[reg_aux_B + B_offset(n_i)
@@ -892,7 +895,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::load_b(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
-        compute_pad_kernel_t kernel_type, Vmm vmm_acc, Vmm vmmb, int n,
+        compute_pad_kernel_t kernel_type, Vmm vmm_acc, Vmm vmmb, dim_t n,
         bool is_tail_block) {
     switch (kernel_type) {
         case compute_pad_kernel_t::s8s8_kernel:
@@ -902,7 +905,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
             const Vmm vmm_zp = isa_has_masks(brg.isa_impl)
                     ? maybe_mask(vmm_zp_comp(), is_tail_block, false)
                     : vmm_zp_comp();
-            const size_t offset = comp_offset(n);
+            const dim_t offset = comp_offset(n);
             if (IMPLICATION(is_tail_block, isa_has_masks(brg.isa_impl))) {
                 if (is_src_zp_bcast_) {
                     if (is_superset(brg.isa_impl, avx512_core))
@@ -937,22 +940,22 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::pad_comp_kernel(
-        compute_pad_kernel_t kernel_type, int m_blocks, int n_blocks,
-        int padding, const Xbyak::Reg64 reg_pad,
-        const std::function<int(int)> &get_mi, bool has_tail) {
+        compute_pad_kernel_t kernel_type, dim_t m_blocks, dim_t n_blocks,
+        dim_t padding, const Xbyak::Reg64 reg_pad,
+        const std::function<dim_t(dim_t)> &get_mi, bool has_tail) {
     assert(vnni_substep() == 1);
-    const int max_m_unroll = padding;
+    const dim_t max_m_unroll = padding;
     const bool is_zero_point_kernel
             = kernel_type == compute_pad_kernel_t::zero_point_kernel;
-    const int max_bvmms
+    const dim_t max_bvmms
             = accm(m_blocks, n_blocks, 0, 0, 0).getIdx() - vmm_b(0).getIdx();
-    const int n_preload_b_vmms = max_bvmms >= n_blocks
+    const dim_t n_preload_b_vmms = max_bvmms >= n_blocks
             ? n_blocks
             : max_bvmms - 1 /*for ad-hoc load*/;
     const bool load_broadcast_wei = is_zero_point_kernel;
-    for (int i = 0; i < n_preload_b_vmms; ++i) {
-        const int n_i = i % n_blocks;
-        const int v_i = i / n_blocks;
+    for (dim_t i = 0; i < n_preload_b_vmms; ++i) {
+        const dim_t n_i = i % n_blocks;
+        const dim_t v_i = i / n_blocks;
         if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
         load_b(vmm_b(i), n_i, v_i, has_tail, load_broadcast_wei);
     }
@@ -965,17 +968,17 @@ void jit_brdgmm_kernel_base_t<Wmm>::pad_comp_kernel(
     jmp(ptr[reg_table_base], T_NEAR);
     align(8);
     L(jmp_table_base);
-    for (int m_i = 0; m_i <= max_m_unroll; ++m_i) {
+    for (dim_t m_i = 0; m_i <= max_m_unroll; ++m_i) {
         putL(jmp_table_labels[m_i]);
     }
 
-    for (int pad_i = max_m_unroll; pad_i > 0; --pad_i) {
+    for (dim_t pad_i = max_m_unroll; pad_i > 0; --pad_i) {
         L(jmp_table_labels[pad_i]);
         if (is_zero_point_kernel) load_src_zp();
         if (pad_i > m_blocks) continue;
-        const int m_i = get_mi(pad_i);
-        int p_b_i = 0;
-        for (int n_i = 0; n_i < n_blocks; ++n_i, ++p_b_i) {
+        const dim_t m_i = get_mi(pad_i);
+        dim_t p_b_i = 0;
+        for (dim_t n_i = 0; n_i < n_blocks; ++n_i, ++p_b_i) {
             const int substep_simd = get_substep_simd(n_i, 0, has_tail);
             if (substep_simd <= 0) continue;
             const Vmm vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, 0);
@@ -998,27 +1001,27 @@ void jit_brdgmm_kernel_base_t<Wmm>::pad_comp_kernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::batch_pad_kernel(
-        int m_blocks, int n_blocks, bool has_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_tail) {
 
     assert(vnni_substep() == 1);
-    const int max_bvmms
+    const dim_t max_bvmms
             = accm(m_blocks, n_blocks, 0, 0, 0).getIdx() - vmm_b(0).getIdx();
 
     auto kernel_body = [&](compute_pad_kernel_t kernel_type) {
         const bool is_zero_point_kernel
                 = kernel_type == compute_pad_kernel_t::zero_point_kernel;
         if (is_zero_point_kernel) load_src_zp();
-        for (int nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
-            const int n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+        for (dim_t nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
+            const dim_t n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 if (get_substep_simd(n_i, 0, has_tail) <= 0) continue;
                 const bool load_broadcast_wei = is_zero_point_kernel;
                 load_b(vmm_b(i), n_i, 0, has_tail, load_broadcast_wei);
             }
-            for_(int m_i = 0; m_i < m_blocks; ++m_i)
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+            for_(dim_t m_i = 0; m_i < m_blocks; ++m_i)
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 const int substep_simd = get_substep_simd(n_i, 0, has_tail);
                 if (substep_simd <= 0) continue;
                 const Vmm vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, 0);
@@ -1036,17 +1039,18 @@ void jit_brdgmm_kernel_base_t<Wmm>::batch_pad_kernel(
 }
 
 template <typename Wmm>
-void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
-        int n_blocks, bool has_top_padding, bool has_bottom_padding,
-        bool has_tail, int shift_a) {
+void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(dim_t m_blocks,
+        dim_t n_blocks, bool has_top_padding, bool has_bottom_padding,
+        bool has_tail, dim_t shift_a) {
 
     const bool has_padding = has_top_padding || has_bottom_padding;
-    const int max_bvmms
+    const dim_t max_bvmms
             = accm(m_blocks, n_blocks, 0, 0, 0).getIdx() - vmm_b(0).getIdx();
     const int v_substep = vnni_substep();
     assert(max_bvmms > 0);
 
-    auto dot_product = [&](Vmm vmma, Vmm vmmb, int m_i, int n_i, int v_i) {
+    auto dot_product
+            = [&](Vmm vmma, Vmm vmmb, dim_t m_i, dim_t n_i, dim_t v_i) {
         auto vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, v_i);
         if (brg.is_f32) {
             if (is_fma_embd()) {
@@ -1074,18 +1078,18 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 
     if (!has_padding) {
         // preload vmm_b if possible.
-        for_(int v_i = 0; v_i < v_substep; ++v_i)
-        for (int nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
-            const int n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+        for_(dim_t v_i = 0; v_i < v_substep; ++v_i)
+        for (dim_t nb_i = 0; nb_i < n_blocks; nb_i += max_bvmms) {
+            const dim_t n_e = nstl::min(nb_i + max_bvmms, n_blocks) - nb_i;
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
                 load_b(vmm_b(i), n_i, v_i, has_tail);
             }
             if (grouped_bs()) {
-                for_(int m_i = 0; m_i < m_blocks; ++m_i)
-                for (int i = 0; i < n_e; ++i) {
-                    const int n_i = nb_i + i;
+                for_(dim_t m_i = 0; m_i < m_blocks; ++m_i)
+                for (dim_t i = 0; i < n_e; ++i) {
+                    const dim_t n_i = nb_i + i;
                     if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
                     const auto vmm_A = vmm_a(m_i + shift_a, i);
                     if (shift_a == 0 || m_i == m_blocks - 1) {
@@ -1097,9 +1101,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
                 }
             }
 
-            for_(int m_i = 0; m_i < m_blocks; ++m_i)
-            for (int i = 0; i < n_e; ++i) {
-                const int n_i = nb_i + i;
+            for_(dim_t m_i = 0; m_i < m_blocks; ++m_i)
+            for (dim_t i = 0; i < n_e; ++i) {
+                const dim_t n_i = nb_i + i;
                 if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
                 const auto vmm_A = vmm_a(m_i + shift_a, i);
                 if (!grouped_bs() && (shift_a == 0 || m_i == m_blocks - 1)) {
@@ -1111,13 +1115,13 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
             }
         }
     } else {
-        const int max_req_preload_vmms = n_blocks * vnni_substep();
-        const int n_preload_b_vmms = max_bvmms >= max_req_preload_vmms
+        const dim_t max_req_preload_vmms = n_blocks * vnni_substep();
+        const dim_t n_preload_b_vmms = max_bvmms >= max_req_preload_vmms
                 ? max_req_preload_vmms
                 : max_bvmms - 1 /*for ad-hoc load*/;
-        for (int i = 0; i < n_preload_b_vmms; ++i) {
-            const int n_i = i % n_blocks;
-            const int v_i = i / n_blocks;
+        for (dim_t i = 0; i < n_preload_b_vmms; ++i) {
+            const dim_t n_i = i % n_blocks;
+            const dim_t v_i = i / n_blocks;
             if (get_substep_simd(n_i, v_i, has_tail) <= 0) continue;
             load_b(vmm_b(i), n_i, v_i, has_tail);
         }
@@ -1174,7 +1178,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
                     dot_product(vmm_A, vmm_b(p_b_i), m_i, n_i, v_i);
                 } else {
                     // preloaded vmm_b not available
-                    const int b_idx = max_bvmms - 1;
+                    const dim_t b_idx = max_bvmms - 1;
                     load_b(vmm_b(b_idx), n_i, v_i, has_tail);
                     dot_product(vmm_A, vmm_b(b_idx), m_i, n_i, v_i);
                 }
@@ -1185,8 +1189,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 }
 
 template <typename Wmm>
-void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
-        const int m_blocks) {
+void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(dim_t m_blocks) {
     const bool do_check_effective_padding = check_effective_padding();
     Label no_top_padding;
 
@@ -1194,7 +1197,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
         if (do_check_effective_padding) {
             Label done_adjust_bottom_padding;
             mov(reg_aux_A_vpad_bottom, reg_aux_M);
-            add(reg_aux_A_vpad_bottom, m_blocks - M());
+            sub(reg_aux_A_vpad_bottom, M() - m_blocks);
             add(reg_aux_A_vpad_bottom,
                     ptr[reg_aux_batch_addr
                             + GET_OFF_BATCH_ELEMENT(vvpad.bottom)]);
@@ -1235,11 +1238,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_batch_padding_info() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
-    const int tpad = brg.brgattr.max_top_vpad;
-    const int bpad = brg.brgattr.max_bottom_vpad;
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
+    const dim_t tpad = brg.brgattr.max_top_vpad;
+    const dim_t bpad = brg.brgattr.max_bottom_vpad;
     if (tpad > 0) {
-        auto get_mi = [=](int pad_i) { return pad_i - 1; };
+        auto get_mi = [=](dim_t pad_i) { return pad_i - 1; };
         if (brg.req_s8s8_compensation)
             pad_comp_kernel(compute_pad_kernel_t::s8s8_kernel, m_blocks,
                     n_blocks, brg.brgattr.max_top_vpad, reg_aux_A_vpad_top,
@@ -1250,7 +1253,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
                     get_mi, has_n_tail);
     }
     if (bpad > 0) {
-        auto get_mi = [=](int pad_i) { return m_blocks - pad_i; };
+        auto get_mi = [=](dim_t pad_i) { return m_blocks - pad_i; };
         if (brg.req_s8s8_compensation)
             pad_comp_kernel(compute_pad_kernel_t::s8s8_kernel, m_blocks,
                     n_blocks, brg.brgattr.max_bottom_vpad,
@@ -1264,11 +1267,11 @@ void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail, int shift_a) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail, dim_t shift_a) {
 
     // padding for vertical dimensions
-    const int tpad = brg.brgattr.max_top_vpad;
-    const int bpad = brg.brgattr.max_bottom_vpad;
+    const dim_t tpad = brg.brgattr.max_top_vpad;
+    const dim_t bpad = brg.brgattr.max_bottom_vpad;
     Label microkernel_with_padding, done_microkernel, skip_microkernel_l;
 
     if (has_vpad_) {
@@ -1294,7 +1297,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
+        dim_t m_blocks, dim_t n_blocks, bool has_n_tail) {
 
     Label bs_loop_label, done_bs_loop;
     load_accumulators(m_blocks, n_blocks);
@@ -1304,7 +1307,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
     mov(reg_BS_loop, reg_BS);
     restore_A_B_matrices();
 
-    auto bs_iteration = [&](int shift_a) {
+    auto bs_iteration = [&](dim_t shift_a) {
         Label compute_brdgemm_l, end_batch_loop_l;
         set_A_B_matrices();
         if (compute_compensation_ && has_bpad_) {
@@ -1323,7 +1326,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
 
     L(bs_loop_label);
     {
-        for (int sh = 0; sh < bs_group(); sh++) {
+        for (dim_t sh = 0; sh < bs_group(); sh++) {
             bs_iteration(sh);
             advance_A_B_matrices();
         }
@@ -1340,23 +1343,23 @@ template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
     const bool has_m_block2_tail = m_block2_tail() > 0;
-    const int loop_m = (nb_m_block2() - has_m_block2_tail);
+    const dim_t loop_m = nb_m_block2() - has_m_block2_tail;
     const bool do_loop_m = loop_m > 1;
 
     const bool has_n_block2_tail = n_block2_tail() > 0;
     const bool need_separate_n_block1_tail_block = n_block1_tail() != 0
             && !has_n_block2_tail && nb_n_block2() > 1
             && !isa_has_masks(brg.isa_impl);
-    const int loop_n = nb_n_block2() - has_n_block2_tail
+    const dim_t loop_n = nb_n_block2() - has_n_block2_tail
             - need_separate_n_block1_tail_block;
     const bool do_loop_n = loop_n > 1;
     const bool loop_n_update_aux_ptrs = do_loop_n || (loop_n < nb_n_block2());
 
-    auto n_loop = [&](int m_blocks) {
+    auto n_loop = [&](dim_t m_blocks) {
         Label n_loop_label;
-        const int n_blocks = n_block2();
-        const int n_loop_step = oc_logical_offset(n_blocks);
-        const int n_loop_work = loop_n * n_blocks * n_block1();
+        const dim_t n_blocks = n_block2();
+        const dim_t n_loop_step = oc_logical_offset(n_blocks);
+        const dim_t n_loop_work = loop_n * n_blocks * n_block1();
         const bool vlen_tail_in_loop = n_block1_tail() != 0
                 && !need_separate_n_block1_tail_block && !has_n_block2_tail;
 
@@ -1404,7 +1407,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
     auto m_loop = [&]() {
         Label m_loop_label;
-        const int m_blocks = m_block2();
+        const dim_t m_blocks = m_block2();
         const bool reset_mask = isa_has_masks(brg.isa_impl)
                 && n_block1_tail() != 0 && do_loop_n && !has_n_block2_tail;
 
@@ -1418,13 +1421,19 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
             if (do_loop_m || has_m_block2_tail) {
                 add(reg_aux_M, m_blocks);
-                const int n_loop_offset
+                const dim_t n_loop_offset
                         = loop_n_update_aux_ptrs * loop_n * n_block2();
-                add(reg_a_offset, A_offset(m_blocks, -n_loop_offset));
+                const dim_t a_shift
+                        = A_offset(m_blocks, 0) - A_offset(0, n_loop_offset);
+                const dim_t c_shift = C_offset(m_blocks, 0, 0)
+                        - C_offset(0, n_loop_offset, 0);
+                const dim_t d_shift = D_offset(m_blocks, 0, 0)
+                        - D_offset(0, n_loop_offset, 0);
+                add(reg_a_offset, a_shift);
                 reg_aux_C.restore();
-                add(reg_aux_C, C_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_C, c_shift);
                 reg_aux_C.save();
-                add(reg_aux_D, D_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_D, d_shift);
             }
 
             if (do_loop_m) {

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -51,9 +51,10 @@ struct jit_brdgmm_kernel_base_t : public jit_base_brgemm_kernel_t {
             : aux_vmm_count_(0)
             , vmm_tmp_count_(0)
             , compute_vmm_base_idx_(-1)
-            , compute_vmm_count_((grouped_bs(brg) ? 0 : 1)
+            , compute_vmm_count_(jit_generator_t::xbyak_register_index(
+                      (grouped_bs(brg) ? 0 : 1)
                       + (!is_fma_embd(brg))
-                              * brg.ld_block2 /*n_block*/) // vmm_a + vmm_b
+                              * brg.ld_block2 /*n_block*/)) // vmm_a + vmm_b
             , idx_vmm_a_(-1)
             , idx_vmm_b_(-1)
             , idx_vmm_permute_(-1)
@@ -88,19 +89,20 @@ struct jit_brdgmm_kernel_base_t : public jit_base_brgemm_kernel_t {
 
             // assign compute vmms
             idx_vmm_a_ = compute_vmm_base_idx_;
-            const int max_m = brg.bd_block2 + brg.bs_group - 1;
-            const int max_n = brg.ld_block2;
+            const dim_t max_m = brg.bd_block2 + brg.bs_group - 1;
+            const dim_t max_n = brg.ld_block2;
             idx_vmm_b_
                     = vmm_a_idx(brg, max_m - 1, max_n - 1) + !is_fma_embd(brg);
         }
         int vnni_substep(const brgemm_desc_t &brg) const {
             return brg.isa_impl == avx2_vnni_2 && brg.is_xf16() ? 2 : 1;
         }
-        int vmm_a_idx(const brgemm_desc_t &brg, int m, int n) const {
+        int vmm_a_idx(const brgemm_desc_t &brg, dim_t m, dim_t n) const {
             const auto idx_offset = grouped_bs(brg)
                     ? (m * brg.ld_block2 + n) * vnni_substep(brg)
                     : 0;
-            return idx_vmm_a_ + idx_offset;
+            return jit_generator_t::xbyak_register_index(
+                    idx_vmm_a_ + idx_offset);
         }
 
         int get_compute_vmm_count() { return compute_vmm_count_; }
@@ -258,8 +260,8 @@ private:
     // note 2: zmm0 collides with vmm_permute, hence need to write this value
     // before every loop.
 
-    const int simd_w_;
-    const int max_vmms_;
+    const dim_t simd_w_;
+    const dim_t max_vmms_;
     const bool compute_dst_zp_, compute_src_zp_;
     const bool is_src_zp_bcast_;
     const bool compute_compensation_; // code-path for either s8s8 or src_zp
@@ -271,21 +273,21 @@ private:
 
     bool with_binary_non_scalar_bcast_ = false;
 
-    inline int M() { return brg.bcast_dim; }
-    inline int N() { return brg.load_dim; }
-    inline int m_block2() { return brg.bd_block2; }
-    inline int nb_m_block2() { return brg.bdb2; }
-    inline int m_block2_tail() { return brg.bdb2_tail; }
+    inline dim_t M() { return brg.bcast_dim; }
+    inline dim_t N() { return brg.load_dim; }
+    inline dim_t m_block2() { return brg.bd_block2; }
+    inline dim_t nb_m_block2() { return brg.bdb2; }
+    inline dim_t m_block2_tail() { return brg.bdb2_tail; }
 
-    inline int n_block1() { return brg.ld_block; }
-    inline int nb_n_block1() { return brg.ldb; }
-    inline int n_block1_tail() { return brg.ldb_tail; }
-    inline int n_block2() { return brg.ld_block2; }
-    inline int nb_n_block2() { return brg.ldb2; }
-    inline int n_block2_tail() { return brg.ldb2_tail; }
-    int tail_length() { return n_block1_tail() % simd_w_; }
+    inline dim_t n_block1() { return brg.ld_block; }
+    inline dim_t nb_n_block1() { return brg.ldb; }
+    inline dim_t n_block1_tail() { return brg.ldb_tail; }
+    inline dim_t n_block2() { return brg.ld_block2; }
+    inline dim_t nb_n_block2() { return brg.ldb2; }
+    inline dim_t n_block2_tail() { return brg.ldb2_tail; }
+    dim_t tail_length() { return n_block1_tail() % simd_w_; }
 
-    inline int bs_group() const { return brg.bs_group; }
+    inline dim_t bs_group() const { return brg.bs_group; }
     static bool grouped_bs(const brgemm_desc_t &brg) {
         return brg.bs_group > 1;
     }
@@ -308,30 +310,34 @@ private:
 
     int vnni_substep() { return vmm_alloc.vnni_substep(brg); }
 
-    int get_substep_simd(int n_i, int v_i, bool has_n_tail) {
-        const int last_n_block_sz
+    int get_substep_simd(dim_t n_i, dim_t v_i, bool has_n_tail) {
+        const dim_t last_n_block_sz
                 = n_block2_tail() > 0 ? n_block2_tail() : n_block2();
         if (has_n_tail && n_i + 1 == last_n_block_sz) {
-            return nstl::min(simd_w_, n_block1_tail() - v_i * simd_w_);
+            return xbyak_register_index(
+                    nstl::min<dim_t>(simd_w_, n_block1_tail() - v_i * simd_w_));
         } else {
             return simd_w_;
         }
     }
-    Vmm vmm_a(int m, int n) {
+    Vmm vmm_a(dim_t m, dim_t n) {
         const auto idx_a = vmm_alloc.vmm_a_idx(brg, m, n);
         assert(idx_a < (vmm_alloc.get_idx_vmm_b() + is_fma_embd()));
         return Vmm(idx_a);
     }
-    Vmm vmm_b(int bi = 0) { return Vmm(vmm_alloc.get_idx_vmm_b() + bi); }
-    Vmm accm(int m_blocks, int n_blocks, int m, int n, int vnni_idx) {
+    Vmm vmm_b(dim_t bi = 0) {
+        return Vmm(xbyak_register_index(vmm_alloc.get_idx_vmm_b() + bi));
+    }
+    Vmm accm(dim_t m_blocks, dim_t n_blocks, dim_t m, dim_t n, dim_t vnni_idx) {
         assert(m_blocks <= m_block2() && m < m_blocks);
         assert(n_blocks <= n_block2() && n < n_blocks);
-        const int accm_start = max_vmms_ - m_blocks * n_blocks * vnni_substep();
-        const int accm_rel_idx
+        const dim_t accm_start
+                = max_vmms_ - m_blocks * n_blocks * vnni_substep();
+        const dim_t accm_rel_idx
                 = m * n_blocks * vnni_substep() + n * vnni_substep() + vnni_idx;
-        const int idx = accm_start + accm_rel_idx;
+        const dim_t idx = accm_start + accm_rel_idx;
         assert(idx < max_vmms_ && idx > vmm_b(0).getIdx());
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
     Vmm vmm_permute() { return Vmm(vmm_alloc.get_idx_vmm_permute()); }
     Vmm vmm_shift() { // -128's
@@ -340,11 +346,11 @@ private:
     Vmm vmm_s8s8_comp() { return Vmm(vmm_alloc.get_idx_vmm_s8s8_comp()); }
     Vmm vmm_zp_comp() { return Vmm(vmm_alloc.get_idx_vmm_zp_comp()); }
     Vmm vmm_bcast() { return Vmm(vmm_alloc.get_idx_vmm_bcast()); }
-    Vmm vmm_tmp(int i) {
-        const int idx
+    Vmm vmm_tmp(dim_t i) {
+        const dim_t idx
                 = max_vmms_ - m_block2() * n_block2() * vnni_substep() - 1 - i;
         assert(idx > (is_fast_vnni_int8() - 1));
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
 
     template <typename U>
@@ -352,61 +358,64 @@ private:
     void init_masks();
     void read_params();
     void load_permute_vmm();
-    void load_accumulators(int m_blocks, int n_blocks);
+    void load_accumulators(dim_t m_blocks, dim_t n_blocks);
     void restore_A_B_matrices();
     void set_A_B_matrices();
     void advance_A_B_matrices();
-    void load_a(Vmm vmma, int m_i, int n_i, int v_i, bool has_n_tail);
-    void load_b(
-            Vmm vmmb, int n_i, int v_i, bool has_n_tail, bool wei_zp = false);
+    void load_a(Vmm vmma, dim_t m_i, dim_t n_i, dim_t v_i, bool has_n_tail);
+    void load_b(Vmm vmmb, dim_t n_i, dim_t v_i, bool has_n_tail,
+            bool wei_zp = false);
     void comp_dot_product(compute_pad_kernel_t kernel_type, Vmm vmm_acc,
-            Vmm vmmb, int n,
+            Vmm vmmb, dim_t n,
             bool is_tail_block); // int8 compensation dot_product (zp and s8s8)
-    void pad_comp_kernel(compute_pad_kernel_t kernel_type, int m_blocks,
-            int n_blocks, int padding, const Xbyak::Reg64 reg_pad,
-            const std::function<int(int)> &get_mi, bool has_tail = false);
-    void vertical_pad_kernel(int m_blocks, int n_blocks, bool has_tail);
-    void batch_pad_kernel(int m_blocks, int n_blocks, bool has_tail = false);
-    void brdgmm_microkernel(int m_blocks, int n_blocks, bool has_top_padding,
-            bool has_bottom_padding, bool has_tail, int shift_a);
+    void pad_comp_kernel(compute_pad_kernel_t kernel_type, dim_t m_blocks,
+            dim_t n_blocks, dim_t padding, const Xbyak::Reg64 reg_pad,
+            const std::function<dim_t(dim_t)> &get_mi, bool has_tail = false);
+    void vertical_pad_kernel(dim_t m_blocks, dim_t n_blocks, bool has_tail);
+    void batch_pad_kernel(
+            dim_t m_blocks, dim_t n_blocks, bool has_tail = false);
+    void brdgmm_microkernel(dim_t m_blocks, dim_t n_blocks,
+            bool has_top_padding, bool has_bottom_padding, bool has_tail,
+            dim_t shift_a);
     void compute_loop();
     void get_batch_padding_info();
-    void get_vertical_padding_info(const int m_blocks);
-    void call_brdgmm_microkernel(const int m_blocks, const int n_blocks,
-            bool has_n_tail, int shift_a);
-    void batch_loop(const int m_blocks, const int n_blocks, bool has_n_tail);
+    void get_vertical_padding_info(dim_t m_blocks);
+    void call_brdgmm_microkernel(
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail, dim_t shift_a);
+    void batch_loop(dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag, bool store);
-    void apply_post_ops(int m_blocks, int n_blocks, bool has_n_tail);
+    void apply_post_ops(dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void maybe_transpose_interleaved_vnni_to_plain(
-            int m_blocks, int n_blocks, bool has_n_tail);
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void load_src_zp();
-    void compute_int8_compensation(int m_blocks, int n_blocks, bool has_n_tail);
-    void store_accumulators(int m_blocks, int n_blocks, bool has_n_tail);
+    void compute_int8_compensation(
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
+    void store_accumulators(dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void store_accumulators_without_post_ops(
-            int m_blocks, int n_blocks, bool has_n_tail);
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     void store_accumulators_apply_post_ops(
-            int m_blocks, int n_blocks, bool has_n_tail);
+            dim_t m_blocks, dim_t n_blocks, bool has_n_tail);
     bool check_effective_padding() { return has_vpad_ && M() > m_block2(); }
-    int oc_logical_offset(int n) { return n * n_block1(); }
-    int A_offset(int m, int n) {
+    dim_t oc_logical_offset(dim_t n) { return n * n_block1(); }
+    dim_t A_offset(dim_t m, dim_t n) {
         return brg.typesize_A * (m * brg.LDA + n * n_block1());
     }
-    int B_offset(int n) { return brg.typesize_B * n * n_block1(); }
-    int C_offset(int m, int n, int v) {
+    dim_t B_offset(dim_t n) { return brg.typesize_B * n * n_block1(); }
+    dim_t C_offset(dim_t m, dim_t n, dim_t v) {
         return brg.typesize_C * (m * brg.LDC + n * n_block1() + v * simd_w_);
     }
-    int D_offset(int m, int n, int v) {
+    dim_t D_offset(dim_t m, dim_t n, dim_t v) {
         return brg.typesize_D * (m * brg.LDD + n * n_block1() + v * simd_w_);
     }
-    int bias_offset(int n, int v) {
+    dim_t bias_offset(dim_t n, dim_t v) {
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
-    int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_per_n_wei_scales
+    dim_t wei_scales_offset(dim_t n, dim_t v) {
+        return static_cast<dim_t>(sizeof(float)) * brg.is_per_n_wei_scales
                 * (n * n_block1() + v * simd_w_);
     }
-    size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
+    dim_t comp_offset(dim_t n) { return sizeof(int32_t) * n * n_block1(); }
 
     void generate() override;
 };

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -3035,7 +3035,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
 
 void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
     was_prev_bi_ = false;
-    const auto bdb2_to_unroll = nstl::max(0,
+    const auto bdb2_to_unroll = nstl::max<dim_t>(0,
             brg.bdb2
                     - (actual_ils(bi.apply_postops, bi.skip_accumulation) ? 1
                                                                           : 0));

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -253,10 +253,10 @@ private:
     // iteration_map_t) describe the structure of cycles and are used for
     // JIT code generation
     struct iteration_block_t {
-        int block = 0;
+        dim_t block = 0;
         dim_t pos = 0;
         bool is_tail = false;
-        iteration_block_t(dim_t pos_, int block_, bool is_tail_ = false)
+        iteration_block_t(dim_t pos_, dim_t block_, bool is_tail_ = false)
             : block(block_), pos(pos_), is_tail(is_tail_) {}
         bool operator==(const iteration_block_t &rhs) const {
             return block == rhs.block && is_tail == rhs.is_tail;
@@ -283,7 +283,7 @@ private:
             return (blocks[b].pos - blocks[0].pos);
         }
 
-        int block(size_t b) const {
+        dim_t block(size_t b) const {
             assert(b < blocks.size());
             return blocks[b].block;
         }
@@ -293,11 +293,11 @@ private:
             return blocks[b].is_tail;
         }
 
-        int block2() const { return static_cast<int>(blocks.size()); }
+        dim_t block2() const { return static_cast<dim_t>(blocks.size()); }
 
-        int length() const {
+        dim_t length() const {
             if (blocks.empty()) return 0;
-            auto n = blocks.size();
+            const dim_t n = blocks.size();
             // only last block may be different
             return ((n - 1) * blocks[0].block + blocks[n - 1].block);
         }
@@ -374,9 +374,9 @@ private:
 
     struct prf_t {
         brgemm_kernel_prefetching_t pft = brgemm_prf_default;
-        int dist = -1;
-        int vec = 0;
-        void set(brgemm_kernel_prefetching_t pft_, int dist_) {
+        dim_t dist = -1;
+        dim_t vec = 0;
+        void set(brgemm_kernel_prefetching_t pft_, dim_t dist_) {
             pft = pft_;
             dist = dist_;
             vec = 0;
@@ -405,8 +405,8 @@ private:
     // saved parameters for storing
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
-    int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    int ils_bd_step_ = 3; // heuristic value
+    dim_t ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
+    dim_t ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -441,22 +441,22 @@ private:
     const Xbyak::Zmm zmm_ubound = zmm9;
 
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
-    Xbyak::Zmm accm(int bd) const {
+    Xbyak::Zmm accm(dim_t bd) const {
         assert(bd < 16);
-        return Xbyak::Zmm(31 - (bd % ils_bd_step_));
+        return Xbyak::Zmm(xbyak_register_index(31 - (bd % ils_bd_step_)));
     }
 
-    Xbyak::Zmm zmm_bias(int ldb) const {
+    Xbyak::Zmm zmm_bias(dim_t ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
-        return Xbyak::Zmm(10 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(10 + ldb));
     }
 
-    Xbyak::Zmm zmm_scales(int ldb) const {
+    Xbyak::Zmm zmm_scales(dim_t ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
-        return Xbyak::Zmm(15 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(15 + ldb));
     }
 
     template <typename U>
@@ -473,26 +473,26 @@ private:
     void maybe_saturation(Xbyak::Zmm &zmm);
     void apply_alpha_beta_to_vector(
             int idx, const Address &addr, bool is_ld_tail);
-    void apply_post_ops_to_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void apply_post_ops_to_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_with_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, int ldb);
+    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, dim_t ldb);
     void prepare_post_ops_registers(brgemm_iteration_t &bi);
 
     bool bi_shift_output(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_A(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_B(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
 
     void uni_prefetch(const Address &addr, brgemm_kernel_prefetching_t pft,
             bool for_write);
     void prefetch_CD_range(brgemm_iteration_t &bi,
-            brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish,
-            int bdb, int ldb);
-    int calc_ops_CD(brgemm_iteration_t &bi) const noexcept;
+            brgemm_kernel_prefetching_t pft, dim_t bd_start, dim_t bd_finish,
+            dim_t bdb, dim_t ldb);
+    dim_t calc_ops_CD(brgemm_iteration_t &bi) const noexcept;
     void prefetch_CD(brgemm_iteration_t &bi, brgemm_iteration_t &pfo_bi,
             prf_t &prf, bool prefetch_all);
 
@@ -502,58 +502,58 @@ private:
             prf_t &prf, bool prefetch_all);
     void prefetching(brgemm_iteration_t &bi, bool prefetch_all);
 
-    void process_output_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void process_output_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_without_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
-    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb, const int idx);
+    void store_vector(brgemm_iteration_t &bi, dim_t bdb, dim_t bd, dim_t ldb);
+    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb, const int idx);
 
     void interleave_store(brgemm_iteration_t &bi, bool store_all);
 
     void store_accumulators(brgemm_iteration_t &bi);
 
-    void set_A_B_matrices(int bs);
+    void set_A_B_matrices(dim_t bs);
     void set_A_B_matrices();
 
     void bf32_downconvert(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf);
     void fp8_to_f16_upconvert(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt);
 
     void fp8_to_f16_upconvert_to_vnni(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt);
 
     void bf32_downconvert_to_vnni(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf);
 
     void maybe_pre_process_data(brgemm_iteration_t &bi, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
 
     bool process_k_tail_only_last_tile();
 
-    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
             bool mem_advice_A);
 
     void maybe_tileloadd_nt(
-            brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset);
+            brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset);
 
-    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, dim_t bdb);
 
     void maybe_sprinkle_prefetches();
 
-    void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
@@ -573,7 +573,7 @@ private:
     void generate() override;
 
     void prepare_bd_mask() noexcept;
-    int skipped_bd_mask(int inp_bd) noexcept;
+    dim_t skipped_bd_mask(dim_t inp_bd) noexcept;
 
     bool get_store_by_vectors(bool apply_post_ops) const {
         const bool need_to_apply_post_ops
@@ -588,46 +588,46 @@ private:
                 && !skip_accumulation);
     }
 
-    dim_t A_offset(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_wsp(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset_wsp(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
-            int bd_elem_idx = 0) const noexcept;
+    dim_t A_offset_line(const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb = 0,
+            dim_t bd_elem_idx = 0) const noexcept;
 
-    dim_t B_offset(
-            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
+    dim_t B_offset(const brgemm_iteration_t &bi, dim_t ldb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
-            int rd_elem_idx = 0) const noexcept;
+    dim_t B_offset_line(const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb = 0,
+            dim_t rd_elem_idx = 0) const noexcept;
 
-    dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+    dim_t C_offset(const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+            dim_t ldb) const noexcept;
 
-    dim_t D_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+    dim_t D_offset(const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+            dim_t ldb) const noexcept;
 
     dim_t lda() const noexcept;
     dim_t ldb() const noexcept;
 
-    dim_t bias_offset(int ldb) const noexcept;
+    dim_t bias_offset(dim_t ldb) const noexcept;
 
-    dim_t scales_offset(int ldb) const noexcept;
-    dim_t zp_comp_a_offset(int ldb) const noexcept;
-    dim_t zp_comp_pad_a_offset(const brgemm_iteration_t &bi, int bdb,
-            int inp_bd, int ldb) const noexcept;
-    dim_t zp_comp_b_offset(int bd) const noexcept;
-    dim_t zp_c_values_offset(brgemm_iteration_t &bi, int ldb) const noexcept;
-    dim_t per_mn_comp_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
-    bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
-    int get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
+    dim_t scales_offset(dim_t ldb) const noexcept;
+    dim_t zp_comp_a_offset(dim_t ldb) const noexcept;
+    dim_t zp_comp_pad_a_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb) const noexcept;
+    dim_t zp_comp_b_offset(dim_t bd) const noexcept;
+    dim_t zp_c_values_offset(brgemm_iteration_t &bi, dim_t ldb) const noexcept;
+    dim_t per_mn_comp_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb) const noexcept;
+    bool is_out_bd(const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const;
+    dim_t get_out_bd(const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const;
 
-    void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void maybe_tilestore(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
-    int get_C_tensor(brgemm_iteration_t &bi, int m, int n) const noexcept;
+    dim_t get_C_tensor(brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept;
     void top_loop(brgemm_iteration_t &bi);
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
@@ -639,7 +639,7 @@ private:
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     if (shift == 0) return true;
 
@@ -669,7 +669,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_output(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_A(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nbdis = tloop.bdis.size();
@@ -689,7 +689,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_A(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_B(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nldis = tloop.ldis.size();
@@ -708,8 +708,8 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_B(
     return true;
 }
 
-int jit_brgemm_amx_uker_base_t::get_C_tensor(
-        brgemm_iteration_t &bi, int m, int n) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::get_C_tensor(
+        brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept {
     return brg.get_C_tensor(m, n, bi.bdi->is_tail(m), bi.ldi->is_tail(n));
 }
 
@@ -720,8 +720,8 @@ void jit_brgemm_amx_uker_base_t::prepare_bd_mask() noexcept {
     adj_bd_mask_buffer_.resize(bd_mask_size);
     skipped_bd_mask_buffer_.resize(bd_mask_size);
     if (bd_mask_buffer_ptr_ != nullptr) {
-        int out_ibd = 0;
-        for (int i = 0; i < bd_mask_size; i++) {
+        dim_t out_ibd = 0;
+        for (dim_t i = 0; i < bd_mask_size; i++) {
             adj_bd_mask_buffer_[i] = out_ibd;
             out_ibd += bd_mask_buffer_ptr_[i];
             skipped_bd_mask_buffer_[i] = i;
@@ -736,7 +736,7 @@ void jit_brgemm_amx_uker_base_t::prepare_bd_mask() noexcept {
         assert(!"struct nullptr error");
 }
 
-int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
+dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
     if (brg.brgattr.bd_mask_level != 2)
         return inp_bd;
     else
@@ -744,7 +744,7 @@ int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     // Full WSP buffer layout:
     //   1. partial C results.
     //   2. data type conversion.
@@ -764,7 +764,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
@@ -775,12 +775,12 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
-        int bdb, int rdb, int bd_elem_idx) const noexcept {
+        dim_t bdb, dim_t rdb, dim_t bd_elem_idx) const noexcept {
     return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
@@ -796,12 +796,12 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
-        int ldb, int rdb, int rd_elem_idx) const noexcept {
+        dim_t ldb, dim_t rdb, dim_t rd_elem_idx) const noexcept {
     return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
-        int bdb, int inp_bd, int ldb) const noexcept {
+        dim_t bdb, dim_t inp_bd, dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -814,7 +814,7 @@ dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
 }
 
 dim_t jit_brgemm_amx_uker_base_t::D_offset(const brgemm_iteration_t &bi,
-        int bdb, int inp_bd, int ldb) const noexcept {
+        dim_t bdb, dim_t inp_bd, dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -829,21 +829,21 @@ dim_t jit_brgemm_amx_uker_base_t::ldb() const noexcept {
     return LDB_size_ * brg.rd_step;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::bias_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::bias_offset(dim_t ldb) const noexcept {
     return ldb * ld_block_bias_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::scales_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::scales_offset(dim_t ldb) const noexcept {
     return brg.is_per_n_wei_scales * ldb * ld_block_scales_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(dim_t ldb) const noexcept {
     return ldb * ld_block_zp_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_comp_pad_a_offset(
-        const brgemm_iteration_t &bi, int bdb, int inp_bd,
-        int ldb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+        dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -851,12 +851,12 @@ dim_t jit_brgemm_amx_uker_base_t::zp_comp_pad_a_offset(
             + (dim_t)ldb * ld_block_zp_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(int bd) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(dim_t bd) const noexcept {
     return sizeof(int32_t) * bd;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
-        brgemm_iteration_t &bi, int ldb) const noexcept {
+        brgemm_iteration_t &bi, dim_t ldb) const noexcept {
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         return (bi.ldi->is_tail(ldb)) ? ldb_tail_zp_size_
                                       : bi.ldi->pos(ldb) * ld_block_zp_size_;
@@ -866,8 +866,8 @@ dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
-        const brgemm_iteration_t &bi, int bdb, int inp_bd,
-        int ldb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd,
+        dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     assert(bd >= 0);
@@ -881,14 +881,14 @@ dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
 }
 
 bool jit_brgemm_amx_uker_base_t::is_out_bd(
-        const bd_iteration_t *bdi, int bdb, int inp_bd) const {
+        const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const {
     const auto bd = bdi->pos(bdb) + inp_bd;
     return IMPLICATION(
             brg.brgattr.bd_mask_level, bdi->bd_mask[bd - bdi->pos(0)] != 0);
 }
 
-int jit_brgemm_amx_uker_base_t::get_out_bd(
-        const bd_iteration_t *bdi, int bdb, int inp_bd) const {
+dim_t jit_brgemm_amx_uker_base_t::get_out_bd(
+        const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const {
     if (!is_out_bd(bdi, bdb, inp_bd)) return -1;
     const auto bd = bdi->pos(bdb) + inp_bd;
     if (brg.brgattr.bd_mask_level) {
@@ -978,17 +978,17 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
         ils_shift = need_ils_shift ? bi.bdi->C_shift : 0;
     }
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
-            tileloadd(Tmm(get_C_tensor(bi, bdb, ldb)),
+            tileloadd(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
         } else {
             // call tilezero on very first iteration
             if (!brg.interleave_tilestores_
                     || everyone_is(0u, bi.bdi->idx, bi.ldi->idx))
-                tilezero(Tmm(get_C_tensor(bi, bdb, ldb)));
+                tilezero(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -1035,8 +1035,8 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     }
 }
 
-void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1127,7 +1127,7 @@ void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
 }
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
-        brgemm_iteration_t &bi, int ldb) {
+        brgemm_iteration_t &bi, dim_t ldb) {
     if (!bi.apply_postops) return;
     auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
 
@@ -1168,7 +1168,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1212,7 +1212,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 case data_type::f32:
                 default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
             }
-            for (int ldb = 0; ldb < ldi->block2(); ldb++)
+            for (dim_t ldb = 0; ldb < ldi->block2(); ldb++)
                 vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
         }
     }
@@ -1222,7 +1222,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
                     = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1233,7 +1233,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
@@ -1261,7 +1261,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1345,10 +1345,10 @@ void jit_brgemm_amx_uker_base_t::uni_prefetch(
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
-        brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish, int bdb,
-        int ldb) {
+        brgemm_kernel_prefetching_t pft, dim_t bd_start, dim_t bd_finish,
+        dim_t bdb, dim_t ldb) {
     const auto ldb_pos = bi.ldi->pos(ldb);
-    for (int bd = bd_start; bd < bd_finish; bd++) {
+    for (dim_t bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
@@ -1371,11 +1371,11 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
     }
 }
 
-int jit_brgemm_amx_uker_base_t::calc_ops_CD(
+dim_t jit_brgemm_amx_uker_base_t::calc_ops_CD(
         brgemm_iteration_t &bi) const noexcept {
     const auto &tloop = imap_[bi.apply_postops];
-    return tloop.rdis.size() * bi.ldi->block2() * bi.bdi->block2()
-            * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
+    return static_cast<dim_t>(tloop.rdis.size()) * bi.ldi->block2()
+            * bi.bdi->block2() * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
@@ -1394,7 +1394,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
             = (are_post_ops_applicable_ && !prev_bi_.apply_postops)
             ? brg.typesize_C
             : brg.typesize_D;
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / bdb_row;
         const auto vec_in_bdb_row = prf.vec - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / pfo_bi.bdi->block(bdb);
@@ -1418,7 +1418,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_A(brgemm_iteration_t &bi,
             ? tot_vecs
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / pfo_bi.bdi->block(0);
         const auto bd = prf.vec % pfo_bi.bdi->block(0);
 
@@ -1442,7 +1442,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_B(brgemm_iteration_t &bi,
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
     // TODO: check these addressing for correctness
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
 
         const auto ldb = prf.vec / pfo_bi.rdi->block(0);
         const auto rb = prf.vec % pfo_bi.rdi->block(0);
@@ -1505,7 +1505,8 @@ void jit_brgemm_amx_uker_base_t::prefetching(
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb, const int idx) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb,
+        const int idx) {
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     auto zmm = Zmm(idx);
@@ -1526,8 +1527,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vaddps(zmm_masked, zmm, zmm_zp_comp_a);
 }
 
-void jit_brgemm_amx_uker_base_t::process_output_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::process_output_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
 
     const auto k_mask = bi.ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
@@ -1778,7 +1779,7 @@ void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb) {
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
@@ -1838,7 +1839,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
     const auto bdb_row = prev_bi_.bdi->block(0) * prev_bi_.ldi->block2();
     const auto total_vectors = prev_bi_.bdi->length() * prev_bi_.ldi->block2();
     const auto nvecs = store_all ? total_vectors : ils_vecs_per_store;
-    for (int vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
+    for (dim_t vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
         const auto bdb = ils_vec_ / bdb_row;
         const auto vec_in_bdb_row = ils_vec_ - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / prev_bi_.bdi->block(bdb);
@@ -1887,8 +1888,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     if (store_by_vectors && !real_ils && !prepare_post_ops_registers_once_)
         prepare_post_ops_registers(bi);
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (store_by_vectors) {
             if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
                 const auto wsp_offset = use_ils_
@@ -1896,13 +1897,13 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
                                 * ld_block_C_size_
                         : 0;
                 tilestored(ptr[reg_buf + reg_stride_ld_block + wsp_offset],
-                        Tmm(get_C_tensor(bi, bdb, ldb)));
+                        Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
             }
             if (real_ils) continue;
 
             prepare_post_ops_registers_ldb(bi, ldb);
 
-            for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
+            for (dim_t bd_step = 0; bd_step < bi.bdi->block(bdb);
                     bd_step += ils_bd_step_) {
                 auto bd_finish
                         = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
@@ -1914,12 +1915,12 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
         } else if (!brg.interleave_tilestores_) {
             const auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb));
             tilestored(ptr[reg_C + reg_stride_ld_block + c_offset],
-                    Tmm(get_C_tensor(bi, bdb, ldb)));
+                    Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
 
-void jit_brgemm_amx_uker_base_t::set_A_B_matrices(int bs) {
+void jit_brgemm_amx_uker_base_t::set_A_B_matrices(dim_t bs) {
     if (one_of(brg.type, brgemm_static_offs)) return;
     assert(one_of(brg.type, brgemm_addr, brgemm_offs));
     if (brg.brgattr.max_bs == 1) return;
@@ -2025,13 +2026,14 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
     current_num_amx_ops++;
 }
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
-        brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset) {
+        brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset) {
 
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
 
-    auto t1 = Tmm(is_A ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
-                       : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb)));
+    auto t1 = Tmm(xbyak_register_index(is_A
+                    ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
+                    : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb))));
     auto reg_base = is_A ? reg_A : reg_B;
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
 
@@ -2066,8 +2068,9 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 }
 
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
-        brgemm_iteration_t &bi, int bdb) {
-    auto t1 = Tmm(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb)));
+        brgemm_iteration_t &bi, dim_t bdb) {
+    auto t1 = Tmm(
+            xbyak_register_index(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
     auto load_a_tile_from_wsp = [&]() {
         if (brg.load_nt_A) {
@@ -2106,7 +2109,7 @@ void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
     };
 }
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
-        int bdb_idx, int ldb_idx, bool do_pre_tilestore,
+        dim_t bdb_idx, dim_t ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
     if (bi.skip_accumulation) return;
     auto current_tensor_idx = get_C_tensor(bi, bdb_idx, ldb_idx);
@@ -2120,8 +2123,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     const auto store_tensor_number = current_tensor_number + store_tensor_shift;
 
     const auto &store_bi = do_pre_tilestore ? prev_bi_ : bi;
-    const int max_store_tensor_number
-            = store_bi.bdi->blocks.size() * store_bi.ldi->blocks.size();
+    const dim_t max_store_tensor_number
+            = store_bi.bdi->block2() * store_bi.ldi->block2();
     bool perform_store
             = (do_pre_tilestore
                       && (store_tensor_number >= 2
@@ -2134,7 +2137,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
         ldb_idx = store_tensor_idx % bi.ldi->block2();
     }
     const bool store_by_vectors = get_store_by_vectors(bi.apply_postops);
-    Tmm acc = Tmm(store_tensor_idx);
+    Tmm acc = Tmm(xbyak_register_index(store_tensor_idx));
     if (store_by_vectors) {
         const auto wsp_offset = (use_ils_ || brg.interleave_tilestores_)
                 ? (bdb_idx * bi.ldi->block2() + ldb_idx) * bi.bdi->block(0)
@@ -2151,14 +2154,17 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     tilezero(acc);
 }
 
-void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
-        int ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
+void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
+        dim_t ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
-    const Tmm &x1 = Tmm(get_C_tensor(bi, bdb_idx, ldb_idx));
-    const Tmm &x2 = Tmm(brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx)));
-    const Tmm &x3 = Tmm(brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx)));
+    const Tmm &x1
+            = Tmm(xbyak_register_index(get_C_tensor(bi, bdb_idx, ldb_idx)));
+    const Tmm &x2 = Tmm(xbyak_register_index(
+            brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx))));
+    const Tmm &x3 = Tmm(xbyak_register_index(
+            brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx))));
 
     using namespace data_type;
     if (brg.is_tf32) {
@@ -2195,12 +2201,12 @@ void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
-        int num_rows, int tile_num_col_bytes, reg64_t reg_data, int offset,
+        int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt) {
     const auto rd_block = bi.rdi->block(0);
-    const int max_num_cols
-            = nstl::min<int>(tile_num_col_bytes / sizeof(float16_t), rd_block);
-    const int col_tail = max_num_cols % 32;
+    const dim_t max_num_cols = nstl::min<dim_t>(
+            tile_num_col_bytes / sizeof(float16_t), rd_block);
+    const dim_t col_tail = max_num_cols % 32;
     auto zmm_1 = zmm_tmp_1();
     auto zmm_1_masked = col_tail ? zmm_1 | fp_col_mask | T_z : zmm_1;
 
@@ -2232,11 +2238,11 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
 // This method down-converts the data from f32 to bf16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 void jit_brgemm_amx_uker_base_t::bf32_downconvert(brgemm_iteration_t &bi,
-        int num_rows, int tile_num_col_bytes, reg64_t reg_data, int offset,
+        int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf) {
     const auto rd_block = bi.rdi->block(0);
-    const auto max_num_cols
-            = nstl::min<int>(tile_num_col_bytes / sizeof(bfloat16_t), rd_block);
+    const auto max_num_cols = nstl::min<dim_t>(
+            tile_num_col_bytes / sizeof(bfloat16_t), rd_block);
     const auto col_tail = max_num_cols % simd_w;
     auto zmm_1 = zmm_tmp_1();
     auto zmm_2 = zmm_tmp_2();
@@ -2276,8 +2282,8 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert(brgemm_iteration_t &bi,
 // format. Generally used by matrix_B.
 void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
         brgemm_iteration_t &bi, int num_rows, int tile_num_col_bytes,
-        reg64_t reg_data, int offset, reg64_t reg_data_stride, reg64_t reg_buf,
-        data_type_t dt) {
+        reg64_t reg_data, dim_t offset, reg64_t reg_data_stride,
+        reg64_t reg_buf, data_type_t dt) {
     const int num_cols_ele = tile_num_col_bytes / 2; // 32 for full tile
     const int num_N = num_cols_ele / 2; // 16 for full tile
     const auto zmm_2 = zmm_tmp_2();
@@ -2290,22 +2296,22 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const int vnni_granularity = 2;
-    const int r_end = utils::div_up(rd_block, vnni_granularity);
+    const dim_t r_end = utils::div_up(rd_block, vnni_granularity);
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else
         assert(!"unsupported data type");
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2314,7 +2320,7 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
 // format. Generally used by matrix_B.
 void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         brgemm_iteration_t &bi, int num_rows, int tile_num_col_bytes,
-        reg64_t reg_data, int offset, reg64_t reg_data_stride,
+        reg64_t reg_data, dim_t offset, reg64_t reg_data_stride,
         reg64_t reg_buf) {
     const auto num_cols_ele = tile_num_col_bytes / sizeof(bfloat16_t);
     const auto num_N = num_cols_ele / sizeof(bfloat16_t);
@@ -2342,12 +2348,12 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const auto rd_block = bi.rdi->block(0);
-    const int vnni_granularity
+    const auto vnni_granularity
             = data_type_vnni_granularity(data_type_t::dnnl_bf16);
-    const auto r_end
-            = nstl::min(utils::div_up(rd_block, vnni_granularity), num_rows);
+    const dim_t r_end = nstl::min<dim_t>(
+            utils::div_up(rd_block, vnni_granularity), num_rows);
 
-    for (int r = 0; r < r_end; ++r) {
+    for (dim_t r = 0; r < r_end; ++r) {
         load(zmm_1, ptr[reg_data_aux]);
 
         if (r * vnni_granularity + 1 >= rd_block) {
@@ -2360,13 +2366,15 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         vpermw(zmm_1, zmm_bf32_permute, zmm_1);
         vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_1);
         lea(reg_data_aux,
-                ptr[reg_data_aux + vnni_granularity * reg_data_stride]);
+                ptr[reg_data_aux
+                        + reg_data_stride
+                                * xbyak_address_scale(vnni_granularity)]);
     }
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2401,9 +2409,9 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     const auto matrix_a_offset = transform_offset;
     const auto matrix_b_offset = transform_offset
             + brgemm_desc_t::tilesize
-                    * (nstl::max<int>(should_save_transform(mk),
+                    * nstl::max<dim_t>(should_save_transform(mk),
                             should_save_transform(matrix_A) * brg.brgattr.max_bs
-                                    * max_bdb2 * max_rdb));
+                                    * max_bdb2 * static_cast<dim_t>(max_rdb));
     const auto matrix_offset = is_A ? matrix_a_offset : matrix_b_offset;
     const std::string key
             = std::to_string(bi.bsi->pos) + "_" + std::to_string(offset);
@@ -2454,7 +2462,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 }
 
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
     if (offset_dst) add(reg_buf, offset_dst);
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
@@ -2466,12 +2474,12 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
     // The check is on the last tile on K dim and tile before last on M dim. If
     // loading that tile exceeds the A matrix, then we need to process K tail
     // on every M tile.
-    int last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
+    const dim_t last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
     return brg.rd_block - brg.rdb_tail <= last_bd_block * brg.reduce_dim;
 }
 
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
         bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
@@ -2513,7 +2521,7 @@ void jit_brgemm_amx_uker_base_t::copy_k_tail_to_wsp(const Tmm &t1,
     const auto num_col_bytes = palette_.cols[t1.getIdx()];
 
     const auto max_num_cols
-            = nstl::min<int>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
+            = nstl::min<dim_t>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
     const size_t col_tail
             = max_num_cols % (zmm_width_in_bytes / brg.typesize_A);
     if (col_tail) {
@@ -2577,7 +2585,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     else
         mov(reg_stride_ld_block, LDC_size_);
 
-    for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+    for (dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++) {
         if (brg.fused_copy_a) {
             maybe_fused_copy_A_nt_load(bi, bdb);
         } else {
@@ -2585,7 +2593,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
                     bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
         }
 
-        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
                         bi, matrix_kind_t::matrix_B, ldb, B_offset(bi, ldb));
@@ -2713,7 +2721,7 @@ void jit_brgemm_amx_uker_base_t::bs_loop(brgemm_iteration_t &bi) {
         store_accumulators(bi);
     } else {
         if (brg.alpha != 0.f) {
-            for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
+            for (dim_t bs = 0; bs < brg.brgattr.max_bs; bs++) {
                 bi.bsi = &(tloop.bsis[bs]);
                 bi.first_bsi = bi.bsi->is_first;
                 bi.last_bsi = bi.bsi->is_last;
@@ -2832,8 +2840,8 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (brg.interleave_tilestores_) {
         prev_bi_ = bi;
         was_prev_bi_ = true;
-        for_(int bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
-        for (int ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
+        for_(dim_t bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
+        for (dim_t ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
             maybe_tilestore(prev_bi_, bdb, ldb, true, false);
         }
     }
@@ -2867,13 +2875,13 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         auto bdi_pos = skipped_bd_mask(0);
         bd_iteration_t bdi;
         bdi.blocks.reserve(brg.bd_block2);
-        int prefetch_distance_m = brg.bcast_dim;
+        dim_t prefetch_distance_m = brg.bcast_dim;
         bd_iteration_t bdi_prefetch;
         bi_prefetch.bdi = &bdi_prefetch;
 
-        for (int bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
+        for (dim_t bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
             bdi.blocks.clear();
-            for (int ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
+            for (dim_t ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
                 auto abdb = bdb + ibdb;
                 if (abdb >= brg.bdb) break;
                 if (brg.bdb_tail && abdb == brg.bdb - 1) {
@@ -2920,16 +2928,16 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
             tloop.bdis.push_back(bdi);
         }
 
-        size_t ldi_pos = 0;
+        dim_t ldi_pos = 0;
         dim_iteration_t ldi;
         ldi.blocks.reserve(brg.ld_block2);
-        size_t prefetch_distance_n = (size_t)brg.ldb;
+        dim_t prefetch_distance_n = brg.ldb;
         bd_iteration_t ldi_prefetch;
         bi_prefetch.ldi = &ldi_prefetch;
 
-        for (int ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
+        for (dim_t ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
             ldi.blocks.clear();
-            for (int ildb = 0; ildb < brg.ld_block2; ildb++) {
+            for (dim_t ildb = 0; ildb < brg.ld_block2; ildb++) {
                 auto aldb = ldb + ildb;
                 if (aldb >= brg.ldb) break;
                 if (brg.ldb_tail && aldb == brg.ldb - 1) {
@@ -2952,13 +2960,13 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
             tloop.ldis.push_back(ldi);
         }
 
-        size_t rdi_pos = 0;
+        dim_t rdi_pos = 0;
         dim_iteration_t rdi;
         rdi.blocks.reserve(1);
         dim_iteration_t rdi_prefetch;
         bi_prefetch.rdi = &rdi_prefetch;
 
-        for (int rdb = 0; rdb < brg.rdb; rdb++) {
+        for (dim_t rdb = 0; rdb < brg.rdb; rdb++) {
             rdi.blocks.clear();
             rdi.blocks.emplace_back(rdi_pos, brg.rd_block);
             if (brg.prfA.sprinkled || brg.prfB.sprinkled) {
@@ -2982,7 +2990,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         // is not supported. In order to support prefetches in this case,
         // current_num_amx_ops needs to be an array per bs in bs_max.
         bs_iteration_t bsi;
-        for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
+        for (dim_t bs = 0; bs < brg.brgattr.max_bs; bs++) {
             bsi.pos = bs;
             bsi.is_first = (bs == 0);
             bsi.is_last = (bs == brg.brgattr.max_bs - 1);
@@ -2996,7 +3004,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                         = find_similar(&(tloop.bdis[ibdi]), apply_postops);
             }
         }
-        size_t rdb_including_tail = brg.rdb + (brg.rdb_tail > 0 ? 1 : 0);
+        const dim_t rdb_including_tail = brg.rdb + (brg.rdb_tail > 0 ? 1 : 0);
         num_amx_ops = brg.bdb * rdb_including_tail * brg.ldb;
         current_num_amx_ops = 0;
         // Calculate the offsets of A's cache lines to prefetch
@@ -3004,8 +3012,8 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.prfA.sprinkled) {
             for (size_t bdb = 0; bdb < bdi_prefetch.blocks.size(); ++bdb) {
                 for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
-                    int bd_block_size = bdi_prefetch.blocks[bdb].block;
-                    for (int bd = 0; bd < bd_block_size; bd++) {
+                    const dim_t bd_block_size = bdi_prefetch.blocks[bdb].block;
+                    for (dim_t bd = 0; bd < bd_block_size; bd++) {
                         prf_sprinkled_a.prefetch_offsets.push_back(
                                 A_offset_line(bi_prefetch, bdb, rdb, bd));
                     }
@@ -3020,8 +3028,8 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.prfB.sprinkled) {
             for (size_t ldb = 0; ldb < ldi_prefetch.blocks.size(); ++ldb) {
                 for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
-                    int rd_block_size = rdi_prefetch.blocks[rdb].block;
-                    for (int rd = 0; rd < rd_block_size; rd += brg.rd_step) {
+                    const dim_t rd_block_size = rdi_prefetch.blocks[rdb].block;
+                    for (dim_t rd = 0; rd < rd_block_size; rd += brg.rd_step) {
                         prf_sprinkled_b.prefetch_offsets.push_back(
                                 B_offset_line(bi_prefetch, ldb, rdb, rd));
                     }

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -305,7 +305,8 @@ private:
     }
 
     Vmm accm(dim_t ld_block, dim_t bd, dim_t ld) const noexcept {
-        return Vmm(max_effective_vregs - 1 - (bd * ld_block + ld));
+        return Vmm(xbyak_register_index(
+                max_effective_vregs - 1 - (bd * ld_block + ld)));
     }
 
     Vmm bcst(dim_t bd = 0) const noexcept {
@@ -313,7 +314,7 @@ private:
             dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         } else
             return Vmm(0);
     }
@@ -325,20 +326,20 @@ private:
             dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - ld;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         }
     }
 
     Vmm gemv_load_a() const noexcept {
         assert(brg.is_gemv);
         const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm gemv_load_b() const noexcept {
         assert(brg.is_gemv);
         const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
-        return Vmm(idx);
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm vmm_tmp(dim_t i) const noexcept {
@@ -346,7 +347,7 @@ private:
         MAYBE_UNUSED(bd_block);
         assert(IMPLICATION(!brg.is_tmm,
                 i >= 0 && i < max_effective_vregs - bd_block * brg.ld_block2));
-        return Vmm(i);
+        return Vmm(xbyak_register_index(i));
     }
 
     Vmm vmm_tail_mask() const noexcept { return vmm_tmp(1); }
@@ -1168,7 +1169,8 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
         for_(dim_t bdb = 0; bdb < bd_block2; bdb++)
         for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
             dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
-            tilezero(Tmm(brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail)));
+            tilezero(Tmm(xbyak_register_index(
+                    brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail))));
         }
     } else if (brg.is_gemv) {
         for (dim_t bd = 0; bd < brg.gemv_bd_block(); bd++) {
@@ -1246,11 +1248,11 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else
         assert(!"unsupported data type");
 
@@ -2431,7 +2433,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
                 for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
                     const dim_t idx = is_ld_tail ? brg.ld_block2 : ldb;
-                    const int c_tensor = brg.get_C_tensor(
+                    const dim_t c_tensor = brg.get_C_tensor(
                             bdb, idx, is_bdb_tail, is_ld_tail);
                     if (do_accum_ops) {
                         if (skip_accumulation) {
@@ -2441,7 +2443,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
                             }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
-                                    Tmm(c_tensor));
+                                    Tmm(xbyak_register_index(c_tensor)));
                             for (dim_t bd = 0; bd < adj_bd_block; bd++) {
                                 const size_t buf_offset
                                         = (bd * brg.ld_block) * brg.typesize_C;
@@ -2481,7 +2483,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
                         reg_buf.restore();
                     } else {
-                        auto tmm = Tmm(c_tensor);
+                        auto tmm = Tmm(xbyak_register_index(c_tensor));
                         if (skip_accumulation) tilezero(tmm);
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
                         if (ldb < ld_block2 - 1)
@@ -2735,7 +2737,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
 
     const dim_t tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
                                : brg.get_B_tensor(idx, is_tail);
-    auto t1 = Tmm(tmm_idx);
+    auto t1 = Tmm(xbyak_register_index(tmm_idx));
 
     auto reg_base = is_A ? reg_aux_A : reg_aux_B;
 
@@ -2752,7 +2754,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
         dim_t rd_block
                 = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
         if (brg.is_input_convert()) {
-            const int vnni_granularity
+            const auto vnni_granularity
                     = data_type_vnni_granularity(data_type::f16);
             rd_block = utils::rnd_up(rd_block, vnni_granularity);
         }
@@ -2901,10 +2903,12 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
                     is_ld_tail, false);
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                tdpbxxd(Tmm(brg.get_C_tensor(
-                                bdb, idx, is_bdb_tail, is_ld_tail)),
-                        Tmm(brg.get_A_tensor(bdb, is_bdb_tail)),
-                        Tmm(brg.get_B_tensor(idx, is_ld_tail)));
+                tdpbxxd(Tmm(xbyak_register_index(brg.get_C_tensor(
+                                bdb, idx, is_bdb_tail, is_ld_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_A_tensor(bdb, is_bdb_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_B_tensor(idx, is_ld_tail))));
             }
         }
     }
@@ -3938,7 +3942,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         L(sum_zp_scale_data_);
         const dim_t scale_int = float2int(brg.sum_scale);
         for (dim_t i = 0; i < simd; ++i)
-            dd(scale_int);
+            dd(static_cast<uint32_t>(scale_int));
     }
 
     if (brg.is_fp8_via_convert()) {

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -23,16 +23,16 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-static std::size_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
+static dim_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
     static constexpr int byte_size_bits = 8;
     return vmm.getBit() / byte_size_bits;
 }
 
-static std::size_t calc_vmm_to_preserve_size_bytes(
+static dim_t calc_vmm_to_preserve_size_bytes(
         const std::initializer_list<Xbyak::Xmm> &vmm_to_preserve) {
 
     return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
-            std::size_t(0u), [](std::size_t accum, const Xbyak::Xmm &vmm) {
+            dim_t(0), [](dim_t accum, const Xbyak::Xmm &vmm) {
         return accum + get_vmm_size_bytes(vmm);
     });
 }
@@ -214,7 +214,7 @@ void reg64_savable_t::addTo(const Xbyak::Reg64 &reg) const {
         regscratchpad_.jit().add(reg, *this);
 }
 
-void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, int imm) const {
+void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, dim_t imm) const {
     if (booking_ >= 0)
         regscratchpad_.jit().imul(reg, getStoragePtr(), imm);
     else

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -67,7 +67,7 @@ private:
     jit_generator_t *host_;
     std::stack<Xbyak::Reg64> reg64_stack_;
     std::stack<Xbyak::Xmm> vmm_stack_;
-    size_t vmm_to_preserve_size_bytes_;
+    dim_t vmm_to_preserve_size_bytes_;
 };
 
 class conditional_register_preserve_guard_t : public register_preserve_guard_t {
@@ -151,7 +151,7 @@ public:
     void restoreTo(const Xbyak::Reg64 &reg) const;
     void restoreTo(const Xbyak::Reg32 &reg32) const;
     void addTo(const Xbyak::Reg64 &reg) const;
-    void imulTo(const Xbyak::Reg64 &reg, int imm) const;
+    void imulTo(const Xbyak::Reg64 &reg, dim_t imm) const;
     Xbyak::Address getStoragePtr() const {
         return regscratchpad_.getPtr(booking_);
     }

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -594,7 +594,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             is_bf32, is_tf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -669,9 +669,9 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     ur_block = brg.bd_block;
-    adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
+    adj_ocblock = nstl::max<dim_t>(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
 

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -713,7 +713,7 @@ status_t jit_brgemm_ip_fwd_conf_t::init_conf(cpu_isa_t isa,
         if (st == success) st = brgemm_desc_finalize(&brg_desc);
 
         if (st == success) {
-            int bd_block = brg_desc.bd_block;
+            dim_t bd_block = brg_desc.bd_block;
 
             if (jbgp.oc_block == 64 && bd_block != 6) jbgp.os_block = 6;
             if (jbgp.oc_block == 48 && bd_block != 8) jbgp.os_block = 8;

--- a/src/cpu/x64/jit_brgemm_primitive_conf.cpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.cpp
@@ -23,11 +23,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-int jit_brgemm_primitive_conf_t::ks() const {
+dim_t jit_brgemm_primitive_conf_t::ks() const {
     return kd * kh * kw;
 }
 
-int jit_brgemm_primitive_conf_t::get_weights_oc_block() const {
+dim_t jit_brgemm_primitive_conf_t::get_weights_oc_block() const {
     using namespace format_tag;
 
     assert(wei_tag != undef && "Weights tag not defined!");

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -30,15 +30,15 @@ struct jit_brgemm_primitive_conf_t {
     conv_harness_t harness;
     int simd_w;
     int ndims;
-    int mb, os;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id = 1, ih = 1, iw = 1;
-    int od = 1, oh = 1, ow = 1;
-    int kd = 1, kh = 1, kw = 1;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t mb, os;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id = 1, ih = 1, iw = 1;
+    dim_t od = 1, oh = 1, ow = 1;
+    dim_t kd = 1, kh = 1, kw = 1;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool is_wei_layout_any;
     bool with_bias;
@@ -46,14 +46,14 @@ struct jit_brgemm_primitive_conf_t {
     bool with_eltwise;
     bool with_binary;
     bool req_s8s8_compensation;
-    int nb_ic, ic_block, ic_block_ext;
-    int nb_oc, oc_block, oc_block_ext;
-    int nb_iw, iw_block;
-    int nb_ow, ow_block;
-    int nb_os, os_block;
-    int nb_oc_blocking;
-    int nb_ic_blocking;
-    int nb_os_blocking;
+    dim_t nb_ic, ic_block, ic_block_ext;
+    dim_t nb_oc, oc_block, oc_block_ext;
+    dim_t nb_iw, iw_block;
+    dim_t nb_ow, ow_block;
+    dim_t nb_os, os_block;
+    dim_t nb_oc_blocking;
+    dim_t nb_ic_blocking;
+    dim_t nb_os_blocking;
 
     data_type_t src_dt;
     data_type_t dst_dt;
@@ -73,9 +73,9 @@ struct jit_brgemm_primitive_conf_t {
     bool with_dst_scales;
     int is_oc_scale;
 
-    int LDA, LDB, LDC, LDD;
-    int M, N, K, M_tail, N_tail, K_tail;
-    int gemm_batch_size, adjusted_batch_size;
+    dim_t LDA, LDB, LDC, LDD;
+    dim_t M, N, K, M_tail, N_tail, K_tail;
+    dim_t gemm_batch_size, adjusted_batch_size;
     brgemm_batch_kind_t brg_type;
     int num_gemm_kernels;
     int nthr, nthr_mb, nthr_oc_b, nthr_ic_b;
@@ -88,10 +88,10 @@ struct jit_brgemm_primitive_conf_t {
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
 
     // Compute kernel-spatial dimension size.
-    int ks() const;
+    dim_t ks() const;
 
     // Compute foward weights oc-block.
-    int get_weights_oc_block() const;
+    dim_t get_weights_oc_block() const;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -83,7 +83,7 @@ struct jit_brgemm_primitive_conf_t {
     cpu_isa_t isa;
     bool use_uker;
     bool use_interleave_stores;
-    int amx_buf_size_per_thread;
+    dim_t amx_buf_size_per_thread;
     brgemm_kernel_prefetching_t hint_prefetching
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -19,6 +19,7 @@
 
 #include <limits.h>
 #include <vector>
+#include <type_traits>
 
 #include "common/bit_cast.hpp"
 #include "common/compiler_workarounds.hpp"
@@ -68,6 +69,11 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace x64 {
+
+// Required so XBYAK_THROW's unqualified 'Error' resolves in this namespace.
+#ifndef XBYAK_NO_EXCEPTION
+using Xbyak::Error;
+#endif
 
 // TODO: move this to jit_generator_t class?
 namespace {
@@ -194,6 +200,73 @@ public:
         _op_floor = 1u,
         _op_mxcsr = 4u,
     };
+
+    using Xbyak::CodeGenerator::add;
+    using Xbyak::CodeGenerator::cmp;
+    using Xbyak::CodeGenerator::imul;
+    using Xbyak::CodeGenerator::shl;
+    using Xbyak::CodeGenerator::sub;
+
+    // These are the dim_t immediate forms used by brgemm. x86 accepts at
+    // most a 32-bit immediate. Offsets and shifts are non-negative; cmp also
+    // supports the verified negative-vpad case.
+    // TODO: Use a scratch register or rebase a pointer for values > INT_MAX.
+    // Note: the enable_if constrains this to T == dim_t exactly, so int/
+    // uint32_t call sites keep resolving to the native Xbyak overloads above
+    // instead of becoming ambiguous with these dim_t ones.
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void add(const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::add(op, static_cast<uint32_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void sub(const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::sub(op, static_cast<uint32_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void cmp(const Xbyak::Operand &op, T imm) {
+        // Negative virtual padding is compared by brgemm kernels.
+        JIT_ASSERT(imm >= INT_MIN && imm <= INT_MAX);
+        Xbyak::CodeGenerator::cmp(
+                op, static_cast<uint32_t>(static_cast<int32_t>(imm)));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void shl(const Xbyak::Operand &op, T count) {
+        JIT_ASSERT(count >= 0 && count <= UINT8_MAX);
+        Xbyak::CodeGenerator::shl(op, static_cast<int>(count));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void imul(const Xbyak::Reg64 &dst, const Xbyak::Operand &src, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
+    }
+
+    static int xbyak_register_index(dim_t index) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        return static_cast<int>(index);
+    }
+
+    static int xbyak_address_scale(dim_t scale) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(utils::one_of(scale, 1, 2, 4, 8), 0);
+        return static_cast<int>(scale);
+    }
 
     Xbyak::Reg64 param1 = abi_param1;
     const int EVEX_max_8b_offt = 0x200;
@@ -2218,7 +2291,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Address &src_addr,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2227,7 +2300,7 @@ public:
             return;
         }
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[src_addr.getRegExp()
                     + Xbyak::RegExp(bytes_offset * sizeof(int8_t))];
         };
@@ -2237,7 +2310,7 @@ public:
 
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2249,7 +2322,7 @@ public:
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[reg + offset + bytes_offset * sizeof(int8_t)];
         };
 
@@ -2258,8 +2331,8 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void helper_load_bytes(const Vmm &vmm, int load_size, const AddrFunc &addr,
-            const bool zero_vmm = true) {
+    void helper_load_bytes(const Vmm &vmm, dim_t load_size,
+            const AddrFunc &addr, const bool zero_vmm = true) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2291,8 +2364,8 @@ private:
         // use clean execution sequence
         if (zero_vmm) uni_vpxor(vmm, vmm, vmm);
 
-        int start_bytes = 0;
-        int bytes_to_load = load_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_load = load_size;
 
         if (load_size > 16) {
             // Prepare to insert to upper bits of ymm
@@ -2379,8 +2452,8 @@ private:
 public:
     template <typename Vmm>
     void store_bytes(
-            const Vmm &vmm, const Xbyak::Address &dst_addr, int store_size) {
-        const auto addr = [&](int bytes_offset) {
+            const Vmm &vmm, const Xbyak::Address &dst_addr, dim_t store_size) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[dst_addr.getRegExp()
                     + Xbyak::RegExp(bytes_offset * sizeof(int8_t))];
         };
@@ -2389,12 +2462,12 @@ public:
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int store_size) {
+            dim_t store_size) {
 
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[reg + offset + bytes_offset * sizeof(int8_t)];
         };
 
@@ -2403,7 +2476,7 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void store_bytes(const Vmm &vmm, int store_size, const AddrFunc &addr) {
+    void store_bytes(const Vmm &vmm, dim_t store_size, const AddrFunc &addr) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2433,8 +2506,8 @@ private:
             return;
         }
 
-        int start_bytes = 0;
-        int bytes_to_store = store_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_store = store_size;
 
         if (store_size > 16) {
             vmovdqu(addr(0), xmm); // load lower bits from ymm
@@ -2517,7 +2590,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, bool is_signed, int load_size,
+            int64_t offset, bool is_signed, dim_t load_size,
             const bool zero_vmm) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2527,7 +2600,7 @@ public:
 
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm,
-            const Xbyak::Address &src_addr, bool is_signed, int load_size,
+            const Xbyak::Address &src_addr, bool is_signed, dim_t load_size,
             const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
@@ -2587,7 +2660,7 @@ public:
      */
     template <typename Vmm>
     void store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
         using supported_vmm_t = typename utils::conditional<is_vmm_supported,
@@ -2604,7 +2677,7 @@ public:
 private:
     template <typename Vmm>
     void helper_store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
 
         assert(is_valid_isa(sse41)
                 && "routine is not supported for the current isa");
@@ -2664,7 +2737,7 @@ public:
      */
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, int load_size, const bool zero_vmm = true) {
+            int64_t offset, dim_t load_size, const bool zero_vmm = true) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
         load_data(type_in, vmm, ptr[reg + offset], load_size, zero_vmm);
@@ -2672,7 +2745,7 @@ public:
 
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm,
-            const Xbyak::Address &src_addr, int load_size,
+            const Xbyak::Address &src_addr, dim_t load_size,
             const bool zero_vmm = true) {
 
         assert(is_valid_isa(sse41)

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -78,12 +78,19 @@ inline int float2int(float x) {
     return utils::bit_cast<int>(x);
 }
 
-inline void tc_configure_tile(palette_config_t *tc, int t, int rows, int cols) {
-    const bool rows_ok = (size_t)t < sizeof(tc->rows) / sizeof(tc->rows[0]);
-    const bool cols_ok = (size_t)t < sizeof(tc->cols) / sizeof(tc->cols[0]);
-    if (rows_ok && cols_ok) {
-        tc->rows[t] = rows;
-        tc->cols[t] = cols;
+inline void tc_configure_tile(
+        palette_config_t *tc, dim_t t, dim_t rows, dim_t cols) {
+    // AMX tile config is a fixed hardware register layout (tile index
+    // bounded by palette_config_t::max_size, uint8_t rows, uint16_t cols)
+    // - narrowing here is unavoidable, so it's consolidated in this single
+    // boundary helper with bounds checks, rather than scattered across
+    // call sites.
+    const bool idx_ok = t >= 0 && t < palette_config_t::max_size;
+    const bool rows_ok = rows >= 0 && rows <= UINT8_MAX;
+    const bool cols_ok = cols >= 0 && cols <= UINT16_MAX;
+    if (idx_ok && rows_ok && cols_ok) {
+        tc->rows[t] = static_cast<uint8_t>(rows);
+        tc->cols[t] = static_cast<uint16_t>(cols);
     } else {
         assert(!"out of range");
     }

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -204,8 +204,14 @@ public:
     using Xbyak::CodeGenerator::add;
     using Xbyak::CodeGenerator::cmp;
     using Xbyak::CodeGenerator::imul;
+    using Xbyak::CodeGenerator::pextrb;
+    using Xbyak::CodeGenerator::pinsrb;
     using Xbyak::CodeGenerator::shl;
     using Xbyak::CodeGenerator::sub;
+    using Xbyak::CodeGenerator::vpblendd;
+    using Xbyak::CodeGenerator::vpermq;
+    using Xbyak::CodeGenerator::vpextrb;
+    using Xbyak::CodeGenerator::vpinsrb;
 
     // These are the dim_t immediate forms used by brgemm. x86 accepts at
     // most a 32-bit immediate. Offsets and shifts are non-negative; cmp also
@@ -256,9 +262,66 @@ public:
         Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
     }
 
+    // dim_t forms of the 8-bit-immediate emit methods, so kernels can pass
+    // dim_t lane indices / blend masks directly. The narrowing to uint8_t and
+    // the bounds check are consolidated here at the XByak boundary.
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void pinsrb(const Xbyak::Xmm &xmm, const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::pinsrb(xmm, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void pextrb(const Xbyak::Operand &op, const Xbyak::Xmm &xmm, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::pextrb(op, xmm, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpinsrb(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
+            const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpinsrb(x1, x2, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpextrb(const Xbyak::Operand &op, const Xbyak::Xmm &x, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpextrb(op, x, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpermq(const Xbyak::Ymm &y, const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpermq(y, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vpblendd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
+            const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vpblendd(x1, x2, op, static_cast<uint8_t>(imm));
+    }
+
     static int xbyak_register_index(dim_t index) {
-        // The fallback is returned only after XByak records the error.
-        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        // The fallback is returned only after XByak records the error,
+        // INT_MIN is used, because some primitives(e.g. pooling)
+        // are creating registers with invlid index, but never uses it,
+        // currently those objects are gracefully die without assertion.
+        // TODO: refactor pooling primitive in order to follow the contract.
+        JIT_ASSERT_RET(index >= INT_MIN && index <= INT_MAX, 0);
         return static_cast<int>(index);
     }
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -208,6 +208,7 @@ public:
     using Xbyak::CodeGenerator::pinsrb;
     using Xbyak::CodeGenerator::shl;
     using Xbyak::CodeGenerator::sub;
+    using Xbyak::CodeGenerator::vcmpps;
     using Xbyak::CodeGenerator::vpblendd;
     using Xbyak::CodeGenerator::vpermq;
     using Xbyak::CodeGenerator::vpextrb;
@@ -313,6 +314,15 @@ public:
             const Xbyak::Operand &op, T imm) {
         JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
         Xbyak::CodeGenerator::vpblendd(x1, x2, op, static_cast<uint8_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void vcmpps(const Xbyak::Opmask &k, const Xbyak::Xmm &x,
+            const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= UINT8_MAX);
+        Xbyak::CodeGenerator::vcmpps(k, x, op, static_cast<uint8_t>(imm));
     }
 
     static int xbyak_register_index(dim_t index) {

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -844,7 +844,7 @@ struct jit_brgemm_conv_conf_t {
 
     int max_batch;
     int max_vpad;
-    int amx_buf_size_per_thread;
+    dim_t amx_buf_size_per_thread;
 
     bool wei_plain;
     bool is_rd_padded_to_block {false}, is_rd_padded_to_vnni {false},

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -261,12 +261,14 @@ struct jit_conv_conf_t {
 };
 
 // calculates filter size taking into account dilation
-inline int calculate_extended_filter_size(int filter_size, int dilation) {
+template <typename T>
+T calculate_extended_filter_size(T filter_size, T dilation) {
     return (filter_size - 1) * (dilation + 1) + 1;
 }
 
-inline int calculate_end_padding(int start_padding, int dst_size, int src_size,
-        int spatial_stride, int dilated_filter_size) {
+template <typename T>
+T calculate_end_padding(T start_padding, T dst_size, T src_size,
+        T spatial_stride, T dilated_filter_size) {
     return (dst_size - 1) * spatial_stride + dilated_filter_size
             - (src_size + start_padding);
 }
@@ -555,11 +557,11 @@ struct jit_1x1_conv_args_t {
 
 struct jit_pool_conf_t {
     int ndims;
-    int mb, c, c_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int stride_d, stride_h, stride_w;
-    int kd, kh, kw;
-    int f_pad, t_pad, l_pad;
+    dim_t mb, c, c_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t kd, kh, kw;
+    dim_t f_pad, t_pad, l_pad;
     alg_kind_t alg;
     bool is_training;
     bool pad_w_is_null;
@@ -568,10 +570,10 @@ struct jit_pool_conf_t {
     bool is_c_padded;
     data_type_t ind_dt;
 
-    int c_block, c_tail, nb_c;
-    int ur_bc, ur_bc_tail;
-    int ur_c, ur_c_tail;
-    int ur;
+    dim_t c_block, c_tail, nb_c;
+    dim_t ur_bc, ur_bc_tail;
+    dim_t ur_c, ur_c_tail;
+    dim_t ur;
     size_t tail[4];
     bool safe_c_tail;
     data_type_t src_dt;

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -32,8 +32,8 @@ static bcast_set_t get_supported_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc};
 }
 
-static inline dim_t get_offset(
-        const memory_desc_wrapper &mdw, int n, int c, int d, int h, int w) {
+static inline dim_t get_offset(const memory_desc_wrapper &mdw, dim_t n, dim_t c,
+        dim_t d, dim_t h, dim_t w) {
     switch (mdw.ndims()) {
         case 3: return mdw.blk_off(n, c, w);
         case 4: return mdw.blk_off(n, c, h, w);
@@ -70,9 +70,9 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_i8i8_pooling_fwd_ker_t)
 
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    Xmm xreg(int idx) const { return Xmm(idx); }
-    Ymm yreg(int idx) const { return Ymm(xreg(idx).getIdx()); }
-    Vmm vreg(int idx) const { return Vmm(xreg(idx).getIdx()); }
+    Xmm xreg(dim_t idx) const { return Xmm(xbyak_register_index(idx)); }
+    Ymm yreg(dim_t idx) const { return Ymm(xreg(idx).getIdx()); }
+    Vmm vreg(dim_t idx) const { return Vmm(xreg(idx).getIdx()); }
 
     // In case of avx2 with data type i8 we need to use
     // maskmovdqu and maskmovq instructions which has its destination hardcoded in rdi.
@@ -105,7 +105,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
 
     Opmask k_cmp_mask = Opmask(7);
 
-    Opmask mask(int idx) { return Opmask(6 - idx); }
+    Opmask mask(dim_t idx) { return Opmask(xbyak_register_index(6 - idx)); }
 
     // ref to any of XYZ-regs via xreg/yreg/vreg functions
     Xmm xmm_tmp = xreg(0); // temp to init vreg_tmp
@@ -143,15 +143,17 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     //"avg" pool uses more registers for unrolling.
     enum : int { avg_vidx_base = utils::one_of(isa, sse41, avx2) ? 4 : 2 };
 
-    Vmm max_base_vr(int idx) const { return vreg(max_vidx_base + idx); }
-    Vmm avg_base_vr(int idx) const { return vreg(avg_vidx_base + idx); }
+    Vmm max_base_vr(dim_t idx) const { return vreg(max_vidx_base + idx); }
+    Vmm avg_base_vr(dim_t idx) const { return vreg(avg_vidx_base + idx); }
 
     size_t sizeof_src_dt() const { return data_type_size(jpp.src_dt); }
     size_t sizeof_dst_dt() const { return data_type_size(jpp.dst_dt); }
 
     /* max pooling */
-    Vmm vreg_src(int idx) const { return max_base_vr(idx); } // [0    .. ur_c-1]
-    Vmm vreg_dst(int idx) const {
+    Vmm vreg_src(dim_t idx) const {
+        return max_base_vr(idx);
+    } // [0    .. ur_c-1]
+    Vmm vreg_dst(dim_t idx) const {
         return max_base_vr(jpp.ur_c + idx);
     } // [ur_c .. 2*ur_c-1]
 
@@ -166,7 +168,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
         mmx_msk_base_reg = 3
     };
 
-    inline size_t get_offset_dst(int jj, int ll) const {
+    inline size_t get_offset_dst(dim_t jj, dim_t ll) const {
         size_t offset = 0;
         switch (jpp.alg) {
             case pooling_max: {
@@ -184,20 +186,20 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
         return offset;
     }
 
-    Vmm vreg_src_s32(int jj, int ll) {
+    Vmm vreg_src_s32(dim_t jj, dim_t ll) {
         return avg_base_vr(3 * max_num_ll * jj + ll + 0 * max_num_ll);
     } // ll: 0..4 [0..3]
 
-    Vmm vreg_dst_s32(int jj, int ll) {
+    Vmm vreg_dst_s32(dim_t jj, dim_t ll) {
         return avg_base_vr(3 * max_num_ll * jj + ll + 1 * max_num_ll);
     } // ll: 0..4 [4..7]
 
-    Vmm vreg_dst_f32(int jj, int ll) {
+    Vmm vreg_dst_f32(dim_t jj, dim_t ll) {
         return avg_base_vr(3 * max_num_ll * jj + ll + 2 * max_num_ll);
     } // ll: 0..4 [8..11]
 
-    Mmx mmx_mask(int ll) {
-        return Mmx(mmx_msk_base_reg + ll);
+    Mmx mmx_mask(dim_t ll) {
+        return Mmx(xbyak_register_index(mmx_msk_base_reg + ll));
     } // ll: 0..4 [Mmx(2)...Mmx(5)]
 
     static status_t init_post_ops_conf(jit_pool_conf_t &jpp,
@@ -206,24 +208,24 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     void init_tmp_reg();
     void init_mask();
 
-    void load_vreg_mask_q(int ll) {};
+    void load_vreg_mask_q(dim_t ll) {};
 
     void load_src_max_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
     void load_src_avg_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void load_src(int jj, int ll, int c_tail);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
+    void load_src(dim_t jj, dim_t ll, dim_t c_tail);
 
     void store_dst_max_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
     void store_dst_avg_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void store_dst(int jj, int ll, int c_tail);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
+    void store_dst(dim_t jj, dim_t ll, dim_t c_tail);
 
-    void compute_avg_step(int ur_c, int c_tail);
-    void compute_max_op(const int jj);
-    void compute_max_step(int ur_c, int c_tail);
-    void compute_step(int ur_c, int c_tail);
+    void compute_avg_step(dim_t ur_c, dim_t c_tail);
+    void compute_max_op(const dim_t jj);
+    void compute_max_step(dim_t ur_c, dim_t c_tail);
+    void compute_step(dim_t ur_c, dim_t c_tail);
 
     void compute_c_block();
     void generate() override;
@@ -272,14 +274,14 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
 };
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_vreg_mask_q(int ll) {};
+void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_vreg_mask_q(dim_t ll) {};
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(int ll) {
+void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(dim_t ll) {
 
     // extract ll-th part of mask (ll-th QWORD)
     vpblendd(vreg_mask_q, vreg_zeros, vreg_mask,
-            0x3 << 2 * ll); // 0x3 - mask for 2 x DWORD
+            static_cast<dim_t>(0x3) << 2 * ll); // 0x3 - mask for 2 x DWORD
 
     // Move mask from ll-th pos to 0-th pos
     if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, ll);
@@ -287,7 +289,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(int ll) {
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -297,7 +299,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
                         ptr[aux_reg_src_w + offset + i * data_type_size(s32)],
                         i);
         else
-            for (int i = 0; i < jpp.c_tail; i++)
+            for (dim_t i = 0; i < jpp.c_tail; i++)
                 pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i], i);
     } else
         movups(vreg_src(jj), ptr[aux_reg_src_w + offset]);
@@ -305,7 +307,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -318,7 +320,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
             // Example:  idx=[31..0]
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
-            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen
+                    - static_cast<uint8_t>(jpp.c_tail);
 
             if (jpp.safe_c_tail) {
 
@@ -361,7 +364,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -375,7 +378,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     const Vmm &vr_src = vreg_src_s32(jj, ll);
@@ -391,7 +394,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
     } else if (utils::one_of(jpp.src_dt, s8, u8)) {
         if (masked) {
             const int copy_range = math::ilog2q(jpp.tail[ll] + 1);
-            for (int i = 0; i < copy_range; i++)
+            for (dim_t i = 0; i < copy_range; i++)
                 pinsrb(vr_src, ptr[aux_reg_src_w + offset + i], i);
 
             if (jpp.src_dt == s8)
@@ -410,7 +413,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     auto load_i8 = [&](bool is_signed, const Vmm &vr_src) {
@@ -427,13 +430,14 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
             // Re-purposing vreg_zeros here. Set it back to zero immmediately.
-            const int msk_gran = cpu_isa_traits_t<avx2>::vlen
+            const dim_t msk_gran = cpu_isa_traits_t<avx2>::vlen
                     / data_type_size(avg_proc_dt);
 
             const uint8_t shift = cpu_isa_traits_t<avx2>::vlen
                     - (jpp.c_tail > (ll + 1) * msk_gran
-                                    ? msk_gran
-                                    : jpp.c_tail - (ll * msk_gran));
+                                    ? static_cast<uint8_t>(msk_gran)
+                                    : static_cast<uint8_t>(
+                                              jpp.c_tail - (ll * msk_gran)));
             if (jpp.safe_c_tail) {
                 /* load src_tail at 'src_address - shift' so that it does not
                  * spill over the memory boundary */
@@ -500,7 +504,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     const Vmm &vr_src
@@ -515,11 +519,12 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_avg_op(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(
+        dim_t jj, dim_t ll, dim_t c_tail) {
     using namespace data_type;
 
-    int c_block = jpp.c_block;
-    int ur_c = jpp.ur_c;
+    const auto c_block = jpp.c_block;
+    const auto ur_c = jpp.ur_c;
 
     switch (jpp.alg) {
         case pooling_max: {
@@ -542,7 +547,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -551,7 +556,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
                         vreg_dst(jj), i);
         else if (utils::one_of(jpp.src_dt, u8, s8))
-            for (int i = 0; i < jpp.c_tail; i++)
+            for (dim_t i = 0; i < jpp.c_tail; i++)
                 pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj), i);
         else
             assert(!"unsupported src data type");
@@ -561,15 +566,16 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     Label store_data_safely, done;
 
-    int c_block = jpp.c_block;
+    const auto c_block = jpp.c_block;
 
     const uint64_t low_mask = (1ULL << (c_block / 2)) - 1;
-    const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+    const uint8_t shift
+            = cpu_isa_traits_t<avx2>::vlen - static_cast<uint8_t>(jpp.c_tail);
 
     if (masked) {
         switch (jpp.src_dt) {
@@ -633,7 +639,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -653,7 +659,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -678,7 +684,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
         const int copy_range = masked
                 ? math::ilog2q(jpp.tail[ll] + 1)
                 : cpu_isa_traits_t<sse41>::vlen / data_type_size(avg_proc_dt);
-        for (int i = 0; i < copy_range; i++)
+        for (dim_t i = 0; i < copy_range; i++)
             pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, i);
     } else
         assert(!"unsupported src data type");
@@ -686,7 +692,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -735,14 +741,15 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
         // mmx_full_msk - mask for all 8 bytes in zero-tail case
         // mmx_mask(ll) - ll-th mask of tail in non-zero-tail case
 
-        const int msk_gran
+        const dim_t msk_gran
                 = cpu_isa_traits_t<avx2>::vlen / data_type_size(avg_proc_dt);
 
-        const int ll_end = (ll + 1) * msk_gran; // ((ll + 1) * 8)
+        const dim_t ll_end = (ll + 1) * msk_gran; // ((ll + 1) * 8)
 
         if (is_masked && (ll_end > jpp.c_tail)) { //implies this tail not full.
             Label store_data_safely, done;
-            const uint8_t shift = msk_gran - jpp.c_tail % msk_gran;
+            const uint8_t shift
+                    = static_cast<uint8_t>(msk_gran - (jpp.c_tail % msk_gran));
 
             if (!jpp.safe_c_tail) {
                 cmp(reg_ptr_maskmovdqu_dst, reg_dst_safe_access);
@@ -786,7 +793,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -805,11 +812,11 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
 
 template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::store_dst(
-        int jj, int ll, int c_tail) {
+        dim_t jj, dim_t ll, dim_t c_tail) {
     using namespace data_type;
 
-    int c_block = jpp.c_block;
-    int ur_c = jpp.ur_c;
+    const auto c_block = jpp.c_block;
+    const auto ur_c = jpp.ur_c;
 
     switch (jpp.alg) {
         case pooling_max: {
@@ -831,7 +838,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::store_dst(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::compute_max_op(const int jj) {
+void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::compute_max_op(const dim_t jj) {
     using namespace data_type;
     switch (jpp.src_dt) {
         case s32: pmaxsd(vreg_dst(jj), vreg_src(jj)); break;
@@ -842,7 +849,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::compute_max_op(const int jj) {
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::compute_max_op(const int jj) {
+void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::compute_max_op(const dim_t jj) {
     using namespace data_type;
     switch (jpp.src_dt) {
         case s32: vpmaxsd(vreg_dst(jj), vreg_dst(jj), vreg_src(jj)); break;
@@ -853,7 +860,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::compute_max_op(const int jj) {
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::compute_max_op(const int jj) {
+void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::compute_max_op(
+        const dim_t jj) {
     using namespace data_type;
 
     // Compare
@@ -879,14 +887,14 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::compute_max_op(const int jj) {
 
 template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
-        int ur_c, int c_tail) {
+        dim_t ur_c, dim_t c_tail) {
     Label l_kd, l_kh, l_kw;
 
-    int ih = jpp.ih;
-    int iw = jpp.iw;
-    int c = jpp.c;
+    const auto ih = jpp.ih;
+    const auto iw = jpp.iw;
+    const auto c = jpp.c;
 
-    for (int jj = 0; jj < ur_c; jj++)
+    for (dim_t jj = 0; jj < ur_c; jj++)
         uni_vmovups(vreg_dst(jj), vreg_tmp);
 
     mov(aux_reg_src_d, reg_ptr_src_i8);
@@ -901,7 +909,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
             xor_(reg_kw_index, reg_kw_index);
             L(l_kw);
             {
-                for (int jj = 0; jj < ur_c; jj++) {
+                for (dim_t jj = 0; jj < ur_c; jj++) {
                     load_src(jj, 0, c_tail);
                     compute_max_op(jj);
                 }
@@ -921,25 +929,25 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
         jl(l_kd, T_NEAR);
     }
 
-    for (int jj = 0; jj < ur_c; jj++)
+    for (dim_t jj = 0; jj < ur_c; jj++)
         store_dst(jj, 0, c_tail);
 }
 
 template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
-        int ur_c, int c_tail) {
+        dim_t ur_c, dim_t c_tail) {
     using namespace data_type;
 
     Label l_kd, l_kh, l_kw;
 
-    int ih = jpp.ih;
-    int iw = jpp.iw;
-    int c = jpp.c;
+    const auto ih = jpp.ih;
+    const auto iw = jpp.iw;
+    const auto c = jpp.c;
 
     const int num_ll = data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt);
 
-    for (int jj = 0; jj < ur_c; jj++) {
-        for (int ll = 0; ll < num_ll; ll++) {
+    for (dim_t jj = 0; jj < ur_c; jj++) {
+        for (dim_t ll = 0; ll < num_ll; ll++) {
             bool masked = jj == ur_c - 1 && c_tail;
             size_t msk = jpp.tail[ll];
             if (!(masked && !msk)) {
@@ -962,10 +970,10 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
             xor_(reg_kw_index, reg_kw_index);
             L(l_kw);
             {
-                for (int jj = 0; jj < ur_c; jj++) {
-                    for (int ll = 0; ll < num_ll; ll++) {
-                        bool masked = jj == ur_c - 1 && c_tail;
-                        size_t msk = jpp.tail[ll];
+                for (dim_t jj = 0; jj < ur_c; jj++) {
+                    for (dim_t ll = 0; ll < num_ll; ll++) {
+                        const bool masked = jj == ur_c - 1 && c_tail;
+                        const size_t msk = jpp.tail[ll];
                         if (!(masked && !msk)) {
                             load_src(jj, ll, c_tail);
                             uni_vpaddd(vreg_dst_s32(jj, ll),
@@ -989,8 +997,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
         jl(l_kd, T_NEAR);
     }
 
-    for (int jj = 0; jj < ur_c; jj++) {
-        for (int ll = 0; ll < num_ll; ll++) {
+    for (dim_t jj = 0; jj < ur_c; jj++) {
+        for (dim_t ll = 0; ll < num_ll; ll++) {
             const bool masked = jj == ur_c - 1 && c_tail;
             const size_t msk = jpp.tail[ll];
             if (!(masked && !msk)) {
@@ -1028,7 +1036,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_step(int ur_c, int c_tail) {
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_step(
+        dim_t ur_c, dim_t c_tail) {
     switch (jpp.alg) {
         case pooling_max: compute_max_step(ur_c, c_tail); break;
         case pooling_avg_include_padding:
@@ -1041,12 +1050,12 @@ template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_c_block() {
     Label l_main_loop;
 
-    int nb_c = jpp.nb_c;
-    int c_block = jpp.c_block;
-    int ur_c = jpp.ur_c;
-    int ur_c_tail = jpp.ur_c_tail;
-    int c_steps = nb_c / ur_c;
-    int c_tail = jpp.c_tail;
+    const auto nb_c = jpp.nb_c;
+    const auto c_block = jpp.c_block;
+    const auto ur_c = jpp.ur_c;
+    const auto ur_c_tail = jpp.ur_c_tail;
+    const auto c_steps = nb_c / ur_c;
+    const auto c_tail = jpp.c_tail;
 
     xor_(c_iter, c_iter);
     if (c_steps > 0) {
@@ -1122,7 +1131,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
             vinserti128(vreg_mask, vreg_mask, xreg_mask_hi, 1);
 
             // Compute mask algned to left from vreg_mask and store it in vreg_mask_2 to be use for tail processing.
-            const uint8_t shift = 32 - jpp.c_tail;
+            const uint8_t shift = 32 - static_cast<uint8_t>(jpp.c_tail);
             vperm2i128(vreg_mask_2, vreg_mask, vreg_mask, 0x08);
             if (shift <= 16) {
                 vpalignr(vreg_mask_2, vreg_mask, vreg_mask_2, 16 - shift);
@@ -1152,7 +1161,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
         }
     };
 
-    uint64_t tail_mask = (1ULL << jpp.c_tail) - 1;
+    const uint64_t tail_mask = (1ULL << jpp.c_tail) - 1;
     switch (jpp.alg) {
         case pooling_max:
             // For "max" we need mask only in case of non-zero tail
@@ -1302,11 +1311,11 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
     jpp.t_pad = is_1d ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
 
-    int back_pad = calculate_end_padding(
+    const auto back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
-    int bottom_pad = calculate_end_padding(
+    const auto bottom_pad = calculate_end_padding(
             jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
-    int right_pad = calculate_end_padding(
+    const auto right_pad = calculate_end_padding(
             jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
 
     VDISPATCH_POOLING_IC(

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -367,11 +367,11 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
     jpp.t_pad = (ndims == 3) ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
 
-    const int back_pad = calculate_end_padding(
+    const auto back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
-    const int bottom_pad = calculate_end_padding(
+    const auto bottom_pad = calculate_end_padding(
             jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
-    const int right_pad = calculate_end_padding(
+    const auto right_pad = calculate_end_padding(
             jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
 
     VDISPATCH_POOLING_IC(
@@ -425,13 +425,15 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
 
     // select jpp.ur_bc
     if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
-        auto min_ur_w = nstl::max(1, utils::div_up(jpp.l_pad, jpp.stride_w));
-        int min_ur_w1 = utils::div_up(nstl::max(0, right_pad), jpp.stride_w);
+        auto min_ur_w
+                = nstl::max(dim_t(1), utils::div_up(jpp.l_pad, jpp.stride_w));
+        auto min_ur_w1
+                = utils::div_up(nstl::max(dim_t(0), right_pad), jpp.stride_w);
         if (min_ur_w < min_ur_w1) { min_ur_w = min_ur_w1; }
-        jpp.ur_bc = nstl::min(jpp.nb_c, nstl::max(1, jpp.ur / min_ur_w));
+        jpp.ur_bc = nstl::min(jpp.nb_c, nstl::max(dim_t(1), jpp.ur / min_ur_w));
         //take into account threading - to have enough work for parallelization
         float best_eff = 0;
-        for (int ur_bc = jpp.ur_bc; ur_bc > 0; ur_bc--) {
+        for (dim_t ur_bc = jpp.ur_bc; ur_bc > 0; ur_bc--) {
 
             const auto nb2_c = utils::div_up(jpp.nb_c, ur_bc);
             auto work = jpp.is_backward
@@ -450,7 +452,8 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         //take into account cache re-usage after zeroing on backward
         if (jpp.is_backward && ndims < 5 && !jpp.needs_f32_accum_for_bf16) {
             const int L2 = platform::get_per_core_cache_size(2) / jpp.dt_size;
-            int ur_bc = nstl::max(1, L2 / (jpp.kh * jpp.iw * jpp.c_block));
+            auto ur_bc
+                    = nstl::max(dim_t(1), L2 / (jpp.kh * jpp.iw * jpp.c_block));
             jpp.ur_bc = nstl::min(jpp.ur_bc, ur_bc);
         }
 
@@ -469,7 +472,8 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         utils::array_copy(dims, src_d.dims(), ndims);
 
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
-        dims[0] = nstl::min(dnnl_get_max_threads(), jpp.mb * nb2_c);
+        const dim_t dnnl_max_threads = dnnl_get_max_threads();
+        dims[0] = nstl::min(dnnl_max_threads, jpp.mb * nb2_c);
         dims[1] = jpp.f32_accum_block_size;
 
         CHECK(memory_desc_init_by_tag(
@@ -485,7 +489,8 @@ void jit_uni_pool_kernel_t<isa>::init_scratchpad(
 
     // scratchpad for c_block slice of input and/or output
     using namespace memory_tracking::names;
-    const int nscr = nstl::min(dnnl_get_max_threads(), jpp.mb * jpp.nb_c);
+    const dim_t dnnl_max_threads = dnnl_get_max_threads();
+    const dim_t nscr = nstl::min(dnnl_max_threads, jpp.mb * jpp.nb_c);
     if (jpp.tag_kind == jit_memory_tag_kind_t::ncsp) {
         scratchpad.book(key_pool_src_plain2blocked_cvt,
                 static_cast<size_t>(jpp.c_block) * jpp.id * jpp.ih * jpp.iw
@@ -506,7 +511,8 @@ void jit_uni_pool_kernel_t<isa>::init_scratchpad(
     }
 }
 
-static int reg_ind(int shift, int bc, int j, int ur_bc, int ur_w) noexcept {
+static dim_t reg_ind(
+        dim_t shift, dim_t bc, dim_t j, dim_t ur_bc, dim_t ur_w) noexcept {
     return shift * ur_bc * ur_w + bc * ur_w + j;
 }
 
@@ -539,51 +545,53 @@ inline void jit_uni_pool_kernel_t<isa>::pop_vmm_val(const int idx) {
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::load(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
+        const dim_t idx, const reg64_t &reg_ptr, const dim_t offset,
         const bool is_c_tail_proccessing) {
-    io_[dt]->load(vmmword[reg_ptr + offset], Vmm(idx),
+    io_[dt]->load(vmmword[reg_ptr + offset], Vmm(xbyak_register_index(idx)),
             is_c_tail_proccessing && !jpp.is_c_padded);
 }
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::store(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
+        const dim_t idx, const reg64_t &reg_ptr, const dim_t offset,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing && jpp.is_c_padded && jpp.with_postops)
         pad_with_zeros(idx);
-    io_[dt]->store(Vmm(idx), vmmword[reg_ptr + offset],
+    io_[dt]->store(Vmm(xbyak_register_index(idx)), vmmword[reg_ptr + offset],
             is_c_tail_proccessing && !jpp.is_c_padded);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const int idx) {
+inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const dim_t idx) {
+    const int vidx = xbyak_register_index(idx);
     if (isa == sse41) {
         uni_vxorps(xmm_tmp_1, xmm_tmp_1, xmm_tmp_1);
         if (jpp.c_tail <= sse41_single_block_size && sse_high_half) {
-            uni_vmovups(Vmm(idx), xmm_tmp_1);
+            uni_vmovups(Vmm(vidx), xmm_tmp_1);
         } else if ((jpp.c_tail < sse41_single_block_size && !sse_high_half)
                 || (jpp.c_tail > sse41_single_block_size && sse_high_half)) {
             const auto c_tail = jpp.c_tail % sse41_single_block_size;
             std::bitset<8> tail_mask((1 << c_tail) - 1);
             tail_mask.flip();
-            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1, tail_mask.to_ulong());
+            const int tail_mask_val = static_cast<int>(tail_mask.to_ulong());
+            uni_vblendps(Vmm(vidx), Vmm(vidx), xmm_tmp_1, tail_mask_val);
         }
     } else if (isa == avx || isa == avx2) {
         uni_vxorps(ymm_tmp_1, ymm_tmp_1, ymm_tmp_1);
-        uni_vblendvps(Vmm(idx), ymm_tmp_1, Vmm(idx), vmm_c_tail_mask);
+        uni_vblendvps(Vmm(vidx), ymm_tmp_1, Vmm(vidx), vmm_c_tail_mask);
     } else
-        uni_vmovups(Vmm(idx) | k_c_tail_mask | T_z, Vmm(idx));
+        uni_vmovups(Vmm(vidx) | k_c_tail_mask | T_z, Vmm(vidx));
 }
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::load_indices(
-        const int indr_i, const int step_index, bool is_c_tail_processing) {
+        const dim_t indr_i, const dim_t step_index, bool is_c_tail_processing) {
     if (jpp.ind_dt == data_type::u8) {
         auto indvr = vreg(indr_i);
         auto indxr = xreg(indr_i);
         if (isa == sse41) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
-                for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
+                for (dim_t i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
                     pinsrb(indxr, ptr[reg_index + step_index + i], i);
             } else {
                 movd(indxr, ptr[reg_index + step_index]);
@@ -591,7 +599,7 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
             pmovzxbd(indvr, indxr);
         } else if (isa == avx || isa == avx2) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
-                for (int i = 0; i < jpp.c_tail; i++)
+                for (dim_t i = 0; i < jpp.c_tail; i++)
                     vpinsrb(indxr, indxr, ptr[reg_index + step_index + i], i);
             } else {
                 vmovq(indxr, ptr[reg_index + step_index]);
@@ -620,13 +628,13 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
-        const int step_index, const bool is_c_tail_processing,
+inline void jit_uni_pool_kernel_t<isa>::store_indices(const dim_t indr_i,
+        const dim_t step_index, const bool is_c_tail_processing,
         const bool is_first_w_block) {
     if (jpp.ind_dt == data_type::u8) {
         auto xr = xreg(indr_i);
         if (isa == sse41) {
-            for (int i = 0; i < (jpp.c_block / 2); ++i) {
+            for (dim_t i = 0; i < (jpp.c_block / 2); ++i) {
                 if (is_c_tail_processing
                         && i + (sse_high_half ? (jpp.c_block / 2) : 0)
                                 >= jpp.c_tail) {
@@ -645,10 +653,10 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
         } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
             auto yr = yreg(indr_i);
             if (is_c_tail_processing && !jpp.is_c_padded) {
-                const int max_nr_of_vals = jpp.c_tail > (jpp.c_block / 2)
+                const auto max_nr_of_vals = jpp.c_tail > (jpp.c_block / 2)
                         ? (jpp.c_block / 2)
                         : jpp.c_tail;
-                for (int i = 0; i < max_nr_of_vals; ++i) {
+                for (dim_t i = 0; i < max_nr_of_vals; ++i) {
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
@@ -658,7 +666,7 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                 if (jpp.c_tail > (jpp.c_block / 2)) {
                     Xmm higher_128bits(vmm_mask.getIdx());
                     vextractf128(higher_128bits, yr, 1);
-                    for (int i = 0; i < jpp.c_tail - (jpp.c_block / 2); ++i) {
+                    for (dim_t i = 0; i < jpp.c_tail - (jpp.c_block / 2); ++i) {
                         // bytes which should be stored are located in
                         // least significant bits(8 to be precise) of 32 bits parts
                         // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
@@ -746,17 +754,18 @@ bool jit_uni_pool_kernel_t<isa>::init_post_ops_conf(jit_pool_conf_t &jpp,
 }
 
 template <cpu_isa_t isa>
-void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
-        const std::function<bool(int, bool)> &is_tail_predicate) {
+void jit_uni_pool_kernel_t<isa>::apply_postops(dim_t ur_bc, dim_t ur_w,
+        dim_t c_block,
+        const std::function<bool(dim_t, bool)> &is_tail_predicate) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
-    const int end_idx = vmm_idx_upper_bound() + 1;
-    const int start_idx = end_idx - (ur_bc * ur_w);
+    const auto end_idx = vmm_idx_upper_bound() + 1;
+    const auto start_idx = end_idx - (ur_bc * ur_w);
     const bool sse41_postops_disabled
             = isa == sse41 && disable_postops_when_sse_high_half_processed_;
     if (end_idx - start_idx == 0) return;
     if (jpp.with_binary && !sse41_postops_disabled) {
 
-        const int c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
+        const auto c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
                 ? jpp.c
                 : c_block;
 
@@ -766,8 +775,8 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
             add(tmp_gpr, ptr[reg_param + GET_OFF(dst_po_helper)]);
         }
 
-        for (int jj = 0; jj < ur_w; jj++) {
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t jj = 0; jj < ur_w; jj++) {
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
                 const auto vmm_idx
                         = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).getIdx();
 
@@ -792,15 +801,15 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
-        int jj, int ur_w, int pad_l, int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(dim_t jj,
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
     if (jpp.alg == pooling_avg_exclude_padding) {
-        int kw = jpp.kw;
-        int stride_w = jpp.stride_w;
+        auto kw = jpp.kw;
+        auto stride_w = jpp.stride_w;
 
-        int non_zero_kw = kw;
-        non_zero_kw -= nstl::max(0, pad_l - jj * stride_w);
-        non_zero_kw -= nstl::max(0, pad_r - (ur_w - 1 - jj) * stride_w);
+        auto non_zero_kw = kw;
+        non_zero_kw -= nstl::max(dim_t(0), pad_l - jj * stride_w);
+        non_zero_kw -= nstl::max(dim_t(0), pad_r - (ur_w - 1 - jj) * stride_w);
 
         if (non_zero_kw != prev_kw) {
             mov(tmp_gpr, float2int((float)non_zero_kw));
@@ -823,20 +832,20 @@ inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
-        int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::avg_step(dim_t ur_w, dim_t ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
 
-    auto iw = jpp.iw;
-    auto kw = jpp.kw;
-    auto stride_w = jpp.stride_w;
-    auto c_block = jpp.c_block;
-    auto dt_size = jpp.dt_size;
-    const int c_off
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto stride_w = jpp.stride_w;
+    const auto c_block = jpp.c_block;
+    const auto dt_size = jpp.dt_size;
+    const auto c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
     Label kd_label, kh_label;
 
     const auto is_tail_processing
-            = [&](int bc, bool process_with_postops = false) {
+            = [&](dim_t bc, bool process_with_postops = false) {
         if (isa == sse41 && (!jpp.is_c_padded || process_with_postops)) {
             return with_c_tail_proccessing && bc == (ur_bc - 1)
                     && ((jpp.c_tail > (jpp.c_block / 2) && sse_high_half)
@@ -846,11 +855,11 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
             return with_c_tail_proccessing && bc == (ur_bc - 1);
     };
 
-    for (int jj = 0; jj < ur_w; jj++) {
+    for (dim_t jj = 0; jj < ur_w; jj++) {
         if (jpp.is_backward)
             maybe_recalculate_divisor(
                     jj, ur_w, pad_l, pad_r, with_c_tail_proccessing);
-        for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t bci = 0; bci < ur_bc; bci++) {
             const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
             auto accvr = vreg(accr_i);
             if (jpp.is_backward) {
@@ -878,21 +887,22 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const auto jj_start
+                    = utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w);
+            const auto jj_end = ur_w
+                    - utils::div_up(nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w);
 
-            for_(int jj = jj_start; jj < jj_end; jj++)
-            for (int bci = 0; bci < ur_bc; bci++) {
+            for_(dim_t jj = jj_start; jj < jj_end; jj++)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                auto aux_input_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_input_offset >= iw * c_off) continue;
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
                 auto inpvr = vreg(inpr_i);
-                int aux_input_offset
-                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
-                if (aux_input_offset >= iw * c_off) continue;
-                int input_offset = dt_size * aux_input_offset;
+                auto input_offset = dt_size * aux_input_offset;
                 if (jpp.is_backward) {
                     load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
                             input_offset, is_tail_processing(bci));
@@ -922,10 +932,10 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     }
 
     if (!jpp.is_backward) {
-        for (int jj = 0; jj < ur_w; jj++) {
+        for (dim_t jj = 0; jj < ur_w; jj++) {
             maybe_recalculate_divisor(
                     jj, ur_w, pad_l, pad_r, with_c_tail_proccessing);
-            for (int bci = 0; bci < ur_bc; bci++) {
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
                 const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
                 const auto accvr = vreg(accr_i);
                 uni_vdivps(accvr, accvr, vmm_tmp);
@@ -935,8 +945,8 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
         if (jpp.with_postops)
             apply_postops(ur_bc, ur_w, c_block, is_tail_processing);
 
-        for (int jj = 0; jj < ur_w; jj++) {
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t jj = 0; jj < ur_w; jj++) {
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
                 const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
                 const auto output_offset
                         = dt_size * (jj * c_off + bci * c_block);
@@ -948,17 +958,17 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
-        int pad_l, int pad_r, bool with_c_tail_proccessing) {
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int stride_w = jpp.stride_w;
-    int c_block = jpp.c_block;
-    const int c_off
+inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(dim_t ur_w, dim_t ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto stride_w = jpp.stride_w;
+    const auto c_block = jpp.c_block;
+    const auto c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
     Label kd_label, kh_label;
 
-    auto is_tail_processing = [&](int bc, bool process_with_postops = false) {
+    auto is_tail_processing = [&](dim_t bc, bool process_with_postops = false) {
         if (isa == sse41 && (!jpp.is_c_padded || process_with_postops)) {
             return with_c_tail_proccessing && bc == (ur_bc - 1)
                     && ((jpp.c_tail > (jpp.c_block / 2) && sse_high_half)
@@ -972,8 +982,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     uni_vmovq(xmm_tmp, tmp_gpr);
     uni_vbroadcastss(vmm_tmp, xmm_tmp);
 
-    for_(int jj = 0; jj < ur_w; jj++)
-    for (int bci = 0; bci < ur_bc; bci++) {
+    for_(dim_t jj = 0; jj < ur_w; jj++)
+    for (dim_t bci = 0; bci < ur_bc; bci++) {
         const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
         uni_vmovups(accvr, vmm_tmp);
         if (jpp.is_training) {
@@ -998,22 +1008,23 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
-            for_(int jj = jj_start; jj < jj_end; jj++)
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const auto jj_start
+                    = utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w);
+            const auto jj_end = ur_w
+                    - utils::div_up(nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w);
+            for_(dim_t jj = jj_start; jj < jj_end; jj++)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                auto aux_input_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_input_offset >= iw * c_off) continue;
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
                 const auto indvr = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_input_offset
-                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
-                if (aux_input_offset >= iw * c_off) continue;
-                int input_offset = jpp.dt_size * aux_input_offset;
+                auto input_offset = jpp.dt_size * aux_input_offset;
                 load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input, input_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1083,8 +1094,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     if (jpp.with_postops)
         apply_postops(ur_bc, ur_w, c_block, is_tail_processing);
 
-    for_(int jj = 0; jj < ur_w; jj++)
-    for (int bci = 0; bci < ur_bc; bci++) {
+    for_(dim_t jj = 0; jj < ur_w; jj++)
+    for (dim_t bci = 0; bci < ur_bc; bci++) {
         const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
         const auto output_offset = jpp.dt_size * (jj * c_off + bci * c_block);
         const bool is_c_tail_processing = is_tail_processing(bci);
@@ -1104,16 +1115,16 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
-        int pad_l, int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(dim_t ur_w, dim_t ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
 
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int stride_w = jpp.stride_w;
-    int c_block = jpp.c_block;
-    const int output_c_off
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto stride_w = jpp.stride_w;
+    const auto c_block = jpp.c_block;
+    const auto output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
+    const auto input_c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : output_c_off;
     const auto input_dt
@@ -1124,7 +1135,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
 
     Label kd_label, kh_label;
 
-    const auto is_tail_processing = [&](int bc) {
+    const auto is_tail_processing = [&](dim_t bc) {
         if (isa == sse41) {
             return with_c_tail_proccessing && bc == (ur_bc - 1)
                     && ((jpp.c_tail > (jpp.c_block / 2) && sse_high_half)
@@ -1136,8 +1147,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
             return with_c_tail_proccessing && bc == (ur_bc - 1);
     };
 
-    for_(int jj = 0; jj < ur_w; jj++)
-    for (int bci = 0; bci < ur_bc; bci++) {
+    for_(dim_t jj = 0; jj < ur_w; jj++)
+    for (dim_t bci = 0; bci < ur_bc; bci++) {
         const auto outr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
         auto out_offset = output_dt_size * (jj * output_c_off + bci * c_block);
         const bool is_c_tail_processing = is_tail_processing(bci);
@@ -1167,22 +1178,23 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
-            for_(int jj = jj_start; jj < jj_end; jj++)
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const auto jj_start
+                    = utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w);
+            const auto jj_end = ur_w
+                    - utils::div_up(nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w);
+            for_(dim_t jj = jj_start; jj < jj_end; jj++)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                auto aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
+                        + bci * c_block;
+                if (aux_inp_offset >= iw * input_c_off) continue;
                 const auto outvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto indvr = vreg(reg_ind(1, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
-                        + bci * c_block;
-                if (aux_inp_offset >= iw * input_c_off) continue;
-                int inp_offset = input_dt_size * aux_inp_offset;
+                auto inp_offset = input_dt_size * aux_inp_offset;
                 load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1254,15 +1266,15 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
 
 template <cpu_isa_t isa>
 void jit_uni_pool_kernel_t<isa>::zero_diff_src(
-        int ur_bc, bool with_c_tail_proccessing) {
-    const int c_off = jpp.needs_f32_accum_for_bf16
+        dim_t ur_bc, bool with_c_tail_proccessing) {
+    const auto c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c
                                                              : jpp.c_block);
 
     Label l_skip, l_ih_loop, l_id_loop;
 
-    auto is_tail_processing = [&](int bc) {
+    auto is_tail_processing = [&](dim_t bc) {
         return with_c_tail_proccessing && bc == (ur_bc - 1);
     };
 
@@ -1282,7 +1294,7 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
     const auto src_dt
             = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
     const auto dt_size = types::data_type_size(src_dt);
-    const int width_size = jpp.iw * c_off * dt_size;
+    const dim_t width_size = jpp.iw * c_off * dt_size;
 
     auto aux_reg_zero_ptr = tmp_gpr;
 
@@ -1293,12 +1305,12 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         L(l_ih_loop);
         {
             const auto vlen = cpu_isa_traits_t<isa>::vlen;
-            const int step = c_off * dt_size;
+            const auto step = c_off * dt_size;
 
             // TODO: maybe a big code generated here
-            for_(int i = 0; i < width_size; i += step)
-            for (int bci = 0; bci < ur_bc; bci++) {
-                const int offs = i + bci * jpp.c_block * dt_size;
+            for_(dim_t i = 0; i < width_size; i += step)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                const auto offs = i + bci * jpp.c_block * dt_size;
                 if (isa == sse41) {
                     bool is_needed_c_tail_processing = false;
                     if (is_tail_processing(bci)
@@ -1338,16 +1350,16 @@ void jit_uni_pool_kernel_t<isa>::generate() {
 
     this->preamble();
 
-    int ow = jpp.ow;
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int kh = jpp.kh;
-    int c_block = jpp.c_block;
-    int stride_w = jpp.stride_w;
-    int l_pad = jpp.l_pad;
-    const int output_c_off
+    const auto ow = jpp.ow;
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto kh = jpp.kh;
+    const auto c_block = jpp.c_block;
+    const auto stride_w = jpp.stride_w;
+    const auto l_pad = jpp.l_pad;
+    const auto output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
+    const auto input_c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : output_c_off;
 
@@ -1368,7 +1380,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
     mov(reg_nbc, ptr[reg_param + GET_OFF(ur_bc)]);
 
     auto process_oi
-            = [&](int ur_w, int ur_bc, int lpad, int rpad,
+            = [&](dim_t ur_w, dim_t ur_bc, dim_t lpad, dim_t rpad,
                       bool with_c_tail_proccessing, bool inc_reg = true) {
         step(ur_w, ur_bc, lpad, rpad, with_c_tail_proccessing);
 
@@ -1400,7 +1412,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         auto output_dt_size = jpp.dt_size;
         auto shift = (isa == sse41) ? vlen : 0;
         add(reg_input,
-                input_dt_size * nstl::max(0, ur_w * stride_w - lpad)
+                input_dt_size * nstl::max(dim_t(0), ur_w * stride_w - lpad)
                                 * input_c_off
                         - shift);
         add(reg_output, output_dt_size * ur_w * output_c_off - shift);
@@ -1411,7 +1423,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         }
     };
 
-    auto perform_ker = [&](int ur_bc, bool with_c_tail_processing) {
+    auto perform_ker = [&](dim_t ur_bc, bool with_c_tail_processing) {
         prev_kw = 0; // re-initialize this value for avg steps
 
         if (jpp.is_backward && jpp.simple_alg)
@@ -1446,27 +1458,27 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             }
         }
 
-        const int ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
-        const int n_oi_iterations = utils::div_up(ow, ur_w);
-        const int ur_stride_w = ur_w * stride_w;
-        const int l_pad_iterations
+        const auto ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
+        const auto n_oi_iterations = utils::div_up(ow, ur_w);
+        const auto ur_stride_w = ur_w * stride_w;
+        const auto l_pad_iterations
                 = nstl::min(n_oi_iterations, utils::div_up(l_pad, ur_stride_w));
 
-        for (int i = 0; i < l_pad_iterations; ++i) {
-            const int ow_s = i * ur_w;
-            const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_l_pad = l_pad - i * ur_stride_w;
-            const int cur_r_pad = nstl::max(
-                    0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
-            const int cur_ur_w = ow_e - ow_s;
+        for (dim_t i = 0; i < l_pad_iterations; ++i) {
+            const auto ow_s = i * ur_w;
+            const auto ow_e = nstl::min(ow, ow_s + ur_w);
+            const auto cur_l_pad = l_pad - i * ur_stride_w;
+            const auto cur_r_pad = nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const auto cur_ur_w = ow_e - ow_s;
             process_oi(cur_ur_w, ur_bc, cur_l_pad, cur_r_pad,
                     with_c_tail_processing);
         }
 
-        const int rem_n_oi_iters = n_oi_iterations - l_pad_iterations;
-        const int cur_iw = l_pad_iterations * ur_stride_w - l_pad;
-        const int cur_iw_rightmost_idx = cur_iw + kw - 1;
-        const int no_pad_full_n_oi_iters = utils::saturate<int>(
+        const auto rem_n_oi_iters = n_oi_iterations - l_pad_iterations;
+        const auto cur_iw = l_pad_iterations * ur_stride_w - l_pad;
+        const auto cur_iw_rightmost_idx = cur_iw + kw - 1;
+        const dim_t no_pad_full_n_oi_iters = utils::saturate<dim_t>(
                 0, rem_n_oi_iters, (iw - cur_iw_rightmost_idx) / ur_stride_w);
 
         if (no_pad_full_n_oi_iters > 0) {
@@ -1483,13 +1495,13 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             }
         }
 
-        for (int i = l_pad_iterations + no_pad_full_n_oi_iters;
+        for (dim_t i = l_pad_iterations + no_pad_full_n_oi_iters;
                 i < n_oi_iterations; ++i) {
-            const int ow_s = i * ur_w;
-            const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_r_pad = nstl::max(
-                    0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
-            const int cur_ur_w = ow_e - ow_s;
+            const auto ow_s = i * ur_w;
+            const auto ow_e = nstl::min(ow, ow_s + ur_w);
+            const auto cur_r_pad = nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const auto cur_ur_w = ow_e - ow_s;
             process_oi(cur_ur_w, ur_bc, 0, cur_r_pad, with_c_tail_processing);
         }
     };

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -65,12 +65,21 @@ private:
         return is_superset(isa, avx512_core) ? 31 : 15;
     }
 
-    int reg_idx(int idx) const noexcept { return vmm_idx_upper_bound() - idx; }
+    // Maps a logical index to a physical XByak register index. The narrowing
+    // and bounds check are done by jit_generator's xbyak_register_index at the
+    // single register-construction boundary.
+    int reg_idx(dim_t idx) const noexcept {
+        // The pooling primitive creates out-of-bounds registers, but never
+        // use it.
+        // TODO: do the proper refactoring eliminating creating registers with
+        // invalid indices.
+        return xbyak_register_index(vmm_idx_upper_bound() - idx);
+    }
 
-    Xmm xreg(int idx) const noexcept { return Xmm(reg_idx(idx)); }
-    Ymm yreg(int idx) const noexcept { return Ymm(reg_idx(idx)); }
-    Zmm zreg(int idx) const noexcept { return Zmm(reg_idx(idx)); }
-    Vmm vreg(int idx) const noexcept { return Vmm(reg_idx(idx)); }
+    Xmm xreg(dim_t idx) const noexcept { return Xmm(reg_idx(idx)); }
+    Ymm yreg(dim_t idx) const noexcept { return Ymm(reg_idx(idx)); }
+    Zmm zreg(dim_t idx) const noexcept { return Zmm(reg_idx(idx)); }
+    Vmm vreg(dim_t idx) const noexcept { return Vmm(reg_idx(idx)); }
 
     const Xbyak::AddressFrame &vmmword = (isa == sse41)  ? xword
             : utils::one_of(isa, avx, avx2, avx2_vnni_2) ? yword
@@ -137,33 +146,34 @@ private:
     bool sse_high_half = false;
     bool disable_postops_when_sse_high_half_processed_ = false;
 
-    int prev_kw = 0;
+    dim_t prev_kw = 0;
 
     void put_one_in_vmm();
     void uni_broadcast_reg_val(const int reg_idx, const int vmm_idx);
     void push_vmm_val(const int idx);
     void pop_vmm_val(const int idx);
-    void load(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
-            const int offset, const bool is_c_tail_proccessing);
-    void store(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
-            const int offset, const bool is_c_tail_proccessing);
-    void pad_with_zeros(int idx);
-    void load_indices(int indr_i, int step_index, bool is_c_tail_processing);
-    void store_indices(int indr_i, int step_index, bool is_c_tail_processing,
-            bool is_first_w_block);
+    void load(const data_type_t dt, const dim_t idx, const reg64_t &reg_ptr,
+            const dim_t offset, const bool is_c_tail_proccessing);
+    void store(const data_type_t dt, const dim_t idx, const reg64_t &reg_ptr,
+            const dim_t offset, const bool is_c_tail_proccessing);
+    void pad_with_zeros(dim_t idx);
+    void load_indices(
+            dim_t indr_i, dim_t step_index, bool is_c_tail_processing);
+    void store_indices(dim_t indr_i, dim_t step_index,
+            bool is_c_tail_processing, bool is_first_w_block);
 
-    void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r,
+    void maybe_recalculate_divisor(dim_t jj, dim_t ur_w, dim_t pad_l,
+            dim_t pad_r, bool with_c_tail_proccessing);
+    void avg_step(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void avg_step(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void max_step_fwd(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void max_step_fwd(int ur_w, int ur_bc, int pad_l, int pad_r,
-            bool with_c_tail_proccessing);
-    void max_step_bwd(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void max_step_bwd(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
 
-    void zero_diff_src(int ur_bc, bool with_c_tail_proccessing);
+    void zero_diff_src(dim_t ur_bc, bool with_c_tail_proccessing);
 
-    void step(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void step(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing) {
         if (jpp.alg == alg_kind::pooling_max) {
             if (jpp.is_backward)
@@ -176,7 +186,7 @@ private:
             avg_step(ur_w, ur_bc, pad_l, pad_r, with_c_tail_proccessing);
     }
 
-    void step_high_half(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void step_high_half(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_processing) {
         add(reg_input, sizeof(float) * 4);
         add(reg_output, sizeof(float) * 4);
@@ -241,8 +251,8 @@ private:
         pcmpeqd(x0, x1);
     }
 
-    void apply_postops(int ur_bc, int ur_w, int c_block,
-            const std::function<bool(int, bool)> &is_tail_predicate);
+    void apply_postops(dim_t ur_bc, dim_t ur_w, dim_t c_block,
+            const std::function<bool(dim_t, bool)> &is_tail_predicate);
 
     static bool init_post_ops_conf(jit_pool_conf_t &jpp,
             const primitive_attr_t &attr, const memory_desc_wrapper &dst_d);

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -184,7 +184,7 @@ struct transpose_ncsp_to_block_fmt_t {
         , block_size_(block_size)
         , offset_multiplier_(offset_multiplier) {}
 
-    void operator()(std::size_t ithr, int n, int b_c) const {
+    void operator()(std::size_t ithr, dim_t n, dim_t b_c) const {
         const dim_t cs
                 = nstl::min(c_without_padding_ - b_c * c_block_, c_block_);
         const src_data_t *src_nscp = src_nscp_base_
@@ -199,8 +199,8 @@ struct transpose_ncsp_to_block_fmt_t {
 private:
     trans_wrapper_t *transposer_;
     trans_wrapper_t *transposer_tail_;
-    const int c_without_padding_;
-    const int c_block_;
+    const dim_t c_without_padding_;
+    const dim_t c_block_;
     const src_data_t *src_nscp_base_;
     const memory_desc_wrapper &src_nscp_desc_;
     dst_data_t *__restrict dst_blocked_base_;
@@ -241,8 +241,8 @@ struct transpose_block_fmt_to_ncsp_t {
 private:
     trans_wrapper_t *transposer_;
     trans_wrapper_t *transposer_tail_;
-    const int c_without_padding_;
-    const int c_block_;
+    const dim_t c_without_padding_;
+    const dim_t c_block_;
     const src_data_t *__restrict src_blocked_base_;
     const dim_t block_size_;
     dst_data_t *dst_ncsp_base_;
@@ -257,8 +257,8 @@ public:
             const memory_desc_wrapper &src_d, const memory_desc_wrapper &dst_d,
             const memory_desc_wrapper &indices_d, const char *indices,
             const data_type_t wsp_dt, const exec_ctx_t &ctx)
-        : src_sp_(static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw)
-        , dst_sp_(static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow)
+        : src_sp_(jpp.id * jpp.ih * jpp.iw)
+        , dst_sp_(jpp.od * jpp.oh * jpp.ow)
         , src_slice_(src_sp_ * jpp.c_block)
         , dst_slice_(dst_sp_ * jpp.c_block)
         , transpose_src_(jpp.tag_kind == jit_memory_tag_kind_t::ncsp)
@@ -292,40 +292,40 @@ public:
     inline bool should_transpose_dst() const noexcept { return transpose_dst_; }
 
     const void *get_src_addr(
-            std::size_t ithr, int ih, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t ih, const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
         return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block]);
     }
 
     const void *get_dst_addr(
-            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t oh, const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
         return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block]);
     }
 
     const void *get_indices_addr(
-            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t oh, const jit_pool_conf_t &jpp) const {
         const char *const wsp
                 = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
         return static_cast<const void *>(
                 &wsp[oh * jpp.ow * jpp.c_block * ind_dt_size_]);
     }
 
-    const void *get_src_addr_3d(std::size_t ithr, int id, int ih,
+    const void *get_src_addr_3d(std::size_t ithr, dim_t id, dim_t ih,
             const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
         return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block
                 + id * jpp.ih * jpp.iw * jpp.c_block]);
     }
 
-    const void *get_dst_addr_3d(std::size_t ithr, int od, int oh,
+    const void *get_dst_addr_3d(std::size_t ithr, dim_t od, dim_t oh,
             const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
         return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block
                 + od * jpp.oh * jpp.ow * jpp.c_block]);
     }
 
-    const void *get_indices_addr_3d(std::size_t ithr, int od, int oh,
+    const void *get_indices_addr_3d(std::size_t ithr, dim_t od, dim_t oh,
             const jit_pool_conf_t &jpp) const {
         const char *const wsp
                 = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
@@ -334,11 +334,11 @@ public:
                         + od * jpp.oh * jpp.ow * jpp.c_block * ind_dt_size_]);
     }
 
-    void execute_transpose_input(std::size_t ithr, int n, int b_c) const {
+    void execute_transpose_input(std::size_t ithr, dim_t n, dim_t b_c) const {
         execute_transpose_input_(ithr, n, b_c);
     }
 
-    void execute_transpose_output(std::size_t ithr, int n, int b_c) const {
+    void execute_transpose_output(std::size_t ithr, dim_t n, dim_t b_c) const {
         execute_transpose_output_(ithr, n, b_c);
     }
 
@@ -360,8 +360,8 @@ protected:
     wsp_data_t *__restrict cvt_slice_dst_wsp_;
     char *__restrict cvt_slice_ind_wsp_;
 
-    std::function<void(std::size_t, int, int)> execute_transpose_input_;
-    std::function<void(std::size_t, int, int)> execute_transpose_output_;
+    std::function<void(std::size_t, dim_t, dim_t)> execute_transpose_input_;
+    std::function<void(std::size_t, dim_t, dim_t)> execute_transpose_output_;
 };
 
 template <typename data_t, typename wsp_data_t, impl::data_type_t d_type>
@@ -554,8 +554,7 @@ void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_2d(int ithr, bfloat16_t *dst,
             cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
         } else {
             const auto c_b = jpp_.c_block * b_c;
-            const auto c_e = nstl::min(
-                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+            const auto c_e = nstl::min(jpp_.c, jpp_.c_block * (b_c + ur_bc));
 
             if (c_b >= c_e) return;
 
@@ -609,8 +608,7 @@ void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_3d(int ithr, bfloat16_t *dst,
                     dst + dst_d.blk_off(n), blk_data(ithr), nelems);
         } else {
             const auto c_b = jpp_.c_block * b_c;
-            const auto c_e = nstl::min(
-                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+            const auto c_e = nstl::min(jpp_.c, jpp_.c_block * (b_c + ur_bc));
 
             if (c_b >= c_e) return;
 
@@ -653,8 +651,8 @@ status_t jit_uni_pooling_fwd_t<isa, d_type>::init_ncsp_trans_ctx() {
 
     const auto &jpp = pd()->jpp_;
     trans_ctx_ = utils::make_unique<trans_context_t>();
-    const dim_t src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
-    const dim_t dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
+    const dim_t src_sp = jpp.id * jpp.ih * jpp.iw;
+    const dim_t dst_sp = jpp.od * jpp.oh * jpp.ow;
     const auto res = std::div(jpp.c_without_padding, jpp.c_block);
     const dim_t &nb_c = res.quot;
     const dim_t &c_tail = res.rem;
@@ -716,18 +714,18 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
     const auto trans_src = transpose_facade->should_transpose_src();
     const auto trans_dst = transpose_facade->should_transpose_dst();
 
-    const auto ker = [= COMPAT_THIS_CAPTURE](std::size_t ithr, int n, int b_c,
-                             int oh, int ur_bc) {
+    const auto ker = [= COMPAT_THIS_CAPTURE](std::size_t ithr, dim_t n,
+                             dim_t b_c, dim_t oh, dim_t ur_bc) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
-        const int c_off
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -768,8 +766,9 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         args.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
         args.kh_padding_shift = i_t_overflow * jpp.kw;
         args.ker_area_h = static_cast<float>(jpp.kh
-                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
-                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+                - nstl::max(dim_t(0),
+                        oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h));
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         args.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
@@ -782,7 +781,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         parallel_nd(jpp.mb, jpp.oh, nb2_c, [=](dim_t n, dim_t oh, dim_t b2_c) {
             const auto b_c = b2_c * jpp.ur_bc;
-            const auto ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+            const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
             ker(0, n, b_c, oh, ur_bc);
         });
     } else {
@@ -800,8 +799,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         } else {
             // nChw16c, nChw8c format
             parallel(nthr, [=](dim_t ithr, dim_t nthr) {
-                dim_t work_amount
-                        = static_cast<dim_t>(jpp.mb) * jpp.nb_c * jpp.oh;
+                dim_t work_amount = jpp.mb * jpp.nb_c * jpp.oh;
                 if (ithr >= work_amount) return;
 
                 dim_t start {0}, end {0};
@@ -848,18 +846,18 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
     const auto trans_src = transpose_facade->should_transpose_src();
     const auto trans_dst = transpose_facade->should_transpose_dst();
 
-    auto ker
-            = [= COMPAT_THIS_CAPTURE](int n, int b_c, int od, int oh, int id,
-                      int d_t_overflow, int d_b_overflow, int ur_bc, int ithr) {
+    auto ker = [= COMPAT_THIS_CAPTURE](dim_t n, dim_t b_c, dim_t od, dim_t oh,
+                       dim_t id, dim_t d_t_overflow, dim_t d_b_overflow,
+                       dim_t ur_bc, int ithr) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
-        const int c_off
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -900,15 +898,16 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         args.kh_padding_shift
                 = i_t_overflow * jpp.kw + d_t_overflow * jpp.kw * jpp.kh;
         args.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
-        args.ker_area_h = (float)(jpp.kh
-                                  - nstl::max(0,
-                                          oh * jpp.stride_h - jpp.t_pad + jpp.kh
-                                                  - jpp.ih)
-                                  - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+        args.ker_area_h
+                = (float)(jpp.kh
+                          - nstl::max(dim_t(0),
+                                  oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                          - jpp.ih)
+                          - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h))
                 * (jpp.kd
-                        - nstl::max(0,
+                        - nstl::max(dim_t(0),
                                 od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
-                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+                        - nstl::max(dim_t(0), jpp.f_pad - od * jpp.stride_d));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
@@ -922,13 +921,12 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         parallel_nd(jpp.mb, jpp.od, nb2_c, [=](dim_t n, dim_t od, dim_t b2_c) {
             const dim_t b_c = b2_c * jpp.ur_bc;
-            const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+            const dim_t ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
 
             const dim_t ik = od * jpp.stride_d;
             const dim_t d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
             const dim_t d_b_overflow
-                    = nstl::max(dim_t(jpp.id), ik + jpp.kd - jpp.f_pad)
-                    - jpp.id;
+                    = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
             const dim_t id = nstl::max(ik - jpp.f_pad, dim_t(0));
             for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                 ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, ur_bc,
@@ -938,18 +936,19 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
     } else {
         if (trans_src || trans_dst) {
             parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                    [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                    [=](int ithr, int nthr, dim_t n, dim_t b_c) {
                 if (trans_src)
                     transpose_facade->execute_transpose_input(ithr, n, b_c);
 
-                for (int od = 0; od < jpp.od; ++od) {
-                    const int ik = od * jpp.stride_d;
-                    const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-                    const int d_b_overflow
+                for (dim_t od = 0; od < jpp.od; ++od) {
+                    const auto ik = od * jpp.stride_d;
+                    const auto d_t_overflow
+                            = nstl::max(dim_t(0), jpp.f_pad - ik);
+                    const auto d_b_overflow
                             = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad)
                             - jpp.id;
-                    const int id = nstl::max(ik - jpp.f_pad, 0);
-                    for (int oh = 0; oh < jpp.oh; ++oh) {
+                    const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
+                    for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                         ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
                                 ithr);
                     }
@@ -961,12 +960,12 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         } else {
             parallel_nd(jpp.mb, jpp.nb_c, jpp.od,
                     [=](dim_t n, dim_t b_c, dim_t od) {
-                const int ik = od * jpp.stride_d;
-                const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-                const int d_b_overflow
+                const auto ik = od * jpp.stride_d;
+                const auto d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
+                const auto d_b_overflow
                         = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
-                const int id = nstl::max(ik - jpp.f_pad, 0);
-                for (int oh = 0; oh < jpp.oh; ++oh) {
+                const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
+                for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                     ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
                             first_ithr);
                 }
@@ -989,8 +988,8 @@ status_t jit_uni_pooling_bwd_t<isa, d_type>::init_ncsp_trans_ctx() {
 
     const auto &jpp = pd()->jpp_;
     trans_ctx_ = utils::make_unique<trans_context_t>();
-    const dim_t diff_src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
-    const dim_t diff_dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
+    const dim_t diff_src_sp = jpp.id * jpp.ih * jpp.iw;
+    const dim_t diff_dst_sp = jpp.od * jpp.oh * jpp.ow;
     const auto res = std::div(jpp.c_without_padding, jpp.c_block);
     const dim_t &nb_c = res.quot;
     const dim_t &c_tail = res.rem;
@@ -1055,19 +1054,21 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
 
     auto f32_accum = std::make_shared<bwd_f32_accum_for_bf16_t>(jpp, ctx);
 
-    auto get_first_ih = [=](int oh) {
-        return nstl::min(nstl::max(oh * jpp.stride_h - jpp.t_pad, 0), jpp.ih);
+    auto get_first_ih = [=](dim_t oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad, dim_t(0)), jpp.ih);
     };
 
-    auto get_last_ih = [=](int oh) {
+    auto get_last_ih = [=](dim_t oh) {
         return nstl::min(
-                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, dim_t(0)),
+                jpp.ih);
     };
-    const auto ker = [= COMPAT_THIS_CAPTURE](
-                             int ithr, int n, int b_c, int oh, int ur_bc) {
+    const auto ker = [= COMPAT_THIS_CAPTURE](int ithr, dim_t n, dim_t b_c,
+                             dim_t oh, dim_t ur_bc) {
         jit_uni_pooling_args_t args;
 
-        const int ih = get_first_ih(oh);
+        const auto ih = get_first_ih(oh);
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
         assert(pd()->ndims() != 3 || utils::everyone_is(0, ih, oh));
 
@@ -1095,8 +1096,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
             }
         }
 
-        const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
-        const int zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+        const auto zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+        const auto zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
 
         args.zero_id = 1;
         args.zero_ih = zero_ih_end - zero_ih_start;
@@ -1109,26 +1110,28 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
             args.zero_ptr
                     = &diff_src[diff_src_d.blk_off(n, c_off, zero_ih_start, 0)];
 
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - oh * jpp.stride_h);
-        const int i_b_overflow
+        const dim_t i_t_overflow
+                = nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h);
+        const dim_t i_b_overflow
                 = nstl::max(jpp.ih, oh * jpp.stride_h + jpp.kh - jpp.t_pad)
                 - jpp.ih;
         args.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
         args.kh_padding_shift = i_t_overflow * jpp.kw;
         args.ker_area_h = static_cast<float>(jpp.kh
-                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
-                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+                - nstl::max(dim_t(0),
+                        oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         (*kernel_)(&args);
     };
 
-    auto process_block = [=](int ithr, int n, int b_c, int ur_bc) {
+    auto process_block = [=](int ithr, dim_t n, dim_t b_c, dim_t ur_bc) {
         if (transpose_facade->should_transpose_dst())
             transpose_facade->execute_transpose_input(ithr, n, b_c);
 
-        for (int oh = 0; oh < jpp.oh; ++oh)
+        for (dim_t oh = 0; oh < jpp.oh; ++oh)
             ker(ithr, n, b_c, oh, ur_bc);
 
         if (transpose_facade->should_transpose_src())
@@ -1193,27 +1196,29 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             ? sizeof(bwd_f32_accum_for_bf16_t::value_type)
             : jpp.dt_size;
 
-    auto get_last_ih = [=](int oh) {
+    auto get_last_ih = [=](dim_t oh) {
         return nstl::min(
-                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, dim_t(0)),
+                jpp.ih);
     };
 
-    auto get_last_id = [=](int od) {
+    auto get_last_id = [=](dim_t od) {
         return nstl::min(
-                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, 0), jpp.id);
+                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, dim_t(0)),
+                jpp.id);
     };
 
-    auto ker = [= COMPAT_THIS_CAPTURE](int n, int b_c, int od, int oh, int id,
-                       int d_t_overflow, int d_b_overflow, bool zero_inp,
-                       int kd, int ur_bc, int ithr) {
+    auto ker = [= COMPAT_THIS_CAPTURE](dim_t n, dim_t b_c, dim_t od, dim_t oh,
+                       dim_t id, dim_t d_t_overflow, dim_t d_b_overflow,
+                       bool zero_inp, dim_t kd, dim_t ur_bc, int ithr) {
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
-        const int c_off
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -1244,14 +1249,14 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         }
 
         if (zero_inp) {
-            const int zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
-            const int zero_id_end
+            const auto zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
+            const auto zero_id_end
                     = (od == jpp.od - 1) ? jpp.id : get_last_id(od);
 
             args.zero_id = zero_id_end - zero_id_start;
 
-            const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
-            const int zero_ih_end
+            const auto zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+            const auto zero_ih_end
                     = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
             args.zero_ih = zero_ih_end - zero_ih_start;
 
@@ -1274,29 +1279,31 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         args.kh_padding_shift = i_t_overflow * jpp.kw
                 + d_t_overflow * jpp.kw * jpp.kh + kd * jpp.kw * jpp.kh;
         args.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
-        args.ker_area_h = (float)(jpp.kh
-                                  - nstl::max(0,
-                                          oh * jpp.stride_h - jpp.t_pad + jpp.kh
-                                                  - jpp.ih)
-                                  - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+        args.ker_area_h
+                = (float)(jpp.kh
+                          - nstl::max(dim_t(0),
+                                  oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                          - jpp.ih)
+                          - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h))
                 * (jpp.kd
-                        - nstl::max(0,
+                        - nstl::max(dim_t(0),
                                 od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
-                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+                        - nstl::max(dim_t(0), jpp.f_pad - od * jpp.stride_d));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         (*kernel_)(&args);
     };
 
-    auto process_simple = [=](int n, int b_c, int od, int ur_bc, int ithr) {
-        const int ik = od * jpp.stride_d;
-        const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-        const int d_b_overflow
+    auto process_simple
+            = [=](dim_t n, dim_t b_c, dim_t od, dim_t ur_bc, int ithr) {
+        const auto ik = od * jpp.stride_d;
+        const auto d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
+        const auto d_b_overflow
                 = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
-        const int id = nstl::max(ik - jpp.f_pad, 0);
+        const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
 
-        for (int oh = 0; oh < jpp.oh; ++oh) {
+        for (dim_t oh = 0; oh < jpp.oh; ++oh) {
             ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, true, 0, ur_bc,
                     ithr);
         }
@@ -1318,11 +1325,11 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                 });
             } else {
                 parallel_nd_ext(nthr, jpp.mb, nb2_c,
-                        [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                        [=](int ithr, dim_t nthr, dim_t n, dim_t b2_c) {
                     const dim_t b_c = b2_c * jpp.ur_bc;
                     const dim_t ur_bc
                             = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
+                    for (dim_t od = 0; od < jpp.od; ++od) {
                         process_simple(n, b_c, od, ur_bc, ithr);
                     }
                     f32_accum->cvt_to_bf16_slice_3d(ithr,
@@ -1333,10 +1340,10 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             assert(jpp.ur_bc == 1);
             if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
                 parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                        [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                        [=](int ithr, dim_t nthr, dim_t n, dim_t b_c) {
                     if (trans_src)
                         transpose_facade->execute_transpose_input(ithr, n, b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
+                    for (dim_t od = 0; od < jpp.od; ++od) {
                         process_simple(n, b_c, od, 1, ithr);
                     }
                     if (trans_dst)
@@ -1370,7 +1377,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                     const size_t chunk_size
                             = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
                     parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                            [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                            [=](int ithr, dim_t nthr, dim_t n, dim_t b_c) {
                         const size_t offset
                                 = ((size_t)n * jpp.nb_c + b_c) * chunk_size;
                         PRAGMA_OMP_SIMD()
@@ -1384,7 +1391,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
             parallel_nd_ext(nthr, jpp.mb, nb2_c,
-                    [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                    [=](int ithr, int nthr, dim_t n, dim_t b2_c) {
                 const dim_t b_c = b2_c * jpp.ur_bc;
 
                 if (trans_dst) {
@@ -1395,15 +1402,15 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
                     const void *src = transpose_facade->get_src_addr_3d(
                             ithr, 0, 0, jpp);
-                    std::memset((void *)src, zero_val, block_size);
+                    std::memset((void *)src, 0, block_size);
                 }
 
                 if (jpp.needs_f32_accum_for_bf16) f32_accum->zero_data(ithr);
 
-                const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+                const dim_t ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
                 for (dim_t kd = 0; kd < jpp.kd; ++kd) {
-                    for (int od = 0; od < jpp.od; ++od) {
-                        const dim_t ik = static_cast<dim_t>(od) * jpp.stride_d;
+                    for (dim_t od = 0; od < jpp.od; ++od) {
+                        const dim_t ik = od * jpp.stride_d;
                         const dim_t d_t_overflow
                                 = nstl::max(dim_t(0), jpp.f_pad - ik);
                         const dim_t d_b_overflow
@@ -1431,10 +1438,9 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             for (dim_t kd = 0; kd < jpp.kd; ++kd) {
                 parallel_nd(jpp.mb, nb2_c, [=](dim_t n, dim_t b2_c) {
                     const dim_t b_c = b2_c * jpp.ur_bc;
-                    const dim_t ur_bc
-                            = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
-                        const dim_t ik = static_cast<dim_t>(od) * jpp.stride_d;
+                    const dim_t ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+                    for (dim_t od = 0; od < jpp.od; ++od) {
+                        const dim_t ik = od * jpp.stride_d;
                         const dim_t d_t_overflow
                                 = nstl::max(dim_t(0), jpp.f_pad - ik);
                         const dim_t d_b_overflow


### PR DESCRIPTION
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
The area of this PR is **pooling** only. 
`third_party` area will be fixed separately. 

The discussion for reference: https://github.com/uxlfoundation/oneDNN/pull/5486

How to validate: 
[check_pooling_c4244.sh](https://github.com/user-attachments/files/29844455/check_pooling_c4244.sh)

```bash
(base) bash-5.1$ ./check_pooling_c4244.sh 
PASS  src/common/resampling.cpp
PASS  src/common/resampling_pd.hpp
PASS  src/cpu/cpu_resampling_pd.hpp
PASS  src/cpu/ref_resampling.hpp
PASS  src/cpu/ref_resampling.cpp
PASS  src/cpu/resampling_utils.hpp
PASS  src/cpu/simple_resampling.hpp
PASS  src/cpu/simple_resampling.cpp
PASS  src/cpu/x64/jit_avx512_core_resampling.hpp
PASS  src/cpu/x64/jit_avx512_core_resampling.cpp
PASS  src/cpu/x64/jit_uni_resampling.hpp
PASS  src/cpu/x64/jit_uni_resampling.cpp
PASS  src/cpu/x64/jit_uni_resampling_kernel.hpp
PASS  src/cpu/x64/jit_uni_resampling_kernel.cpp
RESULT: all resampling C4244 warnings fixed.
```
Remaining warnings outside the pooling: 

```cpp

# ─── xbyak mnemonics (third_party/xbyak/xbyak/xbyak_mnemonic.h)
add       # uint32_t imm  (2 overloads)
cmp       # uint32_t imm
``` 
These wrappers for `add` and `cmp` are introduced in 
https://github.com/uxlfoundation/oneDNN/pull/5565
