### PR TITLE
x64: reduction: fix implicit narrowing conversions

### DIFF
--- a/src/cpu/ref_reduction.cpp
+++ b/src/cpu/ref_reduction.cpp
@@ -63,7 +63,7 @@ void accumulate(T &acc, const T &src, alg_kind_t alg, float p) {
         case reduction_norm_lp_sum:
         case reduction_norm_lp_power_p_max:
         case reduction_norm_lp_power_p_sum:
-            acc += powf(nstl::abs(src), p);
+            acc += static_cast<T>(powf(nstl::abs(src), p));
             break;
         default: assert(!"unknown alg");
     }


### PR DESCRIPTION
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Affected only on reduction.