### PR TITLE
x64: brgemm: widen JIT kernel internals to dim_t

### DIFF
--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -49,7 +49,7 @@ bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
-    const int ref_size = refs_.size();
+    const int ref_size = static_cast<int>(refs_.size());
     if (idx > ref_size - 1) { refs_.resize(idx + 1); }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
@@ -68,7 +68,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
 
     static_offsets_list_.push_back(static_offsets);
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
-    const int ref_size = refs_.size();
+    const int ref_size = static_cast<int>(refs_.size());
     const auto ret = map_.insert({brg, -1});
     if (!ret.second) {
         // if there was no insertion then clean bd_mask and static_offsets
@@ -77,7 +77,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         return ret.first->second;
     }
 
-    int idx = map_.size() - 1;
+    int idx = static_cast<int>(map_.size()) - 1;
     if (idx > ref_size - 1) {
         if (ref_size == 0)
             refs_.resize(1);

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -37,7 +37,10 @@ public:
     brgemm_desc_container_t() = default;
     brgemm_desc_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
-    inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
+    inline const brgemm_desc_t *operator[](int idx) const {
+        assert(idx >= 0);
+        return refs_[idx];
+    }
 
     bool insert(int idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
@@ -75,6 +78,7 @@ struct brgemm_kernel_container_t {
     brgemm_kernel_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_kernel_t *operator[](int idx) const {
+        assert(idx >= 0);
         return refs_[idx];
     }
 
@@ -117,7 +121,10 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](int idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](int idx) const {
+        assert(idx >= 0);
+        return refs_[idx]->data();
+    }
 
     bool insert(int idx, const brgemm_desc_t *brg);
     bool insert(int idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -57,15 +57,14 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         static constexpr bool preserve_vmm = false;
         static constexpr bool use_exact_tail_scalar_bcast = false;
         const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
-        const size_t tail = tail_length();
+        const int tail = tail_length();
 
         static const bcast_set_t enabled_bcast_strategy
                 = {broadcasting_strategy_t::scalar,
                         broadcasting_strategy_t::per_oc,
                         broadcasting_strategy_t::no_broadcast};
-        const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_b().getIdx()), r14, r15, r13,
-                preserve_gpr, preserve_vmm,
+        const binary_injector::rhs_arg_static_params_t rhs_sp {vmm_b().getIdx(),
+                r14, r15, r13, preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
                 dst_md_wrapper, tail, k_mask, use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp {
@@ -228,7 +227,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::set_A_B_matrices() {
     }
 
     add(reg_aux_A, reg_a_offset);
-    lea(reg_aux_B, ptr[reg_aux_B + reg_aux_N * brg.typesize_B]);
+    lea(reg_aux_B,
+            ptr[reg_aux_B + reg_aux_N * xbyak_address_scale(brg.typesize_B)]);
 }
 
 template <typename Wmm>
@@ -459,7 +459,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_bias) {
         reg_aux_bias.restore();
-        lea(reg_aux_bias, ptr[reg_aux_bias + reg_aux_N * brg.typesize_bias]);
+        lea(reg_aux_bias,
+                ptr[reg_aux_bias
+                        + reg_aux_N * xbyak_address_scale(brg.typesize_bias)]);
     }
 
     for_(int v_i = 0; v_i < v_substep; ++v_i)
@@ -710,7 +712,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
     for (int n = 0; n < n_blocks; n++) {
         const int substep_simd = get_substep_simd(n, v_i, has_n_tail);
         if (substep_simd <= 0) continue;
-        const size_t offset = comp_offset(n);
+        const dim_t offset = comp_offset(n);
         if (brg.req_s8s8_compensation) {
             const Vmm vmm_comp = vmm_s8s8_comp();
             uni_vmovups(vmm_comp,
@@ -902,7 +904,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
             const Vmm vmm_zp = isa_has_masks(brg.isa_impl)
                     ? maybe_mask(vmm_zp_comp(), is_tail_block, false)
                     : vmm_zp_comp();
-            const size_t offset = comp_offset(n);
+            const dim_t offset = comp_offset(n);
             if (IMPLICATION(is_tail_block, isa_has_masks(brg.isa_impl))) {
                 if (is_src_zp_bcast_) {
                     if (is_superset(brg.isa_impl, avx512_core))
@@ -1185,8 +1187,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 }
 
 template <typename Wmm>
-void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
-        const int m_blocks) {
+void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(int m_blocks) {
     const bool do_check_effective_padding = check_effective_padding();
     Label no_top_padding;
 
@@ -1194,7 +1195,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
         if (do_check_effective_padding) {
             Label done_adjust_bottom_padding;
             mov(reg_aux_A_vpad_bottom, reg_aux_M);
-            add(reg_aux_A_vpad_bottom, m_blocks - M());
+            sub(reg_aux_A_vpad_bottom, M() - m_blocks);
             add(reg_aux_A_vpad_bottom,
                     ptr[reg_aux_batch_addr
                             + GET_OFF_BATCH_ELEMENT(vvpad.bottom)]);
@@ -1235,7 +1236,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_batch_padding_info() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
+        int m_blocks, int n_blocks, bool has_n_tail) {
     const int tpad = brg.brgattr.max_top_vpad;
     const int bpad = brg.brgattr.max_bottom_vpad;
     if (tpad > 0) {
@@ -1264,7 +1265,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail, int shift_a) {
+        int m_blocks, int n_blocks, bool has_n_tail, int shift_a) {
 
     // padding for vertical dimensions
     const int tpad = brg.brgattr.max_top_vpad;
@@ -1294,7 +1295,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
+        int m_blocks, int n_blocks, bool has_n_tail) {
 
     Label bs_loop_label, done_bs_loop;
     load_accumulators(m_blocks, n_blocks);
@@ -1340,14 +1341,14 @@ template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
     const bool has_m_block2_tail = m_block2_tail() > 0;
-    const int loop_m = (nb_m_block2() - has_m_block2_tail);
+    const dim_t loop_m = nb_m_block2() - has_m_block2_tail;
     const bool do_loop_m = loop_m > 1;
 
     const bool has_n_block2_tail = n_block2_tail() > 0;
     const bool need_separate_n_block1_tail_block = n_block1_tail() != 0
             && !has_n_block2_tail && nb_n_block2() > 1
             && !isa_has_masks(brg.isa_impl);
-    const int loop_n = nb_n_block2() - has_n_block2_tail
+    const dim_t loop_n = nb_n_block2() - has_n_block2_tail
             - need_separate_n_block1_tail_block;
     const bool do_loop_n = loop_n > 1;
     const bool loop_n_update_aux_ptrs = do_loop_n || (loop_n < nb_n_block2());
@@ -1355,8 +1356,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
     auto n_loop = [&](int m_blocks) {
         Label n_loop_label;
         const int n_blocks = n_block2();
-        const int n_loop_step = oc_logical_offset(n_blocks);
-        const int n_loop_work = loop_n * n_blocks * n_block1();
+        const dim_t n_loop_step = oc_logical_offset(n_blocks);
+        const dim_t n_loop_work = loop_n * n_blocks * n_block1();
         const bool vlen_tail_in_loop = n_block1_tail() != 0
                 && !need_separate_n_block1_tail_block && !has_n_block2_tail;
 
@@ -1418,13 +1419,24 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
             if (do_loop_m || has_m_block2_tail) {
                 add(reg_aux_M, m_blocks);
-                const int n_loop_offset
+                const dim_t n_loop_offset
                         = loop_n_update_aux_ptrs * loop_n * n_block2();
-                add(reg_a_offset, A_offset(m_blocks, -n_loop_offset));
+                // n_loop_offset is a tensor-scale N position (in n_block1
+                // units); A_offset/C_offset/D_offset's `n` parameter is the
+                // bounded per-iteration block index, so narrow explicitly at
+                // this documented boundary.
+                const int n_loop_offset_i = static_cast<int>(n_loop_offset);
+                const dim_t a_shift
+                        = A_offset(m_blocks, 0) - A_offset(0, n_loop_offset_i);
+                const dim_t c_shift = C_offset(m_blocks, 0, 0)
+                        - C_offset(0, n_loop_offset_i, 0);
+                const dim_t d_shift = D_offset(m_blocks, 0, 0)
+                        - D_offset(0, n_loop_offset_i, 0);
+                add(reg_a_offset, a_shift);
                 reg_aux_C.restore();
-                add(reg_aux_C, C_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_C, c_shift);
                 reg_aux_C.save();
-                add(reg_aux_D, D_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_D, d_shift);
             }
 
             if (do_loop_m) {

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -57,16 +57,18 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         static constexpr bool preserve_vmm = false;
         static constexpr bool use_exact_tail_scalar_bcast = false;
         const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
-        const int tail = tail_length();
+        const std::size_t tail = tail_length();
 
         static const bcast_set_t enabled_bcast_strategy
                 = {broadcasting_strategy_t::scalar,
                         broadcasting_strategy_t::per_oc,
                         broadcasting_strategy_t::no_broadcast};
-        const binary_injector::rhs_arg_static_params_t rhs_sp {vmm_b().getIdx(),
-                r14, r15, r13, preserve_gpr, preserve_vmm,
+        const binary_injector::rhs_arg_static_params_t rhs_sp {
+                static_cast<std::size_t>(vmm_b().getIdx()), r14, r15, r13,
+                preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                dst_md_wrapper, tail, k_mask, use_exact_tail_scalar_bcast};
+                dst_md_wrapper, static_cast<std::size_t>(tail), k_mask,
+                use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp {
                 this->param1, enabled_bcast_strategy, rhs_sp};
 

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -228,7 +228,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::set_A_B_matrices() {
 
     add(reg_aux_A, reg_a_offset);
     lea(reg_aux_B,
-            ptr[reg_aux_B + reg_aux_N * xbyak_address_scale(brg.typesize_B)]);
+            ptr[reg_aux_B + reg_aux_N * static_cast<int>(brg.typesize_B)]);
 }
 
 template <typename Wmm>
@@ -461,7 +461,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
         reg_aux_bias.restore();
         lea(reg_aux_bias,
                 ptr[reg_aux_bias
-                        + reg_aux_N * xbyak_address_scale(brg.typesize_bias)]);
+                        + reg_aux_N * static_cast<int>(brg.typesize_bias)]);
     }
 
     for_(int v_i = 0; v_i < v_substep; ++v_i)

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -258,6 +258,9 @@ private:
     // note 2: zmm0 collides with vmm_permute, hence need to write this value
     // before every loop.
 
+    // SIMD width and max vector-register count are hardware/ISA-bounded
+    // code-generation values, not tensor-scale quantities, so they stay
+    // `int` rather than `dim_t`.
     const int simd_w_;
     const int max_vmms_;
     const bool compute_dst_zp_, compute_src_zp_;
@@ -271,17 +274,17 @@ private:
 
     bool with_binary_non_scalar_bcast_ = false;
 
-    inline int M() { return brg.bcast_dim; }
-    inline int N() { return brg.load_dim; }
+    inline dim_t M() { return brg.bcast_dim; }
+    inline dim_t N() { return brg.load_dim; }
     inline int m_block2() { return brg.bd_block2; }
-    inline int nb_m_block2() { return brg.bdb2; }
+    inline dim_t nb_m_block2() { return brg.bdb2; }
     inline int m_block2_tail() { return brg.bdb2_tail; }
 
     inline int n_block1() { return brg.ld_block; }
-    inline int nb_n_block1() { return brg.ldb; }
+    inline dim_t nb_n_block1() { return brg.ldb; }
     inline int n_block1_tail() { return brg.ldb_tail; }
     inline int n_block2() { return brg.ld_block2; }
-    inline int nb_n_block2() { return brg.ldb2; }
+    inline dim_t nb_n_block2() { return brg.ldb2; }
     inline int n_block2_tail() { return brg.ldb2_tail; }
     int tail_length() { return n_block1_tail() % simd_w_; }
 
@@ -371,10 +374,10 @@ private:
             bool has_bottom_padding, bool has_tail, int shift_a);
     void compute_loop();
     void get_batch_padding_info();
-    void get_vertical_padding_info(const int m_blocks);
-    void call_brdgmm_microkernel(const int m_blocks, const int n_blocks,
-            bool has_n_tail, int shift_a);
-    void batch_loop(const int m_blocks, const int n_blocks, bool has_n_tail);
+    void get_vertical_padding_info(int m_blocks);
+    void call_brdgmm_microkernel(
+            int m_blocks, int n_blocks, bool has_n_tail, int shift_a);
+    void batch_loop(int m_blocks, int n_blocks, bool has_n_tail);
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag, bool store);
     void apply_post_ops(int m_blocks, int n_blocks, bool has_n_tail);
@@ -388,25 +391,25 @@ private:
     void store_accumulators_apply_post_ops(
             int m_blocks, int n_blocks, bool has_n_tail);
     bool check_effective_padding() { return has_vpad_ && M() > m_block2(); }
-    int oc_logical_offset(int n) { return n * n_block1(); }
-    int A_offset(int m, int n) {
+    dim_t oc_logical_offset(int n) { return n * n_block1(); }
+    dim_t A_offset(int m, int n) {
         return brg.typesize_A * (m * brg.LDA + n * n_block1());
     }
-    int B_offset(int n) { return brg.typesize_B * n * n_block1(); }
-    int C_offset(int m, int n, int v) {
+    dim_t B_offset(int n) { return brg.typesize_B * n * n_block1(); }
+    dim_t C_offset(int m, int n, int v) {
         return brg.typesize_C * (m * brg.LDC + n * n_block1() + v * simd_w_);
     }
-    int D_offset(int m, int n, int v) {
+    dim_t D_offset(int m, int n, int v) {
         return brg.typesize_D * (m * brg.LDD + n * n_block1() + v * simd_w_);
     }
-    int bias_offset(int n, int v) {
+    dim_t bias_offset(int n, int v) {
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
-    int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_per_n_wei_scales
+    dim_t wei_scales_offset(int n, int v) {
+        return static_cast<dim_t>(sizeof(float)) * brg.is_per_n_wei_scales
                 * (n * n_block1() + v * simd_w_);
     }
-    size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
+    dim_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
 
     void generate() override;
 };

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -253,10 +253,10 @@ private:
     // iteration_map_t) describe the structure of cycles and are used for
     // JIT code generation
     struct iteration_block_t {
-        int block = 0;
+        dim_t block = 0;
         dim_t pos = 0;
         bool is_tail = false;
-        iteration_block_t(dim_t pos_, int block_, bool is_tail_ = false)
+        iteration_block_t(dim_t pos_, dim_t block_, bool is_tail_ = false)
             : block(block_), pos(pos_), is_tail(is_tail_) {}
         bool operator==(const iteration_block_t &rhs) const {
             return block == rhs.block && is_tail == rhs.is_tail;
@@ -283,7 +283,7 @@ private:
             return (blocks[b].pos - blocks[0].pos);
         }
 
-        int block(size_t b) const {
+        dim_t block(size_t b) const {
             assert(b < blocks.size());
             return blocks[b].block;
         }
@@ -293,9 +293,9 @@ private:
             return blocks[b].is_tail;
         }
 
-        int block2() const { return static_cast<int>(blocks.size()); }
+        dim_t block2() const { return static_cast<dim_t>(blocks.size()); }
 
-        int length() const {
+        dim_t length() const {
             if (blocks.empty()) return 0;
             const int n = static_cast<int>(blocks.size());
             // only last block may be different
@@ -374,9 +374,9 @@ private:
 
     struct prf_t {
         brgemm_kernel_prefetching_t pft = brgemm_prf_default;
-        int dist = -1;
-        int vec = 0;
-        void set(brgemm_kernel_prefetching_t pft_, int dist_) {
+        dim_t dist = -1;
+        dim_t vec = 0;
+        void set(brgemm_kernel_prefetching_t pft_, dim_t dist_) {
             pft = pft_;
             dist = dist_;
             vec = 0;
@@ -405,8 +405,8 @@ private:
     // saved parameters for storing
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
-    int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    int ils_bd_step_ = 3; // heuristic value
+    dim_t ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
+    dim_t ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -441,22 +441,22 @@ private:
     const Xbyak::Zmm zmm_ubound = zmm9;
 
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
-    Xbyak::Zmm accm(int bd) const {
+    Xbyak::Zmm accm(dim_t bd) const {
         assert(bd < 16);
-        return Xbyak::Zmm(31 - (bd % ils_bd_step_));
+        return Xbyak::Zmm(xbyak_register_index(31 - (bd % ils_bd_step_)));
     }
 
-    Xbyak::Zmm zmm_bias(int ldb) const {
+    Xbyak::Zmm zmm_bias(dim_t ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
-        return Xbyak::Zmm(10 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(10 + ldb));
     }
 
-    Xbyak::Zmm zmm_scales(int ldb) const {
+    Xbyak::Zmm zmm_scales(dim_t ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
-        return Xbyak::Zmm(15 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(15 + ldb));
     }
 
     template <typename U>
@@ -473,19 +473,19 @@ private:
     void maybe_saturation(Xbyak::Zmm &zmm);
     void apply_alpha_beta_to_vector(
             int idx, const Address &addr, bool is_ld_tail);
-    void apply_post_ops_to_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void apply_post_ops_to_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_with_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, int ldb);
+    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, dim_t ldb);
     void prepare_post_ops_registers(brgemm_iteration_t &bi);
 
     bool bi_shift_output(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_A(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_B(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
 
     void uni_prefetch(const Address &addr, brgemm_kernel_prefetching_t pft,
             bool for_write);
@@ -502,13 +502,13 @@ private:
             prf_t &prf, bool prefetch_all);
     void prefetching(brgemm_iteration_t &bi, bool prefetch_all);
 
-    void process_output_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void process_output_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_without_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
-    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb, const int idx);
+    void store_vector(brgemm_iteration_t &bi, dim_t bdb, dim_t bd, dim_t ldb);
+    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb, const int idx);
 
     void interleave_store(brgemm_iteration_t &bi, bool store_all);
 
@@ -536,24 +536,24 @@ private:
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
 
     bool process_k_tail_only_last_tile();
 
-    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
             bool mem_advice_A);
 
     void maybe_tileloadd_nt(
-            brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset);
+            brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset);
 
-    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, dim_t bdb);
 
     void maybe_sprinkle_prefetches();
 
-    void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
@@ -588,20 +588,20 @@ private:
                 && !skip_accumulation);
     }
 
-    dim_t A_offset(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_wsp(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset_wsp(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
-            int bd_elem_idx = 0) const noexcept;
+    dim_t A_offset_line(const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb = 0,
+            dim_t bd_elem_idx = 0) const noexcept;
 
-    dim_t B_offset(
-            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
+    dim_t B_offset(const brgemm_iteration_t &bi, dim_t ldb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
-            int rd_elem_idx = 0) const noexcept;
+    dim_t B_offset_line(const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb = 0,
+            dim_t rd_elem_idx = 0) const noexcept;
 
     dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             dim_t ldb) const noexcept;
@@ -625,9 +625,9 @@ private:
     bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
     dim_t get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
 
-    void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void maybe_tilestore(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
-    int get_C_tensor(brgemm_iteration_t &bi, int m, int n) const noexcept;
+    dim_t get_C_tensor(brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept;
     void top_loop(brgemm_iteration_t &bi);
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
@@ -639,7 +639,7 @@ private:
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     if (shift == 0) return true;
 
@@ -669,7 +669,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_output(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_A(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nbdis = tloop.bdis.size();
@@ -689,7 +689,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_A(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_B(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nldis = tloop.ldis.size();
@@ -708,8 +708,8 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_B(
     return true;
 }
 
-int jit_brgemm_amx_uker_base_t::get_C_tensor(
-        brgemm_iteration_t &bi, int m, int n) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::get_C_tensor(
+        brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept {
     return brg.get_C_tensor(m, n, bi.bdi->is_tail(m), bi.ldi->is_tail(n));
 }
 
@@ -744,7 +744,7 @@ dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     // Full WSP buffer layout:
     //   1. partial C results.
     //   2. data type conversion.
@@ -764,7 +764,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
@@ -775,12 +775,12 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
-        int bdb, int rdb, int bd_elem_idx) const noexcept {
+        dim_t bdb, dim_t rdb, dim_t bd_elem_idx) const noexcept {
     return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
@@ -796,7 +796,7 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
-        int ldb, int rdb, int rd_elem_idx) const noexcept {
+        dim_t ldb, dim_t rdb, dim_t rd_elem_idx) const noexcept {
     return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
@@ -978,17 +978,17 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
         ils_shift = need_ils_shift ? bi.bdi->C_shift : 0;
     }
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
-            tileloadd(Tmm(get_C_tensor(bi, bdb, ldb)),
+            tileloadd(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
         } else {
             // call tilezero on very first iteration
             if (!brg.interleave_tilestores_
                     || everyone_is(0u, bi.bdi->idx, bi.ldi->idx))
-                tilezero(Tmm(get_C_tensor(bi, bdb, ldb)));
+                tilezero(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -1035,8 +1035,8 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     }
 }
 
-void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1127,7 +1127,7 @@ void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
 }
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
-        brgemm_iteration_t &bi, int ldb) {
+        brgemm_iteration_t &bi, dim_t ldb) {
     if (!bi.apply_postops) return;
     auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
 
@@ -1168,7 +1168,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1212,7 +1212,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 case data_type::f32:
                 default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
             }
-            for (int ldb = 0; ldb < ldi->block2(); ldb++)
+            for (dim_t ldb = 0; ldb < ldi->block2(); ldb++)
                 vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
         }
     }
@@ -1222,7 +1222,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
                     = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1233,7 +1233,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
@@ -1261,7 +1261,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1348,7 +1348,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
         brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish, int bdb,
         int ldb) {
     const auto ldb_pos = bi.ldi->pos(ldb);
-    for (int bd = bd_start; bd < bd_finish; bd++) {
+    for (dim_t bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
@@ -1394,7 +1394,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
             = (are_post_ops_applicable_ && !prev_bi_.apply_postops)
             ? brg.typesize_C
             : brg.typesize_D;
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / bdb_row;
         const auto vec_in_bdb_row = prf.vec - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / pfo_bi.bdi->block(bdb);
@@ -1418,7 +1418,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_A(brgemm_iteration_t &bi,
             ? tot_vecs
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / pfo_bi.bdi->block(0);
         const auto bd = prf.vec % pfo_bi.bdi->block(0);
 
@@ -1442,7 +1442,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_B(brgemm_iteration_t &bi,
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
     // TODO: check these addressing for correctness
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
 
         const auto ldb = prf.vec / pfo_bi.rdi->block(0);
         const auto rb = prf.vec % pfo_bi.rdi->block(0);
@@ -1505,7 +1505,8 @@ void jit_brgemm_amx_uker_base_t::prefetching(
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb, const int idx) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb,
+        const int idx) {
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     auto zmm = Zmm(idx);
@@ -1526,8 +1527,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vaddps(zmm_masked, zmm, zmm_zp_comp_a);
 }
 
-void jit_brgemm_amx_uker_base_t::process_output_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::process_output_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
 
     const auto k_mask = bi.ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
@@ -1778,7 +1779,7 @@ void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb) {
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
@@ -1838,7 +1839,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
     const auto bdb_row = prev_bi_.bdi->block(0) * prev_bi_.ldi->block2();
     const auto total_vectors = prev_bi_.bdi->length() * prev_bi_.ldi->block2();
     const auto nvecs = store_all ? total_vectors : ils_vecs_per_store;
-    for (int vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
+    for (dim_t vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
         const auto bdb = ils_vec_ / bdb_row;
         const auto vec_in_bdb_row = ils_vec_ - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / prev_bi_.bdi->block(bdb);
@@ -1887,8 +1888,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     if (store_by_vectors && !real_ils && !prepare_post_ops_registers_once_)
         prepare_post_ops_registers(bi);
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (store_by_vectors) {
             if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
                 const auto wsp_offset = use_ils_
@@ -1896,13 +1897,13 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
                                 * ld_block_C_size_
                         : 0;
                 tilestored(ptr[reg_buf + reg_stride_ld_block + wsp_offset],
-                        Tmm(get_C_tensor(bi, bdb, ldb)));
+                        Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
             }
             if (real_ils) continue;
 
             prepare_post_ops_registers_ldb(bi, ldb);
 
-            for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
+            for (dim_t bd_step = 0; bd_step < bi.bdi->block(bdb);
                     bd_step += ils_bd_step_) {
                 auto bd_finish
                         = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
@@ -1914,7 +1915,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
         } else if (!brg.interleave_tilestores_) {
             const auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb));
             tilestored(ptr[reg_C + reg_stride_ld_block + c_offset],
-                    Tmm(get_C_tensor(bi, bdb, ldb)));
+                    Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -2025,13 +2026,14 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
     current_num_amx_ops++;
 }
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
-        brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset) {
+        brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset) {
 
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
 
-    auto t1 = Tmm(is_A ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
-                       : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb)));
+    auto t1 = Tmm(xbyak_register_index(is_A
+                    ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
+                    : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb))));
     auto reg_base = is_A ? reg_A : reg_B;
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
 
@@ -2066,8 +2068,9 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 }
 
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
-        brgemm_iteration_t &bi, int bdb) {
-    auto t1 = Tmm(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb)));
+        brgemm_iteration_t &bi, dim_t bdb) {
+    auto t1 = Tmm(
+            xbyak_register_index(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
     auto load_a_tile_from_wsp = [&]() {
         if (brg.load_nt_A) {
@@ -2106,7 +2109,7 @@ void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
     };
 }
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
-        int bdb_idx, int ldb_idx, bool do_pre_tilestore,
+        dim_t bdb_idx, dim_t ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
     if (bi.skip_accumulation) return;
     auto current_tensor_idx = get_C_tensor(bi, bdb_idx, ldb_idx);
@@ -2134,7 +2137,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
         ldb_idx = store_tensor_idx % bi.ldi->block2();
     }
     const bool store_by_vectors = get_store_by_vectors(bi.apply_postops);
-    Tmm acc = Tmm(store_tensor_idx);
+    Tmm acc = Tmm(xbyak_register_index(store_tensor_idx));
     if (store_by_vectors) {
         const auto wsp_offset = (use_ils_ || brg.interleave_tilestores_)
                 ? (bdb_idx * bi.ldi->block2() + ldb_idx) * bi.bdi->block(0)
@@ -2151,14 +2154,17 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     tilezero(acc);
 }
 
-void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
-        int ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
+void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
+        dim_t ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
-    const Tmm &x1 = Tmm(get_C_tensor(bi, bdb_idx, ldb_idx));
-    const Tmm &x2 = Tmm(brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx)));
-    const Tmm &x3 = Tmm(brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx)));
+    const Tmm &x1
+            = Tmm(xbyak_register_index(get_C_tensor(bi, bdb_idx, ldb_idx)));
+    const Tmm &x2 = Tmm(xbyak_register_index(
+            brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx))));
+    const Tmm &x3 = Tmm(xbyak_register_index(
+            brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx))));
 
     using namespace data_type;
     if (brg.is_tf32) {
@@ -2198,9 +2204,9 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
         int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt) {
     const auto rd_block = bi.rdi->block(0);
-    const int max_num_cols
-            = nstl::min<int>(tile_num_col_bytes / sizeof(float16_t), rd_block);
-    const int col_tail = max_num_cols % 32;
+    const dim_t max_num_cols = nstl::min<dim_t>(
+            tile_num_col_bytes / sizeof(float16_t), rd_block);
+    const dim_t col_tail = max_num_cols % 32;
     auto zmm_1 = zmm_tmp_1();
     auto zmm_1_masked = col_tail ? zmm_1 | fp_col_mask | T_z : zmm_1;
 
@@ -2290,22 +2296,22 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const int vnni_granularity = 2;
-    const int r_end = utils::div_up(rd_block, vnni_granularity);
+    const dim_t r_end = utils::div_up(rd_block, vnni_granularity);
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else
         assert(!"unsupported data type");
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2346,10 +2352,11 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
     // fixed ISA constant (1, 2 or 4), so narrow it at this boundary.
     const int vnni_granularity = static_cast<int>(
             data_type_vnni_granularity(data_type_t::dnnl_bf16));
-    const int r_end
-            = nstl::min(utils::div_up(rd_block, vnni_granularity), num_rows);
+    const int r_end = nstl::min(
+            static_cast<int>(utils::div_up(rd_block, vnni_granularity)),
+            num_rows);
 
-    for (int r = 0; r < r_end; ++r) {
+    for (dim_t r = 0; r < r_end; ++r) {
         load(zmm_1, ptr[reg_data_aux]);
 
         if (r * vnni_granularity + 1 >= rd_block) {
@@ -2362,13 +2369,15 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         vpermw(zmm_1, zmm_bf32_permute, zmm_1);
         vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_1);
         lea(reg_data_aux,
-                ptr[reg_data_aux + vnni_granularity * reg_data_stride]);
+                ptr[reg_data_aux
+                        + reg_data_stride
+                                * xbyak_address_scale(vnni_granularity)]);
     }
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2459,7 +2468,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 }
 
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
     if (offset_dst) add(reg_buf, offset_dst);
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
@@ -2476,7 +2485,7 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
 }
 
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
         bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
@@ -2582,7 +2591,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     else
         mov(reg_stride_ld_block, LDC_size_);
 
-    for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+    for (dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++) {
         if (brg.fused_copy_a) {
             maybe_fused_copy_A_nt_load(bi, bdb);
         } else {
@@ -2590,7 +2599,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
                     bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
         }
 
-        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
                         bi, matrix_kind_t::matrix_B, ldb, B_offset(bi, ldb));
@@ -2837,8 +2846,8 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (brg.interleave_tilestores_) {
         prev_bi_ = bi;
         was_prev_bi_ = true;
-        for_(int bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
-        for (int ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
+        for_(dim_t bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
+        for (dim_t ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
             maybe_tilestore(prev_bi_, bdb, ldb, true, false);
         }
     }

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -443,20 +443,20 @@ private:
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
     Xbyak::Zmm accm(dim_t bd) const {
         assert(bd < 16);
-        return Xbyak::Zmm(xbyak_register_index(31 - (bd % ils_bd_step_)));
+        return Xbyak::Zmm(static_cast<int>(31 - (bd % ils_bd_step_)));
     }
 
     Xbyak::Zmm zmm_bias(dim_t ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
-        return Xbyak::Zmm(xbyak_register_index(10 + ldb));
+        return Xbyak::Zmm(static_cast<int>(10 + ldb));
     }
 
     Xbyak::Zmm zmm_scales(dim_t ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
-        return Xbyak::Zmm(xbyak_register_index(15 + ldb));
+        return Xbyak::Zmm(static_cast<int>(15 + ldb));
     }
 
     template <typename U>
@@ -982,13 +982,13 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
     for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
-            tileloadd(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))),
+            tileloadd(Tmm(static_cast<int>(get_C_tensor(bi, bdb, ldb))),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
         } else {
             // call tilezero on very first iteration
             if (!brg.interleave_tilestores_
                     || everyone_is(0u, bi.bdi->idx, bi.ldi->idx))
-                tilezero(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
+                tilezero(Tmm(static_cast<int>(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -1897,7 +1897,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
                                 * ld_block_C_size_
                         : 0;
                 tilestored(ptr[reg_buf + reg_stride_ld_block + wsp_offset],
-                        Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
+                        Tmm(static_cast<int>(get_C_tensor(bi, bdb, ldb))));
             }
             if (real_ils) continue;
 
@@ -1915,7 +1915,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
         } else if (!brg.interleave_tilestores_) {
             const auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb));
             tilestored(ptr[reg_C + reg_stride_ld_block + c_offset],
-                    Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
+                    Tmm(static_cast<int>(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -2031,7 +2031,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
 
-    auto t1 = Tmm(xbyak_register_index(is_A
+    auto t1 = Tmm(static_cast<int>(is_A
                     ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
                     : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb))));
     auto reg_base = is_A ? reg_A : reg_B;
@@ -2070,7 +2070,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
         brgemm_iteration_t &bi, dim_t bdb) {
     auto t1 = Tmm(
-            xbyak_register_index(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
+            static_cast<int>(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
     auto load_a_tile_from_wsp = [&]() {
         if (brg.load_nt_A) {
@@ -2137,7 +2137,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
         ldb_idx = store_tensor_idx % bi.ldi->block2();
     }
     const bool store_by_vectors = get_store_by_vectors(bi.apply_postops);
-    Tmm acc = Tmm(xbyak_register_index(store_tensor_idx));
+    Tmm acc = Tmm(static_cast<int>(store_tensor_idx));
     if (store_by_vectors) {
         const auto wsp_offset = (use_ils_ || brg.interleave_tilestores_)
                 ? (bdb_idx * bi.ldi->block2() + ldb_idx) * bi.bdi->block(0)
@@ -2159,11 +2159,10 @@ void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
-    const Tmm &x1
-            = Tmm(xbyak_register_index(get_C_tensor(bi, bdb_idx, ldb_idx)));
-    const Tmm &x2 = Tmm(xbyak_register_index(
+    const Tmm &x1 = Tmm(static_cast<int>(get_C_tensor(bi, bdb_idx, ldb_idx)));
+    const Tmm &x2 = Tmm(static_cast<int>(
             brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx))));
-    const Tmm &x3 = Tmm(xbyak_register_index(
+    const Tmm &x3 = Tmm(static_cast<int>(
             brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx))));
 
     using namespace data_type;
@@ -2300,10 +2299,10 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(static_cast<int>(r_end),
                 reg_data_aux, reg_data_stride, reg_buf);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(static_cast<int>(r_end),
                 reg_data_aux, reg_data_stride, reg_buf);
     else
         assert(!"unsupported data type");
@@ -2371,7 +2370,7 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         lea(reg_data_aux,
                 ptr[reg_data_aux
                         + reg_data_stride
-                                * xbyak_address_scale(vnni_granularity)]);
+                                * static_cast<int>(vnni_granularity)]);
     }
 
     // zero rest of the tile data

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2419,14 +2419,15 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
 
             if (brg.is_runtime_ldc && bd_block2 > 1) {
                 xor_(reg_dynamic_C_offset, reg_dynamic_C_offset);
-                reg_stride_ld_block.imulTo(
-                        reg_dynamic_C_offset, bdb_C_offset(1));
+                reg_stride_ld_block.imulTo(reg_dynamic_C_offset,
+                        static_cast<int>(bdb_C_offset(1)));
                 reg_dynamic_C_offset.save();
             }
 
             if (apply_post_ops && brg.is_runtime_ldd && bd_block2 > 1) {
                 xor_(reg_D_bdb_loop_shift, reg_D_bdb_loop_shift);
-                reg_D_shift_bytes.imulTo(reg_D_bdb_loop_shift, bdb_D_offset(1));
+                reg_D_shift_bytes.imulTo(reg_D_bdb_loop_shift,
+                        static_cast<int>(bdb_D_offset(1)));
                 reg_D_bdb_loop_shift.save();
             }
 
@@ -3618,7 +3619,8 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         if (brg.is_runtime_ldc) {
             reg_C.saveTo(reg_C_backup);
             xor_(reg_C, reg_C);
-            reg_stride_ld_block.imulTo(reg_C, bdb_C_offset(bd_block2));
+            reg_stride_ld_block.imulTo(
+                    reg_C, static_cast<int>(bdb_C_offset(bd_block2)));
             reg_C_backup.addTo(reg_C);
         } else {
             add(reg_C, bdb_C_offset(bd_block2));
@@ -3626,7 +3628,8 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         if (brg.is_runtime_ldd) {
             reg_D.saveTo(reg_aux_D_backup);
             xor_(reg_D, reg_D);
-            reg_D_shift_bytes.imulTo(reg_D, bdb_D_offset(bd_block2));
+            reg_D_shift_bytes.imulTo(
+                    reg_D, static_cast<int>(bdb_D_offset(bd_block2)));
             reg_aux_D_backup.addTo(reg_D);
         } else {
             add(reg_D, bdb_D_offset(bd_block2));

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -108,16 +108,16 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
             // one element can be safely loaded. Therefore, we need to
             // provide information about what the tail size would have
             // been in a non-GEMV case.
-            const dim_t tail_size = !brg.is_gemv
+            const int tail_size = !brg.is_gemv
                     ? brg.ldb_tail
                     : (brg.gemv_acc_is_vector() ? brg.gemv_tail : 1);
             const auto k_mask = !brg.is_gemv ? ld_tail_mask : gemv_partial_mask;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    static_cast<size_t>(vmm_tmp(0).getIdx()), this->r14,
-                    this->r15, this->r13, preserve_gpr, preserve_vmm,
+                    vmm_tmp(0).getIdx(), this->r14, this->r15, this->r13,
+                    preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(tail_size), k_mask,
+                    dst_md_wrapper, static_cast<dim_t>(tail_size), k_mask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {this->param1,
@@ -304,49 +304,50 @@ private:
         return isa_num_vregs(brg.isa_impl) - used_vregs;
     }
 
-    Vmm accm(dim_t ld_block, dim_t bd, dim_t ld) const noexcept {
-        return Vmm(max_effective_vregs - 1 - (bd * ld_block + ld));
+    Vmm accm(int ld_block, int bd, int ld) const noexcept {
+        return Vmm(xbyak_register_index(
+                max_effective_vregs - 1 - (bd * ld_block + ld)));
     }
 
-    Vmm bcst(dim_t bd = 0) const noexcept {
+    Vmm bcst(int bd = 0) const noexcept {
         if (brg.n_bcast_1_load) {
-            dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
+            int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         } else
             return Vmm(0);
     }
 
-    Vmm load(dim_t ld = 0) const noexcept {
+    Vmm load(int ld = 0) const noexcept {
         if (brg.n_bcast_1_load) {
             return Vmm(0);
         } else {
-            dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
+            int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - ld;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         }
     }
 
     Vmm gemv_load_a() const noexcept {
         assert(brg.is_gemv);
-        const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
-        return Vmm(idx);
+        const int idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm gemv_load_b() const noexcept {
         assert(brg.is_gemv);
-        const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
-        return Vmm(idx);
+        const int idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm vmm_tmp(dim_t i) const noexcept {
-        const dim_t bd_block = brg.is_gemv ? brg.gemv_bd_block() : brg.bd_block;
+        const int bd_block = brg.is_gemv ? brg.gemv_bd_block() : brg.bd_block;
         MAYBE_UNUSED(bd_block);
         assert(IMPLICATION(!brg.is_tmm,
                 i >= 0 && i < max_effective_vregs - bd_block * brg.ld_block2));
-        return Vmm(i);
+        return Vmm(xbyak_register_index(i));
     }
 
     Vmm vmm_tail_mask() const noexcept { return vmm_tmp(1); }
@@ -414,128 +415,125 @@ private:
 
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag, bool store, Xbyak::Opmask ktail_mask,
-            dim_t tail_size);
+            int tail_size);
 
     void advance_ldb_post_op_regs();
-    void restore_ldb_post_op_regs(dim_t ld_block2);
-    void advance_bdb_post_op_regs(dim_t adj_bd_block);
-    void restore_bdb_post_op_regs(dim_t bd_block2);
-    void ldb_regs_shift(dim_t ld_block2, bool is_tail = false);
-    void advance_bd_block2_post_op_regs(dim_t bd_block2);
+    void restore_ldb_post_op_regs(int ld_block2);
+    void advance_bdb_post_op_regs(int adj_bd_block);
+    void restore_bdb_post_op_regs(int bd_block2);
+    void ldb_regs_shift(int ld_block2, bool is_tail = false);
+    void advance_bd_block2_post_op_regs(int bd_block2);
 
     void copy_post_ops_stack_values_to_aux(bool is_reg_tail);
     void read_params();
-    void zero_accumulators(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
+    void zero_accumulators(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_ld_tail, bool skip_accumulation);
 
-    void fp8_to_f16_upconvert(dim_t num_rows, dim_t tile_num_col_bytes,
+    void fp8_to_f16_upconvert(int num_rows, int tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
-    void fp8_to_f16_upconvert_to_vnni(dim_t num_rows, dim_t tile_num_col_bytes,
+    void fp8_to_f16_upconvert_to_vnni(int num_rows, int tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
-    void reduce_gemv_accumulators(dim_t bd_block);
-    void store_accumulators(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
+    void reduce_gemv_accumulators(int bd_block);
+    void store_accumulators(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_ld_tail, bool skip_accumulation);
     void store_accumulators_without_post_ops(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
-    void store_accumulators_apply_post_ops(dim_t bd_block, dim_t ld_block,
+            int bd_block, int ld_block, bool is_ld_tail, bool is_bdb_tail);
+    void store_accumulators_apply_post_ops(int bd_block, int ld_block,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
     void apply_zp_s8s8_compensation(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail);
-    void apply_per_mn_compensation(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail);
+            int bd_block, int ld_block, bool is_ld_tail);
+    void apply_per_mn_compensation(int bd_block, int ld_block, bool is_ld_tail);
     void apply_alpha_beta(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
-    void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
+            int bd_block, int ld_block, bool is_ld_tail, bool is_bdb_tail);
+    void apply_wei_scales(int bd_block, int ld_block2, bool is_ld_tail,
             bool dq2ps_required, bool &dq2ps_cvt_done);
-    void apply_src_scales_per_k(dim_t bd_block, dim_t ld_block2,
+    void apply_src_scales_per_k(int bd_block, int ld_block2,
             bool dq2ps_required, bool &dq2ps_cvt_done);
-    void apply_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail);
-    void apply_post_ops(dim_t bd_block, dim_t ld_block2,
-            dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
-    void gemv_apply_bias(dim_t bd_block, bool is_bdb_tail);
-    void gemv_apply_wei_scales(dim_t bd_block, bool is_bdb_tail);
+    void apply_scales(int bd_block, int ld_block2, bool is_ld_tail);
+    void apply_post_ops(int bd_block, int ld_block2, dim_t ldb_and_bdb_offset,
+            bool is_ld_tail, bool is_bdb_tail);
+    void gemv_apply_bias(int bd_block, bool is_bdb_tail);
+    void gemv_apply_wei_scales(int bd_block, bool is_bdb_tail);
 
     void restore_A_B_matrices();
     void set_A_B_matrices();
 
-    void compute_int8_compensation(dim_t rd_loop, dim_t bd_b, dim_t bd_e,
-            dim_t bd_block, dim_t ld_block2, bool is_ld_tail, dim_t vpad);
+    void compute_int8_compensation(int rd_loop, int bd_b, int bd_e,
+            int bd_block, int ld_block2, bool is_ld_tail, int vpad);
     void maybe_pre_process_data(
             data_type_t dt, const Vmm &vmm_out1, const Vmm &vmm_out2);
     void maybe_pre_process_data(matrix_kind_t matrix_kind, const Tmm &t1,
-            reg64_t reg_base, dim_t offset, reg64_t reg_stride, dim_t num_rows,
-            dim_t num_col_bytes, bool is_rd_tail);
+            reg64_t reg_base, dim_t offset, reg64_t reg_stride, int num_rows,
+            int num_col_bytes, bool is_rd_tail);
     bool maybe_pre_process_k_tail(bool last_bdb, bool is_rd_tail, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
-    void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
+    void maybe_tileloadd_nt(matrix_kind_t matrix_kind, int idx, dim_t offset,
             bool is_rd_tail, bool is_tail, bool last_bdb);
     void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
             const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
-    void gemm_microkernel(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
-            bool is_rd_tail, bool is_ld_tail, dim_t vpad,
-            dim_t rows_for_rd_tail);
-    void gemv_microkernel(bool is_bdb_tail, dim_t ld_block, bool is_rd_tail);
-    void gemm_microkernel_amx(dim_t bd_block2, bool is_bdb_tail,
-            dim_t ld_block2, bool is_rd_tail, bool is_ld_tail, bool last_bdb);
+    void gemm_microkernel(int bd_block2, bool is_bdb_tail, int ld_block,
+            bool is_rd_tail, bool is_ld_tail, int vpad, int rows_for_rd_tail);
+    void gemv_microkernel(bool is_bdb_tail, int ld_block, bool is_rd_tail);
+    void gemm_microkernel_amx(int bd_block2, bool is_bdb_tail, int ld_block2,
+            bool is_rd_tail, bool is_ld_tail, bool last_bdb);
 
-    void bs_loop(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
-            bool is_ld_tail, bool first_bdb, bool last_bdb,
-            dim_t rows_for_rd_tail, bool skip_accumulation);
+    void bs_loop(int bd_block2, bool is_bdb_tail, int ld_block, bool is_ld_tail,
+            bool first_bdb, bool last_bdb, int rows_for_rd_tail,
+            bool skip_accumulation);
 
-    void ldb_loop(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
+    void ldb_loop(int bd_block2, bool is_bdb_tail, int ld_block,
             dim_t ldb_loop_length, bool is_reg_tail, bool is_ld_tail,
-            bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
+            bool first_bdb, bool last_bdb, int rows_for_rd_tail,
             bool skip_accumulation);
     void bdb_loop();
 
     void generate() override;
 
-    bool gemv_is_tail_acc(
-            dim_t bd, dim_t bd_end, bool is_bdb_tail) const noexcept;
-    dim_t gemv_elems_per_vector_acc() const noexcept;
+    bool gemv_is_tail_acc(int bd, int bd_end, bool is_bdb_tail) const noexcept;
+    int gemv_elems_per_vector_acc() const noexcept;
 
-    dim_t A_offset(dim_t bd, dim_t rd, bool is_amx = false) const noexcept;
-    dim_t B_offset(dim_t ld, dim_t rd, bool is_amx = false) const noexcept;
-    dim_t C_offset(dim_t bd, dim_t ld) const noexcept;
-    dim_t D_offset(dim_t bd, dim_t ld) const noexcept;
+    dim_t A_offset(int bd, int rd, bool is_amx = false) const noexcept;
+    dim_t B_offset(int ld, int rd, bool is_amx = false) const noexcept;
+    dim_t C_offset(int bd, int ld) const noexcept;
+    dim_t D_offset(int bd, int ld) const noexcept;
 
     dim_t rdb_A_offset() const noexcept;
     dim_t rdb_B_offset() const noexcept;
 
-    dim_t ldb_B_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t ldb_C_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t ldb_D_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t ldb_po_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_B_offset(int ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_C_offset(int ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_D_offset(int ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_po_offset(int ld_block2, bool is_tail = false) const noexcept;
 
-    dim_t bdb_A_offset(dim_t bd_block2) const noexcept;
-    dim_t bdb_C_offset(dim_t bd_block2) const noexcept;
-    dim_t bdb_D_offset(dim_t bd_block2) const noexcept;
-    dim_t bdb_po_offset(dim_t bd_block2) const noexcept;
+    dim_t bdb_A_offset(int bd_block2) const noexcept;
+    dim_t bdb_C_offset(int bd_block2) const noexcept;
+    dim_t bdb_D_offset(int bd_block2) const noexcept;
+    dim_t bdb_po_offset(int bd_block2) const noexcept;
 
-    dim_t bias_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t oc_logical_offset(dim_t ld, bool is_tail = false) const noexcept;
+    dim_t bias_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t oc_logical_offset(int ld, bool is_tail = false) const noexcept;
 
-    dim_t compensations_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t bdb_compensation_offset(dim_t bd_block2) const noexcept;
-    dim_t bd_compensation_offset(dim_t ld, dim_t bd) const noexcept;
-    dim_t wei_scales_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t zp_comp_a_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t bd_zp_comp_a_offset(dim_t ld, dim_t bd) const noexcept;
-    dim_t bdb_zp_comp_a_offset(dim_t bd_block2) const noexcept;
-    dim_t zp_comp_b_offset(dim_t bd) const noexcept;
-    dim_t bdb_zp_comp_b_offset(dim_t bd_block2) const noexcept;
-    dim_t zp_c_values_offset(dim_t ld, bool is_tail = false) const noexcept;
+    dim_t compensations_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t bdb_compensation_offset(int bd_block2) const noexcept;
+    dim_t bd_compensation_offset(int ld, int bd) const noexcept;
+    dim_t wei_scales_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t zp_comp_a_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t bd_zp_comp_a_offset(int ld, int bd) const noexcept;
+    dim_t bdb_zp_comp_a_offset(int bd_block2) const noexcept;
+    dim_t zp_comp_b_offset(int bd) const noexcept;
+    dim_t bdb_zp_comp_b_offset(int bd_block2) const noexcept;
+    dim_t zp_c_values_offset(int ld, bool is_tail = false) const noexcept;
 
     // Offsets into the per-(M,N) f32 compensation buffer. The buffer mirrors
     // buf_C layout but with f32 stride (= brg.LDC elements).
-    dim_t per_mn_comp_offset(dim_t bd, dim_t ld) const noexcept;
+    dim_t per_mn_comp_offset(int bd, int ld) const noexcept;
     dim_t ldb_per_mn_comp_offset(
-            dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t bdb_per_mn_comp_offset(dim_t bd_block2) const noexcept;
+            int ld_block2, bool is_tail = false) const noexcept;
+    dim_t bdb_per_mn_comp_offset(int bd_block2) const noexcept;
 
     bool vpad_exist = false;
     bool need_comp_pads = false;
@@ -555,7 +553,7 @@ private:
  */
 template <typename Wmm>
 bool jit_brgemm_kernel_t<Wmm>::gemv_is_tail_acc(
-        dim_t bd, dim_t bd_end, bool is_bdb_tail) const noexcept {
+        int bd, int bd_end, bool is_bdb_tail) const noexcept {
     assert(brg.is_gemv);
     if (!brg.gemv_acc_is_vector()) return false;
     return (bd + 1) == bd_end && is_bdb_tail && brg.gemv_tail > 0;
@@ -573,7 +571,7 @@ bool jit_brgemm_kernel_t<Wmm>::gemv_is_tail_acc(
  * by the number of accumulator indices.
  */
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::gemv_elems_per_vector_acc() const noexcept {
+int jit_brgemm_kernel_t<Wmm>::gemv_elems_per_vector_acc() const noexcept {
     assert(brg.is_gemv && brg.gemv_acc_is_vector());
     if (!brg.is_gemv || !brg.gemv_acc_is_vector()) return 1;
     return brg.bd_block / brg.gemv_bd_block();
@@ -581,7 +579,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::gemv_elems_per_vector_acc() const noexcept {
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::A_offset(
-        dim_t bd, dim_t rd, bool is_amx) const noexcept {
+        int bd, int rd, bool is_amx) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_A * bd * gemv_elems_per_vector_acc();
 
@@ -591,7 +589,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::A_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::B_offset(
-        dim_t ld, dim_t rd, bool is_amx) const noexcept {
+        int ld, int rd, bool is_amx) const noexcept {
     if (is_amx) {
         return brg.typesize_B * (brg.rd_step * ld * brg.ld_block);
     } else {
@@ -606,7 +604,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::B_offset(
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::C_offset(dim_t bd, dim_t ld) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::C_offset(int bd, int ld) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_C * bd * gemv_elems_per_vector_acc() * brg.LDC;
 
@@ -615,7 +613,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::C_offset(dim_t bd, dim_t ld) const noexcept {
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::D_offset(dim_t bd, dim_t ld) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::D_offset(int bd, int ld) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_D * bd * gemv_elems_per_vector_acc() * brg.LDD;
 
@@ -639,40 +637,40 @@ dim_t jit_brgemm_kernel_t<Wmm>::rdb_B_offset() const noexcept {
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_B_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.typesize_B * brg.ldb_tail * brg.ld_step
                      : brg.typesize_B * ld_block2 * brg.ld_block * brg.ld_step;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_C_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.typesize_C * brg.ldb_tail
                      : brg.typesize_C * ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_D_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.typesize_D * brg.ldb_tail
                      : brg.typesize_D * ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_po_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.ldb_tail : ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_A_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_A_offset(int bd_block2) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_A * bd_block2 * brg.bd_block;
     return brg.typesize_A * bd_block2 * brg.bd_block * brg.LDA;
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(int bd_block2) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_C * bd_block2 * brg.bd_block * brg.LDC;
     return bd_block2 * brg.bd_block
@@ -680,7 +678,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(dim_t bd_block2) const noexcept {
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(int bd_block2) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_D * bd_block2 * brg.bd_block * brg.LDD;
     return bd_block2 * brg.bd_block
@@ -688,13 +686,13 @@ dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(dim_t bd_block2) const noexcept {
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_po_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_po_offset(int bd_block2) const noexcept {
     return bd_block2 * brg.bd_block * brg.LDD;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bias_offset(
-        dim_t bias_dim, bool is_tail) const noexcept {
+        int bias_dim, bool is_tail) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return bias_dim * gemv_elems_per_vector_acc() * brg.typesize_bias;
 
@@ -704,32 +702,32 @@ dim_t jit_brgemm_kernel_t<Wmm>::bias_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::oc_logical_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     return (is_tail) ? brg.ldb_tail : ld * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::compensations_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
                      : sizeof(int32_t) * ld * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_compensation_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bd_compensation_offset(
-        dim_t ld, dim_t bd) const noexcept {
+        int ld, int bd) const noexcept {
     return sizeof(int32_t) * (ld * brg.ld_block + bd * brg.LDB);
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return ld * (brg.bd_block / brg.gemv_bd_block())
                 * brg.is_per_n_wei_scales
@@ -742,37 +740,37 @@ dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_a_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
                      : sizeof(int32_t) * ld * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_zp_comp_a_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bd_zp_comp_a_offset(
-        dim_t ld, dim_t bd) const noexcept {
+        int ld, int bd) const noexcept {
     return sizeof(int32_t) * (ld * brg.ld_block + bd * brg.LDB);
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_b_offset(dim_t bd) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_b_offset(int bd) const noexcept {
     return sizeof(int32_t) * bd;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_zp_comp_b_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return zp_comp_b_offset(bd_block2 * brg.bd_block);
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::zp_c_values_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
                          : sizeof(int32_t) * ld * brg.ld_block;
@@ -783,20 +781,20 @@ dim_t jit_brgemm_kernel_t<Wmm>::zp_c_values_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::per_mn_comp_offset(
-        dim_t bd, dim_t ld) const noexcept {
+        int bd, int ld) const noexcept {
     return sizeof(float) * (bd * brg.LDC + ld * brg.ld_block);
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_per_mn_comp_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? sizeof(float) * brg.ldb_tail
                      : sizeof(float) * ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_per_mn_comp_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return sizeof(float) * bd_block2 * brg.bd_block * brg.LDC;
 }
 template <typename Wmm>
@@ -821,7 +819,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_set_avx_mask(bool is_tail) {
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::cvt2ps(data_type_t type_in, const Vmm vmm_in,
         const Xbyak::Operand &op, bool mask_flag, bool store,
-        Xbyak::Opmask ktail_mask, dim_t tail_size) {
+        Xbyak::Opmask ktail_mask, int tail_size) {
     Vmm vmm = vmm_in;
     const bool has_tail = op.isMEM()
             && tail_size != vreg_traits_t<Vmm>::vlen / sizeof(float);
@@ -880,7 +878,7 @@ void jit_brgemm_kernel_t<Wmm>::advance_ldb_post_op_regs() {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(dim_t ld_block2) {
+void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(int ld_block2) {
     if (brg.with_bias) {
         reg_aux_bias.restore();
         sub(reg_aux_bias, bias_offset(ld_block2 - 1));
@@ -909,7 +907,7 @@ void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(dim_t ld_block2) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(dim_t adj_bd_block) {
+void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(int adj_bd_block) {
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_b.restore();
         add(reg_aux_zp_comp_b, bdb_zp_comp_b_offset(1));
@@ -924,7 +922,7 @@ void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(dim_t adj_bd_block) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(dim_t bd_block2) {
+void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(int bd_block2) {
     bool post_processed = false;
     if (bd_block2 > 1) {
         if (brg.zp_type_b != brgemm_broadcast_t::none) {
@@ -944,7 +942,7 @@ void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(dim_t bd_block2) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(dim_t ld_block2, bool is_tail) {
+void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(int ld_block2, bool is_tail) {
     dim_t C_offset
             = (is_tail) ? ldb_C_offset(1, true) : ldb_C_offset(ld_block2);
     dim_t D_offset
@@ -999,7 +997,7 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(dim_t ld_block2, bool is_tail) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(dim_t bd_block2) {
+void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(int bd_block2) {
     if (brg.req_comp_pads_with_bcast && brg.req_s8s8_compensation) {
         reg_buf.restore();
         add(reg_buf, bdb_compensation_offset(bd_block2));
@@ -1135,13 +1133,19 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
 
     if (brg.is_runtime_ldc) {
         mov(reg_stride_ld_block, ptr[param1 + GET_OFF(dynamic_LDC)]);
-        if (brg.typesize_C > 1) shl(reg_stride_ld_block, (brg.typesize_C >> 1));
+        // typesize_C is always 1/2/4/8, so this shift amount is provably
+        // bounded regardless of typesize_C's declared (dim_t) type.
+        if (brg.typesize_C > 1)
+            shl(reg_stride_ld_block, static_cast<int>(brg.typesize_C >> 1));
         reg_stride_ld_block.save();
     }
 
     if (brg.is_runtime_ldd) {
         mov(reg_D_shift_bytes, ptr[param1 + GET_OFF(dynamic_LDD)]);
-        if (brg.typesize_D > 1) shl(reg_D_shift_bytes, (brg.typesize_D >> 1));
+        // typesize_D is always 1/2/4/8, so this shift amount is provably
+        // bounded regardless of typesize_D's declared (dim_t) type.
+        if (brg.typesize_D > 1)
+            shl(reg_D_shift_bytes, static_cast<int>(brg.typesize_D >> 1));
         reg_D_shift_bytes.save();
     }
 
@@ -1159,26 +1163,27 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::zero_accumulators(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_ld_tail,
         bool skip_accumulation) {
     if (brg.is_tmm) {
         // avoid usage of tile registers if there is no accumulation
         if (skip_accumulation) return;
-        for_(dim_t bdb = 0; bdb < bd_block2; bdb++)
-        for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
-            dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
-            tilezero(Tmm(brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail)));
+        for_(int bdb = 0; bdb < bd_block2; bdb++)
+        for (int ldb = 0; ldb < ld_block2; ldb++) {
+            int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
+            tilezero(Tmm(xbyak_register_index(
+                    brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail))));
         }
     } else if (brg.is_gemv) {
-        for (dim_t bd = 0; bd < brg.gemv_bd_block(); bd++) {
+        for (int bd = 0; bd < brg.gemv_bd_block(); bd++) {
             auto vmm = accm(1, bd, 0);
             uni_vpxor(vmm, vmm, vmm);
         }
     } else {
-        dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
-        for_(dim_t bd = 0; bd < bd_block; bd++)
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+        for_(int bd = 0; bd < bd_block; bd++)
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             uni_vpxor(vmm, vmm, vmm);
         }
@@ -1188,11 +1193,11 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(dim_t num_rows,
-        dim_t tile_num_col_bytes, reg64_t reg_base, dim_t offset,
+void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(int num_rows,
+        int tile_num_col_bytes, reg64_t reg_base, dim_t offset,
         reg64_t reg_data_stride, data_type_t dt, bool is_rd_tail) {
 
-    dim_t rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+    int rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
 
     const dim_t max_num_cols
             = rd_block; //tile_num_col_bytes / sizeof(float16_t);
@@ -1227,8 +1232,8 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(dim_t num_rows,
 // This method up-converts and transforms the data from fp8_vnni to f16_vnni
 // format. Generally used by matrix_B.
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
-        dim_t tile_num_col_bytes, reg64_t reg_base, dim_t offset,
+void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(int num_rows,
+        int tile_num_col_bytes, reg64_t reg_base, dim_t offset,
         reg64_t reg_data_stride, data_type_t dt, bool is_rd_tail) {
     const dim_t num_cols_ele = tile_num_col_bytes / 2; // 32 for full tile
     const dim_t num_N = num_cols_ele / 2; // 16 for full tile
@@ -1240,17 +1245,17 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
     const auto reg_data_aux = reg_tmp_gpr;
     lea(reg_data_aux, ptr[reg_base + offset]);
 
-    dim_t rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+    int rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
     const dim_t vnni_granularity = data_type_vnni_granularity(data_type::f16);
     const dim_t r_end = utils::div_up(rd_block, vnni_granularity);
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else
         assert(!"unsupported data type");
 
@@ -1347,8 +1352,7 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
  * are consistent with the GEMV blocking model used in the kernel.
  */
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
-        dim_t bd_block, bool is_bdb_tail) {
+void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(int bd_block, bool is_bdb_tail) {
 
     reg_aux_bias.restore();
 
@@ -1372,7 +1376,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
         }
     }
 
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
 
         if (is_bias_scalar) {
@@ -1465,7 +1469,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
  */
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
-        dim_t bd_block, bool is_bdb_tail) {
+        int bd_block, bool is_bdb_tail) {
 
     reg_aux_wei_scales.restore();
 
@@ -1490,7 +1494,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
         }
     }
 
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
 
         if (brg.gemv_single_wei_scale()) {
@@ -1540,7 +1544,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail, bool is_bdb_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail, bool is_bdb_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
 
     auto vmm_alpha = vmm_tmp(0);
@@ -1550,8 +1554,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
         uni_vbroadcastss(vmm_alpha, Xmm(vmm_alpha.getIdx()));
     }
 
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         auto vmm = accm(ld_block2, bd, ld);
         if (brg.do_dq2ps_cvt()) uni_vcvtdq2ps(vmm, vmm);
         if (apply_alpha) uni_vmulps(vmm, vmm, vmm_alpha);
@@ -1571,8 +1575,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
             {{{&reg_aux_C}, brg.is_runtime_ldc && bd_block > 1},
                     {{&reg64_fp8_aux}, brg.is_fp8_via_convert()}});
 
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
         const auto k_mask = is_tail ? ld_tail_mask : ld_full_mask;
         auto vmm = accm(ld_block2, bd, ld);
@@ -1609,7 +1613,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
             }
         } else {
             assert(!brg.is_gemv && "int8 data type is not supported for gemv");
-            const dim_t ld_size = is_tail ? brg.ldb_tail : brg.ld_block;
+            const int ld_size = is_tail ? brg.ldb_tail : brg.ld_block;
             cvt2ps(brg.dt_c, vmm_prev_dst, ptr_C, is_tail, false, k_mask,
                     ld_size);
             if (brg.beta == 1.f)
@@ -1625,7 +1629,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
+void jit_brgemm_kernel_t<Wmm>::apply_post_ops(int bd_block, int ld_block2,
         dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     reg64_savable_guard_t registers_guard({{{&param1_backup}, true},
@@ -1633,16 +1637,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
 
     if (brg.with_binary) param1.restore();
 
-    const dim_t bd_block_shift = brg.is_runtime_ldd ? 1 : bd_block;
-    for (dim_t bd_block_idx = 0; bd_block_idx < bd_block;
+    const int bd_block_shift = brg.is_runtime_ldd ? 1 : bd_block;
+    for (int bd_block_idx = 0; bd_block_idx < bd_block;
             bd_block_idx += bd_block_shift) {
-        dim_t bd_start = bd_block_idx;
-        dim_t bd_end = bd_start + bd_block_shift;
+        int bd_start = bd_block_idx;
+        int bd_end = bd_start + bd_block_shift;
 
         const auto set_binary_injecotr_params = [&] {
             if (!brg.with_binary || !with_binary_non_scalar_bcast_) return;
-            for_(dim_t bd = bd_start; bd < bd_end; bd++)
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            for_(int bd = bd_start; bd < bd_end; bd++)
+            for (int ld = 0; ld < ld_block2; ld++) {
                 const auto vmm_idx = accm(ld_block2, bd, ld).getIdx();
 
                 rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_aux_D);
@@ -1699,8 +1703,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                     }
                 }
 
-                for_(dim_t bd = bd_start; bd < bd_end; bd++)
-                for (dim_t ld = 0; ld < ld_block2; ld++) {
+                for_(int bd = bd_start; bd < bd_end; bd++)
+                for (int ld = 0; ld < ld_block2; ld++) {
                     const auto vmm = accm(ld_block2, bd, ld);
                     const auto addr = ptr[reg_aux_D + D_offset(bd, ld)];
                     const auto vmm_prev_dst = vmm_tmp(0);
@@ -1708,7 +1712,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
                         const auto k_mask
                                 = is_tail ? ld_tail_mask : ld_full_mask;
-                        const dim_t ld_size
+                        const int ld_size
                                 = is_tail ? brg.ldb_tail : brg.ld_block;
                         cvt2ps(brg.sum_dt, vmm_prev_dst, addr, is_tail, false,
                                 k_mask, ld_size);
@@ -1718,7 +1722,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                         const auto k_mask = use_partial_mask ? gemv_partial_mask
                                                              : gemv_full_mask;
 
-                        const dim_t elements_to_load = use_partial_mask
+                        const int elements_to_load = use_partial_mask
                                 ? brg.gemv_acc_is_vector() ? brg.gemv_tail : 1
                                 : brg.bd_block / brg.gemv_bd_block();
                         cvt2ps(brg.sum_dt, vmm_prev_dst, addr, use_partial_mask,
@@ -1759,10 +1763,10 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(dim_t bd_block) {
+void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(int bd_block) {
     // At this point the broadcast registers are not used.
     auto workspace = bcst();
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
         regops::horizontal_add_ps(this, acc, workspace);
     }
@@ -1823,10 +1827,10 @@ void jit_brgemm_kernel_t<Wmm>::load_scales_to_vmm(const data_type_t type_in,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
+void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(int bd_block, int ld_block2,
         bool is_ld_tail, bool dq2ps_required, bool &dq2ps_cvt_done) {
     reg_aux_wei_scales.restore();
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for (int ld = 0; ld < ld_block2; ld++) {
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
 
@@ -1834,7 +1838,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
         load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr, is_tail,
                 brg.is_single_wei_scale);
 
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
             uni_vmulps(vmm, vmm, vmm_wei_scales);
@@ -1844,16 +1848,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(dim_t bd_block,
-        dim_t ld_block2, bool dq2ps_required, bool &dq2ps_cvt_done) {
+void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(int bd_block,
+        int ld_block2, bool dq2ps_required, bool &dq2ps_cvt_done) {
     reg_src_scales.restoreTo(reg_aux_src_scales);
     const auto vmm_src_sc = vmm_tmp(0);
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         const auto src_sc_addr
                 = ptr[reg_aux_src_scales + bd * brg.src_scale_m_stride];
         load_scales_to_vmm(brg.dt_src_scales, vmm_src_sc, src_sc_addr,
                 /*is_ld_tail=*/false, /*is_single_scale=*/true);
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
             uni_vmulps(vmm, vmm, vmm_src_sc);
@@ -1867,7 +1871,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(dim_t bd_block,
 // f32 so apply_alpha_beta uses vaddps against f32 buffer C.
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_scales(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail) {
     assert(brg.has_per_k_scales());
     const bool dq2ps_required = brg.is_int8;
     // When per-MN compensation was applied before this call, dq2ps is
@@ -1881,8 +1885,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
         apply_src_scales_per_k(
                 bd_block, ld_block2, dq2ps_required, dq2ps_cvt_done);
     if (dq2ps_required && !dq2ps_cvt_done) {
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             uni_vcvtdq2ps(vmm, vmm);
         }
@@ -1890,8 +1894,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
-        dim_t ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(int bd_block,
+        int ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
         bool is_bdb_tail) {
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
 
@@ -1922,8 +1926,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                     ptr[reg_aux_src_scales],
                     /*is_ld_tail=*/false, /*is_single_scale=*/true);
 
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
 
@@ -1954,8 +1958,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         uni_vmovq(xmm_scale_adjust, reg_aux_scale_adjust);
         uni_vbroadcastss(vmm_scale_adjust, xmm_scale_adjust);
 
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
             uni_vmulps(vmm, vmm, vmm_scale_adjust);
@@ -1968,7 +1972,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     if (!brg.is_gemv) {
         reg_aux_bias.restore();
 
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm_bias = vmm_tmp(0);
             if (brg.with_bias) {
                 auto ptr_bias = ptr[reg_aux_bias + bias_offset(ld)];
@@ -1976,7 +1980,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                 cvt2ps(brg.dt_bias, vmm_bias, ptr_bias, is_tail, false, k_mask,
                         is_tail ? brg.ldb_tail : brg.ld_block);
             }
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
                 if (brg.with_bias) uni_vaddps(vmm, vmm, vmm_bias);
@@ -1996,8 +2000,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         auto vmm_dst_scales = vmm_tmp(0);
         vbroadcastss(vmm_dst_scales, ptr[reg_dst_scales]);
 
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             vmulps(vmm, vmm, vmm_dst_scales);
         }
@@ -2018,7 +2022,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         }
         if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
 
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
             if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
                 dim_t zp_c_off = zp_c_values_offset(ld);
@@ -2033,7 +2037,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                             k_mask, is_tail ? brg.ldb_tail : brg.ld_block);
                 }
             }
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 uni_vaddps(vmm, vmm, vmm_zp_c);
             }
@@ -2049,8 +2053,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     if (dt_requires_saturation) {
         init_saturate_f32(vmm_lbound(), vmm_ubound(), reg_tmp_gpr,
                 data_type::f32, brg.dt_d, false, use_sat_cvt);
-        for (dim_t bd = 0; bd < bd_block; bd++) {
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int bd = 0; bd < bd_block; bd++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 saturate_cvt_f32(vmm, vmm_lbound(), vmm_ubound(), brg.dt_d,
                         false, use_sat_cvt);
@@ -2072,8 +2076,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     else if (brg.brgattr.hint_prefetchw == brgemm_prfw_store)
         prefetchw(ptr[reg_aux_D]);
 
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         auto addr = ptr[reg_aux_D + D_offset(bd, ld)];
         auto vmm = accm(ld_block2, bd, ld);
         auto vmm_lower = Vmm_lower_t(vmm.getIdx());
@@ -2154,7 +2158,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                 }
             }
         } else {
-            const dim_t ld_block = is_tail ? brg.ldb_tail : brg.ld_block;
+            const int ld_block = is_tail ? brg.ldb_tail : brg.ld_block;
             if (is_tail && types::data_type_size(brg.dt_b) == sizeof(float))
                 vmaskmovps(addr, vmm_tail_mask(), vmm);
             else
@@ -2169,7 +2173,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail) {
     assert(!brg.is_gemv && "compensation is not supported for gemv");
     // apply compensation to accumulated values
     // to avoid the loss of accuracy when converting s32 to f32
@@ -2182,9 +2186,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
 
         reg_aux_zp_comp_a.restore();
         const auto vmm_zp_comp_a = vmm_tmp(0);
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 if (IMPLICATION(!brg.req_comp_pads_with_bcast, bd == 0)) {
                     const auto zp_comp_a_addr = ptr[reg_aux_zp_comp_a
                             + bd_zp_comp_a_offset(ld, bd)];
@@ -2209,9 +2213,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
 
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_b.restore();
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             dim_t zp_comp_b_off = zp_comp_b_offset(bd);
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (is_superset(brg.isa_impl, avx512_core)) {
                     const auto zp_comp_b_addr = EVEX_compress_addr(
@@ -2230,9 +2234,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
     if (!brg.req_cal_comp_pads && brg.req_s8s8_compensation) {
         reg_aux_compensation.restore();
         auto vmm_comp = vmm_tmp(0);
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 if (IMPLICATION(!brg.req_comp_pads_with_bcast, bd == 0)) {
                     const auto comp_addr = ptr[reg_aux_compensation
                             + bd_compensation_offset(ld, bd)];
@@ -2253,15 +2257,15 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail) {
     assert(brg.with_per_mn_compensation);
     assert(!brg.is_gemv && "per-(M,N) compensation is not supported for gemv");
     assert(!brg.is_integer_acc()
             && "per-(M,N) compensation is not supported for int accumulation");
 
     if (brg.is_int8) {
-        for_(dim_t bd = 0; bd < bd_block; bd++)
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for_(int bd = 0; bd < bd_block; bd++)
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             uni_vcvtdq2ps(vmm, vmm);
         }
@@ -2270,8 +2274,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
     const auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     reg_aux_per_mn_comp.restore();
     const auto vmm_delta = vmm_tmp(0);
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
         const auto delta_addr
                 = ptr[reg_aux_per_mn_comp + per_mn_comp_offset(bd, ld)];
@@ -2289,7 +2293,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail, bool is_bdb_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail, bool is_bdb_tail) {
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are converted to ps in apply_alpha_beta()
     const bool alpha_or_beta_applicable = brg.alpha != 1.0f || brg.beta != 0.f;
@@ -2303,8 +2307,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
     if (dt_requires_saturation) {
         init_saturate_f32(vmm_lbound(), vmm_ubound(), reg_tmp_gpr,
                 data_type::f32, brg.dt_d, false, use_sat_cvt);
-        for (dim_t bd = 0; bd < bd_block; bd++) {
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int bd = 0; bd < bd_block; bd++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 saturate_cvt_f32(vmm, vmm_lbound(), vmm_ubound(), brg.dt_d,
                         false, use_sat_cvt);
@@ -2323,7 +2327,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
         prefetchw(ptr[reg_aux_C]);
 
     if (brg.is_gemv) {
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             const bool need_prefetch
                     = brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
                     && !is_superset(brg.isa_impl, avx10_2);
@@ -2352,8 +2356,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
             }
         }
     } else {
-        for_(dim_t bd = 0; bd < bd_block; bd++)
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for_(int bd = 0; bd < bd_block; bd++)
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             const auto addr_c = ptr[reg_aux_C + C_offset(bd, ld)];
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
@@ -2374,8 +2378,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_ld_tail,
         bool skip_accumulation) {
     const bool has_zero_points = !everyone_is(brgemm_broadcast_t::none,
             brg.zp_type_a, brg.zp_type_b, brg.zp_type_c);
@@ -2409,7 +2413,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
             const bool do_accum_ops = need_to_apply_alpha_beta
                     || are_post_ops_applicable || apply_zp_a_compensation;
-            const dim_t adj_bd_block = (brg.is_M_tail && is_bdb_tail)
+            const int adj_bd_block = (brg.is_M_tail && is_bdb_tail)
                     ? brg.bdb_tail
                     : brg.bd_block;
 
@@ -2428,21 +2432,21 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
             reg_buf.restore();
 
-            for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
-                    const dim_t idx = is_ld_tail ? brg.ld_block2 : ldb;
+            for (int bdb = 0; bdb < bd_block2; bdb++) {
+                for (int ldb = 0; ldb < ld_block2; ldb++) {
+                    const int idx = is_ld_tail ? brg.ld_block2 : ldb;
                     const int c_tensor = brg.get_C_tensor(
                             bdb, idx, is_bdb_tail, is_ld_tail);
                     if (do_accum_ops) {
                         if (skip_accumulation) {
-                            for (dim_t bd = 0; bd < adj_bd_block; bd++) {
+                            for (int bd = 0; bd < adj_bd_block; bd++) {
                                 auto vreg_acc = accm(1, bd, 0);
                                 uni_vpxor(vreg_acc, vreg_acc, vreg_acc);
                             }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
-                                    Tmm(c_tensor));
-                            for (dim_t bd = 0; bd < adj_bd_block; bd++) {
+                                    Tmm(xbyak_register_index(c_tensor)));
+                            for (int bd = 0; bd < adj_bd_block; bd++) {
                                 const size_t buf_offset
                                         = (bd * brg.ld_block) * brg.typesize_C;
                                 auto vreg_acc = is_ld_tail
@@ -2481,7 +2485,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
                         reg_buf.restore();
                     } else {
-                        auto tmm = Tmm(c_tensor);
+                        auto tmm = Tmm(xbyak_register_index(c_tensor));
                         if (skip_accumulation) tilezero(tmm);
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
                         if (ldb < ld_block2 - 1)
@@ -2563,7 +2567,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
         store_accumulators_amx(false);
         L_aligned(label_done);
     } else {
-        dim_t bd_block = 0;
+        int bd_block = 0;
         if (brg.is_gemv)
             bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
         else
@@ -2704,7 +2708,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
         const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
-        dim_t num_rows, dim_t num_col_bytes, bool is_rd_tail) {
+        int num_rows, int num_col_bytes, bool is_rd_tail) {
     const auto transform_offset = brg.brgattr.use_interleave_stores
             ? brg.get_num_C_tiles() * brgemm_desc_t::tilesize
             : 0;
@@ -2729,13 +2733,13 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
-        dim_t idx, dim_t offset, bool is_rd_tail, bool is_tail, bool last_bdb) {
+        int idx, dim_t offset, bool is_rd_tail, bool is_tail, bool last_bdb) {
 
     const bool is_A = matrix_kind == matrix_kind_t::matrix_A;
 
-    const dim_t tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
-                               : brg.get_B_tensor(idx, is_tail);
-    auto t1 = Tmm(tmm_idx);
+    const int tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
+                             : brg.get_B_tensor(idx, is_tail);
+    auto t1 = Tmm(xbyak_register_index(tmm_idx));
 
     auto reg_base = is_A ? reg_aux_A : reg_aux_B;
 
@@ -2744,25 +2748,24 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
             == (is_A ? brgemm_bd_loop_innermost : brgemm_ld_loop_innermost);
 
     if (brg.is_fp8_via_convert()) {
-        const dim_t typesize_A
+        const int typesize_A
                 = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_A;
-        const dim_t typesize_B
+        const int typesize_B
                 = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_B;
-        dim_t rd_step = 4 / typesize_A;
-        dim_t rd_block
-                = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
+        int rd_step = 4 / typesize_A;
+        int rd_block = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
         if (brg.is_input_convert()) {
-            const int vnni_granularity
+            const auto vnni_granularity
                     = data_type_vnni_granularity(data_type::f16);
             rd_block = utils::rnd_up(rd_block, vnni_granularity);
         }
 
-        dim_t A_col = typesize_A * rd_block;
-        dim_t A_row = is_tail ? brg.bdb_tail : brg.bd_block;
+        int A_col = typesize_A * rd_block;
+        int A_row = is_tail ? brg.bdb_tail : brg.bd_block;
 
-        dim_t B_col = (is_tail ? brg.ldb_tail : brg.ld_block) * typesize_B
+        int B_col = (is_tail ? brg.ldb_tail : brg.ld_block) * typesize_B
                 * rd_step;
-        dim_t B_row = brg.typesize_C != 0 ? A_col / brg.typesize_C : 0;
+        int B_row = brg.typesize_C != 0 ? A_col / brg.typesize_C : 0;
         reg64_savable_guard_t reg_fp8_buf_guard({&reg64_fp8_aux, &reg_buf_aux});
 
         reg_buf.restoreTo(reg_buf_aux);
@@ -2806,8 +2809,8 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
     //TODO: reuse transformed data from matrix A for ldi > 0
     const int max_tiles = amx::get_max_palette_size();
     JIT_ASSERT_RET(t1.getIdx() >= 0 && t1.getIdx() < max_tiles, false);
-    const dim_t num_rows = palette_.rows[t1.getIdx()];
-    const dim_t num_col_bytes = palette_.cols[t1.getIdx()];
+    const int num_rows = palette_.rows[t1.getIdx()];
+    const int num_col_bytes = palette_.cols[t1.getIdx()];
 
     const auto max_num_cols
             = nstl::min<dim_t>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
@@ -2854,8 +2857,8 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_rd_tail, bool is_ld_tail,
         bool last_bdb) {
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         using namespace data_type;
@@ -2889,22 +2892,24 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
     };
     dim_t rbd_block = (is_rd_tail) ? 1 : brg.rdb;
     for (dim_t rdb = 0; rdb < rbd_block; rdb++) {
-        for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
+        for (int bdb = 0; bdb < bd_block2; bdb++) {
             maybe_tileloadd_nt(matrix_kind_t::matrix_A, bdb,
                     rdb * rdb_A_offset() + A_offset(bdb, 0, true), is_rd_tail,
                     is_bdb_tail, last_bdb && bdb == bd_block2 - 1);
         }
-        for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
+        for (int ldb = 0; ldb < ld_block2; ldb++) {
 
-            const dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
+            const int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
             maybe_tileloadd_nt(matrix_kind_t::matrix_B, idx,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
                     is_ld_tail, false);
-            for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                tdpbxxd(Tmm(brg.get_C_tensor(
-                                bdb, idx, is_bdb_tail, is_ld_tail)),
-                        Tmm(brg.get_A_tensor(bdb, is_bdb_tail)),
-                        Tmm(brg.get_B_tensor(idx, is_ld_tail)));
+            for (int bdb = 0; bdb < bd_block2; bdb++) {
+                tdpbxxd(Tmm(xbyak_register_index(brg.get_C_tensor(
+                                bdb, idx, is_bdb_tail, is_ld_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_A_tensor(bdb, is_bdb_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_B_tensor(idx, is_ld_tail))));
             }
         }
     }
@@ -2940,13 +2945,12 @@ void jit_brgemm_kernel_t<Wmm>::dot_product(Vmm v1, Vmm v2, Vmm v3) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
-        dim_t bd_b, dim_t bd_e, dim_t bd_block, dim_t ld_block2,
-        bool is_ld_tail, dim_t vpad) {
+void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(int rd_loop, int bd_b,
+        int bd_e, int bd_block, int ld_block2, bool is_ld_tail, int vpad) {
     assert(brg.is_int8);
 
     auto compensation_padding = [this, ld_block2](Vmm vmm_load, Vmm vmm_tmp,
-                                        dim_t ld, dim_t bd_b, dim_t bd_e) {
+                                        int ld, int bd_b, int bd_e) {
         // req_cal_comp_pads -> only calculate compensation along with
         // computation and do not use pre-calculated compensation.
         // Calculate comp padding as:
@@ -2957,7 +2961,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
                 dot_product(vmm_tmp, vmm_load, vmm_inp_shift());
             }
 
-            for (dim_t bd = bd_b; bd < bd_e; bd++) {
+            for (int bd = bd_b; bd < bd_e; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (brg.req_cal_comp_pads) {
                     uni_vpsubd(vmm, vmm, vmm_tmp);
@@ -2972,7 +2976,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
             dot_product(vmm_tmp, vmm_load, vmm_one_bytes());
             uni_vpmulld(vmm_tmp, vmm_tmp, vmm_zp_a_shift());
 
-            for (dim_t bd = bd_b; bd < bd_e; bd++) {
+            for (int bd = bd_b; bd < bd_e; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (brg.req_cal_comp_pads) {
                     uni_vpsubd(vmm, vmm, vmm_tmp);
@@ -2992,15 +2996,15 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
         uni_vpbroadcastd(vmm_zp_a_shift(), reg32_scratch);
     }
 
-    for_(dim_t rd = 0; rd < rd_loop; rd += brg.rd_step)
-    for (dim_t ld = 0; ld < ld_block2; ++ld) {
+    for_(int rd = 0; rd < rd_loop; rd += brg.rd_step)
+    for (int ld = 0; ld < ld_block2; ++ld) {
         const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
         if (IMPLICATION(is_tail, is_superset(brg.isa_impl, avx512_core))) {
             auto vmm_store = vmm_mask(load(), is_tail, false, ld_tail_mask);
             uni_vmovups(vmm_store, addr);
         } else {
-            load_bytes(load(), addr, ldb_B_offset(0, true));
+            load_bytes(load(), addr, static_cast<int>(ldb_B_offset(0, true)));
         }
 
         if (brg.req_cal_comp_pads) {
@@ -3015,13 +3019,13 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail) {
+        bool is_bdb_tail, int ld_block2, bool is_rd_tail) {
 
     assert(brg.is_gemv);
     assert(brg.ld_block == 1);
     assert(ld_block2 == 1);
 
-    const dim_t bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
+    const int bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
 
     const auto load_and_convert_to_f32
             = [this](const Vmm vmm, const Xbyak::Address addr,
@@ -3093,7 +3097,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
             load_and_convert_to_f32(b_vmm, b_addr, brg.dt_b, is_rd_tail);
         }
 
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             const auto acc = accm(1, bd, 0);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
 
@@ -3123,7 +3127,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
         const bool do_pf = is_superset(brg.isa_impl, avx512_core);
 
         bcast_and_convert_to_f32(gemv_load_b(), ptr[reg_aux_B], brg.dt_b);
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             const bool is_tail_acc
                     = gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
@@ -3140,13 +3144,13 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
-        dim_t vpad, dim_t rows_for_rd_tail) {
+void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
+        int ld_block2, bool is_rd_tail, bool is_ld_tail, int vpad,
+        int rows_for_rd_tail) {
 
     MAYBE_UNUSED(bd_block2);
-    dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
-    const auto bd_b = nstl::max(dim_t(0), vpad);
+    int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const auto bd_b = nstl::max(0, vpad);
     const auto bd_e = nstl::min(bd_block, bd_block + vpad);
     const auto is_valid_bd
             = need_comp_pads && vpad != 0 ? bd_b <= bd_e : bd_b < bd_e;
@@ -3154,7 +3158,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     bool is_emdbd = brg.embd_bcst;
 
-    dim_t rd_loop = 0, rd_tail_size = 0;
+    int rd_loop = 0, rd_tail_size = 0;
     if (is_rd_tail) {
         if (brg.is_bf16 || brg.is_f16 || brg.is_int8 || brg.is_fp8) {
             rd_tail_size = brg.rdb_tail % brg.rd_step;
@@ -3175,7 +3179,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     auto broadcast_A
             = [this, rd_tail_size, is_rd_tail, rd_loop, rows_for_rd_tail, bd_e](
-                      Vmm vmm_bcast, dim_t bd, dim_t rd) {
+                      Vmm vmm_bcast, int bd, int rd) {
         const auto offset = A_offset(bd, rd);
         const auto dt = brg.dt_a;
         const bool maybe_load_bytes
@@ -3191,8 +3195,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         const auto is_tail = have_to_load_bytes && bd_by_load_bytes;
         if (is_tail) {
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
-            load_bytes(
-                    xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
+            load_bytes(xmm_tmp, reg_aux_A, offset,
+                    static_cast<int>(rd_tail_size * brg.typesize_A));
             uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
@@ -3221,7 +3225,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             uni_vpaddb(vmm_bcast, vmm_bcast, vmm_inp_shift());
     };
 
-    auto load_B = [this, is_ld_tail](dim_t vmm_load_idx, dim_t rd, dim_t ld) {
+    auto load_B = [this, is_ld_tail](int vmm_load_idx, int rd, int ld) {
         const bool mem_advice_B
                 = utils::one_of(brg.brgattr.mem_advice,
                           brgemm_hint_mem_advice_B, brgemm_hint_mem_advice_A_B)
@@ -3255,7 +3259,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     vpermw(vmm_load, f16_perm_odd_vreg(), vmm_load);
                 vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
             } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr,
+                        static_cast<int>(ldb_B_offset(0, true)));
                 vcvtph2ps(vmm_load, Xmm(vmm_load.getIdx()));
             } else {
                 uni_vcvtph2psx(vmm_load, addr);
@@ -3271,7 +3276,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 uni_vpmovzxwd(vmm_load, addr);
                 uni_vpslld(vmm_load, vmm_load, 16);
             } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr,
+                        static_cast<int>(ldb_B_offset(0, true)));
             } else {
                 uni_vmovups(vmm_load, addr);
             }
@@ -3279,7 +3285,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             if (is_superset(brg.isa_impl, avx512_core)) {
                 uni_vmovups(vmm_load, addr);
             } else {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr,
+                        static_cast<int>(ldb_B_offset(0, true)));
             }
         } else {
             uni_vmovups(vmm_load, addr);
@@ -3303,15 +3310,15 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
 
-    for (dim_t rd = 0; rd < rd_loop; rd += brg.rd_step) {
+    for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
         if (brg.n_bcast_1_load) {
-            for (dim_t bd = bd_b; bd < bd_e && !is_emdbd; bd++)
+            for (int bd = bd_b; bd < bd_e && !is_emdbd; bd++)
                 broadcast_A(bcst(bd), bd, rd);
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 load_B(0, rd, ld);
                 if (brg.is_fp8_via_convert_non_amx())
                     maybe_pre_process_data(brg.dt_b, load(), vmm_fp8_load());
-                for (dim_t bd = bd_b; bd < bd_e; bd++) {
+                for (int bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
                     if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(),
@@ -3330,12 +3337,12 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             }
 
         } else {
-            dim_t prefetch_count_B = 0;
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            int prefetch_count_B = 0;
+            for (int ld = 0; ld < ld_block2; ld++) {
                 load_B(ld, rd, ld);
             }
 
-            for (dim_t bd = bd_b; bd < bd_e; bd++) {
+            for (int bd = bd_b; bd < bd_e; bd++) {
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
                 if (brg.is_fp8_via_convert_non_amx())
                     maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
@@ -3358,7 +3365,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                         }
                     }
                 }
-                for (dim_t ld = 0; ld < ld_block2; ld++) {
+                for (int ld = 0; ld < ld_block2; ld++) {
                     auto vmm = accm(ld_block2, bd, ld);
                     if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(ld),
@@ -3384,15 +3391,15 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
-        dim_t ld_block2, bool is_ld_tail, bool first_bdb, bool last_bdb,
-        dim_t rows_for_rd_tail, bool skip_accumulation) {
+void jit_brgemm_kernel_t<Wmm>::bs_loop(int bd_block2, bool is_bdb_tail,
+        int ld_block2, bool is_ld_tail, bool first_bdb, bool last_bdb,
+        int rows_for_rd_tail, bool skip_accumulation) {
 
-    auto bs_loop_body = [&](dim_t vpad, bool last_bdb) {
+    auto bs_loop_body = [&](int vpad, bool last_bdb) {
         set_A_B_matrices();
 
-        dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
-        const auto bd_b = nstl::max(dim_t(0), vpad);
+        int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+        const auto bd_b = nstl::max(0, vpad);
         const auto bd_e = nstl::min(bd_block, bd_block + vpad);
         const auto is_valid_bd
                 = need_comp_pads && vpad != 0 ? bd_b <= bd_e : bd_b < bd_e;
@@ -3477,7 +3484,7 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
                 } else
                     xor_(reg_aux_A_vpad, reg_aux_A_vpad);
 
-                for (dim_t vpad = vpad_first; vpad <= vpad_last; vpad++) {
+                for (int vpad = vpad_first; vpad <= vpad_last; vpad++) {
                     const auto label_vpad = vpad - vpad_first;
                     L(Vpad_loop_iter_label[label_vpad]);
                     if (!first_bdb && vpad > 0) continue;
@@ -3522,9 +3529,9 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
-        dim_t ld_block2, dim_t ldb_loop_length, bool is_reg_tail,
-        bool is_ld_tail, bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
+void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
+        int ld_block2, dim_t ldb_loop_length, bool is_reg_tail, bool is_ld_tail,
+        bool first_bdb, bool last_bdb, int rows_for_rd_tail,
         bool skip_accumulation) {
 
     Label ldb_loop_label;
@@ -3576,8 +3583,8 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
-    auto do_ldb_loop = [this](dim_t bd_block2, bool is_bdb_tail, bool first_bdb,
-                               bool last_bdb, dim_t rows_for_rd_tail,
+    auto do_ldb_loop = [this](int bd_block2, bool is_bdb_tail, bool first_bdb,
+                               bool last_bdb, int rows_for_rd_tail,
                                bool skip_accumulation) {
         if (brg.ldb2 > 0) {
             const bool is_ld_reg_tail = false;
@@ -3602,10 +3609,9 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         }
     };
 
-    auto bdb_loop_body
-            = [this, do_ldb_loop](dim_t bd_block2, bool is_bdb_tail,
-                      bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
-                      bool skip_accumulation) {
+    auto bdb_loop_body = [this, do_ldb_loop](int bd_block2, bool is_bdb_tail,
+                                 bool first_bdb, bool last_bdb,
+                                 int rows_for_rd_tail, bool skip_accumulation) {
         do_ldb_loop(bd_block2, is_bdb_tail, first_bdb, last_bdb,
                 rows_for_rd_tail, skip_accumulation);
 
@@ -3655,7 +3661,7 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         advance_bd_block2_post_op_regs(bd_block2);
     };
 
-    dim_t rows_for_rd_tail, bd_blocks_for_rd_tail;
+    int rows_for_rd_tail, bd_blocks_for_rd_tail;
 
     if (brg.is_tmm) {
         rows_for_rd_tail = 0;
@@ -3670,7 +3676,7 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                     : 0;
         }
         bd_blocks_for_rd_tail
-                = div_up(nstl::max(dim_t(0),
+                = div_up(nstl::max(0,
                                  rows_for_rd_tail - brg.bdb_tail
                                          + brg.brgattr.max_bottom_vpad),
                         brg.bd_block);
@@ -3925,9 +3931,9 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
 
     align(32);
 
-    const dim_t simd = vreg_traits_t<Vmm>::vlen / sizeof(float);
+    const int simd = vreg_traits_t<Vmm>::vlen / sizeof(float);
     if (!isa_has_masks(brg.isa_impl) && (brg.ldb_tail || brg.gemv_tail)) {
-        const dim_t tail_size = brg.is_gemv ? brg.gemv_tail : brg.ldb_tail;
+        const int tail_size = brg.is_gemv ? brg.gemv_tail : brg.ldb_tail;
         L(avx_tail_mask_);
         for (dim_t i = 0; i < tail_size; ++i)
             dd(0xffffffff);
@@ -3940,7 +3946,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         L(sum_zp_scale_data_);
         const dim_t scale_int = float2int(brg.sum_scale);
         for (dim_t i = 0; i < simd; ++i)
-            dd(scale_int);
+            dd(static_cast<uint32_t>(scale_int));
     }
 
     if (brg.is_fp8_via_convert()) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -305,7 +305,7 @@ private:
     }
 
     Vmm accm(int ld_block, int bd, int ld) const noexcept {
-        return Vmm(xbyak_register_index(
+        return Vmm(static_cast<int>(
                 max_effective_vregs - 1 - (bd * ld_block + ld)));
     }
 
@@ -314,7 +314,7 @@ private:
             int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
-            return Vmm(xbyak_register_index(idx));
+            return Vmm(static_cast<int>(idx));
         } else
             return Vmm(0);
     }
@@ -326,20 +326,20 @@ private:
             int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - ld;
             assert(idx > 0);
-            return Vmm(xbyak_register_index(idx));
+            return Vmm(static_cast<int>(idx));
         }
     }
 
     Vmm gemv_load_a() const noexcept {
         assert(brg.is_gemv);
         const int idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
-        return Vmm(xbyak_register_index(idx));
+        return Vmm(static_cast<int>(idx));
     }
 
     Vmm gemv_load_b() const noexcept {
         assert(brg.is_gemv);
         const int idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
-        return Vmm(xbyak_register_index(idx));
+        return Vmm(static_cast<int>(idx));
     }
 
     Vmm vmm_tmp(dim_t i) const noexcept {
@@ -347,7 +347,7 @@ private:
         MAYBE_UNUSED(bd_block);
         assert(IMPLICATION(!brg.is_tmm,
                 i >= 0 && i < max_effective_vregs - bd_block * brg.ld_block2));
-        return Vmm(xbyak_register_index(i));
+        return Vmm(static_cast<int>(i));
     }
 
     Vmm vmm_tail_mask() const noexcept { return vmm_tmp(1); }
@@ -1172,7 +1172,7 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(int bd_block2,
         for_(int bdb = 0; bdb < bd_block2; bdb++)
         for (int ldb = 0; ldb < ld_block2; ldb++) {
             int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
-            tilezero(Tmm(xbyak_register_index(
+            tilezero(Tmm(static_cast<int>(
                     brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail))));
         }
     } else if (brg.is_gemv) {
@@ -1251,10 +1251,10 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(int num_rows,
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(static_cast<int>(r_end),
                 reg_data_aux, reg_data_stride, reg_buf_aux);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(static_cast<int>(r_end),
                 reg_data_aux, reg_data_stride, reg_buf_aux);
     else
         assert(!"unsupported data type");
@@ -2445,7 +2445,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
                             }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
-                                    Tmm(xbyak_register_index(c_tensor)));
+                                    Tmm(static_cast<int>(c_tensor)));
                             for (int bd = 0; bd < adj_bd_block; bd++) {
                                 const size_t buf_offset
                                         = (bd * brg.ld_block) * brg.typesize_C;
@@ -2485,7 +2485,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
 
                         reg_buf.restore();
                     } else {
-                        auto tmm = Tmm(xbyak_register_index(c_tensor));
+                        auto tmm = Tmm(static_cast<int>(c_tensor));
                         if (skip_accumulation) tilezero(tmm);
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
                         if (ldb < ld_block2 - 1)
@@ -2739,7 +2739,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
 
     const int tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
                              : brg.get_B_tensor(idx, is_tail);
-    auto t1 = Tmm(xbyak_register_index(tmm_idx));
+    auto t1 = Tmm(static_cast<int>(tmm_idx));
 
     auto reg_base = is_A ? reg_aux_A : reg_aux_B;
 
@@ -2904,11 +2904,11 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
                     is_ld_tail, false);
             for (int bdb = 0; bdb < bd_block2; bdb++) {
-                tdpbxxd(Tmm(xbyak_register_index(brg.get_C_tensor(
+                tdpbxxd(Tmm(static_cast<int>(brg.get_C_tensor(
                                 bdb, idx, is_bdb_tail, is_ld_tail))),
-                        Tmm(xbyak_register_index(
+                        Tmm(static_cast<int>(
                                 brg.get_A_tensor(bdb, is_bdb_tail))),
-                        Tmm(xbyak_register_index(
+                        Tmm(static_cast<int>(
                                 brg.get_B_tensor(idx, is_ld_tail))));
             }
         }

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -114,10 +114,10 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
             const auto k_mask = !brg.is_gemv ? ld_tail_mask : gemv_partial_mask;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    vmm_tmp(0).getIdx(), this->r14, this->r15, this->r13,
-                    preserve_gpr, preserve_vmm,
+                    static_cast<size_t>(vmm_tmp(0).getIdx()), this->r14,
+                    this->r15, this->r13, preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<dim_t>(tail_size), k_mask,
+                    dst_md_wrapper, static_cast<size_t>(tail_size), k_mask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {this->param1,

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -23,16 +23,16 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-static std::size_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
+static dim_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
     static constexpr int byte_size_bits = 8;
     return vmm.getBit() / byte_size_bits;
 }
 
-static std::size_t calc_vmm_to_preserve_size_bytes(
+static dim_t calc_vmm_to_preserve_size_bytes(
         const std::initializer_list<Xbyak::Xmm> &vmm_to_preserve) {
 
     return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
-            std::size_t(0u), [](std::size_t accum, const Xbyak::Xmm &vmm) {
+            dim_t(0), [](dim_t accum, const Xbyak::Xmm &vmm) {
         return accum + get_vmm_size_bytes(vmm);
     });
 }
@@ -214,7 +214,7 @@ void reg64_savable_t::addTo(const Xbyak::Reg64 &reg) const {
         regscratchpad_.jit().add(reg, *this);
 }
 
-void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, int imm) const {
+void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, dim_t imm) const {
     if (booking_ >= 0)
         regscratchpad_.jit().imul(reg, getStoragePtr(), imm);
     else

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -214,7 +214,7 @@ void reg64_savable_t::addTo(const Xbyak::Reg64 &reg) const {
         regscratchpad_.jit().add(reg, *this);
 }
 
-void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, dim_t imm) const {
+void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, int imm) const {
     if (booking_ >= 0)
         regscratchpad_.jit().imul(reg, getStoragePtr(), imm);
     else

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -30,8 +30,8 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-using vmm_index_set_t = typename std::set<size_t>;
-using vmm_index_set_iterator_t = typename std::set<size_t>::iterator;
+using vmm_index_set_t = typename std::set<int>;
+using vmm_index_set_iterator_t = typename std::set<int>::iterator;
 
 enum class layout_t { ncsp, c_blocked, nspc, cspn, unsupported };
 
@@ -67,7 +67,7 @@ private:
     jit_generator_t *host_;
     std::stack<Xbyak::Reg64> reg64_stack_;
     std::stack<Xbyak::Xmm> vmm_stack_;
-    size_t vmm_to_preserve_size_bytes_;
+    dim_t vmm_to_preserve_size_bytes_;
 };
 
 class conditional_register_preserve_guard_t : public register_preserve_guard_t {
@@ -151,7 +151,7 @@ public:
     void restoreTo(const Xbyak::Reg64 &reg) const;
     void restoreTo(const Xbyak::Reg32 &reg32) const;
     void addTo(const Xbyak::Reg64 &reg) const;
-    void imulTo(const Xbyak::Reg64 &reg, int imm) const;
+    void imulTo(const Xbyak::Reg64 &reg, dim_t imm) const;
     Xbyak::Address getStoragePtr() const {
         return regscratchpad_.getPtr(booking_);
     }

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -151,7 +151,7 @@ public:
     void restoreTo(const Xbyak::Reg64 &reg) const;
     void restoreTo(const Xbyak::Reg32 &reg32) const;
     void addTo(const Xbyak::Reg64 &reg) const;
-    void imulTo(const Xbyak::Reg64 &reg, dim_t imm) const;
+    void imulTo(const Xbyak::Reg64 &reg, int imm) const;
     Xbyak::Address getStoragePtr() const {
         return regscratchpad_.getPtr(booking_);
     }

--- a/src/cpu/x64/jit_generator.cpp
+++ b/src/cpu/x64/jit_generator.cpp
@@ -85,7 +85,8 @@ void jit_generator_t::transpose(const Xbyak::Reg64 &reg_src,
             // Load the remaining xf16 values one by one.
             for (int i = 0; i < rem; i++) {
                 vpinsrw(xmm_tmp, xmm_tmp,
-                        ptr[reg_src + r * src_stride + (c + i) * dt_size], i);
+                        ptr[reg_src + r * src_stride + (c + i) * dt_size],
+                        static_cast<uint8_t>(i));
             }
         }
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -247,8 +247,12 @@ public:
     }
 
     static int xbyak_register_index(dim_t index) {
-        // The fallback is returned only after XByak records the error.
-        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        // The fallback is returned only after XByak records the error,
+        // INT_MIN is used, because some primitives(e.g. pooling)
+        // are creating registers with invlid index, but never uses it,
+        // currently those objects are gracefully die without assertion.
+        // TODO: refactor pooling primitive in order to follow the contract.
+        JIT_ASSERT_RET(index >= INT_MIN && index <= INT_MAX, 0);
         return static_cast<int>(index);
     }
 
@@ -1507,7 +1511,7 @@ public:
     void uni_vpslld(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpslld(x, op, imm);
+            vpslld(x, op, static_cast<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) movdqa(x, op);
             pslld(x, imm);
@@ -1515,13 +1519,13 @@ public:
     }
     void uni_vpslld(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpslld(x, op, imm);
+        vpslld(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpsrld(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpsrld(x, op, imm);
+            vpsrld(x, op, static_cast<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) uni_vmovups(x, op);
             psrld(x, imm);
@@ -1529,7 +1533,7 @@ public:
     }
     void uni_vpsrld(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpsrld(x, op, imm);
+        vpsrld(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vmaxps(const Xbyak::Xmm &x, const Xbyak::Operand &op1,
@@ -1605,15 +1609,15 @@ public:
     void uni_vcmpps(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, int cmp_predicate) {
         if (is_valid_isa(avx))
-            vcmpps(x1, x2, op, cmp_predicate);
+            vcmpps(x1, x2, op, static_cast<uint8_t>(cmp_predicate));
         else {
             if (x1.getIdx() != x2.getIdx()) uni_vmovups(x1, x2);
-            cmpps(x1, op, cmp_predicate);
+            cmpps(x1, op, static_cast<uint8_t>(cmp_predicate));
         }
     }
     void uni_vcmpps(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, int cmp_predicate) {
-        vcmpps(x1, x2, op, cmp_predicate);
+        vcmpps(x1, x2, op, static_cast<uint8_t>(cmp_predicate));
     }
 
     void uni_vtestps(const Xbyak::Xmm &x1, const Xbyak::Operand &op) {
@@ -1657,7 +1661,7 @@ public:
             const Xbyak::Operand &op, const int imm) {
         assert(!x1.isZMM() && !x2.isZMM());
         if (is_valid_isa(avx))
-            vblendps(x1, x2, op, imm);
+            vblendps(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (!x1.isEqualIfNotInherited(x2)) movups(x1, x2);
             blendps(x1, op, imm);
@@ -1669,9 +1673,9 @@ public:
         if (is_valid_isa(avx512_core))
             vrndscaleps(x, op, imm & 0x3);
         else if (is_valid_isa(avx))
-            vroundps(x, op, imm);
+            vroundps(x, op, static_cast<uint8_t>(imm));
         else
-            roundps(x, op, imm);
+            roundps(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vroundps(
@@ -1679,7 +1683,7 @@ public:
         if (is_valid_isa(avx512_core))
             vrndscaleps(x, op, imm & 0x3);
         else
-            vroundps(x, op, imm);
+            vroundps(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vroundps(
@@ -1839,50 +1843,50 @@ public:
     void uni_vpinsrb(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrb(x1, x2, op, imm);
+            vpinsrb(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrb(x1, op, imm);
+            pinsrb(x1, op, static_cast<uint8_t>(imm));
         }
     }
 
     void uni_vpinsrb(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrb(x1, x2, op, imm);
+        vpinsrb(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpinsrd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrd(x1, x2, op, imm);
+            vpinsrd(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrd(x1, op, imm);
+            pinsrd(x1, op, static_cast<uint8_t>(imm));
         }
     }
     void uni_vpinsrd(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrd(x1, x2, op, imm);
+        vpinsrd(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpinsrq(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrq(x1, x2, op, imm);
+            vpinsrq(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrq(x1, op, imm);
+            pinsrq(x1, op, static_cast<uint8_t>(imm));
         }
     }
     void uni_vpinsrq(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrq(x1, x2, op, imm);
+        vpinsrq(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpinsrw(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrw(x1, x2, op, imm);
+            vpinsrw(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             pinsrw(x1, op, imm);
@@ -1890,56 +1894,56 @@ public:
     }
     void uni_vpinsrw(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrw(x1, x2, op, imm);
+        vpinsrw(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrb(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrb(op, x, imm);
+            vpextrb(op, x, static_cast<uint8_t>(imm));
         else
-            pextrb(op, x, imm);
+            pextrb(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrb(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrb(op, x, imm);
+        vpextrb(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrw(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrw(op, x, imm);
+            vpextrw(op, x, static_cast<uint8_t>(imm));
         else
-            pextrw(op, x, imm);
+            pextrw(op, x, static_cast<uint8_t>(imm));
     }
     void uni_vpextrw(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrw(op, x, imm);
+        vpextrw(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrd(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrd(op, x, imm);
+            vpextrd(op, x, static_cast<uint8_t>(imm));
         else
-            pextrd(op, x, imm);
+            pextrd(op, x, static_cast<uint8_t>(imm));
     }
     void uni_vpextrd(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrd(op, x, imm);
+        vpextrd(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrq(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrq(op, x, imm);
+            vpextrq(op, x, static_cast<uint8_t>(imm));
         else
-            pextrq(op, x, imm);
+            pextrq(op, x, static_cast<uint8_t>(imm));
     }
     void uni_vpextrq(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrq(op, x, imm);
+        vpextrq(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpmaxsd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
@@ -2015,7 +2019,7 @@ public:
     void uni_vpslldq(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpslldq(x, op, imm);
+            vpslldq(x, op, static_cast<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) movdqa(x, op);
             pslldq(x, imm);
@@ -2023,7 +2027,7 @@ public:
     }
     void uni_vpslldq(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpslldq(x, op, imm);
+        vpslldq(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpmovsxwd(const Xbyak::Xmm &x, const Xbyak::Operand &op) {
@@ -2281,7 +2285,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Address &src_addr,
-            dim_t load_size, const bool zero_vmm = true) {
+            int load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2300,7 +2304,7 @@ public:
 
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            dim_t load_size, const bool zero_vmm = true) {
+            int load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2321,8 +2325,8 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void helper_load_bytes(const Vmm &vmm, dim_t load_size,
-            const AddrFunc &addr, const bool zero_vmm = true) {
+    void helper_load_bytes(const Vmm &vmm, int load_size, const AddrFunc &addr,
+            const bool zero_vmm = true) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2354,8 +2358,8 @@ private:
         // use clean execution sequence
         if (zero_vmm) uni_vpxor(vmm, vmm, vmm);
 
-        dim_t start_bytes = 0;
-        dim_t bytes_to_load = load_size;
+        int start_bytes = 0;
+        int bytes_to_load = load_size;
 
         if (load_size > 16) {
             // Prepare to insert to upper bits of ymm
@@ -2452,7 +2456,7 @@ public:
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            dim_t store_size) {
+            int store_size) {
 
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2466,7 +2470,7 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void store_bytes(const Vmm &vmm, dim_t store_size, const AddrFunc &addr) {
+    void store_bytes(const Vmm &vmm, int store_size, const AddrFunc &addr) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2496,8 +2500,8 @@ private:
             return;
         }
 
-        dim_t start_bytes = 0;
-        dim_t bytes_to_store = store_size;
+        int start_bytes = 0;
+        int bytes_to_store = store_size;
 
         if (store_size > 16) {
             vmovdqu(addr(0), xmm); // load lower bits from ymm
@@ -2580,7 +2584,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, bool is_signed, dim_t load_size,
+            int64_t offset, bool is_signed, int load_size,
             const bool zero_vmm) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2590,7 +2594,7 @@ public:
 
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm,
-            const Xbyak::Address &src_addr, bool is_signed, dim_t load_size,
+            const Xbyak::Address &src_addr, bool is_signed, int load_size,
             const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
@@ -2650,7 +2654,7 @@ public:
      */
     template <typename Vmm>
     void store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
         using supported_vmm_t = typename utils::conditional<is_vmm_supported,
@@ -2667,7 +2671,7 @@ public:
 private:
     template <typename Vmm>
     void helper_store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
 
         assert(is_valid_isa(sse41)
                 && "routine is not supported for the current isa");
@@ -2727,7 +2731,7 @@ public:
      */
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, dim_t load_size, const bool zero_vmm = true) {
+            int64_t offset, int load_size, const bool zero_vmm = true) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
         load_data(type_in, vmm, ptr[reg + offset], load_size, zero_vmm);
@@ -2735,7 +2739,7 @@ public:
 
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm,
-            const Xbyak::Address &src_addr, dim_t load_size,
+            const Xbyak::Address &src_addr, int load_size,
             const bool zero_vmm = true) {
 
         assert(is_valid_isa(sse41)

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -238,30 +238,6 @@ public:
                 op, static_cast<uint32_t>(static_cast<int32_t>(imm)));
     }
 
-    template <typename T,
-            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
-            = 0>
-    void imul(const Xbyak::Reg64 &dst, const Xbyak::Operand &src, T imm) {
-        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
-        Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
-    }
-
-    static int xbyak_register_index(dim_t index) {
-        // The fallback is returned only after XByak records the error,
-        // INT_MIN is used, because some primitives(e.g. pooling)
-        // are creating registers with invlid index, but never uses it,
-        // currently those objects are gracefully die without assertion.
-        // TODO: refactor pooling primitive in order to follow the contract.
-        JIT_ASSERT_RET(index >= INT_MIN && index <= INT_MAX, 0);
-        return static_cast<int>(index);
-    }
-
-    static int xbyak_address_scale(dim_t scale) {
-        // The fallback is returned only after XByak records the error.
-        JIT_ASSERT_RET(utils::one_of(scale, 1, 2, 4, 8), 0);
-        return static_cast<int>(scale);
-    }
-
     Xbyak::Reg64 param1 = abi_param1;
     const int EVEX_max_8b_offt = 0x200;
     const Xbyak::Reg64 reg_EVEX_max_8b_offt = rbp;

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -238,6 +238,26 @@ public:
                 op, static_cast<uint32_t>(static_cast<int32_t>(imm)));
     }
 
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void imul(const Xbyak::Reg64 &dst, const Xbyak::Operand &src, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
+    }
+
+    static int xbyak_register_index(dim_t index) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        return static_cast<int>(index);
+    }
+
+    static int xbyak_address_scale(dim_t scale) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(utils::one_of(scale, 1, 2, 4, 8), 0);
+        return static_cast<int>(scale);
+    }
+
     Xbyak::Reg64 param1 = abi_param1;
     const int EVEX_max_8b_offt = 0x200;
     const Xbyak::Reg64 reg_EVEX_max_8b_offt = rbp;
@@ -2261,7 +2281,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Address &src_addr,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2280,7 +2300,7 @@ public:
 
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2301,8 +2321,8 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void helper_load_bytes(const Vmm &vmm, int load_size, const AddrFunc &addr,
-            const bool zero_vmm = true) {
+    void helper_load_bytes(const Vmm &vmm, dim_t load_size,
+            const AddrFunc &addr, const bool zero_vmm = true) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2334,8 +2354,8 @@ private:
         // use clean execution sequence
         if (zero_vmm) uni_vpxor(vmm, vmm, vmm);
 
-        int start_bytes = 0;
-        int bytes_to_load = load_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_load = load_size;
 
         if (load_size > 16) {
             // Prepare to insert to upper bits of ymm
@@ -2432,7 +2452,7 @@ public:
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int store_size) {
+            dim_t store_size) {
 
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2446,7 +2466,7 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void store_bytes(const Vmm &vmm, int store_size, const AddrFunc &addr) {
+    void store_bytes(const Vmm &vmm, dim_t store_size, const AddrFunc &addr) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2476,8 +2496,8 @@ private:
             return;
         }
 
-        int start_bytes = 0;
-        int bytes_to_store = store_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_store = store_size;
 
         if (store_size > 16) {
             vmovdqu(addr(0), xmm); // load lower bits from ymm
@@ -2560,7 +2580,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, bool is_signed, int load_size,
+            int64_t offset, bool is_signed, dim_t load_size,
             const bool zero_vmm) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2570,7 +2590,7 @@ public:
 
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm,
-            const Xbyak::Address &src_addr, bool is_signed, int load_size,
+            const Xbyak::Address &src_addr, bool is_signed, dim_t load_size,
             const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
@@ -2630,7 +2650,7 @@ public:
      */
     template <typename Vmm>
     void store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
         using supported_vmm_t = typename utils::conditional<is_vmm_supported,
@@ -2647,7 +2667,7 @@ public:
 private:
     template <typename Vmm>
     void helper_store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
 
         assert(is_valid_isa(sse41)
                 && "routine is not supported for the current isa");
@@ -2707,7 +2727,7 @@ public:
      */
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, int load_size, const bool zero_vmm = true) {
+            int64_t offset, dim_t load_size, const bool zero_vmm = true) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
         load_data(type_in, vmm, ptr[reg + offset], load_size, zero_vmm);
@@ -2715,7 +2735,7 @@ public:
 
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm,
-            const Xbyak::Address &src_addr, int load_size,
+            const Xbyak::Address &src_addr, dim_t load_size,
             const bool zero_vmm = true) {
 
         assert(is_valid_isa(sse41)


### PR DESCRIPTION
## Summary

Widen brgemm JIT kernel internals from `int` to `dim_t` to eliminate implicit narrowing conversions, following the design direction agreed in #5486: implementations work with `dim_t` throughout, narrowing happens only at the XByak/hardware-register JIT boundary.

This PR builds on top of the infra PR (#5547) and adds the JIT-kernel-scope piece deferred from it: shared XByak boundary overloads (`add`/`sub`/`cmp`/`shl`/`imul` constrained to `dim_t`, plus `xbyak_register_index`/`xbyak_address_scale` helpers), and widens the brgemm/brdgmm/AMX-uker JIT kernel generators and their supporting containers/injector utilities to consume them.

**Note:** It's for review purposes only.

## Update

Rebased on the infra fix above (#5547). Also added the Xbyak boundary overloads discussed with reviewers:
- Kernel creation fails cleanly if a value doesn't fit in 32 bits (no crash).
- Call sites pass bit masks as `uint32_t` to hit the normal Xbyak path.
- `ptr[reg + off]` is left unchanged — Xbyak already handles the full 64-bit value there.

Applied the same `int` reclassification to `jit_brgemm_amx_uker.cpp`/`jit_brgemm_kernel.cpp`.
