### PR TITLE
graph: backend: dnnl: exec: enable verbose log for host_scalar

### DIFF
--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -16,12 +16,14 @@
 
 #include "graph/backend/dnnl/executables/host_scalar.hpp"
 
+#include "common/stream.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace graph {
 namespace dnnl_impl {
 
-void host_scalar_executable_t::execute(const stream &stream,
+void host_scalar_executable_t::execute_impl(const stream &stream,
         const std::unordered_map<int, memory> &args) const {
     auto it_src = args.find(DNNL_ARG_FROM);
     auto it_dst = args.find(DNNL_ARG_TO);
@@ -39,8 +41,24 @@ void host_scalar_executable_t::execute(const stream &stream,
     });
 }
 
+void host_scalar_executable_t::execute(const stream &stream,
+        const std::unordered_map<int, memory> &args) const {
+    if (get_verbose(dnnl::impl::verbose_t::exec_profile,
+                dnnl::impl::component_t::graph)) {
+        stream.get()->wait();
+        double start_ms = dnnl::impl::get_msec();
+        execute_impl(stream, args);
+        stream.get()->wait();
+        double duration_ms = dnnl::impl::get_msec() - start_ms;
+        VPROF(start_ms, graph, exec, VERBOSE_profile, info_.c_str(),
+                duration_ms);
+    } else {
+        execute_impl(stream, args);
+    }
+}
+
 #ifdef DNNL_WITH_SYCL
-std::optional<::sycl::event> host_scalar_executable_t::execute_sycl(
+std::optional<::sycl::event> host_scalar_executable_t::execute_sycl_impl(
         const stream &stream, const std::unordered_map<int, memory> &args,
         const std::vector<::sycl::event> &deps) const {
     auto it_src = args.find(DNNL_ARG_FROM);
@@ -56,6 +74,10 @@ std::optional<::sycl::event> host_scalar_executable_t::execute_sycl(
     const memory &src_mem = it_src->second;
     const memory &dst_mem = it_dst->second;
 
+    double start_ms = dnnl::impl::get_msec();
+    auto *strm = stream.get();
+    strm->before_exec_hook();
+
     // get_data_handle() is blocked for host scalar memories at the C API
     // level, so we access the underlying storage pointer directly.
     void *src_ptr = const_cast<memory_t *>(src_mem.get())
@@ -63,16 +85,50 @@ std::optional<::sycl::event> host_scalar_executable_t::execute_sycl(
                             ->data_handle();
     void *dst_ptr = dst_mem.get_data_handle();
     const size_t size = src_mem.get_desc().get_size();
+
     auto sycl_queue = dnnl::sycl_interop::get_queue(stream);
-    return sycl_queue.submit([&](::sycl::handler &cgh) {
+    auto event = sycl_queue.submit([&](::sycl::handler &cgh) {
         cgh.depends_on(deps);
         cgh.memcpy(dst_ptr, src_ptr, size);
     });
+
+    // SYCL GPU only.
+    if (strm->is_verbose_profiler_enabled()) {
+        auto *gpu_strm = dnnl::impl::utils::downcast<gpu::stream_t *>(strm);
+        auto verbose_event = std::make_shared<xpu::sycl::event_t>(
+                std::vector<::sycl::event> {event});
+        gpu_strm->verbose_profiler()->register_event(verbose_event);
+        strm->run_verbose_profiler(info_, start_ms);
+    }
+    strm->after_exec_hook();
+    return event;
+}
+
+std::optional<::sycl::event> host_scalar_executable_t::execute_sycl(
+        const stream &stream, const std::unordered_map<int, memory> &args,
+        const std::vector<::sycl::event> &deps) const {
+    if (get_verbose(dnnl::impl::verbose_t::exec_profile,
+                dnnl::impl::component_t::graph)) {
+        if (!stream.get()->is_verbose_profiler_enabled()) {
+            stream.get()->wait();
+            double start_ms = dnnl::impl::get_msec();
+            execute_sycl_impl(stream, args, deps);
+            stream.get()->wait();
+            double duration_ms = dnnl::impl::get_msec() - start_ms;
+            VPROF(start_ms, graph, exec, VERBOSE_profile, info_.c_str(),
+                    duration_ms);
+            return std::nullopt;
+        } else {
+            return execute_sycl_impl(stream, args, deps);
+        }
+    } else {
+        return execute_sycl_impl(stream, args, deps);
+    }
 }
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-ocl_event_t host_scalar_executable_t::execute_ocl(const stream &stream,
+ocl_event_t host_scalar_executable_t::execute_ocl_impl(const stream &stream,
         const std::unordered_map<int, memory> &args,
         const std::vector<ocl_event_t> &deps) const {
     auto it_src = args.find(DNNL_ARG_FROM);
@@ -86,24 +142,57 @@ ocl_event_t host_scalar_executable_t::execute_ocl(const stream &stream,
     const memory &src_mem = it_src->second;
     const memory &dst_mem = it_dst->second;
 
+    double start_ms = dnnl::impl::get_msec();
+    auto *strm = stream.get();
+    strm->before_exec_hook();
+
     assert(deps.size() <= 1);
     // Passing the empty event to memcpy below causes failure.
     std::vector<cl_event> raw_deps(deps.begin(), deps.end());
     const bool empty = raw_deps.empty() || raw_deps[0] == nullptr;
     const cl_uint num = empty ? 0 : static_cast<cl_uint>(raw_deps.size());
     const size_t size = src_mem.get_desc().get_size();
-    const auto dt = src_mem.get_desc().get_data_type();
-    assert(size == types::data_type_size(static_cast<impl::data_type_t>(dt)));
+
+    // get_data_handle() is blocked for host scalar memories at the C API
+    // level, so we access the underlying storage pointer directly.
+    void *src_ptr = const_cast<memory_t *>(src_mem.get())
+                            ->memory_storage()
+                            ->data_handle();
+
     cl_event e = nullptr;
-    DNNL_HOST_SCALAR_TYPE_SWITCH(dt, DType, {
-        const DType val = src_mem.get_host_scalar_value<DType>();
-        UNUSED_STATUS(xpu::ocl::usm::memcpy(stream.get(),
-                dst_mem.get_data_handle(), static_cast<const void *>(&val),
-                size, num, empty ? nullptr : raw_deps.data(), &e));
-        xpu::ocl::clWaitForEvents(1, &e);
-        xpu::ocl::clReleaseEvent(e);
-    });
-    return {};
+    UNUSED_STATUS(xpu::ocl::usm::memcpy(strm, dst_mem.get_data_handle(),
+            src_ptr, size, num, empty ? nullptr : raw_deps.data(), &e));
+    if (strm->is_verbose_profiler_enabled() && e) {
+        auto *gpu_strm = dnnl::impl::utils::downcast<gpu::stream_t *>(strm);
+        auto verbose_event = std::make_shared<xpu::ocl::event_t>(
+                xpu::ocl::wrapper_t<cl_event>(e, true));
+        gpu_strm->verbose_profiler()->register_event(verbose_event);
+        strm->run_verbose_profiler(info_, start_ms);
+    }
+    strm->after_exec_hook();
+    return ocl_event_t(e);
+}
+
+ocl_event_t host_scalar_executable_t::execute_ocl(const stream &stream,
+        const std::unordered_map<int, memory> &args,
+        const std::vector<ocl_event_t> &deps) const {
+    if (get_verbose(dnnl::impl::verbose_t::exec_profile,
+                dnnl::impl::component_t::graph)) {
+        if (!stream.get()->is_verbose_profiler_enabled()) {
+            stream.get()->wait();
+            double start_ms = dnnl::impl::get_msec();
+            execute_ocl_impl(stream, args, deps);
+            stream.get()->wait();
+            double duration_ms = dnnl::impl::get_msec() - start_ms;
+            VPROF(start_ms, graph, exec, VERBOSE_profile, info_.c_str(),
+                    duration_ms);
+            return {};
+        } else {
+            return execute_ocl_impl(stream, args, deps);
+        }
+    } else {
+        return execute_ocl_impl(stream, args, deps);
+    }
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/host_scalar.hpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.hpp
@@ -30,29 +30,43 @@ struct host_scalar_executable_t : public op_executable_t {
     host_scalar_executable_t(std::shared_ptr<op_t> &op,
             const dnnl::engine &p_engine, pd_cache_t &pd_cache,
             const fpmath_t &fpmath, bool use_block_layout) {
-        UNUSED(op);
-        UNUSED(p_engine);
         UNUSED(pd_cache);
         UNUSED(fpmath);
         UNUSED(use_block_layout);
+        info_ = std::string(dnnl_engine_kind2str(
+                        static_cast<dnnl_engine_kind_t>(p_engine.get_kind())))
+                + "," + op->str();
     }
 
     void execute(const stream &stream,
             const std::unordered_map<int, memory> &args) const override;
+    void execute_impl(const stream &stream,
+            const std::unordered_map<int, memory> &args) const;
 
 #ifdef DNNL_WITH_SYCL
     std::optional<::sycl::event> execute_sycl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<::sycl::event> &deps) const override;
+    std::optional<::sycl::event> execute_sycl_impl(const stream &stream,
+            const std::unordered_map<int, memory> &args,
+            const std::vector<::sycl::event> &deps) const;
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
             const std::vector<ocl_event_t> &deps) const override;
+
+    ocl_event_t execute_ocl_impl(const stream &stream,
+            const std::unordered_map<int, memory> &args,
+            const std::vector<ocl_event_t> &deps) const;
 #endif
 
     bool is_initialized() const override { return true; }
+
+private:
+    // needed for verbose profiling.
+    std::string info_;
 };
 
 } // namespace dnnl_impl


### PR DESCRIPTION
1. `host_scalar` is not implemented via primitive, hence a dedicate verbose log is needed for performance analysis and debug.
2. Enable both sync and async verbose profiler under SYCL and OCL runtime.