### PR TITLE
x64: matmul: reject select post-op with broadcast condition

### DIFF
--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -134,6 +134,8 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
                                 post_ops.entry_, dst_md()),
                         broadcasting_strategy_t::per_oc);
         const bool has_prelu = post_ops.find(prelu) != -1;
+        for (const auto &entry : post_ops.entry_)
+            if (entry.is_binary_with_ternary_op()) return false;
         return cpu::inner_product_utils::post_ops_ok(
                        post_ops, dst_md(), enabled_bcast_strategy)
                 && IMPLICATION(is_binary_po_per_oc,

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -77,6 +77,8 @@ status_t gemm_f32_matmul_t::pd_t::init(const engine_t *engine) {
                                 post_ops.entry_, dst_md()),
                         broadcasting_strategy_t::per_oc);
         const bool has_prelu = post_ops.find(prelu) != -1;
+        for (const auto &entry : post_ops.entry_)
+            if (entry.is_binary_with_ternary_op()) return false;
         return cpu::inner_product_utils::post_ops_ok(
                        post_ops, dst_md(), enabled_bcast_strategy)
                 && IMPLICATION(is_binary_po_per_oc,

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -101,6 +101,8 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(const engine_t *engine) {
                                 post_ops.entry_, dst_md()),
                         broadcasting_strategy_t::per_oc);
         const bool has_prelu = post_ops.find(prelu) != -1;
+        for (const auto &entry : post_ops.entry_)
+            if (entry.is_binary_with_ternary_op()) return false;
         return cpu::inner_product_utils::post_ops_ok(
                        post_ops, dst_md(), enabled_bcast_strategy)
                 && IMPLICATION(is_binary_po_per_oc,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -217,6 +217,12 @@ bool any_binary_postop_rhs_with_ternary_scalar_bcast(
     });
 }
 
+bool is_ternary_bcast_supported(
+        const memory_desc_t &src2_md, const memory_desc_wrapper &dst_d) {
+    if (src2_md.ndims != dst_d.ndims()) return false;
+    return utils::array_cmp(src2_md.dims, dst_d.dims(), dst_d.ndims());
+}
+
 bool any_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
         const memory_desc_wrapper &dst_d,
         const bcast_set_t &supported_strategy_set) {

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -54,6 +54,8 @@ bool any_binary_postop_rhs_non_scalar_broadcast(
         const post_ops_t &post_ops, const memory_desc_wrapper &dst_d);
 bool any_binary_postop_rhs_with_ternary_scalar_bcast(
         const post_ops_t &post_ops, const memory_desc_wrapper &dst_d);
+bool is_ternary_bcast_supported(
+        const memory_desc_t &src2_md, const memory_desc_wrapper &dst_d);
 bool any_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
         const memory_desc_wrapper &dst_d,
         const bcast_set_t &supported_strategy_set);

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -292,6 +292,10 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
                                     VERBOSE_ISA_DT_MISMATCH);
                             VCHECK_PO_INJ_BOOL(dst_d->is_dense(),
                                     VERBOSE_UNSUPPORTED_FORMAT_KIND);
+                            VCHECK_PO_INJ_BOOL(
+                                    binary_injector::is_ternary_bcast_supported(
+                                            src2_d, *dst_d),
+                                    VERBOSE_UNSUPPORTED_POSTOP);
                         }
                         return ok;
                     }

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -16,3 +16,11 @@
 --reset --dt=s8:s8:f32 --attr-scales=src:2 3x17x64:3x64x19
 --reset --dt=s8:s8:bf16 --attr-scales=src:2+wei:0:2 5x32x64:5x64x48
 --reset --dt=u8:s8:f32 --attr-scales=src:2+wei:4 3x17x64:3x64x19
+
+# Binary select post-op with broadcast
+--reset
+--dt=f32,bf16
+--stag=abcd --wtag=abcd --dtag=abcd
+--attr-post-ops=select:f32:common
+1x16x32x256:1x16x256x33n"sdpa_cond_bcast"
+1x16x33x257:1x16x257x37n"sdpa_cond_bcast_tail"


### PR DESCRIPTION
A `select` (binary-with-ternary) post-op whose **condition** input (ternary
src2) is broadcast against dst — smaller dims than dst — SIGSEGVs at execute in
`brgemm_matmul` and the gemm-based f32/bf16 matmul: optimized post-op
application indexes the condition at full dst shape and reads out of bounds.
The reference implementation handles a broadcast condition correctly.

Fix: reject a broadcast condition at matmul dispatch so the iterator falls back
to ref. Full-shape conditions are unaffected (still fused).

### Reproducing

Requires the benchdnn `select` src2 grammar from #5530 (merged) — stock benchdnn
built the condition at full dst shape, so it never crashed.

    benchdnn --matmul --stag=abcd --wtag=abcd --dtag=abcd --dt=f32,bf16 \
      --attr-post-ops=select:f32:common 1x16x32x256:1x16x256x33

- Before: SIGSEGV (139) at execute.
- After: falls back to ref, passes. Full-shape `select:f32` still fuses to
  `brg_matmul`.

Verified on Intel Xeon 6767P (Granite Rapids, AVX-512 + AMX).

Fixes MFDNN-15313