### PR TITLE
graph: interface: enable non-blocked verbose logging for partitions

### DIFF
--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -188,7 +188,7 @@ status_t primitive_execute(
             // measured execution times in a non-blocking manner.
             double start_ms = get_msec();
             status = stream->enqueue_primitive(primitive_iface, ctx);
-            CHECK(stream->run_verbose_profiler(pd_info, start_ms));
+            CHECK(stream->run_verbose_profiler(pd_info, start_ms, 0));
         }
     } else {
         status = stream->enqueue_primitive(primitive_iface, ctx);

--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -78,7 +78,7 @@ struct dnnl_stream {
     }
 
     virtual dnnl::impl::status_t run_verbose_profiler(
-            const std::string &pd_info, double start_ms) {
+            const std::string &pd_info, double start_ms, uint64_t component) {
         // TODO: Change interface to std::string &&pd_info to allow direct
         // move into primitive profiling data, avoiding string copy overhead
         return dnnl::impl::status::unimplemented;

--- a/src/common/stream.hpp
+++ b/src/common/stream.hpp
@@ -78,7 +78,7 @@ struct dnnl_stream : public dnnl::impl::c_compatible {
     }
 
     virtual dnnl::impl::status_t run_verbose_profiler(
-            const std::string &pd_info, double start_ms) {
+            const std::string &pd_info, double start_ms, uint64_t component) {
         // TODO: Change interface to std::string &&pd_info to allow direct
         // move into primitive profiling data, avoiding string copy overhead
         return dnnl::impl::status::unimplemented;

--- a/src/gpu/intel/ocl/stream.cpp
+++ b/src/gpu/intel/ocl/stream.cpp
@@ -152,7 +152,7 @@ void stream_t::after_exec_hook() {
 }
 
 status_t stream_t::run_verbose_profiler(
-        const std::string &pd_info, double start_ms) {
+        const std::string &pd_info, double start_ms, uint64_t component) {
     if (!is_verbose_profiler_enabled()) {
         VERROR(primitive, exec,
                 "running verbose profiler while it is not enabled");
@@ -160,7 +160,7 @@ status_t stream_t::run_verbose_profiler(
     }
 
     auto *vp = verbose_profiler();
-    vp->add_to_pending_primitive_list(start_ms, pd_info);
+    vp->add_to_pending_primitive_list(start_ms, pd_info, component);
     return status::success;
 }
 

--- a/src/gpu/intel/ocl/stream.hpp
+++ b/src/gpu/intel/ocl/stream.hpp
@@ -86,8 +86,8 @@ struct stream_t : public intel::stream_t {
         return profiler_->get_info(data_kind, num_entries, data);
     }
 
-    status_t run_verbose_profiler(
-            const std::string &pd_info, double start_ms) override;
+    status_t run_verbose_profiler(const std::string &pd_info, double start_ms,
+            uint64_t component) override;
 
     cl_command_queue queue() const { return impl()->queue(); }
 

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -162,7 +162,7 @@ void stream_t::after_exec_hook() {
 }
 
 status_t stream_t::run_verbose_profiler(
-        const std::string &pd_info, double start_ms) {
+        const std::string &pd_info, double start_ms, uint64_t component) {
     if (!is_verbose_profiler_enabled()) {
         VERROR(primitive, exec,
                 "running verbose profiler while it is not enabled");
@@ -170,7 +170,7 @@ status_t stream_t::run_verbose_profiler(
     }
 
     auto *vp = verbose_profiler();
-    vp->add_to_pending_primitive_list(start_ms, pd_info);
+    vp->add_to_pending_primitive_list(start_ms, pd_info, component);
     return status::success;
 }
 

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -86,8 +86,8 @@ struct stream_t : public gpu::intel::stream_t {
         return profiler_->get_info(data_kind, num_entries, data);
     }
 
-    status_t run_verbose_profiler(
-            const std::string &pd_info, double start_ms) override;
+    status_t run_verbose_profiler(const std::string &pd_info, double start_ms,
+            uint64_t component) override;
 
     ::sycl::queue &queue() const { return *impl()->queue(); }
 

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -141,7 +141,8 @@ std::optional<::sycl::event> genindex_executable_t::execute_sycl_impl(
             sycl_stream->sycl_ctx().get_deps());
     auto return_event = sycl_stream->get_output_event();
     if (sycl_stream->is_verbose_profiler_enabled())
-        sycl_stream->run_verbose_profiler(info_, start_ms);
+        sycl_stream->run_verbose_profiler(info_, start_ms,
+                static_cast<uint64_t>(dnnl::impl::component_t::graph));
     sycl_stream->after_exec_hook();
     return return_event;
 #else
@@ -211,7 +212,8 @@ ocl_event_t genindex_executable_t::execute_ocl_impl(const stream &stream,
         return_event = last.release();
     }
     if (ocl_stream->is_verbose_profiler_enabled())
-        ocl_stream->run_verbose_profiler(info_, start_ms);
+        ocl_stream->run_verbose_profiler(info_, start_ms,
+                static_cast<uint64_t>(dnnl::impl::component_t::graph));
     ocl_stream->after_exec_hook();
     return ocl_event_t(return_event);
 #else

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -141,7 +141,8 @@ std::optional<::sycl::event> genindex_executable_t::execute_sycl_impl(
             sycl_stream->sycl_ctx().get_deps());
     auto return_event = sycl_stream->get_output_event();
     if (sycl_stream->is_verbose_profiler_enabled())
-        sycl_stream->run_verbose_profiler(info_, start_ms);
+        sycl_stream->run_verbose_profiler(info_, start_ms,
+                static_cast<uint64_t>(dnnl::impl::component_t::graph));
     sycl_stream->after_exec_hook();
     return return_event;
 #else
@@ -213,7 +214,8 @@ cl_event genindex_executable_t::execute_ocl_impl(const stream &stream,
         return_event = last.release();
     }
     if (ocl_stream->is_verbose_profiler_enabled())
-        ocl_stream->run_verbose_profiler(info_, start_ms);
+        ocl_stream->run_verbose_profiler(info_, start_ms,
+                static_cast<uint64_t>(dnnl::impl::component_t::graph));
     ocl_stream->after_exec_hook();
     return return_event;
 #else

--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -98,7 +98,8 @@ std::optional<::sycl::event> host_scalar_executable_t::execute_sycl_impl(
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {event});
         gpu_strm->verbose_profiler()->register_event(verbose_event);
-        strm->run_verbose_profiler(info_, start_ms);
+        strm->run_verbose_profiler(info_, start_ms,
+                static_cast<uint64_t>(dnnl::impl::component_t::graph));
     }
     strm->after_exec_hook();
     return event;
@@ -167,7 +168,8 @@ ocl_event_t host_scalar_executable_t::execute_ocl_impl(const stream &stream,
         auto verbose_event = std::make_shared<xpu::ocl::event_t>(
                 xpu::ocl::wrapper_t<cl_event>(e, true));
         gpu_strm->verbose_profiler()->register_event(verbose_event);
-        strm->run_verbose_profiler(info_, start_ms);
+        strm->run_verbose_profiler(info_, start_ms,
+                static_cast<uint64_t>(dnnl::impl::component_t::graph));
     }
     strm->after_exec_hook();
     return ocl_event_t(e);

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -390,7 +390,8 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
     }
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
-        stream->wait();
+        bool use_profiler = stream->is_verbose_profiler_enabled();
+        if (!use_profiler) stream->wait();
         double start_ms = dnnl::impl::get_msec();
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
@@ -401,11 +402,16 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
             CHECK(compiled_partition->execute_sycl(stream, ins, outs,
                     scratchpad, {}, static_cast<::sycl::event *>(sycl_event)));
         }
-        stream->wait();
-        double duration_ms = dnnl::impl::get_msec() - start_ms;
         auto info = compiled_partition->exec_info(scratchpad != nullptr);
-        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
-                duration_ms);
+        if (!use_profiler) {
+            stream->wait();
+            double duration_ms = dnnl::impl::get_msec() - start_ms;
+            VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                    duration_ms);
+        } else {
+            CHECK(stream->run_verbose_profiler(info, start_ms,
+                    static_cast<uint64_t>(dnnl::impl::component_t::graph)));
+        }
     } else {
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
@@ -467,7 +473,8 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
 
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
-        stream->wait();
+        bool use_profiler = stream->is_verbose_profiler_enabled();
+        if (!use_profiler) stream->wait();
         double start_ms = dnnl::impl::get_msec();
         if (deps != nullptr) {
             std::vector<cl_event> ocl_deps(deps, deps + ndeps);
@@ -477,11 +484,16 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
             CHECK(compiled_partition->execute_ocl(
                     stream, ins, outs, scratchpad, {}, ocl_event));
         }
-        stream->wait();
-        double duration_ms = dnnl::impl::get_msec() - start_ms;
         auto info = compiled_partition->exec_info(scratchpad != nullptr);
-        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
-                duration_ms);
+        if (!use_profiler) {
+            stream->wait();
+            double duration_ms = dnnl::impl::get_msec() - start_ms;
+            VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                    duration_ms);
+        } else {
+            CHECK(stream->run_verbose_profiler(info, start_ms,
+                    static_cast<uint64_t>(dnnl::impl::component_t::graph)));
+        }
     } else {
         if (deps != nullptr) {
             std::vector<cl_event> ocl_deps(deps, deps + ndeps);

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -390,7 +390,8 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
     }
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
-        stream->wait();
+        bool use_profiler = stream->is_verbose_profiler_enabled();
+        if (!use_profiler) stream->wait();
         double start_ms = dnnl::impl::get_msec();
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
@@ -401,11 +402,16 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
             CHECK(compiled_partition->execute_sycl(stream, ins, outs,
                     scratchpad, {}, static_cast<::sycl::event *>(sycl_event)));
         }
-        stream->wait();
-        double duration_ms = dnnl::impl::get_msec() - start_ms;
         auto info = compiled_partition->exec_info(scratchpad != nullptr);
-        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
-                duration_ms);
+        if (!use_profiler) {
+            stream->wait();
+            double duration_ms = dnnl::impl::get_msec() - start_ms;
+            VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                    duration_ms);
+        } else {
+            CHECK(stream->run_verbose_profiler(info, start_ms,
+                    static_cast<uint64_t>(dnnl::impl::component_t::graph)));
+        }
     } else {
         if (deps != nullptr) {
             const auto &sycl_deps = *(const std::vector<::sycl::event> *)deps;
@@ -480,17 +486,23 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
 
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
-        stream->wait();
+        bool use_profiler = stream->is_verbose_profiler_enabled();
+        if (!use_profiler) stream->wait();
         double start_ms = dnnl::impl::get_msec();
         CHECK(compiled_partition->execute_ocl(
                 stream, ins, outs, scratchpad, wrapped_deps, ret_event));
         // Transfer ownership to caller.
         if (ocl_event) *ocl_event = ret_event.release();
-        stream->wait();
-        double duration_ms = dnnl::impl::get_msec() - start_ms;
         auto info = compiled_partition->exec_info(scratchpad != nullptr);
-        VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
-                duration_ms);
+        if (!use_profiler) {
+            stream->wait();
+            double duration_ms = dnnl::impl::get_msec() - start_ms;
+            VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
+                    duration_ms);
+        } else {
+            CHECK(stream->run_verbose_profiler(info, start_ms,
+                    static_cast<uint64_t>(dnnl::impl::component_t::graph)));
+        }
     } else {
         CHECK(compiled_partition->execute_ocl(
                 stream, ins, outs, scratchpad, wrapped_deps, ret_event));

--- a/src/xpu/stream_profiler.cpp
+++ b/src/xpu/stream_profiler.cpp
@@ -39,13 +39,14 @@ void verbose_profiler_t::cleanup() {
 }
 
 void verbose_profiler_t::add_to_pending_primitive_list(
-        double start_ms, const std::string &pd_info) {
+        double start_ms, const std::string &pd_info, uint64_t component) {
     assert(!profiling_data_.empty());
 
     // Adds metadata to the last entry
     auto &last_entry = profiling_data_.back();
     last_entry.start_ms_ = start_ms;
     last_entry.pd_info_ = pd_info;
+    last_entry.component_kind_ = component;
 }
 
 void verbose_profiler_t::check_for_completed_primitives() {
@@ -59,6 +60,27 @@ void verbose_profiler_t::check_for_completed_primitives() {
         const auto &evts = prof_data.prim_events_;
         double duration_ms = 0.0;
 
+        auto log_profile
+                = [](const prim_profile_data_t &prof_data, double duration_ms) {
+            // allows execution time-tracking for different component kinds
+            switch (static_cast<component_t::flag_kind>(
+                    prof_data.component_kind_)) {
+                case component_t::graph:
+                    VPROF(prof_data.start_ms_, graph, exec, VERBOSE_profile,
+                            prof_data.pd_info_.c_str(), duration_ms);
+                    break;
+                case component_t::ukernel:
+                    VPROF(prof_data.start_ms_, ukernel, exec, VERBOSE_profile,
+                            prof_data.pd_info_.c_str(), duration_ms);
+                    break;
+                case component_t::primitive:
+                default:
+                    VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
+                            prof_data.pd_info_.c_str(), duration_ms);
+                    break;
+            }
+        };
+
         // Handles primitives with no kernels
         if (evts.empty()) {
             // Will be erased in second pass
@@ -68,6 +90,9 @@ void verbose_profiler_t::check_for_completed_primitives() {
             continue;
         }
 
+        // No point in logging entries without info strings
+        if (prof_data.pd_info_.empty()) continue;
+
         // Check if the current primitive has finished executing and break
         // the loop if it is pending completion
         if (!is_event_complete(evts.back())) {
@@ -76,8 +101,7 @@ void verbose_profiler_t::check_for_completed_primitives() {
         }
         status_t status = get_aggregate_exec_time(index, duration_ms);
         if (status == status::success) {
-            VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
-                    prof_data.pd_info_.c_str(), duration_ms);
+            log_profile(prof_data, duration_ms);
         } else {
             VERROR(common, runtime,
                     "%s, profiling error: failures in exec time computation",

--- a/src/xpu/stream_profiler.cpp
+++ b/src/xpu/stream_profiler.cpp
@@ -39,13 +39,14 @@ void verbose_profiler_t::cleanup() {
 }
 
 void verbose_profiler_t::add_to_pending_primitive_list(
-        double start_ms, const std::string &pd_info) {
+        double start_ms, const std::string &pd_info, uint64_t component) {
     assert(!profiling_data_.empty());
 
     // Adds metadata to the last entry
     auto &last_entry = profiling_data_.back();
     last_entry.start_ms_ = start_ms;
     last_entry.pd_info_ = pd_info;
+    last_entry.component_kind_ = component;
 }
 
 void verbose_profiler_t::check_for_completed_primitives() {
@@ -53,6 +54,27 @@ void verbose_profiler_t::check_for_completed_primitives() {
     // and resumed again at the next check. This ensures the
     // primitives are logged in the same order they were enqueued
     size_t first_pending = profiling_data_.size();
+
+    auto log_profile
+            = [](const prim_profile_data_t &prof_data, double duration_ms) {
+        // allows execution time-tracking for different component kinds
+        switch (static_cast<component_t::flag_kind>(
+                prof_data.component_kind_)) {
+            case component_t::graph:
+                VPROF(prof_data.start_ms_, graph, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
+                break;
+            case component_t::ukernel:
+                VPROF(prof_data.start_ms_, ukernel, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
+                break;
+            case component_t::primitive:
+            default:
+                VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
+                break;
+        }
+    };
 
     for (size_t index = 0; index < profiling_data_.size(); ++index) {
         const auto &prof_data = profiling_data_[index];
@@ -63,10 +85,12 @@ void verbose_profiler_t::check_for_completed_primitives() {
         if (evts.empty()) {
             // Will be erased in second pass
             if (!prof_data.pd_info_.empty())
-                VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
-                        prof_data.pd_info_.c_str(), duration_ms);
+                log_profile(prof_data, duration_ms);
             continue;
         }
+
+        // No point in logging entries without info strings
+        if (prof_data.pd_info_.empty()) continue;
 
         // Check if the current primitive has finished executing and break
         // the loop if it is pending completion
@@ -76,8 +100,7 @@ void verbose_profiler_t::check_for_completed_primitives() {
         }
         status_t status = get_aggregate_exec_time(index, duration_ms);
         if (status == status::success) {
-            VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
-                    prof_data.pd_info_.c_str(), duration_ms);
+            log_profile(prof_data, duration_ms);
         } else {
             VERROR(common, runtime,
                     "%s, profiling error: failures in exec time computation",

--- a/src/xpu/stream_profiler.hpp
+++ b/src/xpu/stream_profiler.hpp
@@ -145,6 +145,7 @@ struct verbose_profiler_t {
     virtual ~verbose_profiler_t() = default;
 
     struct prim_profile_data_t {
+        uint64_t component_kind_ = 0;
         double start_ms_ = 0.0;
         std::string pd_info_;
         std::vector<std::shared_ptr<xpu::event_t>> prim_events_;
@@ -186,7 +187,7 @@ struct verbose_profiler_t {
     // populates profiling metadata for the last primitive entry in
     // profiling_data_
     void add_to_pending_primitive_list(
-            double start_ms, const std::string &pd_info);
+            double start_ms, const std::string &pd_info, uint64_t component);
 
     // Completed primitive executions are periodically checked and logged
     // during after_exec_hook() calls and during stream destruction.


### PR DESCRIPTION
# Description

The PR adds asynchronous verbose profiling support for logging executions for compiled partitions. The addition helps preserve execution order for the graph operations.

Addresses [MFDNN-15288](https://jira.devtools.intel.com/browse/MFDNN-15288).