### PR TITLE
cpu: x64: improve fp8 performance on NVL

### DIFF
--- a/doc/common_concepts/data_types.md
+++ b/doc/common_concepts/data_types.md
@@ -33,8 +33,7 @@ oneDNN supports training and inference with the following data types:
 | f32       | `+`       | `+`      |
 | bf16      | `+`       | `+`      |
 | f16       | `+`       | `+`      |
-| f8\_e5m2  | `+`       | `+`      |
-| f8\_e4m3  | `+`       | `+`      |
+| fp8(3)    | `+`       | `+`      |
 | s8        | `+`       |          |
 | u8        | `+`       |          |
 | f4\_e2m1  | `+`       |          |
@@ -47,6 +46,7 @@ Footnotes:
 2. `s4`/`u4` data types are only supported as a storage data type for weights argument
    in case of weight-only quantization. For more details, refer to
    [Matmul Tutorial: weight-only quantization](@ref matmul_with_weight_only_quantization_cpp).
+3. `fp8` data type includes `f8_e5m2` and `f8_e4m3`.
 
 @note
     Data type support may also be limited by hardware capabilities. Refer to
@@ -169,20 +169,20 @@ oneDNN performance optimizations for Intel Architecture Processors are
 specialized based on Instruction Set Architecture (ISA). The following
 table indicates data types support for every supported ISA:
 
-| ISA                                                  | f64     | f32     | bf16    | f16     | s8/u8   | f8_e4m3 | f8_e5m2 | f4_e2m1 | s4/u4   |
-| ---------------------------------------------------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | 
-| Intel SSE4.1                                         |         | `+`     |         |         |         |         |         |         |         |
-| Intel AVX                                            |         | `+`     |         |         |         |         |         |         |         |
-| Intel AVX2                                           |         | `+`     |         |         | `+`(1)  |         |         |         |         |
-| Intel AVX2 with Intel DL Boost (int8)                |         | `+`     |         |         | `+`     |         |         |         |         |
-| Intel AVX-512                                        |         | `+`     | `.`(2)  |         | `+`(1)  |         |         |         |         |
-| Intel AVX-512 with Intel DL Boost (int8)             |         | `+`     | `.`(2)  |         | `+`     |         |         |         |         |
-| Intel AVX-512 with Intel DL Boost (int8, bf16)       |         | `+`     | `+`     |         | `+`     |         |         |         |         |
-| Intel AVX2 with Intel DL Boost (int8) and NE_CONVERT |         | `+`     | `.`     | `.`     | `+`     |         |         |         |         |
-| Intel AVX10.1 with Intel AMX (int8, bf16)            |         | `+`     | `+`     | `.`(3)  | `+`     |         |         |         | `.`     |
-| Intel AVX10.1 with Intel AMX (int8, bf16, f16)       |         | `+`     | `+`     | `+`     | `+`     | `.`     | `.`     |         | `.`     |
-| Intel AVX10.2                                        |         | `+`     | `+`     | `+`     | `+`     | `.`     |         |         | `.`     |
-| Intel AVX10.2 with Intel AMX (int8, bf16, fp16, fp8) |         | `+`     | `+`     | `+`     | `+`     | `+`     | `+`     |         | `.`     |
+| ISA                                                  | f64     | f32     | bf16    | f16     | s8/u8   | fp8     | f4_e2m1 | s4/u4   |
+| ---------------------------------------------------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | 
+| Intel SSE4.1                                         |         | `+`     |         |         |         |         |         |         |
+| Intel AVX                                            |         | `+`     |         |         |         |         |         |         |
+| Intel AVX2                                           |         | `+`     |         |         | `+`(1)  |         |         |         |
+| Intel AVX2 with Intel DL Boost (int8)                |         | `+`     |         |         | `+`     |         |         |         |
+| Intel AVX-512                                        |         | `+`     | `.`(2)  |         | `+`(1)  |         |         |         |
+| Intel AVX-512 with Intel DL Boost (int8)             |         | `+`     | `.`(2)  |         | `+`     |         |         |         |
+| Intel AVX-512 with Intel DL Boost (int8, bf16)       |         | `+`     | `+`     |         | `+`     |         |         |         |
+| Intel AVX2 with Intel DL Boost (int8) and NE_CONVERT |         | `+`     | `.`     | `.`     | `+`     |         |         |         |
+| Intel AVX10.1 with Intel AMX (int8, bf16)            |         | `+`     | `+`     | `.`(3)  | `+`     |         |         | `.`     |
+| Intel AVX10.1 with Intel AMX (int8, bf16, f16)       |         | `+`     | `+`     | `+`     | `+`     | `.`     |         | `.`     |
+| Intel AVX10.2                                        |         | `+`     | `+`     | `+`     | `+`     | `.`     |         | `.`     |
+| Intel AVX10.2 with Intel AMX (int8, bf16, fp16, fp8) |         | `+`     | `+`     | `+`     | `+`     | `+`     |         | `.`     |
 
 Legend:
 * `+` indicates oneDNN uses hardware-native compute support for this data type.

--- a/doc/ukernel_api/operations/brgemm.md
+++ b/doc/ukernel_api/operations/brgemm.md
@@ -33,13 +33,16 @@ is carried in integer arithmetic, C should be of type `s32`.
 
 The BRGeMM ukernel supports the following combinations of data-types.
 
-| A                | B                | C    | D                           |
-|:-----------------|:-----------------|:-----|:----------------------------|
-| f32              | f32              | f32  | u8, s8, s32, f32, f16, bf16 |
-| f16              | f16              | f32  | u8, s8, s32, f32, f16, bf16 |
-| bf16             | bf16             | f32  | u8, s8, s32, f32, f16, bf16 |
-| f8_e4m3, f8_e5m2 | f8_e4m3, f8_e5m2 | f32  | u8, s8, s32, f32, f16, bf16 |
-| u8, s8           | u8, s8           | s32  | u8, s8, s32, f32, f16, bf16 |
+| A      | B      | C    | D                                   |
+|:-------|:-------|:-----|:------------------------------------|
+| f32    | f32    | f32  | u8, s8, s32, f32, f16, bf16         |
+| f16    | f16    | f32  | u8, s8, s32, f32, f16, bf16, fp8(1) |
+| bf16   | bf16   | f32  | u8, s8, s32, f32, f16, bf16         |
+| fp8(1) | fp8(1) | f32  | u8, s8, s32, f32, f16, bf16, fp8(1) |
+| u8, s8 | u8, s8 | s32  | u8, s8, s32, f32, f16, bf16         |
+
+Footnotes:
+1. `fp8` data type includes `f8_e5m2` and `f8_e4m3`.
 
 ## Data Representation
 

--- a/src/common/memory_tracking.hpp
+++ b/src/common/memory_tracking.hpp
@@ -170,6 +170,7 @@ enum {
     // src and/or wei zero points (consumed by apply_per_mn_compensation).
     key_brgemm_primitive_per_mn_comp,
     key_brgemm_primitive_buffer_reduce,
+    key_brgemm_primitive_fp8_convert_wsp,
     key_concat_iptrs,
     key_concat_istrides,
     key_concat_nelems,

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -405,9 +405,10 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         return status::unimplemented;
     if (!IMPLICATION(brg->is_f16,
                 one_of(dt_d, data_type::f32, data_type::f16, data_type::u8,
-                        data_type::s8)
+                        data_type::s8, data_type::f8_e5m2, data_type::f8_e4m3)
                         && one_of(dt_bias, data_type::undef, data_type::f32,
-                                data_type::bf16, data_type::f16)))
+                                data_type::bf16, data_type::f16,
+                                data_type::f8_e5m2, data_type::f8_e4m3)))
         return status::unimplemented;
     const auto bias_f8_e5m2_compatible
             = one_of(dt_d, data_type::f32, data_type::f16, data_type::bf16,

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -408,9 +408,10 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         return status::unimplemented;
     if (!IMPLICATION(brg->is_f16,
                 one_of(dt_d, data_type::f32, data_type::f16, data_type::u8,
-                        data_type::s8)
+                        data_type::s8, data_type::f8_e5m2, data_type::f8_e4m3)
                         && one_of(dt_bias, data_type::undef, data_type::f32,
-                                data_type::bf16, data_type::f16)))
+                                data_type::bf16, data_type::f16,
+                                data_type::f8_e5m2, data_type::f8_e4m3)))
         return status::unimplemented;
     const auto bias_f8_e5m2_compatible
             = one_of(dt_d, data_type::f32, data_type::f16, data_type::bf16,

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -299,6 +299,7 @@ struct brgemm_desc_t {
     bool skip_zp_b_compensation = false;
     bool skip_zp_a_compensation = false;
     bool n_bcast_1_load = false;
+    bool fp8_with_f16_vnni_block = false;
 
     brgemm_broadcast_t zp_type_a = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -574,11 +574,16 @@ struct brgemm_desc_t {
 
     int get_convert_wsp_buffer_size() const noexcept {
         if (!is_input_convert()) return 0;
-        const int n_bdb = bd_block2;
-        const int n_rdb = rdb + (rdb_tail != 0);
-        const int n_ldb = ldb + (ldb_tail != 0);
-        const int downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
-        return downcvt_tiles * tilesize;
+        if (is_tmm) {
+            const int n_bdb = bd_block2;
+            const int n_rdb = rdb + (rdb_tail != 0);
+            const int n_ldb = ldb + (ldb_tail != 0);
+            const int downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
+            return downcvt_tiles * tilesize;
+        } else {
+            return nstl::min(bcast_dim, 32)
+                    * cpu_isa_traits_t<avx512_core>::vlen * 2;
+        }
     }
 
     int get_fused_copy_a_wsp_buffer_size() const noexcept {
@@ -596,7 +601,8 @@ struct brgemm_desc_t {
             sz += get_convert_wsp_buffer_size();
             if (amx_wary_k_tail()) sz += tilesize;
             sz += get_fused_copy_a_wsp_buffer_size();
-        }
+        } else
+            sz = get_convert_wsp_buffer_size();
         return sz;
     }
 

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -303,6 +303,7 @@ struct brgemm_desc_t {
     bool skip_zp_b_compensation = false;
     bool skip_zp_a_compensation = false;
     bool n_bcast_1_load = false;
+    bool fp8_with_f16_vnni_block = false;
 
     brgemm_broadcast_t zp_type_a = brgemm_broadcast_t::none;
     brgemm_broadcast_t zp_type_b = brgemm_broadcast_t::none;

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -902,8 +902,10 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     brg->bdb_tail = brg->bcast_dim % brg->bd_block;
 
     const int rd_unroll = 4;
-    const data_type_t rd_block_dt = get_mac_emu_data_type(
-            brg->dt_a, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
+    const bool req_emulation = brg->isa_impl != avx2_vnni_2
+            && IMPLICATION(brg->is_fp8, brg->fp8_with_f16_vnni_block);
+    const data_type_t rd_block_dt
+            = get_mac_emu_data_type(brg->dt_a, brg->isa_impl, req_emulation);
     if (rd_block_dt == dnnl_data_type_undef) return status::unimplemented;
     const int vnni_granularity = data_type_vnni_granularity(rd_block_dt);
     brg->rd_block = rd_unroll * vnni_granularity;
@@ -920,13 +922,16 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
 }
 
 status_t brgemm_blocking(brgemm_desc_t *brg) {
-    const data_type_t ld_step_compute_dt = get_mac_emu_data_type(
-            brg->dt_b, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
+    const bool req_emulation = brg->isa_impl != avx2_vnni_2
+            && IMPLICATION(brg->is_fp8, brg->fp8_with_f16_vnni_block);
+    const data_type_t ld_step_compute_dt
+            = get_mac_emu_data_type(brg->dt_b, brg->isa_impl, req_emulation);
     brg->ld_step = brg->is_f16_b_non_amx_vnni()
             ? 2
             : data_type_vnni_granularity(ld_step_compute_dt);
     const data_type_t rd_step_compute_dt
-            = get_mac_emu_data_type(brg->dt_b, brg->isa_impl);
+            = get_mac_emu_data_type(brg->dt_b, brg->isa_impl,
+                    IMPLICATION(brg->is_fp8, brg->fp8_with_f16_vnni_block));
     brg->rd_step = data_type_vnni_granularity(rd_step_compute_dt);
 
     set_isa_impl(brg);

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -913,8 +913,10 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     brg->bdb_tail = brg->bcast_dim % brg->bd_block;
 
     const int rd_unroll = 4;
-    const data_type_t rd_block_dt = get_mac_emu_data_type(
-            brg->dt_a, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
+    const bool req_emulation = brg->isa_impl != avx2_vnni_2
+            && IMPLICATION(brg->is_fp8, brg->fp8_with_f16_vnni_block);
+    const data_type_t rd_block_dt
+            = get_mac_emu_data_type(brg->dt_a, brg->isa_impl, req_emulation);
     if (rd_block_dt == dnnl_data_type_undef) return status::unimplemented;
     const int vnni_granularity
             = static_cast<int>(data_type_vnni_granularity(rd_block_dt));
@@ -932,13 +934,16 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
 }
 
 status_t brgemm_blocking(brgemm_desc_t *brg) {
-    const data_type_t ld_step_compute_dt = get_mac_emu_data_type(
-            brg->dt_b, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
+    const bool req_emulation = brg->isa_impl != avx2_vnni_2
+            && IMPLICATION(brg->is_fp8, brg->fp8_with_f16_vnni_block);
+    const data_type_t ld_step_compute_dt
+            = get_mac_emu_data_type(brg->dt_b, brg->isa_impl, req_emulation);
     brg->ld_step = brg->is_f16_b_non_amx_vnni()
             ? 2
             : static_cast<int>(data_type_vnni_granularity(ld_step_compute_dt));
     const data_type_t rd_step_compute_dt
-            = get_mac_emu_data_type(brg->dt_b, brg->isa_impl);
+            = get_mac_emu_data_type(brg->dt_b, brg->isa_impl,
+                    IMPLICATION(brg->is_fp8, brg->fp8_with_f16_vnni_block));
     brg->rd_step
             = static_cast<int>(data_type_vnni_granularity(rd_step_compute_dt));
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -47,6 +47,8 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
 
         bool has_f8_e5m2_binary_postops = false;
         bool has_f8_e4m3_binary_postops = false;
+        bool has_f8_dt = one_of(data_type::f8_e5m2, brg.dt_d, brg.dt_bias)
+                || one_of(data_type::f8_e4m3, brg.dt_d, brg.dt_bias);
         if (brg.with_binary) {
             const auto &post_ops = brg.attr()->post_ops_;
             for (int i = 0; i < post_ops.len(); i++) {
@@ -61,14 +63,16 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             }
         }
 
-        if (brg.is_fp8 || has_f8_e5m2_binary_postops
+        if (brg.is_fp8 || has_f8_dt || has_f8_e5m2_binary_postops
                 || has_f8_e4m3_binary_postops) {
-            if (one_of(data_type::f8_e5m2, brg.dt_a, brg.dt_b, brg.dt_d)
+            if (one_of(data_type::f8_e5m2, brg.dt_a, brg.dt_b, brg.dt_d,
+                        brg.dt_bias)
                     || has_f8_e5m2_binary_postops)
                 f8_e5m2_cvt_ = utils::make_unique<fp8_conversion_e5m2_t>(this,
                         fp8_emu_xmm_1(), fp8_emu_xmm_2(), fp8_emu_xmm_3(),
                         fp8_tmp_mask, fp8_tmp_reg);
-            if (one_of(data_type::f8_e4m3, brg.dt_a, brg.dt_b, brg.dt_d)
+            if (one_of(data_type::f8_e4m3, brg.dt_a, brg.dt_b, brg.dt_d,
+                        brg.dt_bias)
                     || has_f8_e4m3_binary_postops)
                 f8_e4m3_cvt_ = utils::make_unique<fp8_conversion_e4m3_t>(this,
                         fp8_emu_xmm_1(), fp8_emu_xmm_2(), fp8_emu_xmm_3(),

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -292,6 +292,7 @@ private:
     Xbyak::Opmask kmask_fp8_aux = Xbyak::Opmask(5);
     // Used for both AMX GEMM and GEMV code paths.
     Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(6);
+    Xbyak::Opmask fp8_tail_mask = Xbyak::Opmask(7);
 
     static int get_max_effective_vregs(const brgemm_desc_t &brg) {
         auto used_vregs = 0;
@@ -428,6 +429,8 @@ private:
     void zero_accumulators(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
             bool is_ld_tail, bool skip_accumulation);
 
+    void fp8_to_f16_upconvert(
+            data_type_t dt, const Vmm &vmm_out, const Operand &op_in);
     void fp8_to_f16_upconvert(dim_t num_rows, dim_t tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
@@ -1183,6 +1186,20 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
             uni_vpxor(vmm, vmm, vmm);
         }
     }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(
+        data_type_t dt, const Vmm &vmm_out, const Operand &op_in) {
+    if (!one_of(dt, data_type::f8_e4m3, data_type::f8_e5m2)) {
+        assert(!"unsupported data type");
+        return;
+    }
+
+    if (dt == data_type::f8_e4m3)
+        f8_e4m3_cvt_->vcvt_f8_to_f16(vmm_out, op_in);
+    else if (dt == data_type::f8_e5m2)
+        f8_e5m2_cvt_->vcvt_f8_to_f16(vmm_out, op_in);
 }
 
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
@@ -3193,7 +3210,11 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
             load_bytes(
                     xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
-            uni_vpbroadcastd(vmm_bcast, xmm_tmp);
+            if (brg.fp8_with_f16_vnni_block) {
+                vpbroadcastw(vmm_bcast, xmm_tmp);
+                fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
+            } else
+                uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
                 uni_vbroadcastss(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3202,9 +3223,14 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     vbcstnebf162ps(vmm_bcast, ptr[reg_aux_A + offset]);
                 else
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
-            } else if (one_of(dt, data_type::s8, data_type::u8,
-                               data_type::f8_e5m2, data_type::f8_e4m3)) {
+            } else if (one_of(dt, data_type::s8, data_type::u8)) {
                 uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
+            } else if (one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
+                if (brg.fp8_with_f16_vnni_block) {
+                    vpbroadcastw(vmm_bcast, ptr[reg_aux_A + offset]);
+                    fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
+                } else
+                    uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (dt == data_type::f16) {
                 if (brg.isa_impl == avx10_2) {
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3229,8 +3255,10 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                         brg.dt_b == data_type::f16, brg.isa_impl == avx10_2)
                 && IMPLICATION(brg.dt_b == data_type::bf16,
                         brg.isa_impl != avx2_vnni_2);
+        const auto tail_mask
+                = brg.fp8_with_f16_vnni_block ? fp8_tail_mask : ld_tail_mask;
         const Vmm vmm_load
-                = vmm_mask(load(vmm_load_idx), is_ld_tail, false, ld_tail_mask);
+                = vmm_mask(load(vmm_load_idx), is_ld_tail, false, tail_mask);
         const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
         // Note: Assuming the tails are properly padded/blocked for
         // avx2_vnni_2 with xf16 data type, as the B matrix is generally
@@ -3275,6 +3303,11 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             } else {
                 uni_vmovups(vmm_load, addr);
             }
+        } else if (one_of(brg.dt_b, data_type::f8_e5m2, data_type::f8_e4m3)) {
+            if (brg.fp8_with_f16_vnni_block)
+                fp8_to_f16_upconvert(brg.dt_b, vmm_load, addr);
+            else
+                uni_vmovups(vmm_load, addr);
         } else if (is_ld_tail) {
             if (is_superset(brg.isa_impl, avx512_core)) {
                 uni_vmovups(vmm_load, addr);
@@ -3309,7 +3342,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 broadcast_A(bcst(bd), bd, rd);
             for (dim_t ld = 0; ld < ld_block2; ld++) {
                 load_B(0, rd, ld);
-                if (brg.is_fp8_via_convert_non_amx())
+                if (brg.is_fp8_via_convert_non_amx()
+                        && !brg.fp8_with_f16_vnni_block)
                     maybe_pre_process_data(brg.dt_b, load(), vmm_fp8_load());
                 for (dim_t bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
@@ -3317,7 +3351,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                         uni_vfmadd231ps(vmm, load(),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
                     else {
-                        if (brg.is_fp8_via_convert_non_amx()) {
+                        if (brg.is_fp8_via_convert_non_amx()
+                                && !brg.fp8_with_f16_vnni_block) {
                             broadcast_A(bcst(bd), bd, rd);
                             maybe_pre_process_data(
                                     brg.dt_a, bcst(bd), vmm_fp8_bcst());
@@ -3337,7 +3372,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
             for (dim_t bd = bd_b; bd < bd_e; bd++) {
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
-                if (brg.is_fp8_via_convert_non_amx())
+                if (brg.is_fp8_via_convert_non_amx()
+                        && !brg.fp8_with_f16_vnni_block)
                     maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
                 if (prefetch_count_B < ld_block2) {
                     const dim_t prefetch_offset
@@ -3364,7 +3400,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                         uni_vfmadd231ps(vmm, load(ld),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
                     else {
-                        if (brg.is_fp8_via_convert_non_amx()) {
+                        if (brg.is_fp8_via_convert_non_amx()
+                                && !brg.fp8_with_f16_vnni_block) {
                             load_B(ld, rd, ld);
                             maybe_pre_process_data(
                                     brg.dt_b, load(ld), vmm_fp8_load());
@@ -3872,6 +3909,12 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
             kmovq(ld_full_mask, reg_mask);
             mov(reg_mask, tail_mask);
             kmovq(ld_tail_mask, reg_mask);
+
+            if (brg.fp8_with_f16_vnni_block) {
+                const auto f8_tail = size_t((1 << (brg.ldb_tail * 2)) - 1);
+                mov(reg_mask.cvt32(), f8_tail);
+                kmovd(fp8_tail_mask, reg_mask.cvt32());
+            }
         } else {
             const auto partial_mask
                     = brg.transA ? size_t((1 << brg.gemv_tail) - 1) : 1;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -61,6 +61,8 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
 
         bool has_f8_e5m2_binary_postops = false;
         bool has_f8_e4m3_binary_postops = false;
+        bool has_f8_dst_dt
+                = one_of(brg.dt_d, data_type::f8_e5m2, data_type::f8_e4m3);
         if (brg.with_binary) {
             const auto &post_ops = brg.attr()->post_ops_;
             for (int i = 0; i < post_ops.len(); i++) {
@@ -76,7 +78,7 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
         }
 
         if (brg.is_fp8 || has_f8_e5m2_binary_postops
-                || has_f8_e4m3_binary_postops) {
+                || has_f8_e4m3_binary_postops || has_f8_dst_dt) {
             if (one_of(data_type::f8_e5m2, brg.dt_a, brg.dt_b, brg.dt_c,
                         brg.dt_d)
                     || has_f8_e5m2_binary_postops)

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -243,6 +243,7 @@ private:
     const reg64_savable_t reg_buf_aux {regscratchpad_, abi_param1};
     const reg64_savable_backup_t reg_buf_aux_backup {reg_buf_aux};
     const reg64_savable_t reg_aux_compensation {regscratchpad_, rbx, r29};
+    const reg64_savable_t reg_buf_A {regscratchpad_, rbx, r26};
 
     // Base / working pointers for the per-(M,N) f32 compensation buffer used
     // by apply_per_mn_compensation. Lifecycle mirrors reg_C / reg_aux_C.
@@ -477,6 +478,8 @@ private:
             matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
             bool is_rd_tail, bool is_tail, bool last_bdb);
+    void maybe_pre_process_buf_A(reg64_t reg_base, const int bd_b,
+            const int bd_e, const int rd_block);
     void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
             const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
@@ -541,6 +544,7 @@ private:
     dim_t ldb_per_mn_comp_offset(
             dim_t ld_block2, bool is_tail = false) const noexcept;
     dim_t bdb_per_mn_comp_offset(dim_t bd_block2) const noexcept;
+    dim_t buf_A_offset(dim_t bd, dim_t rd) const noexcept;
 
     bool vpad_exist = false;
     bool need_comp_pads = false;
@@ -804,6 +808,13 @@ dim_t jit_brgemm_kernel_t<Wmm>::bdb_per_mn_comp_offset(
         dim_t bd_block2) const noexcept {
     return sizeof(float) * bd_block2 * brg.bd_block * brg.LDC;
 }
+
+template <typename Wmm>
+dim_t jit_brgemm_kernel_t<Wmm>::buf_A_offset(
+        dim_t bd, dim_t rd) const noexcept {
+    return bd * zmm_width_in_bytes_ + sizeof(float16_t) * rd;
+}
+
 template <typename Wmm>
 template <typename U>
 U jit_brgemm_kernel_t<Wmm>::vmm_mask(const U vmm_in, bool mask_flag, bool store,
@@ -1148,6 +1159,11 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
         mov(reg_D_shift_bytes, ptr[param1 + GET_OFF(dynamic_LDD)]);
         if (brg.typesize_D > 1) shl(reg_D_shift_bytes, (brg.typesize_D >> 1));
         reg_D_shift_bytes.save();
+    }
+
+    if (brg.is_fp8_via_convert_non_amx()) {
+        mov(reg_buf_A, ptr[param1 + GET_OFF(ptr_buf)]);
+        reg_buf_A.save();
     }
 
     mov(reg_do_post_ops, ptr[param1 + GET_OFF(do_post_ops)]);
@@ -2873,6 +2889,25 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
 }
 
 template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_buf_A(
+        reg64_t reg_base, const int bd_b, const int bd_e, const int rd_block) {
+    if (!brg.is_fp8_via_convert_non_amx()) return;
+
+    reg64_savable_guard_t reg_fp8_buf_guard({&reg64_fp8_aux, &reg_buf_A});
+
+    reg_buf_A.restore();
+
+    for (dim_t bd = bd_b; bd < bd_e; bd++) {
+        const auto offset = A_offset(bd, 0);
+        auto vmm = vmm_tmp(0);
+        auto xmm_tmp = Xmm(vmm.getIdx());
+        load_bytes(xmm_tmp, reg_base, offset, rd_block);
+        fp8_to_f16_upconvert(brg.dt_a, vmm, xmm_tmp);
+        vmovdqu16(ptr[reg_buf_A + bd * zmm_width_in_bytes_], vmm);
+    }
+}
+
+template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
         bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
         bool last_bdb) {
@@ -3208,15 +3243,13 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         const auto bd_by_load_bytes = (bd >= bd_e - rows_by_load_bytes
                 || brg.brgattr.wary_A_k_tail_read);
         const auto is_tail = have_to_load_bytes && bd_by_load_bytes;
-        if (is_tail) {
+        const auto is_fp8 = one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3);
+        reg64_savable_guard_t reg_fp8_buf_guard({&reg64_fp8_aux, &reg_buf_A});
+        if (is_tail && !is_fp8) {
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
             load_bytes(
                     xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
-            if (brg.fp8_with_f16_vnni_block) {
-                vpbroadcastw(vmm_bcast, xmm_tmp);
-                fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
-            } else
-                uni_vpbroadcastd(vmm_bcast, xmm_tmp);
+            uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
                 uni_vbroadcastss(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3227,12 +3260,10 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (one_of(dt, data_type::s8, data_type::u8)) {
                 uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
-            } else if (one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
-                if (brg.fp8_with_f16_vnni_block) {
-                    vpbroadcastw(vmm_bcast, ptr[reg_aux_A + offset]);
-                    fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
-                } else
-                    uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
+            } else if (is_fp8) {
+                reg_buf_A.restore();
+                const auto buf_offset = buf_A_offset(bd, rd);
+                uni_vpbroadcastd(vmm_bcast, ptr[reg_buf_A + buf_offset]);
             } else if (dt == data_type::f16) {
                 if (brg.isa_impl == avx10_2) {
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3338,6 +3369,9 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
 
+    maybe_pre_process_buf_A(
+            reg_aux_A, bd_b, bd_e, is_rd_tail ? brg.rdb_tail : rd_loop);
+
     for (dim_t rd = 0; rd < rd_loop; rd += brg.rd_step) {
         if (brg.n_bcast_1_load) {
             for (dim_t bd = bd_b; bd < bd_e && !is_emdbd; bd++)
@@ -3356,8 +3390,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                         if (brg.is_fp8_via_convert_non_amx()
                                 && !brg.fp8_with_f16_vnni_block) {
                             broadcast_A(bcst(bd), bd, rd);
-                            maybe_pre_process_data(
-                                    brg.dt_a, bcst(bd), vmm_fp8_bcst());
+                            broadcast_A(vmm_fp8_bcst(), bd, rd + 2);
                             dot_product(vmm, load(), bcst(bd));
                             dot_product(vmm, vmm_fp8_load(), vmm_fp8_bcst());
                         } else
@@ -3375,8 +3408,9 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             for (dim_t bd = bd_b; bd < bd_e; bd++) {
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
                 if (brg.is_fp8_via_convert_non_amx()
-                        && !brg.fp8_with_f16_vnni_block)
-                    maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
+                        && !brg.fp8_with_f16_vnni_block) {
+                    broadcast_A(vmm_fp8_bcst(), bd, rd + 2);
+                }
                 if (prefetch_count_B < ld_block2) {
                     const dim_t prefetch_offset
                             = B_offset(prefetch_count_B++, rd)

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -286,6 +286,7 @@ private:
     Xbyak::Opmask kmask_fp8_aux = Xbyak::Opmask(5);
     // Used for both AMX GEMM and GEMV code paths.
     Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(6);
+    Xbyak::Opmask fp8_tail_mask = Xbyak::Opmask(7);
 
     static int get_max_effective_vregs(const brgemm_desc_t &brg) {
         auto used_vregs = 0;
@@ -425,6 +426,8 @@ private:
     void fp8_to_f16_upconvert(int num_rows, int tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
+    void fp8_to_f16_upconvert(
+            data_type_t dt, const Vmm &vmm_out, const Operand &op_in);
     void fp8_to_f16_upconvert_to_vnni(int num_rows, int tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
@@ -1178,6 +1181,20 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(int bd_block2,
             uni_vpxor(vmm, vmm, vmm);
         }
     }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(
+        data_type_t dt, const Vmm &vmm_out, const Operand &op_in) {
+    if (!one_of(dt, data_type::f8_e4m3, data_type::f8_e5m2)) {
+        assert(!"unsupported data type");
+        return;
+    }
+
+    if (dt == data_type::f8_e4m3)
+        f8_e4m3_cvt_->vcvt_f8_to_f16(vmm_out, op_in);
+    else if (dt == data_type::f8_e5m2)
+        f8_e5m2_cvt_->vcvt_f8_to_f16(vmm_out, op_in);
 }
 
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
@@ -3107,7 +3124,11 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
             load_bytes(
                     xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
-            uni_vpbroadcastd(vmm_bcast, xmm_tmp);
+            if (brg.fp8_with_f16_vnni_block) {
+                vpbroadcastw(vmm_bcast, xmm_tmp);
+                fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
+            } else
+                uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
                 uni_vbroadcastss(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3116,9 +3137,14 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                     vbcstnebf162ps(vmm_bcast, ptr[reg_aux_A + offset]);
                 else
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
-            } else if (one_of(dt, data_type::s8, data_type::u8,
-                               data_type::f8_e5m2, data_type::f8_e4m3)) {
+            } else if (one_of(dt, data_type::s8, data_type::u8)) {
                 uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
+            } else if (one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
+                if (brg.fp8_with_f16_vnni_block) {
+                    vpbroadcastw(vmm_bcast, ptr[reg_aux_A + offset]);
+                    fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
+                } else
+                    uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (dt == data_type::f16) {
                 if (brg.isa_impl == avx10_2) {
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3143,8 +3169,10 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                         brg.dt_b == data_type::f16, brg.isa_impl == avx10_2)
                 && IMPLICATION(brg.dt_b == data_type::bf16,
                         brg.isa_impl != avx2_vnni_2);
+        const auto tail_mask
+                = brg.fp8_with_f16_vnni_block ? fp8_tail_mask : ld_tail_mask;
         const Vmm vmm_load
-                = vmm_mask(load(vmm_load_idx), is_ld_tail, false, ld_tail_mask);
+                = vmm_mask(load(vmm_load_idx), is_ld_tail, false, tail_mask);
         const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
         // Note: Assuming the tails are properly padded/blocked for
         // avx2_vnni_2 with xf16 data type, as the B matrix is generally
@@ -3191,6 +3219,11 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
             } else {
                 uni_vmovups(vmm_load, addr);
             }
+        } else if (one_of(brg.dt_b, data_type::f8_e5m2, data_type::f8_e4m3)) {
+            if (brg.fp8_with_f16_vnni_block)
+                fp8_to_f16_upconvert(brg.dt_b, vmm_load, addr);
+            else
+                uni_vmovups(vmm_load, addr);
         } else if (is_ld_tail) {
             if (is_superset(brg.isa_impl, avx512_core)) {
                 uni_vmovups(vmm_load, addr);
@@ -3226,7 +3259,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                 broadcast_A(bcst(bd), bd, rd);
             for (int ld = 0; ld < ld_block2; ld++) {
                 load_B(0, rd, ld);
-                if (brg.is_fp8_via_convert_non_amx())
+                if (brg.is_fp8_via_convert_non_amx()
+                        && !brg.fp8_with_f16_vnni_block)
                     maybe_pre_process_data(brg.dt_b, load(), vmm_fp8_load());
                 for (int bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
@@ -3234,7 +3268,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                         uni_vfmadd231ps(vmm, load(),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
                     else {
-                        if (brg.is_fp8_via_convert_non_amx()) {
+                        if (brg.is_fp8_via_convert_non_amx()
+                                && !brg.fp8_with_f16_vnni_block) {
                             broadcast_A(bcst(bd), bd, rd);
                             maybe_pre_process_data(
                                     brg.dt_a, bcst(bd), vmm_fp8_bcst());
@@ -3254,7 +3289,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
 
             for (int bd = bd_b; bd < bd_e; bd++) {
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
-                if (brg.is_fp8_via_convert_non_amx())
+                if (brg.is_fp8_via_convert_non_amx()
+                        && !brg.fp8_with_f16_vnni_block)
                     maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
                 if (prefetch_count_B < ld_block2) {
                     const dim_t prefetch_offset
@@ -3281,7 +3317,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                         uni_vfmadd231ps(vmm, load(ld),
                                 ptr_b[reg_aux_A + A_offset(bd, rd)]);
                     else {
-                        if (brg.is_fp8_via_convert_non_amx()) {
+                        if (brg.is_fp8_via_convert_non_amx()
+                                && !brg.fp8_with_f16_vnni_block) {
                             load_B(ld, rd, ld);
                             maybe_pre_process_data(
                                     brg.dt_b, load(ld), vmm_fp8_load());
@@ -3788,6 +3825,12 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
             kmovq(ld_full_mask, reg_mask);
             mov(reg_mask, tail_mask);
             kmovq(ld_tail_mask, reg_mask);
+
+            if (brg.fp8_with_f16_vnni_block) {
+                const auto f8_tail = size_t((1 << (brg.ldb_tail * 2)) - 1);
+                mov(reg_mask.cvt32(), f8_tail);
+                kmovd(fp8_tail_mask, reg_mask.cvt32());
+            }
         } else {
             const auto partial_mask
                     = brg.transA ? size_t((1 << brg.gemv_tail) - 1) : 1;

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -61,8 +61,8 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
 
         bool has_f8_e5m2_binary_postops = false;
         bool has_f8_e4m3_binary_postops = false;
-        bool has_f8_dst_dt
-                = one_of(brg.dt_d, data_type::f8_e5m2, data_type::f8_e4m3);
+        bool has_f8_dt = one_of(data_type::f8_e5m2, brg.dt_d, brg.dt_bias)
+                || one_of(data_type::f8_e4m3, brg.dt_d, brg.dt_bias);
         if (brg.with_binary) {
             const auto &post_ops = brg.attr()->post_ops_;
             for (int i = 0; i < post_ops.len(); i++) {
@@ -78,9 +78,9 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
         }
 
         if (brg.is_fp8 || has_f8_e5m2_binary_postops
-                || has_f8_e4m3_binary_postops || has_f8_dst_dt) {
+                || has_f8_e4m3_binary_postops || has_f8_dt) {
             if (one_of(data_type::f8_e5m2, brg.dt_a, brg.dt_b, brg.dt_c,
-                        brg.dt_d)
+                        brg.dt_d, brg.dt_bias)
                     || has_f8_e5m2_binary_postops)
                 // Note: avoid using 'vmm0' since it is used as
                 // 'fp8_to_f16_upconvert()' param and would collision with these
@@ -89,7 +89,7 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
                         vmm_fp8_emu_aux1(), vmm_fp8_emu_aux2(),
                         vmm_fp8_emu_aux3(), kmask_fp8_aux, reg64_fp8_aux);
             if (one_of(data_type::f8_e4m3, brg.dt_a, brg.dt_b, brg.dt_c,
-                        brg.dt_d)
+                        brg.dt_d, brg.dt_bias)
                     || has_f8_e4m3_binary_postops)
                 f8_e4m3_cvt_ = utils::make_unique<fp8_conversion_e4m3_t>(this,
                         vmm_fp8_emu_aux1(), vmm_fp8_emu_aux2(),

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2816,7 +2816,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_buf_A(
 
     reg_buf_A.restore();
 
-    for (dim_t bd = bd_b; bd < bd_e; bd++) {
+    for (int bd = bd_b; bd < bd_e; bd++) {
         const auto offset = A_offset(bd, 0);
         auto vmm = vmm_tmp(0);
         auto xmm_tmp = Xmm(vmm.getIdx());

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -61,8 +61,8 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
 
         bool has_f8_e5m2_binary_postops = false;
         bool has_f8_e4m3_binary_postops = false;
-        bool has_f8_dst_dt
-                = one_of(brg.dt_d, data_type::f8_e5m2, data_type::f8_e4m3);
+        bool has_f8_dt = one_of(data_type::f8_e5m2, brg.dt_d, brg.dt_bias)
+                || one_of(data_type::f8_e4m3, brg.dt_d, brg.dt_bias);
         if (brg.with_binary) {
             const auto &post_ops = brg.attr()->post_ops_;
             for (int i = 0; i < post_ops.len(); i++) {
@@ -78,9 +78,9 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
         }
 
         if (brg.is_fp8 || has_f8_e5m2_binary_postops
-                || has_f8_e4m3_binary_postops || has_f8_dst_dt) {
+                || has_f8_e4m3_binary_postops || has_f8_dt) {
             if (one_of(data_type::f8_e5m2, brg.dt_a, brg.dt_b, brg.dt_c,
-                        brg.dt_d)
+                        brg.dt_d, brg.dt_bias)
                     || has_f8_e5m2_binary_postops)
                 // Note: avoid using 'vmm0' since it is used as
                 // 'fp8_to_f16_upconvert()' param and would collision with these
@@ -89,7 +89,7 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
                         vmm_fp8_emu_aux1(), vmm_fp8_emu_aux2(),
                         vmm_fp8_emu_aux3(), kmask_fp8_aux, reg64_fp8_aux);
             if (one_of(data_type::f8_e4m3, brg.dt_a, brg.dt_b, brg.dt_c,
-                        brg.dt_d)
+                        brg.dt_d, brg.dt_bias)
                     || has_f8_e4m3_binary_postops)
                 f8_e4m3_cvt_ = utils::make_unique<fp8_conversion_e4m3_t>(this,
                         vmm_fp8_emu_aux1(), vmm_fp8_emu_aux2(),
@@ -237,6 +237,7 @@ private:
     const reg64_savable_t reg_buf_aux {regscratchpad_, abi_param1};
     const reg64_savable_backup_t reg_buf_aux_backup {reg_buf_aux};
     const reg64_savable_t reg_aux_compensation {regscratchpad_, rbx, r29};
+    const reg64_savable_t reg_buf_A {regscratchpad_, rbx, r26};
 
     // Base / working pointers for the per-(M,N) f32 compensation buffer used
     // by apply_per_mn_compensation. Lifecycle mirrors reg_C / reg_aux_C.
@@ -470,6 +471,8 @@ private:
             matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, int idx, dim_t offset,
             bool is_rd_tail, bool is_tail);
+    void maybe_pre_process_buf_A(reg64_t reg_base, const int bd_b,
+            const int bd_e, const int rd_block);
     void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
             const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
@@ -532,6 +535,7 @@ private:
     dim_t ldb_per_mn_comp_offset(
             int ld_block2, bool is_tail = false) const noexcept;
     dim_t bdb_per_mn_comp_offset(int bd_block2) const noexcept;
+    dim_t buf_A_offset(int bd, int rd) const noexcept;
 
     bool vpad_exist = false;
     bool need_comp_pads = false;
@@ -795,6 +799,12 @@ dim_t jit_brgemm_kernel_t<Wmm>::bdb_per_mn_comp_offset(
         int bd_block2) const noexcept {
     return sizeof(float) * bd_block2 * brg.bd_block * brg.LDC;
 }
+
+template <typename Wmm>
+dim_t jit_brgemm_kernel_t<Wmm>::buf_A_offset(int bd, int rd) const noexcept {
+    return bd * zmm_width_in_bytes_ + sizeof(float16_t) * rd;
+}
+
 template <typename Wmm>
 template <typename U>
 U jit_brgemm_kernel_t<Wmm>::vmm_mask(const U vmm_in, bool mask_flag, bool store,
@@ -1145,6 +1155,11 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
         reg_D_shift_bytes.save();
     }
 
+    if (brg.is_fp8_via_convert_non_amx() && brg.fp8_with_f16_vnni_block) {
+        mov(reg_buf_A, ptr[param1 + GET_OFF(ptr_buf)]);
+        reg_buf_A.save();
+    }
+
     mov(reg_do_post_ops, ptr[param1 + GET_OFF(do_post_ops)]);
     reg_do_post_ops.save();
 
@@ -1196,7 +1211,8 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(
     if (dt == data_type::f8_e4m3)
         f8_e4m3_cvt_->vcvt_f8_to_f16(vmm_out, op_in);
     else if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16(vmm_out, op_in);
+        // skip setting q nan bit for performance purpose
+        f8_e5m2_cvt_->vcvt_f8_to_f16_skip_q_nan(vmm_out, op_in);
 }
 
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
@@ -2791,6 +2807,26 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool is_rd_tail,
 }
 
 template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_buf_A(
+        reg64_t reg_base, const int bd_b, const int bd_e, const int rd_block) {
+    if (!(brg.is_fp8_via_convert_non_amx() && brg.fp8_with_f16_vnni_block))
+        return;
+
+    reg64_savable_guard_t reg_fp8_buf_guard({&reg64_fp8_aux, &reg_buf_A});
+
+    reg_buf_A.restore();
+
+    for (dim_t bd = bd_b; bd < bd_e; bd++) {
+        const auto offset = A_offset(bd, 0);
+        auto vmm = vmm_tmp(0);
+        auto xmm_tmp = Xmm(vmm.getIdx());
+        load_bytes(xmm_tmp, reg_base, offset, rd_block);
+        fp8_to_f16_upconvert(brg.dt_a, vmm, xmm_tmp);
+        vmovdqu16(ptr[reg_buf_A + bd * zmm_width_in_bytes_], vmm);
+    }
+}
+
+template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
         bool is_bdb_tail, int ld_block2, bool is_rd_tail, bool is_ld_tail) {
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
@@ -3121,16 +3157,16 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                 = have_to_load_bytes ? rows_for_rd_tail : 0;
         const auto bd_by_load_bytes = (bd >= bd_e - rows_by_load_bytes
                 || brg.brgattr.wary_A_k_tail_read);
-        const auto is_tail = have_to_load_bytes && bd_by_load_bytes;
+        const auto is_pre_process_fp8
+                = one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)
+                && brg.fp8_with_f16_vnni_block;
+        const auto is_tail
+                = have_to_load_bytes && bd_by_load_bytes && !is_pre_process_fp8;
         if (is_tail) {
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
             load_bytes(
                     xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
-            if (brg.fp8_with_f16_vnni_block) {
-                vpbroadcastw(vmm_bcast, xmm_tmp);
-                fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
-            } else
-                uni_vpbroadcastd(vmm_bcast, xmm_tmp);
+            uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
                 uni_vbroadcastss(vmm_bcast, ptr[reg_aux_A + offset]);
@@ -3143,8 +3179,9 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                 uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (one_of(dt, data_type::f8_e5m2, data_type::f8_e4m3)) {
                 if (brg.fp8_with_f16_vnni_block) {
-                    vpbroadcastw(vmm_bcast, ptr[reg_aux_A + offset]);
-                    fp8_to_f16_upconvert(dt, vmm_bcast, vmm_bcast);
+                    reg_buf_A.restore();
+                    const auto buf_offset = buf_A_offset(bd, rd);
+                    uni_vpbroadcastd(vmm_bcast, ptr[reg_buf_A + buf_offset]);
                 } else
                     uni_vpbroadcastd(vmm_bcast, ptr[reg_aux_A + offset]);
             } else if (dt == data_type::f16) {
@@ -3254,6 +3291,9 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
     if (max_prefetch_offset > INT_MAX) reg_aux_C.save();
 
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
+
+    maybe_pre_process_buf_A(
+            reg_aux_A, bd_b, bd_e, is_rd_tail ? brg.rdb_tail : rd_loop);
 
     for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
         if (brg.n_bcast_1_load) {

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -590,6 +590,10 @@ inline data_type_t get_mac_emu_data_type(const data_type_t data_type,
                         isa, avx2, avx2_vnni_2, avx512_core, avx512_core_fp16))
                 return f32;
             break;
+        case f8_e4m3:
+        case f8_e5m2:
+            if (utils::one_of(isa, avx10_2)) return f16;
+            break;
         default: return data_type;
     }
     return data_type;

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -647,7 +647,7 @@ inline data_type_t get_mac_emu_data_type(const data_type_t data_type,
             break;
         case f8_e4m3:
         case f8_e5m2:
-            if (utils::one_of(isa, avx10_2)) return f16;
+            if (isa == avx10_2) return f16;
             break;
         default: return data_type;
     }

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -645,6 +645,10 @@ inline data_type_t get_mac_emu_data_type(const data_type_t data_type,
                         isa, avx2, avx2_vnni_2, avx512_core, avx512_core_fp16))
                 return f32;
             break;
+        case f8_e4m3:
+        case f8_e5m2:
+            if (utils::one_of(isa, avx10_2)) return f16;
+            break;
         default: return data_type;
     }
     return data_type;

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -215,6 +215,15 @@ void fp8_conversion_e5m2_t::vcvt_f8_to_f16(
     }
 }
 
+void fp8_conversion_e5m2_t::vcvt_f8_to_f16_skip_q_nan(
+        const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
+    assert(utils::one_of(
+            true, op_in.isXMM(), op_in.isYMM(), op_in.isZMM(), op_in.isMEM()));
+    // f16 <- f8_e5m2
+    host_->vpmovzxbw(xmm_out, op_in);
+    host_->vpsllw(xmm_out, xmm_out, 8);
+}
+
 void fp8_conversion_e5m2_t::vcvt_f8_to_bf16(
         const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in) {
     assert(utils::one_of(

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.hpp
@@ -147,6 +147,8 @@ struct fp8_conversion_e5m2_t : public fp8_conversion_base_t {
     void vcvt_f8_to_bf16_vnni_block(int num_rows,
             const Xbyak::Reg64 &reg_data_in, const Xbyak::Reg64 &reg_stride_in,
             const Xbyak::Reg64 &reg_data_out) override;
+    void vcvt_f8_to_f16_skip_q_nan(
+            const Xbyak::Xmm &xmm_out, const Xbyak::Operand &op_in);
 
 private:
     const Xbyak::Opmask kmask_aux_;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -399,7 +399,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
         const void *src_scales, const void *wei_scales, const void *dst_scales,
-        const bool is_last_os) const {
+        char *fp8_convert_wsp, const bool is_last_os) const {
 
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper weights_d(pd()->weights_md());
@@ -534,12 +534,16 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
                     dst_scales};
 
             void *scratch = is_amx ? static_cast<void *>(wsp_tile)
-                                   : static_cast<void *>(s8s8_comp_ptr);
+                    : jcp.req_fp8_convert_wsp
+                    ? static_cast<void *>(fp8_convert_wsp)
+                    : static_cast<void *>(s8s8_comp_ptr);
             brgemm_kernel_execute_postops(brg_ker, n_ic_blocks, brg_batch,
                     (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch);
         } else {
             void *scratch = is_amx ? static_cast<void *>(wsp_tile)
-                                   : static_cast<void *>(s8s8_comp_ptr);
+                    : jcp.req_fp8_convert_wsp
+                    ? static_cast<void *>(fp8_convert_wsp)
+                    : static_cast<void *>(s8s8_comp_ptr);
             brgemm_kernel_execute(
                     brg_ker, n_ic_blocks, brg_batch, (void *)ptr_C, scratch);
         }
@@ -575,7 +579,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
         char *const c_buffer_global, char *inp_buffer_base,
-        uint8_t *inp_buffer_mask_base) const {
+        uint8_t *inp_buffer_mask_base, char *fp8_wsp_base) const {
 
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
@@ -596,6 +600,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
                 : nullptr;
         uint8_t *__restrict inp_buffer_mask = (jcp.is_rtus)
                 ? inp_buffer_mask_base + ithr * jcp.inp_buffer_mask_size
+                : nullptr;
+        char *fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_wsp_base + ithr * jcp.fp8_convert_wsp_size
                 : nullptr;
 
         float *dst_scales_inv_ptr = nullptr;
@@ -646,7 +653,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
                             inp_buffer_sp, g, n, ocb, od, oh, ow, icc,
                             &last_brg_idx, src_zero_points, src_zp_comp,
                             dst_zero_points, s8s8_compensation, src_scales,
-                            wei_scales, dst_scales_inv_ptr, is_last_os);
+                            wei_scales, dst_scales_inv_ptr, fp8_convert_wsp,
+                            is_last_os);
                 }
             }
             last_n = n;
@@ -671,7 +679,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
         const void *wei_scales, const void *dst_scales, void *dst_scales_inv,
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
-        char *const c_buffer_global) const {
+        char *const c_buffer_global, char *fp8_wsp_base) const {
 
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
@@ -684,6 +692,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
                 = brg_batch_global + (size_t)ithr * jcp.adjusted_batch_size;
         char *const c_buffer = (jcp.use_buffer)
                 ? c_buffer_global + ithr * acc_dsz * jcp.LDC * jcp.M
+                : nullptr;
+        char *fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_wsp_base + ithr * jcp.fp8_convert_wsp_size
                 : nullptr;
 
         float *dst_scales_inv_ptr = nullptr;
@@ -714,7 +725,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
                 exec_ker(brgemm_ctx, ithr, brg_batch, c_buffer, nullptr, g, n,
                         ocb, od, oh, ow, icc, &last_brg_idx, src_zero_points,
                         src_zp_comp, dst_zero_points, s8s8_compensation,
-                        src_scales, wei_scales, dst_scales_inv_ptr);
+                        src_scales, wei_scales, dst_scales_inv_ptr,
+                        fp8_convert_wsp);
             }
             if (jcp.loop_order == loop_ndhwgc)
                 nd_iterator_step(n, jcp.mb, od, OD, oh, OH, owb, jcp.nb_ow, g,
@@ -782,17 +794,22 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::execute_forward_all(
     void *dst_scales_inv = jcp.with_dst_scales
             ? scratchpad.template get<void>(key_conv_dst_scales)
             : nullptr;
+    char *fp8_convert_wsp_base = jcp.req_fp8_convert_wsp
+            ? scratchpad.template get<char>(
+                      key_brgemm_primitive_fp8_convert_wsp)
+            : nullptr;
 
     if (jcp.is_os_blocking) {
         execute_os_blocking(brgemm_ctx, brg_batch_global, src_scales,
                 wei_scales, dst_scales, dst_scales_inv, src_zero_points,
                 zp_compensation, dst_zero_points, s8s8_compensation,
-                c_buffer_global, inp_buffer_base, inp_buffer_mask_base);
+                c_buffer_global, inp_buffer_base, inp_buffer_mask_base,
+                fp8_convert_wsp_base);
     } else {
         execute_full_spatial(brgemm_ctx, brg_batch_global, src_scales,
                 wei_scales, dst_scales, dst_scales_inv, src_zero_points,
                 zp_compensation, dst_zero_points, s8s8_compensation,
-                c_buffer_global);
+                c_buffer_global, fp8_convert_wsp_base);
     }
 
     return status::success;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -185,6 +185,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         const auto brg_idx = get_brg_idx(jcp_, params);
 
         brgemm_desc_t brg;
+        brg.fp8_with_f16_vnni_block = jcp_.is_fp8 && jcp_.vnni_block == 2;
         brgemm_strides_t brg_strides;
         brg_strides.stride_a = jcp_.brg_stride_a;
         brg_strides.stride_b = jcp_.brg_stride_b;
@@ -270,8 +271,9 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
     dst_d_sz = OD * dst_h_sz;
 
     const auto src_type = pd()->src_md(0)->data_type;
+    const bool req_emulation = utils::one_of(isa, avx512_core_fp16, avx10_2);
     const data_type_t last_ic_block_dt
-            = get_mac_emu_data_type(src_type, isa, isa == avx512_core_fp16);
+            = get_mac_emu_data_type(src_type, isa, req_emulation);
     const auto last_ic_block = data_type_vnni_granularity(last_ic_block_dt);
 
     wei_ic_stride = jcp.wei_plain ? jcp.oc_without_padding : jcp.oc_block;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -399,7 +399,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
         const void *src_scales, const void *wei_scales, const void *dst_scales,
-        const bool is_last_os) const {
+        char *fp8_convert_wsp, const bool is_last_os) const {
 
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper weights_d(pd()->weights_md());
@@ -535,12 +535,16 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
                     dst_scales};
 
             void *scratch = is_amx ? static_cast<void *>(wsp_tile)
-                                   : static_cast<void *>(s8s8_comp_ptr);
+                    : jcp.req_fp8_convert_wsp
+                    ? static_cast<void *>(fp8_convert_wsp)
+                    : static_cast<void *>(s8s8_comp_ptr);
             brgemm_kernel_execute_postops(brg_ker, n_ic_blocks, brg_batch,
                     (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch);
         } else {
             void *scratch = is_amx ? static_cast<void *>(wsp_tile)
-                                   : static_cast<void *>(s8s8_comp_ptr);
+                    : jcp.req_fp8_convert_wsp
+                    ? static_cast<void *>(fp8_convert_wsp)
+                    : static_cast<void *>(s8s8_comp_ptr);
             brgemm_kernel_execute(
                     brg_ker, n_ic_blocks, brg_batch, (void *)ptr_C, scratch);
         }
@@ -576,7 +580,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
         char *const c_buffer_global, char *inp_buffer_base,
-        uint8_t *inp_buffer_mask_base) const {
+        uint8_t *inp_buffer_mask_base, char *fp8_wsp_base) const {
 
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
@@ -598,6 +602,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
                 : nullptr;
         uint8_t *__restrict inp_buffer_mask = (jcp.is_rtus)
                 ? inp_buffer_mask_base + ithr * jcp.inp_buffer_mask_size
+                : nullptr;
+        char *fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_wsp_base + ithr * jcp.fp8_convert_wsp_size
                 : nullptr;
 
         float *dst_scales_inv_ptr = nullptr;
@@ -648,7 +655,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
                             inp_buffer_sp, g, n, ocb, od, oh, ow, icc,
                             &last_brg_idx, src_zero_points, src_zp_comp,
                             dst_zero_points, s8s8_compensation, src_scales,
-                            wei_scales, dst_scales_inv_ptr, is_last_os);
+                            wei_scales, dst_scales_inv_ptr, fp8_convert_wsp,
+                            is_last_os);
                 }
             }
             last_n = n;
@@ -673,7 +681,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
         const void *wei_scales, const void *dst_scales, void *dst_scales_inv,
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
-        char *const c_buffer_global) const {
+        char *const c_buffer_global, char *fp8_wsp_base) const {
 
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
@@ -686,6 +694,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
                 = brg_batch_global + (size_t)ithr * jcp.adjusted_batch_size;
         char *const c_buffer = (jcp.use_buffer)
                 ? c_buffer_global + ithr * acc_dsz * jcp.LDC * jcp.M
+                : nullptr;
+        char *fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_wsp_base + ithr * jcp.fp8_convert_wsp_size
                 : nullptr;
 
         float *dst_scales_inv_ptr = nullptr;
@@ -716,7 +727,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
                 exec_ker(brgemm_ctx, ithr, brg_batch, c_buffer, nullptr, g, n,
                         ocb, od, oh, ow, icc, &last_brg_idx, src_zero_points,
                         src_zp_comp, dst_zero_points, s8s8_compensation,
-                        src_scales, wei_scales, dst_scales_inv_ptr);
+                        src_scales, wei_scales, dst_scales_inv_ptr,
+                        fp8_convert_wsp);
             }
             if (jcp.loop_order == loop_ndhwgc)
                 nd_iterator_step(n, jcp.mb, od, OD, oh, OH, owb, jcp.nb_ow, g,
@@ -784,17 +796,22 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::execute_forward_all(
     void *dst_scales_inv = jcp.with_dst_scales
             ? scratchpad.template get<void>(key_conv_dst_scales)
             : nullptr;
+    char *fp8_convert_wsp_base = jcp.req_fp8_convert_wsp
+            ? scratchpad.template get<char>(
+                      key_brgemm_primitive_fp8_convert_wsp)
+            : nullptr;
 
     if (jcp.is_os_blocking) {
         execute_os_blocking(brgemm_ctx, brg_batch_global, src_scales,
                 wei_scales, dst_scales, dst_scales_inv, src_zero_points,
                 zp_compensation, dst_zero_points, s8s8_compensation,
-                c_buffer_global, inp_buffer_base, inp_buffer_mask_base);
+                c_buffer_global, inp_buffer_base, inp_buffer_mask_base,
+                fp8_convert_wsp_base);
     } else {
         execute_full_spatial(brgemm_ctx, brg_batch_global, src_scales,
                 wei_scales, dst_scales, dst_scales_inv, src_zero_points,
                 zp_compensation, dst_zero_points, s8s8_compensation,
-                c_buffer_global);
+                c_buffer_global, fp8_convert_wsp_base);
     }
 
     return status::success;

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -125,7 +125,8 @@ private:
             const int32_t *src_zero_points, int32_t *src_zp_comp,
             const int32_t *dst_zero_points, int32_t *s8s8_compensation,
             const void *src_scales, const void *wei_scales,
-            const void *dst_scales_inv, const bool is_last_os = false) const;
+            const void *dst_scales_inv, char *fp8_wsp_base,
+            const bool is_last_os = false) const;
     void execute_os_blocking(const brgemm_exec_ctx_t &brgemm_ctx,
             brgemm_batch_element_t *const brg_batch_global,
             const void *src_scales, const void *wei_scales,
@@ -133,14 +134,14 @@ private:
             const int32_t *src_zero_points, int32_t *src_zp_comp,
             const int32_t *dst_zero_points, int32_t *s8s8_compensation,
             char *const c_buffer_global, char *inp_buffer_base,
-            uint8_t *inp_buffer_mask_base) const;
+            uint8_t *inp_buffer_mask_base, char *fp8_wsp_base) const;
     void execute_full_spatial(const brgemm_exec_ctx_t &brgemm_ctx,
             brgemm_batch_element_t *const brg_batch_global,
             const void *src_scales, const void *wei_scales,
             const void *dst_scales, void *dst_scales_inv,
             const int32_t *src_zero_points, int32_t *src_zp_comp,
             const int32_t *dst_zero_points, int32_t *s8s8_compensation,
-            char *const c_buffer_global) const;
+            char *const c_buffer_global, char *fp8_wsp_base) const;
 
     status_t execute_forward_all(const exec_ctx_t &ctx) const;
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1325,6 +1325,7 @@ struct brgemm_convolution_fwd_t<isa>::brgemm_thread_ctx_t {
     uint8_t *__restrict inp_buffer_mask {nullptr};
     const char *const __restrict weights {nullptr};
     void *__restrict inp_buffer_zero {nullptr};
+    void *__restrict fp8_convert_wsp {nullptr};
 };
 
 template <cpu_isa_t isa>
@@ -1392,6 +1393,10 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                                               key_brgemm_primitive_buffer_comp)
                                     : s8s8_compensation)
             : nullptr;
+    auto *fp8_convert_wsp_base = jcp.req_fp8_convert_wsp
+            ? scratchpad.template get<char>(
+                      key_brgemm_primitive_fp8_convert_wsp)
+            : nullptr;
 
     cal_compensation(wei, src_zp_comp_base, s8s8_comp_base);
 
@@ -1442,6 +1447,10 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 
         btc.inp_buffer_mask = (jcp.exec_type == exec_trans)
                 ? inp_p_buffer_mask + ithr * jcp.inp_buffer_mask_size
+                : nullptr;
+
+        btc.fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_convert_wsp_base + ithr * jcp.fp8_convert_wsp_size
                 : nullptr;
 
         btc.input = jcp.copy_input ? btc.inp_buffer : src;
@@ -1763,7 +1772,9 @@ inline void brgemm_convolution_fwd_t<isa>::call_brgemm_kernel(
                 btc.dst_scales};
 
         void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
-                               : static_cast<void *>(s8s8_comp);
+                : jcp.req_fp8_convert_wsp
+                ? static_cast<void *>(btc.fp8_convert_wsp)
+                : static_cast<void *>(s8s8_comp);
 
         if (do_postops)
             brgemm_kernel_execute_postops(brg_ker, batch_size, ptrA, ptrB,
@@ -1771,9 +1782,12 @@ inline void brgemm_convolution_fwd_t<isa>::call_brgemm_kernel(
         else
             brgemm_kernel_execute_postops(brg_ker, batch_size, ptrA, ptrB,
                     btc.brg_batch, ptr_C, ptr_C, post_ops_data, scratch);
-    } else
-        brgemm_kernel_execute(brg_ker, batch_size, ptrA, ptrB, btc.brg_batch,
-                ptr_C, static_cast<void *>(btc.wsp_tile));
+    } else {
+        void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
+                               : static_cast<void *>(btc.fp8_convert_wsp);
+        brgemm_kernel_execute(
+                brg_ker, batch_size, ptrA, ptrB, btc.brg_batch, ptr_C, scratch);
+    }
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -270,6 +270,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     brg.req_cal_comp_pads = jcp_.req_brg_comp_pad;
     brg.req_comp_pads_with_bcast
             = jcp_.req_cal_comp_pad && jcp_.exec_type != exec_vpad;
+    brg.fp8_with_f16_vnni_block = jcp_.is_fp8 && jcp_.vnni_block == 2;
     const auto strides_ptr
             = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
     CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, src_type, wei_type, false,

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -272,6 +272,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(dim_t vM,
     brg.req_cal_comp_pads = jcp_.req_brg_comp_pad;
     brg.req_comp_pads_with_bcast
             = jcp_.req_cal_comp_pad && jcp_.exec_type != exec_vpad;
+    brg.fp8_with_f16_vnni_block = jcp_.is_fp8 && jcp_.vnni_block == 2;
     const auto strides_ptr
             = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
     CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, src_type, wei_type, false,

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1337,6 +1337,7 @@ struct brgemm_convolution_fwd_t<isa>::brgemm_thread_ctx_t {
     uint8_t *__restrict inp_buffer_mask {nullptr};
     const char *const __restrict weights {nullptr};
     void *__restrict inp_buffer_zero {nullptr};
+    void *__restrict fp8_convert_wsp {nullptr};
 };
 
 template <cpu_isa_t isa>
@@ -1404,6 +1405,10 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                                               key_brgemm_primitive_buffer_comp)
                                     : s8s8_compensation)
             : nullptr;
+    auto *fp8_convert_wsp_base = jcp.req_fp8_convert_wsp
+            ? scratchpad.template get<char>(
+                      key_brgemm_primitive_fp8_convert_wsp)
+            : nullptr;
 
     cal_compensation(wei, src_zp_comp_base, s8s8_comp_base);
 
@@ -1454,6 +1459,10 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 
         btc.inp_buffer_mask = (jcp.exec_type == exec_trans)
                 ? inp_p_buffer_mask + ithr * jcp.inp_buffer_mask_size
+                : nullptr;
+
+        btc.fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_convert_wsp_base + ithr * jcp.fp8_convert_wsp_size
                 : nullptr;
 
         btc.input = jcp.copy_input ? btc.inp_buffer : src;
@@ -1776,7 +1785,9 @@ inline void brgemm_convolution_fwd_t<isa>::call_brgemm_kernel(
                 btc.dst_scales};
 
         void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
-                               : static_cast<void *>(s8s8_comp);
+                : jcp.req_fp8_convert_wsp
+                ? static_cast<void *>(btc.fp8_convert_wsp)
+                : static_cast<void *>(s8s8_comp);
 
         if (do_postops)
             brgemm_kernel_execute_postops(brg_ker, batch_size, ptrA, ptrB,
@@ -1784,9 +1795,12 @@ inline void brgemm_convolution_fwd_t<isa>::call_brgemm_kernel(
         else
             brgemm_kernel_execute_postops(brg_ker, batch_size, ptrA, ptrB,
                     btc.brg_batch, ptr_C, ptr_C, post_ops_data, scratch);
-    } else
-        brgemm_kernel_execute(brg_ker, batch_size, ptrA, ptrB, btc.brg_batch,
-                ptr_C, static_cast<void *>(btc.wsp_tile));
+    } else {
+        void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
+                               : static_cast<void *>(btc.fp8_convert_wsp);
+        brgemm_kernel_execute(
+                brg_ker, batch_size, ptrA, ptrB, btc.brg_batch, ptr_C, scratch);
+    }
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -836,6 +836,11 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                                     : s8s8_compensation)
             : nullptr;
 
+    auto *fp8_convert_wsp_base = jcp.req_fp8_convert_wsp
+            ? scratchpad.template get<char>(
+                      key_brgemm_primitive_fp8_convert_wsp)
+            : nullptr;
+
     cal_compensation(wei, src_zp_comp_base, s8s8_comp_base);
 
     char *const wsp_tile_global = is_amx
@@ -870,6 +875,10 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                 ? wsp_tile_global + ithr * 2 * brgemm_convolution_bwd_utils::P4K
                 : nullptr;
 
+        char *const fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_convert_wsp_base + ithr * jcp.fp8_convert_wsp_size
+                : nullptr;
+
         float *dst_scales_inv_ptr = nullptr;
         if (jcp.with_dst_scales) {
             const float *dst_scales_ptr
@@ -896,8 +905,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
         else
             assert(!"Unknown loop order");
 
-        brgemm_bwd_thread_ctx_t btc(
-                brgemm_ctx, ithr, brg_batch, c_buffer, out_buffer, wsp_tile);
+        brgemm_bwd_thread_ctx_t btc(brgemm_ctx, ithr, brg_batch, c_buffer,
+                out_buffer, wsp_tile, fp8_convert_wsp);
 
         int last_n = -1;
         int last_g = -1;
@@ -1231,7 +1240,9 @@ void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
                 btc.dst_scales};
 
         void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
-                               : static_cast<void *>(s8s8_comp);
+                : jcp.req_fp8_convert_wsp
+                ? static_cast<void *>(btc.fp8_convert_wsp)
+                : static_cast<void *>(s8s8_comp);
 
         if (do_postops || do_skip_accm) {
             brgemm_kernel_execute_postops(brg_ker, batch_size, btc.brg_batch,
@@ -1239,9 +1250,12 @@ void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
         } else
             brgemm_kernel_execute_postops(brg_ker, batch_size, btc.brg_batch,
                     ptr_C, ptr_C, post_ops_data, scratch);
-    } else
-        brgemm_kernel_execute(brg_ker, batch_size, btc.brg_batch, ptr_C,
-                static_cast<void *>(btc.wsp_tile));
+    } else {
+        void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
+                               : static_cast<void *>(btc.fp8_convert_wsp);
+        brgemm_kernel_execute(
+                brg_ker, batch_size, btc.brg_batch, ptr_C, scratch);
+    }
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -53,7 +53,7 @@ static bool impl_supports_datatype(data_type_t data_type) {
             return x64::mayiuse(x64::avx512_core_fp16)
                     || x64::mayiuse(x64::avx2_vnni_2);
         case data_type::f8_e5m2:
-            return x64::mayiuse(x64::avx10_2_amx_2)
+            return x64::mayiuse(x64::avx10_2)
                     || x64::mayiuse(x64::avx512_core_amx_fp16);
         case data_type::f8_e4m3:
             return x64::mayiuse(x64::avx10_2)

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -327,6 +327,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
             = jcp_.req_cal_comp_pad && jcp_.exec_type == exec_trans;
     const auto strides_ptr
             = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
+    brg.fp8_with_f16_vnni_block = jcp_.is_fp8 && jcp_.vnni_block == 2;
     CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, jcp_.src_dt, jcp_.wei_dt,
             false, false, brgemm_row_major, alpha, vbeta, jcp_.LDA, jcp_.LDB,
             jcp_.LDC, vM, vN, vK, strides_ptr, jcp_.is_tf32));

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -330,6 +330,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(
             = jcp_.req_cal_comp_pad && jcp_.exec_type == exec_trans;
     const auto strides_ptr
             = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
+    brg.fp8_with_f16_vnni_block = jcp_.is_fp8 && jcp_.vnni_block == 2;
     CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, jcp_.src_dt, jcp_.wei_dt,
             false, false, brgemm_row_major, alpha, vbeta, jcp_.LDA, jcp_.LDB,
             jcp_.LDC, vM, vN, vK, strides_ptr));

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -843,6 +843,11 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                                     : s8s8_compensation)
             : nullptr;
 
+    auto *fp8_convert_wsp_base = jcp.req_fp8_convert_wsp
+            ? scratchpad.template get<char>(
+                      key_brgemm_primitive_fp8_convert_wsp)
+            : nullptr;
+
     cal_compensation(wei, src_zp_comp_base, s8s8_comp_base);
 
     char *const wsp_tile_global = is_amx
@@ -877,6 +882,10 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                 ? wsp_tile_global + ithr * 2 * brgemm_convolution_bwd_utils::P4K
                 : nullptr;
 
+        char *const fp8_convert_wsp = jcp.req_fp8_convert_wsp
+                ? fp8_convert_wsp_base + ithr * jcp.fp8_convert_wsp_size
+                : nullptr;
+
         float *dst_scales_inv_ptr = nullptr;
         if (jcp.with_dst_scales) {
             const float *dst_scales_ptr
@@ -903,8 +912,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
         else
             assert(!"Unknown loop order");
 
-        brgemm_bwd_thread_ctx_t btc(
-                brgemm_ctx, ithr, brg_batch, c_buffer, out_buffer, wsp_tile);
+        brgemm_bwd_thread_ctx_t btc(brgemm_ctx, ithr, brg_batch, c_buffer,
+                out_buffer, wsp_tile, fp8_convert_wsp);
 
         dim_t last_n = -1;
         dim_t last_g = -1;
@@ -1242,7 +1251,9 @@ void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
                 btc.dst_scales};
 
         void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
-                               : static_cast<void *>(s8s8_comp);
+                : jcp.req_fp8_convert_wsp
+                ? static_cast<void *>(btc.fp8_convert_wsp)
+                : static_cast<void *>(s8s8_comp);
 
         if (do_postops || do_skip_accm) {
             brgemm_kernel_execute_postops(brg_ker, batch_size, btc.brg_batch,
@@ -1250,9 +1261,12 @@ void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
         } else
             brgemm_kernel_execute_postops(brg_ker, batch_size, btc.brg_batch,
                     ptr_C, ptr_C, post_ops_data, scratch);
-    } else
-        brgemm_kernel_execute(brg_ker, batch_size, btc.brg_batch, ptr_C,
-                static_cast<void *>(btc.wsp_tile));
+    } else {
+        void *scratch = is_amx ? static_cast<void *>(btc.wsp_tile)
+                               : static_cast<void *>(btc.fp8_convert_wsp);
+        brgemm_kernel_execute(
+                brg_ker, batch_size, btc.brg_batch, ptr_C, scratch);
+    }
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
@@ -133,13 +133,15 @@ private:
     struct brgemm_bwd_thread_ctx_t {
         brgemm_bwd_thread_ctx_t(const brgemm_bwd_exec_ctx_t &brgemm_ctx_,
                 int ithr_, brgemm_batch_element_t *__restrict brg_batch_,
-                char *c_buffer_, char *out_buffer_, char *wsp_tile_)
+                char *c_buffer_, char *out_buffer_, char *wsp_tile_,
+                char *fp8_convert_wsp_)
             : brgemm_ctx(brgemm_ctx_)
             , ithr(ithr_)
             , brg_batch(brg_batch_)
             , c_buffer(c_buffer_)
             , out_buffer(out_buffer_)
             , wsp_tile(wsp_tile_)
+            , fp8_convert_wsp(fp8_convert_wsp_)
             , cur_brg_idx(-1)
             , g(0)
             , n(0)
@@ -165,6 +167,7 @@ private:
         char *c_buffer;
         char *out_buffer;
         char *wsp_tile;
+        char *fp8_convert_wsp;
         int cur_brg_idx;
         int g, n, icb;
         int id, idb, ih, ihb, iwb;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
@@ -134,13 +134,15 @@ private:
     struct brgemm_bwd_thread_ctx_t {
         brgemm_bwd_thread_ctx_t(const brgemm_bwd_exec_ctx_t &brgemm_ctx_,
                 int ithr_, brgemm_batch_element_t *__restrict brg_batch_,
-                char *c_buffer_, char *out_buffer_, char *wsp_tile_)
+                char *c_buffer_, char *out_buffer_, char *wsp_tile_,
+                char *fp8_convert_wsp_)
             : brgemm_ctx(brgemm_ctx_)
             , ithr(ithr_)
             , brg_batch(brg_batch_)
             , c_buffer(c_buffer_)
             , out_buffer(out_buffer_)
             , wsp_tile(wsp_tile_)
+            , fp8_convert_wsp(fp8_convert_wsp_)
             , cur_brg_idx(-1)
             , g(0)
             , n(0)
@@ -166,6 +168,7 @@ private:
         char *c_buffer;
         char *out_buffer;
         char *wsp_tile;
+        char *fp8_convert_wsp;
         int cur_brg_idx;
         dim_t g, n, icb;
         dim_t id, idb, ih, ihb, iwb;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1519,13 +1519,16 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.is_tf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
             && one_of(attr.fpmath_.mode_, fpmath_mode::tf32, fpmath_mode::any)
             && is_superset(isa, avx10_2_amx_2);
+    jcp.is_fp8 = one_of(jcp.src_dt, f8_e5m2, f8_e4m3)
+            && one_of(jcp.wei_dt, f8_e4m3, f8_e5m2);
 
     VDISPATCH_CONV_IC(!jcp.is_bf32, VERBOSE_UNSUPPORTED_DT);
 
     const auto wei_dt
             = jcp.is_f32_f16 || jcp.is_f32_bf16 ? jcp.src_dt : jcp.wei_dt;
+    const bool req_emulation = one_of(isa, avx512_core_fp16, avx10_2);
     const data_type_t last_oc_block_dt
-            = get_mac_emu_data_type(wei_dt, isa, isa == avx512_core_fp16);
+            = get_mac_emu_data_type(wei_dt, isa, req_emulation);
     jcp.vnni_block = data_type_vnni_granularity(last_oc_block_dt);
 
     // TODO: optimize grouped convolutions with small oc

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1521,6 +1521,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             && is_superset(isa, avx10_2_amx_2);
     jcp.is_fp8 = one_of(jcp.src_dt, f8_e5m2, f8_e4m3)
             && one_of(jcp.wei_dt, f8_e4m3, f8_e5m2);
+    jcp.req_fp8_convert_wsp = jcp.is_fp8 && isa == avx10_2;
 
     VDISPATCH_CONV_IC(!jcp.is_bf32, VERBOSE_UNSUPPORTED_DT);
 
@@ -2120,6 +2121,9 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
     }
 
+    jcp.fp8_convert_wsp_size = static_cast<dim_t>(sizeof(float16_t))
+            * isa_max_vlen(jcp.isa)
+            * nstl::max(isa_num_vregs(jcp.isa), jcp.iw_block);
     return status::success;
 }
 
@@ -2167,6 +2171,12 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
         // See brgemm_types.hpp comment for `with_dst_scales`.
         scratchpad.book(key_conv_dst_scales,
                 static_cast<size_t>(jcp.nthr) * sizeof(float), P4K);
+    }
+
+    if (jcp.req_fp8_convert_wsp) {
+        scratchpad.book(key_brgemm_primitive_fp8_convert_wsp,
+                static_cast<size_t>(jcp.nthr) * jcp.fp8_convert_wsp_size,
+                sizeof(float16_t), 0, P4K);
     }
 }
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -113,16 +113,20 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
         const bool no_vnni_format = jcp.wei_dt == f32
                 || (jcp.wei_dt == f16 && jcp.isa == avx512_core_fp16)
                 || jcp.is_f32_bf16 || jcp.is_f32_f16;
+        const bool req_emulation = jcp.isa == avx10_2 && jcp.is_fp8;
+        const auto vnni_block_dt
+                = get_mac_emu_data_type(jcp.wei_dt, jcp.isa, req_emulation);
+        const auto vnni_block = data_type_vnni_granularity(vnni_block_dt);
         if (jcp.ic_block == 64) {
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo64i : Idhwo64i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o64i4o : IdhwO16o64i4o;
                     else
                         wei_tag = with_groups ? gIdhwO64i4o : IdhwO64i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o64i2o : IdhwO16o64i2o;
                     else
@@ -132,12 +136,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo64i : Iwo64i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o64i4o : IwO16o64i4o;
                     else
                         wei_tag = with_groups ? gIwO64i4o : IwO64i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o64i2o : IwO16o64i2o;
                     else
@@ -149,12 +153,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
                 UNUSED(is_2d);
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo64i : Ihwo64i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o64i4o : IhwO16o64i4o;
                     else
                         wei_tag = with_groups ? gIhwO64i4o : IhwO64i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o64i2o : IhwO16o64i2o;
                     else
@@ -166,12 +170,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo48i : Idhwo48i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o48i4o : IdhwO16o48i4o;
                     else
                         wei_tag = with_groups ? gIdhwO48i4o : IdhwO48i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o48i2o : IdhwO16o48i2o;
                     else
@@ -181,12 +185,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo48i : Iwo48i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o48i4o : IwO16o48i4o;
                     else
                         wei_tag = with_groups ? gIwO48i4o : IwO48i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o48i2o : IwO16o48i2o;
                     else
@@ -198,12 +202,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
                 UNUSED(is_2d);
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo48i : Ihwo48i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o48i4o : IhwO16o48i4o;
                     else
                         wei_tag = with_groups ? gIhwO48i4o : IhwO48i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o48i2o : IhwO16o48i2o;
                     else
@@ -215,12 +219,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo32i : Idhwo32i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o32i4o : IdhwO16o32i4o;
                     else
                         wei_tag = with_groups ? gIdhwO32i4o : IdhwO32i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o32i2o : IdhwO16o32i2o;
                     else
@@ -230,12 +234,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo32i : Iwo32i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o32i4o : IwO16o32i4o;
                     else
                         wei_tag = with_groups ? gIwO32i4o : IwO32i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o32i2o : IwO16o32i2o;
                     else
@@ -247,12 +251,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
                 UNUSED(is_2d);
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo32i : Ihwo32i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o32i4o : IhwO16o32i4o;
                     else
                         wei_tag = with_groups ? gIhwO32i4o : IhwO32i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o32i2o : IhwO16o32i2o;
                     else
@@ -264,18 +268,18 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo24i : Idhwo24i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3))
+                else if (vnni_block == 4)
                     wei_tag = with_groups ? gIdhwO24i4o : IdhwO24i4o;
-                else if (one_of(jcp.wei_dt, bf16, f16))
+                else if (vnni_block == 2)
                     wei_tag = with_groups ? gIdhwO24i2o : IdhwO24i2o;
                 else
                     return status::unimplemented;
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo24i : Iwo24i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3))
+                else if (vnni_block == 4)
                     wei_tag = with_groups ? gIwO24i4o : IwO24i4o;
-                else if (one_of(jcp.wei_dt, bf16, f16))
+                else if (vnni_block == 2)
                     wei_tag = with_groups ? gIwO24i2o : IwO24i2o;
                 else
                     return status::unimplemented;
@@ -285,9 +289,9 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
 
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo24i : Ihwo24i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3))
+                else if (vnni_block == 4)
                     wei_tag = with_groups ? gIhwO24i4o : IhwO24i4o;
-                else if (one_of(jcp.wei_dt, bf16, f16))
+                else if (vnni_block == 2)
                     wei_tag = with_groups ? gIhwO24i2o : IhwO24i2o;
                 else
                     return status::unimplemented;
@@ -296,12 +300,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo16i : Idhwo16i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o16i4o : IdhwO16o16i4o;
                     else
                         wei_tag = with_groups ? gIdhwO16i4o : IdhwO16i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o16i2o : IdhwO16o16i2o;
                     else
@@ -311,12 +315,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo16i : Iwo16i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o16i4o : IwO16o16i4o;
                     else
                         wei_tag = with_groups ? gIwO16i4o : IwO16i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o16i2o : IwO16o16i2o;
                     else
@@ -329,12 +333,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
 
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo16i : Ihwo16i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3)) {
+                else if (vnni_block == 4) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o16i4o : IhwO16o16i4o;
                     else
                         wei_tag = with_groups ? gIhwO16i4o : IhwO16i4o;
-                } else if (one_of(jcp.wei_dt, bf16, f16)) {
+                } else if (vnni_block == 2) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o16i2o : IhwO16o16i2o;
                     else
@@ -346,18 +350,18 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo8i : Idhwo8i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3))
+                else if (vnni_block == 4)
                     wei_tag = with_groups ? gIdhwO8i4o : IdhwO8i4o;
-                else if (one_of(jcp.wei_dt, bf16, f16))
+                else if (vnni_block == 2)
                     wei_tag = with_groups ? gIdhwO8i2o : IdhwO8i2o;
                 else
                     return status::unimplemented;
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo8i : Iwo8i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3))
+                else if (vnni_block == 4)
                     wei_tag = with_groups ? gIwO8i4o : IwO8i4o;
-                else if (one_of(jcp.wei_dt, bf16, f16))
+                else if (vnni_block == 2)
                     wei_tag = with_groups ? gIwO8i2o : IwO8i2o;
                 else
                     return status::unimplemented;
@@ -367,9 +371,9 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
 
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo8i : Ihwo8i;
-                else if (one_of(jcp.wei_dt, s8, f8_e5m2, f8_e4m3))
+                else if (vnni_block == 4)
                     wei_tag = with_groups ? gIhwO8i4o : IhwO8i4o;
-                else if (one_of(jcp.wei_dt, bf16, f16))
+                else if (vnni_block == 2)
                     wei_tag = with_groups ? gIhwO8i2o : IhwO8i2o;
                 else
                     return status::unimplemented;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -117,16 +117,18 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
         const auto vnni_block_dt
                 = get_mac_emu_data_type(jcp.wei_dt, jcp.isa, req_emulation);
         const auto vnni_block = data_type_vnni_granularity(vnni_block_dt);
+        constexpr int vnni_block_8bit = 4; // s8, u8, fp8: 4 elements per dword
+        constexpr int vnni_block_16bit = 2; // bf16, f16: 2 elements per dword
         if (jcp.ic_block == 64) {
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo64i : Idhwo64i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o64i4o : IdhwO16o64i4o;
                     else
                         wei_tag = with_groups ? gIdhwO64i4o : IdhwO64i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o64i2o : IdhwO16o64i2o;
                     else
@@ -136,12 +138,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo64i : Iwo64i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o64i4o : IwO16o64i4o;
                     else
                         wei_tag = with_groups ? gIwO64i4o : IwO64i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o64i2o : IwO16o64i2o;
                     else
@@ -153,12 +155,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
                 UNUSED(is_2d);
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo64i : Ihwo64i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o64i4o : IhwO16o64i4o;
                     else
                         wei_tag = with_groups ? gIhwO64i4o : IhwO64i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o64i2o : IhwO16o64i2o;
                     else
@@ -170,12 +172,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo48i : Idhwo48i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o48i4o : IdhwO16o48i4o;
                     else
                         wei_tag = with_groups ? gIdhwO48i4o : IdhwO48i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o48i2o : IdhwO16o48i2o;
                     else
@@ -185,12 +187,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo48i : Iwo48i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o48i4o : IwO16o48i4o;
                     else
                         wei_tag = with_groups ? gIwO48i4o : IwO48i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o48i2o : IwO16o48i2o;
                     else
@@ -202,12 +204,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
                 UNUSED(is_2d);
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo48i : Ihwo48i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o48i4o : IhwO16o48i4o;
                     else
                         wei_tag = with_groups ? gIhwO48i4o : IhwO48i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o48i2o : IhwO16o48i2o;
                     else
@@ -219,12 +221,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo32i : Idhwo32i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o32i4o : IdhwO16o32i4o;
                     else
                         wei_tag = with_groups ? gIdhwO32i4o : IdhwO32i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o32i2o : IdhwO16o32i2o;
                     else
@@ -234,12 +236,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo32i : Iwo32i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o32i4o : IwO16o32i4o;
                     else
                         wei_tag = with_groups ? gIwO32i4o : IwO32i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o32i2o : IwO16o32i2o;
                     else
@@ -251,12 +253,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
                 UNUSED(is_2d);
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo32i : Ihwo32i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o32i4o : IhwO16o32i4o;
                     else
                         wei_tag = with_groups ? gIhwO32i4o : IhwO32i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o32i2o : IhwO16o32i2o;
                     else
@@ -268,18 +270,18 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo24i : Idhwo24i;
-                else if (vnni_block == 4)
+                else if (vnni_block == vnni_block_8bit)
                     wei_tag = with_groups ? gIdhwO24i4o : IdhwO24i4o;
-                else if (vnni_block == 2)
+                else if (vnni_block == vnni_block_16bit)
                     wei_tag = with_groups ? gIdhwO24i2o : IdhwO24i2o;
                 else
                     return status::unimplemented;
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo24i : Iwo24i;
-                else if (vnni_block == 4)
+                else if (vnni_block == vnni_block_8bit)
                     wei_tag = with_groups ? gIwO24i4o : IwO24i4o;
-                else if (vnni_block == 2)
+                else if (vnni_block == vnni_block_16bit)
                     wei_tag = with_groups ? gIwO24i2o : IwO24i2o;
                 else
                     return status::unimplemented;
@@ -289,9 +291,9 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
 
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo24i : Ihwo24i;
-                else if (vnni_block == 4)
+                else if (vnni_block == vnni_block_8bit)
                     wei_tag = with_groups ? gIhwO24i4o : IhwO24i4o;
-                else if (vnni_block == 2)
+                else if (vnni_block == vnni_block_16bit)
                     wei_tag = with_groups ? gIhwO24i2o : IhwO24i2o;
                 else
                     return status::unimplemented;
@@ -300,12 +302,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo16i : Idhwo16i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o16i4o : IdhwO16o16i4o;
                     else
                         wei_tag = with_groups ? gIdhwO16i4o : IdhwO16i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIdhwO16o16i2o : IdhwO16o16i2o;
                     else
@@ -315,12 +317,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo16i : Iwo16i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o16i4o : IwO16o16i4o;
                     else
                         wei_tag = with_groups ? gIwO16i4o : IwO16i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIwO16o16i2o : IwO16o16i2o;
                     else
@@ -333,12 +335,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
 
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo16i : Ihwo16i;
-                else if (vnni_block == 4) {
+                else if (vnni_block == vnni_block_8bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o16i4o : IhwO16o16i4o;
                     else
                         wei_tag = with_groups ? gIhwO16i4o : IhwO16i4o;
-                } else if (vnni_block == 2) {
+                } else if (vnni_block == vnni_block_16bit) {
                     if (jcp.is_oc_padded)
                         wei_tag = with_groups ? gIhwO16o16i2o : IhwO16o16i2o;
                     else
@@ -350,18 +352,18 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
             if (is_3d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIdhwo8i : Idhwo8i;
-                else if (vnni_block == 4)
+                else if (vnni_block == vnni_block_8bit)
                     wei_tag = with_groups ? gIdhwO8i4o : IdhwO8i4o;
-                else if (vnni_block == 2)
+                else if (vnni_block == vnni_block_16bit)
                     wei_tag = with_groups ? gIdhwO8i2o : IdhwO8i2o;
                 else
                     return status::unimplemented;
             } else if (is_1d) {
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIwo8i : Iwo8i;
-                else if (vnni_block == 4)
+                else if (vnni_block == vnni_block_8bit)
                     wei_tag = with_groups ? gIwO8i4o : IwO8i4o;
-                else if (vnni_block == 2)
+                else if (vnni_block == vnni_block_16bit)
                     wei_tag = with_groups ? gIwO8i2o : IwO8i2o;
                 else
                     return status::unimplemented;
@@ -371,9 +373,9 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &diff_dst_md,
 
                 if (no_vnni_format)
                     wei_tag = with_groups ? gIhwo8i : Ihwo8i;
-                else if (vnni_block == 4)
+                else if (vnni_block == vnni_block_8bit)
                     wei_tag = with_groups ? gIhwO8i4o : IhwO8i4o;
-                else if (vnni_block == 2)
+                else if (vnni_block == vnni_block_16bit)
                     wei_tag = with_groups ? gIhwO8i2o : IhwO8i2o;
                 else
                     return status::unimplemented;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1550,13 +1550,16 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = everyone_is(f32, jcp.src_dt, jcp.dst_dt) && jcp.wei_dt == bf16;
     jcp.is_f32_f16
             = everyone_is(f32, jcp.src_dt, jcp.dst_dt) && jcp.wei_dt == f16;
+    jcp.is_fp8 = one_of(jcp.src_dt, f8_e5m2, f8_e4m3)
+            && one_of(jcp.wei_dt, f8_e4m3, f8_e5m2);
 
     VDISPATCH_CONV_IC(!jcp.is_bf32, VERBOSE_UNSUPPORTED_DT);
 
     const auto wei_dt
             = jcp.is_f32_f16 || jcp.is_f32_bf16 ? jcp.src_dt : jcp.wei_dt;
+    const bool req_emulation = one_of(isa, avx512_core_fp16, avx10_2);
     const data_type_t last_oc_block_dt
-            = get_mac_emu_data_type(wei_dt, isa, isa == avx512_core_fp16);
+            = get_mac_emu_data_type(wei_dt, isa, req_emulation);
     jcp.vnni_block
             = static_cast<int>(data_type_vnni_granularity(last_oc_block_dt));
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1552,6 +1552,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = everyone_is(f32, jcp.src_dt, jcp.dst_dt) && jcp.wei_dt == f16;
     jcp.is_fp8 = one_of(jcp.src_dt, f8_e5m2, f8_e4m3)
             && one_of(jcp.wei_dt, f8_e4m3, f8_e5m2);
+    jcp.req_fp8_convert_wsp = jcp.is_fp8 && isa == avx10_2;
 
     VDISPATCH_CONV_IC(!jcp.is_bf32, VERBOSE_UNSUPPORTED_DT);
 
@@ -2156,6 +2157,10 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
     }
 
+    jcp.fp8_convert_wsp_size = static_cast<dim_t>(sizeof(float16_t))
+            * isa_max_vlen(jcp.isa)
+            * nstl::max(
+                    static_cast<dim_t>(isa_num_vregs(jcp.isa)), jcp.iw_block);
     return status::success;
 }
 
@@ -2203,6 +2208,12 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
         // See brgemm_types.hpp comment for `with_dst_scales`.
         scratchpad.book(key_conv_dst_scales,
                 static_cast<size_t>(jcp.nthr) * sizeof(float), P4K);
+    }
+
+    if (jcp.req_fp8_convert_wsp) {
+        scratchpad.book(key_brgemm_primitive_fp8_convert_wsp,
+                static_cast<size_t>(jcp.nthr) * jcp.fp8_convert_wsp_size,
+                sizeof(float16_t), 0, P4K);
     }
 }
 

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1777,6 +1777,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             && is_superset(isa, avx10_2_amx_2);
     jcp.wei_plain = everyone_is(true, jcp.wei_dt == data_type::f32,
             is_superset(isa, avx512_core), weights_d.is_plain());
+    jcp.req_fp8_convert_wsp = jcp.is_fp8_convert && !is_amx(isa);
     if (jcp.wei_plain)
         CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
 
@@ -2472,6 +2473,10 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = static_cast<dim_t>(jcp.M) * jcp.N * (jcp.is_bf32 ? 1 : 2)
             > 8 * 1024;
 
+    jcp.fp8_convert_wsp_size = static_cast<dim_t>(sizeof(float16_t))
+            * isa_max_vlen(jcp.isa)
+            * nstl::max(isa_num_vregs(jcp.isa), jcp.ow_block);
+
     VDISPATCH_CONV_IC(IMPLICATION(jcp.is_bf32, jcp.use_uker),
             "cannot use unrolled kernel for current datatype configuration");
 
@@ -2704,6 +2709,10 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = static_cast<dim_t>(jcp.M) * jcp.N * (jcp.is_bf32 ? 1 : 2)
             > 8 * 1024;
 
+    jcp.fp8_convert_wsp_size = static_cast<dim_t>(sizeof(float16_t))
+            * isa_max_vlen(jcp.isa)
+            * nstl::max(isa_num_vregs(jcp.isa), jcp.ow_block);
+
     return status::success;
 }
 
@@ -2790,6 +2799,12 @@ status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
                 = nstl::min(scratchpad_limit_by_absolute_value,
                         scratchpad_limit_by_tensor_sizes);
         if (scratchpad.size() > scratchpad_limit) return status::unimplemented;
+    }
+
+    if (jcp.req_fp8_convert_wsp) {
+        scratchpad.book(key_brgemm_primitive_fp8_convert_wsp,
+                static_cast<size_t>(jcp.nthr) * jcp.fp8_convert_wsp_size,
+                sizeof(float16_t), 0, P4K);
     }
 
     return status::success;

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1891,7 +1891,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             VERBOSE_ISA_DT_MISMATCH);
     VDISPATCH_CONV_IC(
             IMPLICATION(jcp.wei_dt == f8_e5m2,
-                    mayiuse(avx512_core_amx_fp16) || mayiuse(avx10_2_amx_2)),
+                    mayiuse(avx512_core_amx_fp16) || mayiuse(avx10_2)),
             VERBOSE_ISA_DT_MISMATCH);
     const bool is_f32
             = utils::everyone_is(f32, jcp.src_dt, jcp.wei_dt, jcp.dst_dt);

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1784,8 +1784,9 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             ? jcp.dst_dt
             : utils::one_of(true, jcp.is_f32_bf16, jcp.is_f32_f16) ? jcp.src_dt
                                                                    : jcp.wei_dt;
+    const bool req_emulation = utils::one_of(isa, avx10_1_512, avx10_2);
     const data_type_t vnni_block_dt
-            = get_mac_emu_data_type(vnni_dt, isa, isa == avx10_1_512);
+            = get_mac_emu_data_type(vnni_dt, isa, req_emulation);
     jcp.vnni_block = data_type_vnni_granularity(vnni_block_dt);
 
     if (one_of(jcp.prop_kind, prop_kind::forward_training,
@@ -2149,7 +2150,9 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     bool relo_conv_weights_wi = true;
     const auto rd_wi = jcp.kw * jcp.ic;
     const auto rnd_rd_wi = (float)rnd_up(rd_wi, jcp.simd_w);
-    if (!jcp.wei_plain && relo_supported_isa && relo_reasonable_isa) {
+    // TODO: enable relo for fp8 with f16 vnni block later
+    if (!jcp.wei_plain && !jcp.is_fp8 && relo_supported_isa
+            && relo_reasonable_isa) {
         if (jcp.vnni_block == 1 /* For f32 weights are in needed layout */
                 || (jcp.ic % jcp.vnni_block == 0
                         && IMPLICATION(

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1928,7 +1928,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             VERBOSE_ISA_DT_MISMATCH);
     VDISPATCH_CONV_IC(
             IMPLICATION(jcp.wei_dt == f8_e5m2,
-                    mayiuse(avx512_core_amx_fp16) || mayiuse(avx10_2_amx_2)),
+                    mayiuse(avx512_core_amx_fp16) || mayiuse(avx10_2)),
             VERBOSE_ISA_DT_MISMATCH);
     const bool is_f32
             = utils::everyone_is(f32, jcp.src_dt, jcp.wei_dt, jcp.dst_dt);

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1820,8 +1820,9 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             ? jcp.dst_dt
             : utils::one_of(true, jcp.is_f32_bf16, jcp.is_f32_f16) ? jcp.src_dt
                                                                    : jcp.wei_dt;
+    const bool req_emulation = utils::one_of(isa, avx10_1_512, avx10_2);
     const data_type_t vnni_block_dt
-            = get_mac_emu_data_type(vnni_dt, isa, isa == avx10_1_512);
+            = get_mac_emu_data_type(vnni_dt, isa, req_emulation);
     jcp.vnni_block
             = static_cast<int>(data_type_vnni_granularity(vnni_block_dt));
 
@@ -2187,7 +2188,9 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     bool relo_conv_weights_wi = true;
     const auto rd_wi = jcp.kw * jcp.ic;
     const auto rnd_rd_wi = (float)rnd_up(rd_wi, jcp.simd_w);
-    if (!jcp.wei_plain && relo_supported_isa && relo_reasonable_isa) {
+    // TODO: enable relo for fp8 with f16 vnni block later
+    if (!jcp.wei_plain && !jcp.is_fp8 && relo_supported_isa
+            && relo_reasonable_isa) {
         if (jcp.vnni_block == 1 /* For f32 weights are in needed layout */
                 || (jcp.ic % jcp.vnni_block == 0
                         && IMPLICATION(

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1813,6 +1813,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             && isa == avx512_core_amx;
     jcp.wei_plain = everyone_is(true, jcp.wei_dt == data_type::f32,
             is_superset(isa, avx512_core), weights_d.is_plain());
+    jcp.req_fp8_convert_wsp = jcp.is_fp8_convert && !is_amx(isa);
     if (jcp.wei_plain)
         CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
 
@@ -2189,8 +2190,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     const auto rd_wi = jcp.kw * jcp.ic;
     const auto rnd_rd_wi = (float)rnd_up(rd_wi, jcp.simd_w);
     // TODO: enable relo for fp8 with f16 vnni block later
-    if (!jcp.wei_plain && !jcp.is_fp8 && relo_supported_isa
-            && relo_reasonable_isa) {
+    if (!jcp.wei_plain && !(jcp.is_fp8 && jcp.vnni_block == 2)
+            && relo_supported_isa && relo_reasonable_isa) {
         if (jcp.vnni_block == 1 /* For f32 weights are in needed layout */
                 || (jcp.ic % jcp.vnni_block == 0
                         && IMPLICATION(
@@ -2512,6 +2513,11 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = static_cast<dim_t>(jcp.M) * jcp.N * (jcp.is_bf32 ? 1 : 2)
             > 8 * 1024;
 
+    jcp.fp8_convert_wsp_size = static_cast<dim_t>(sizeof(float16_t))
+            * isa_max_vlen(jcp.isa)
+            * nstl::max(
+                    static_cast<dim_t>(isa_num_vregs(jcp.isa)), jcp.ow_block);
+
     VDISPATCH_CONV_IC(IMPLICATION(jcp.is_bf32, jcp.use_uker),
             "cannot use unrolled kernel for current datatype configuration");
 
@@ -2741,6 +2747,11 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = static_cast<dim_t>(jcp.M) * jcp.N * (jcp.is_bf32 ? 1 : 2)
             > 8 * 1024;
 
+    jcp.fp8_convert_wsp_size = static_cast<dim_t>(sizeof(float16_t))
+            * isa_max_vlen(jcp.isa)
+            * nstl::max(
+                    static_cast<dim_t>(isa_num_vregs(jcp.isa)), jcp.ow_block);
+
     return status::success;
 }
 
@@ -2827,6 +2838,12 @@ status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
                 = nstl::min(scratchpad_limit_by_absolute_value,
                         scratchpad_limit_by_tensor_sizes);
         if (scratchpad.size() > scratchpad_limit) return status::unimplemented;
+    }
+
+    if (jcp.req_fp8_convert_wsp) {
+        scratchpad.book(key_brgemm_primitive_fp8_convert_wsp,
+                static_cast<size_t>(jcp.nthr) * jcp.fp8_convert_wsp_size,
+                sizeof(float16_t), 0, P4K);
     }
 
     return status::success;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -824,6 +824,7 @@ struct jit_brgemm_conv_conf_t {
     dim_t ker_ranges_size;
     dim_t comp_a_buffer_size;
     dim_t s8s8_comp_buffer_size;
+    dim_t fp8_convert_wsp_size;
 
     bool with_src_scales;
     bool with_wei_scales;
@@ -873,6 +874,7 @@ struct jit_brgemm_conv_conf_t {
     bool is_f32_f16 {false};
     bool is_f32_bf16 {false};
     bool comp_with_vpads;
+    bool req_fp8_convert_wsp {false};
 
     int nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, nthr_oh;
     bool transform_to_vnni;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -852,6 +852,7 @@ struct jit_brgemm_conv_conf_t {
     dim_t ker_ranges_size;
     dim_t comp_a_buffer_size;
     dim_t s8s8_comp_buffer_size;
+    dim_t fp8_convert_wsp_size;
 
     bool with_src_scales;
     bool with_wei_scales;
@@ -900,6 +901,7 @@ struct jit_brgemm_conv_conf_t {
     bool is_f32_f16 {false};
     bool is_f32_bf16 {false};
     bool comp_with_vpads;
+    bool req_fp8_convert_wsp {false};
 
     int nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, nthr_oh;
     bool transform_to_vnni;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -6455,11 +6455,14 @@ private:
     Vmm vmm_wei_scales1 = Vmm(5);
 
     Vmm get_vmm(const int blk, const int idx) {
+        // fp8->f16 path needs only 1 VMM per block
+        // so that the full register pool is available for loop unrolling.
         const int max_isa_regs = isa_num_vregs(conf_->isa);
-        const int max_unroll = (max_isa_regs - reserved_regs_) / k_blk_step;
-        assert(idx >= 0 && idx < k_blk_step && blk >= 0);
+        const int blk_sz = req_cvtf82f16_ ? 1 : k_blk_step;
+        const int max_unroll = (max_isa_regs - reserved_regs_) / blk_sz;
+        assert(idx >= 0 && idx < blk_sz && blk >= 0);
         const auto reg_idx
-                = max_unroll * ((idx + 1) % k_blk_step) + blk + reserved_regs_;
+                = max_unroll * ((idx + 1) % blk_sz) + blk + reserved_regs_;
         assert(reg_idx >= reserved_regs_ && reg_idx < max_isa_regs);
         return Vmm(reg_idx);
     }
@@ -6608,7 +6611,9 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
         }
     }
 
-    static constexpr int blk_sz = k_blk_step;
+    // fp8->f16: only 1 VMM per block needed(not 2-register packing)
+    // and the full register pool is used
+    static int blk_sz = req_cvtf82f16_ ? 1 : k_blk_step;
     const int max_regs_available = isa_num_vregs(conf_->isa) - reserved_regs_;
     const int max_unroll = max_regs_available / blk_sz;
 
@@ -6616,12 +6621,9 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
     auto load = [this, nrows, ncolumns](int blk, int k, int n) {
         const int k_blk = k / k_blk_step;
         const auto src_vmm0 = get_vmm(blk, 0);
-        const auto src_vmm1 = get_vmm(blk, 1);
         const dim_t offset = k_blk * src_stride_
                 + (n * k_blk_step * typesize_) / src_elems_per_byte_;
-        const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
         auto load_addr0 = maybe_EVEX_compress_addr(reg_src, offset);
-        auto load_addr1 = maybe_EVEX_compress_addr(reg_src, offset + stride);
 
         const bool is_n_tail = ncolumns - n < n_blk_step;
         const bool is_k_tail = nrows - k < k_blk_step;
@@ -6630,15 +6632,19 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
             f8_to_f16_upconvert(
                     conf_->orig_wei_dt, src_vmm0, load_addr0, false, true);
         else {
+            const auto src_vmm1 = get_vmm(blk, 1);
+            const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
+            auto load_addr1
+                    = maybe_EVEX_compress_addr(reg_src, offset + stride);
             load_value(src_vmm0, load_addr0, vmm_permd, conf_->orig_wei_dt);
             load_value(src_vmm1, load_addr1, vmm_permd, conf_->orig_wei_dt);
-        }
-        get_wei_scales(n, is_n_tail, is_k_tail);
-        get_zero_points(n, is_n_tail, is_k_tail);
-        if (!req_cvtf82f16_)
+
+            get_wei_scales(n, is_n_tail, is_k_tail);
+            get_zero_points(n, is_n_tail, is_k_tail);
             decompress_and_downcvt_2reg(src_vmm0, src_vmm1, vmm_zp_b_val0,
                     vmm_zp_b_val1, vmm_wei_scales0, vmm_wei_scales1,
                     conf_->orig_wei_dt, conf_->wei_dt);
+        }
     };
 
     maybe_update_strides(nrows);

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -60,6 +60,9 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
         , use_fp16_instructions_(conf_->isa == avx512_core_fp16
                   && conf_->orig_src_dt == data_type::f16
                   && conf_->src_dt == data_type::f32)
+        , req_cvtf82f16_(conf->isa == avx10_2 && conf->src_dt == data_type::f16
+                  && utils::one_of(conf->orig_src_dt, data_type::f8_e4m3,
+                          data_type::f8_e5m2))
         , k_loop_unroll_(is_ymm_ ? 7 : 16)
         , vmm_copy_idx_(is_ymm_                      ? 13
                           : avx512_core_dot_product_ ? 27
@@ -90,6 +93,7 @@ private:
     const bool do_compute_compensation_;
     const bool avx512_core_dot_product_;
     const bool use_fp16_instructions_;
+    const bool req_cvtf82f16_;
 
     const int k_loop_unroll_;
     const int vmm_copy_idx_;
@@ -160,8 +164,17 @@ private:
 template <>
 void jit_brgemm_matmul_copy_a_impl_t<Zmm>::load_vmm(int idx, int offset) {
     const auto addr = EVEX_compress_addr(reg_src, offset);
+    const auto vmm_copy = get_vmm_copy(idx);
     if (use_fp16_instructions_) {
-        vcvtph2psx(get_vmm_copy(idx), addr);
+        vcvtph2psx(vmm_copy, addr);
+    } else if (req_cvtf82f16_) {
+        if (conf_->orig_src_dt == data_type::f8_e4m3)
+            vcvthf82ph(vmm_copy, addr);
+        else if (conf_->orig_src_dt == data_type::f8_e5m2) {
+            vpmovzxbw(vmm_copy, addr);
+            vpsllw(vmm_copy, vmm_copy, 8);
+        } else
+            assert(!"unsupported data type.");
     } else {
         vmovdqu8(get_vmm_copy(idx), addr);
     }
@@ -214,7 +227,15 @@ void jit_brgemm_matmul_copy_a_impl_t<Zmm>::load_tail(
         vmovups(zmm_tail, load_addr);
     else if (use_fp16_instructions_)
         vcvtph2psx(zmm_tail, load_addr);
-    else
+    else if (req_cvtf82f16_) {
+        if (conf_->orig_src_dt == data_type::f8_e4m3)
+            vcvthf82ph(zmm_tail, load_addr);
+        else if (conf_->orig_src_dt == data_type::f8_e5m2) {
+            vpmovzxbw(zmm_tail, load_addr);
+            vpsllw(zmm_tail, zmm_tail, 8);
+        } else
+            assert(!"unsupported data type.");
+    } else
         vmovdqu8(zmm_tail, load_addr);
 }
 
@@ -235,6 +256,8 @@ void jit_brgemm_matmul_copy_a_impl_t<Zmm>::store_tail(
         vmovdqu16(tr_src_addr, ymm_downcvt_bf16 | kTail_store);
     } else if (use_fp16_instructions_) {
         vmovups(tr_src_addr, get_vmm_copy(0) | kTail_store);
+    } else if (req_cvtf82f16_) {
+        vmovdqu16(tr_src_addr, get_vmm_copy(0) | kTail_store);
     } else
         vmovdqu8(tr_src_addr, get_vmm_copy(0) | kTail_store);
 }
@@ -556,6 +579,9 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
                   conf_->src_dt, data_type::f8_e4m3, data_type::f8_e5m2))
         , is_dynamic_src_ld(conf_->is_runtime_M)
         // See the note in `create_brgemm_matmul_copy_b` why `orig_src_dt` used.
+        , req_cvtf82f16_(utils::one_of(conf_->orig_src_dt, data_type::f8_e4m3,
+                                 data_type::f8_e5m2)
+                  && conf_->src_dt == data_type::f16 && conf_->isa == avx10_2)
         , use_fp16_instructions_(conf_->isa == avx512_core_fp16
                   && conf_->orig_src_dt == data_type::f16
                   && conf_->src_dt == data_type::f32) {}
@@ -587,6 +613,7 @@ private:
     const bool is_bf32;
     const bool is_f8;
     const bool is_dynamic_src_ld;
+    const bool req_cvtf82f16_;
     const bool use_fp16_instructions_;
 
     opmask_t kFFFF = k1;
@@ -648,6 +675,8 @@ private:
         jit_generator_t::kmovw(mask_reg, regw_tmp);
     }
 
+    void f8_to_f16_upconvert(const data_type_t dt, const Vmm &vmm_out,
+            const Xbyak::Address &addr);
     void transpose_f32(reg64_t dst, reg64_t src, int nrows, int ncolumns);
     void transpose_bf16(reg64_t dst, reg64_t src, int nrows, int ncolumns);
     void transpose_f16(reg64_t dst, reg64_t src, int nrows, int ncolumns);
@@ -675,6 +704,22 @@ private:
     void init_masks();
     void generate() override;
 };
+
+template <typename Vmm>
+void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::f8_to_f16_upconvert(
+        const data_type_t dt, const Vmm &vmm_out, const Xbyak::Address &addr) {
+    if (!utils::one_of(dt, data_type::f8_e4m3, data_type::f8_e5m2)) {
+        assert(!"unsupported data type");
+        return;
+    }
+
+    if (dt == data_type::f8_e4m3)
+        vcvthf82ph(vmm_out, addr);
+    else if (dt == data_type::f8_e5m2) {
+        vpmovzxbw(vmm_out, addr);
+        vpsllw(vmm_out, vmm_out, 8);
+    }
+}
 
 template <typename Vmm>
 void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::transpose_f8(
@@ -964,6 +1009,13 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Xbyak::Zmm>::transpose_bf16(
             vmovups(zmm_src0 | kFFFF | T_z, src_addr_0);
             vmovups(zmm_src1 | kFFFF | T_z, src_addr_1);
             vcvtne2ps2bf16(zmm_src0, zmm_src1, zmm_src0);
+        } else if (req_cvtf82f16_) {
+            auto src1 = src_ymm(idx1);
+            f8_to_f16_upconvert(
+                    conf_->orig_src_dt, zmm_src0 | kFFFF | T_z, src_addr_0);
+            f8_to_f16_upconvert(
+                    conf_->orig_src_dt, zmm_src1 | kFFFF | T_z, src_addr_1);
+            vinsertf64x4(zmm_src0, zmm_src0, src1, 1);
         } else {
             auto src1 = src_ymm(idx1);
             vmovdqu16(zmm_src0 | kFFFF | T_z, src_addr_0);
@@ -990,6 +1042,9 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Xbyak::Zmm>::transpose_bf16(
         if (is_bf32) {
             vmovups(zmm_src0 | kFFFF | T_z, src_addr);
             vcvtneps2bf16(Ymm(zmm_src0.getIdx()), zmm_src0);
+        } else if (req_cvtf82f16_) {
+            f8_to_f16_upconvert(
+                    conf_->orig_src_dt, zmm_src0 | kFFFF | T_z, src_addr);
         } else
             vmovdqu16(zmm_src0 | kFFFF | T_z, src_addr);
         vpermw(zmm_src0, vidx5, zmm_src0);
@@ -2375,13 +2430,14 @@ protected:
     * @return The potentially masked vector register (original if no masking needed)
     */
     template <typename Vmm>
-    Vmm maybe_mask(Vmm vmm, bool is_tail, bool is_int4 = false) {
+    Vmm maybe_mask(Vmm vmm, bool is_tail, bool is_int4 = false,
+            bool skip_unmask = false) {
         // Transposed kernel uses the same kTail mask for both cases
         const auto tail_mask
                 = is_int4 && !conf_->transposed_B ? kTail_int4 : kTail;
         const auto unmask_tail
                 = one_of(conf_->wei_dt, data_type::bf16, data_type::f16)
-                && !conf_->transposed_B;
+                && !conf_->transposed_B && !skip_unmask;
         if (isa_has_masks(conf_->isa))
             return is_tail ? vmm | tail_mask | T_z
                     // bf16 and f16 requires masking for tail
@@ -2685,6 +2741,34 @@ protected:
         // should be unreachable
         else
             assert(!"Unable to shift input for zero-point");
+    }
+
+    /**
+    / @brief Converts float8 data types to float16 format
+    * 
+    * @tparam Vmm Vector register type (Zmm, Ymm, etc.)
+    * @param dt Input data type of the values to be converted
+    * @param vmm_in Vector register containing data to be converted
+    * @param op Source memory operand to load from
+    * @param is_tail Flag indicating if tail processing is needed
+    * @param skip_unmask Flag indicating if unmask tail is needed
+    */
+    template <typename Vmm>
+    void f8_to_f16_upconvert(data_type_t dt, const Vmm &vmm_in,
+            const Xbyak::Operand &op, const bool is_tail = false,
+            const bool skip_unmask = false) {
+        if (!one_of(dt, data_type::f8_e4m3, data_type::f8_e5m2)) {
+            assert(!"unsupported data type");
+            return;
+        }
+
+        const auto vmm_masked = maybe_mask(vmm_in, is_tail, false, skip_unmask);
+        if (dt == data_type::f8_e4m3)
+            vcvthf82ph(vmm_masked, op);
+        else {
+            vpmovzxbw(vmm_masked, op);
+            vpsllw(vmm_masked, vmm_masked, 8);
+        }
     }
 
     /**
@@ -3974,6 +4058,7 @@ struct jit_brgemm_matmul_copy_b_bf16_t
         , is_dynamic_stride(is_runtime_value(src_stride))
         , is_dynamic_N(conf->is_runtime_N)
         , do_N_loop(conf->LDB < conf->N_blk)
+        , req_cvtf82f16(conf->is_f8 && conf->isa == avx10_2)
         , req_cvtps2bf16(conf->is_bf32 || conf->is_bf16_with_int_wei)
         , req_zp_b_shift(conf->has_zero_point_b && conf->with_wei_decompression)
         , req_apply_wei_scales(conf->apply_scales_in_buffer_b)
@@ -4003,6 +4088,7 @@ private:
     const bool is_dynamic_stride;
     const bool is_dynamic_N;
     const bool do_N_loop;
+    const bool req_cvtf82f16;
     const bool req_cvtps2bf16;
     const bool req_zp_b_shift;
     const bool req_apply_wei_scales;
@@ -4155,14 +4241,18 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
             else
                 uni_vmovups(src_load, load_addr);
             load_value(src_reg, src_reg, vmm_permd, conf_->orig_wei_dt, false);
+        } else if (req_cvtf82f16) {
+            f8_to_f16_upconvert(
+                    conf_->orig_wei_dt, src_reg, load_addr, is_tail);
         } else {
             load_value(
                     src_reg, load_addr, vmm_permd, conf_->orig_wei_dt, is_tail);
         }
         load_zero_point(n);
         load_scales(n);
-        decompress_and_downcvt_reg(src_reg, vmm_zp_b_shift, vmm_wei_scales,
-                conf_->orig_wei_dt, conf_->wei_dt);
+        if (!req_cvtf82f16)
+            decompress_and_downcvt_reg(src_reg, vmm_zp_b_shift, vmm_wei_scales,
+                    conf_->orig_wei_dt, conf_->wei_dt);
     };
 
     /** Stores half of the block using mask for the case when vnni_granularity == 2 */
@@ -4827,6 +4917,10 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , use_bf16_instructions_(is_subset(conf_->isa, avx512_core_bf16)
                   && conf_->orig_wei_dt == data_type::bf16
                   && conf_->wei_dt == data_type::f32)
+        , req_cvtf82f16_(conf_->isa == avx10_2
+                  && conf_->wei_dt == data_type::f16
+                  && utils::one_of(conf_->orig_wei_dt, data_type::f8_e4m3,
+                          data_type::f8_e5m2))
         , max_tmp_idx(16
                   - (avx512_core_dot_product_
                                   ? 8
@@ -4886,6 +4980,7 @@ private:
     const bool avx512_core_dot_product_;
     const bool use_fp16_instructions_;
     const bool use_bf16_instructions_;
+    const bool req_cvtf82f16_;
     const int max_tmp_idx;
 
     const dim_t src_stride_, tr_src_stride_, src_elems_per_byte_;
@@ -5571,6 +5666,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::copy_row_x_col(
             // Upconvert: load 16 bits and move them 16 bits left.
             uni_vpmovzxwd(src_masked_reg, addr);
             uni_vpslld(src_masked_reg, src_masked_reg, 16);
+        } else if (req_cvtf82f16_) {
+            f8_to_f16_upconvert(
+                    conf_->orig_wei_dt, src_masked_reg, addr, is_tail);
         } else if (conf_->with_int8_grouped_quantization && is_src_int4_) {
             // Int8 grouped quantization with int4 weights:
             // Load packed int4 data into Ymm (half of Zmm), then
@@ -6298,6 +6396,7 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
         , src_stride_(
                   (conf->LDB * k_blk_step * typesize_) / src_elems_per_byte_)
         , tr_src_stride_(conf_->LDB * k_blk_step * tr_typesize_)
+        , req_cvtf82f16_(conf_->is_f8 && conf_->isa == avx10_2)
         , req_zp_b_shift_(
                   conf_->has_zero_point_b && conf_->with_wei_decompression)
         , req_apply_wei_scales_(conf_->apply_scales_in_buffer_b)
@@ -6327,6 +6426,7 @@ private:
     const int typesize_, tr_typesize_, wei_scales_typesize_;
     const bool is_src_int4_;
     const dim_t src_elems_per_byte_, src_stride_, tr_src_stride_;
+    const bool req_cvtf82f16_;
     const bool req_zp_b_shift_;
     const bool req_apply_wei_scales_;
     const int reserved_regs_;
@@ -6519,20 +6619,26 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
         const auto src_vmm1 = get_vmm(blk, 1);
         const dim_t offset = k_blk * src_stride_
                 + (n * k_blk_step * typesize_) / src_elems_per_byte_;
-        const auto stride = (n_blk_step * typesize_) / src_elems_per_byte_;
+        const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
         auto load_addr0 = maybe_EVEX_compress_addr(reg_src, offset);
         auto load_addr1 = maybe_EVEX_compress_addr(reg_src, offset + stride);
 
         const bool is_n_tail = ncolumns - n < n_blk_step;
         const bool is_k_tail = nrows - k < k_blk_step;
 
-        load_value(src_vmm0, load_addr0, vmm_permd, conf_->orig_wei_dt);
-        load_value(src_vmm1, load_addr1, vmm_permd, conf_->orig_wei_dt);
+        if (req_cvtf82f16_)
+            f8_to_f16_upconvert(
+                    conf_->orig_wei_dt, src_vmm0, load_addr0, false, true);
+        else {
+            load_value(src_vmm0, load_addr0, vmm_permd, conf_->orig_wei_dt);
+            load_value(src_vmm1, load_addr1, vmm_permd, conf_->orig_wei_dt);
+        }
         get_wei_scales(n, is_n_tail, is_k_tail);
         get_zero_points(n, is_n_tail, is_k_tail);
-        decompress_and_downcvt_2reg(src_vmm0, src_vmm1, vmm_zp_b_val0,
-                vmm_zp_b_val1, vmm_wei_scales0, vmm_wei_scales1,
-                conf_->orig_wei_dt, conf_->wei_dt);
+        if (!req_cvtf82f16_)
+            decompress_and_downcvt_2reg(src_vmm0, src_vmm1, vmm_zp_b_val0,
+                    vmm_zp_b_val1, vmm_wei_scales0, vmm_wei_scales1,
+                    conf_->orig_wei_dt, conf_->wei_dt);
     };
 
     maybe_update_strides(nrows);
@@ -7008,7 +7114,8 @@ status_t create_brgemm_matmul_copy_b(
     } else {
         if ((conf->is_bf16_with_int_wei
                     || (conf->is_f16_with_int_wei
-                            && conf->isa != avx512_core_fp16))
+                            && conf->isa != avx512_core_fp16)
+                    || (conf->is_f8 && conf->isa == avx10_2))
                 && conf->blocked_B) {
             if (is_superset(conf->isa, avx512_core))
                 CHECK(safe_ptr_assign(copy_ker,

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -61,6 +61,9 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
         , use_fp16_instructions_(conf_->isa == avx512_core_fp16
                   && conf_->orig_src_dt == data_type::f16
                   && conf_->src_dt == data_type::f32)
+        , req_cvtf82f16_(conf->isa == avx10_2 && conf->src_dt == data_type::f16
+                  && utils::one_of(conf->orig_src_dt, data_type::f8_e4m3,
+                          data_type::f8_e5m2))
         , k_loop_unroll_(is_ymm_ ? 7 : 16)
         , vmm_copy_idx_(is_ymm_                      ? 13
                           : avx512_core_dot_product_ ? 27
@@ -91,6 +94,7 @@ private:
     const bool do_compute_compensation_;
     const bool avx512_core_dot_product_;
     const bool use_fp16_instructions_;
+    const bool req_cvtf82f16_;
 
     const int k_loop_unroll_;
     const int vmm_copy_idx_;
@@ -161,8 +165,18 @@ private:
 template <>
 void jit_brgemm_matmul_copy_a_impl_t<Zmm>::load_vmm(int idx, int offset) {
     const auto addr = EVEX_compress_addr(reg_src, offset);
+    const auto vmm_copy = get_vmm_copy(idx);
     if (use_fp16_instructions_) {
-        vcvtph2psx(get_vmm_copy(idx), addr);
+        vcvtph2psx(vmm_copy, addr);
+    } else if (req_cvtf82f16_) {
+        if (conf_->orig_src_dt == data_type::f8_e4m3)
+            vcvthf82ph(vmm_copy, addr);
+        else if (conf_->orig_src_dt == data_type::f8_e5m2) {
+            vpmovzxbw(vmm_copy, addr);
+            vpsllw(vmm_copy, vmm_copy, 8);
+        } else {
+            assert(!"unsupported data type.");
+        }
     } else {
         vmovdqu8(get_vmm_copy(idx), addr);
     }
@@ -215,7 +229,15 @@ void jit_brgemm_matmul_copy_a_impl_t<Zmm>::load_tail(
         vmovups(zmm_tail, load_addr);
     else if (use_fp16_instructions_)
         vcvtph2psx(zmm_tail, load_addr);
-    else
+    else if (req_cvtf82f16_) {
+        if (conf_->orig_src_dt == data_type::f8_e4m3)
+            vcvthf82ph(zmm_tail, load_addr);
+        else if (conf_->orig_src_dt == data_type::f8_e5m2) {
+            vpmovzxbw(zmm_tail, load_addr);
+            vpsllw(zmm_tail, zmm_tail, 8);
+        } else
+            assert(!"unsupported data type.");
+    } else
         vmovdqu8(zmm_tail, load_addr);
 }
 
@@ -236,6 +258,8 @@ void jit_brgemm_matmul_copy_a_impl_t<Zmm>::store_tail(
         vmovdqu16(tr_src_addr, ymm_downcvt_bf16 | kTail_store);
     } else if (use_fp16_instructions_) {
         vmovups(tr_src_addr, get_vmm_copy(0) | kTail_store);
+    } else if (req_cvtf82f16_) {
+        vmovdqu16(tr_src_addr, get_vmm_copy(0) | kTail_store);
     } else
         vmovdqu8(tr_src_addr, get_vmm_copy(0) | kTail_store);
 }
@@ -558,6 +582,9 @@ struct jit_brgemm_matmul_copy_a_transposed_impl_t
                   conf_->src_dt, data_type::f8_e4m3, data_type::f8_e5m2))
         , is_dynamic_src_ld(conf_->is_runtime_M)
         // See the note in `create_brgemm_matmul_copy_b` why `orig_src_dt` used.
+        , req_cvtf82f16_(utils::one_of(conf_->orig_src_dt, data_type::f8_e4m3,
+                                 data_type::f8_e5m2)
+                  && conf_->src_dt == data_type::f16 && conf_->isa == avx10_2)
         , use_fp16_instructions_(conf_->isa == avx512_core_fp16
                   && conf_->orig_src_dt == data_type::f16
                   && conf_->src_dt == data_type::f32) {}
@@ -589,6 +616,7 @@ private:
     const bool is_bf32;
     const bool is_f8;
     const bool is_dynamic_src_ld;
+    const bool req_cvtf82f16_;
     const bool use_fp16_instructions_;
 
     opmask_t kFFFF = k1;
@@ -650,6 +678,8 @@ private:
         jit_generator_t::kmovw(mask_reg, regw_tmp);
     }
 
+    void f8_to_f16_upconvert(const data_type_t dt, const Vmm &vmm_out,
+            const Xbyak::Address &addr);
     void transpose_f32(reg64_t dst, reg64_t src, int nrows, int ncolumns);
     void transpose_bf16(reg64_t dst, reg64_t src, int nrows, int ncolumns);
     void transpose_f16(reg64_t dst, reg64_t src, int nrows, int ncolumns);
@@ -677,6 +707,22 @@ private:
     void init_masks();
     void generate() override;
 };
+
+template <typename Vmm>
+void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::f8_to_f16_upconvert(
+        const data_type_t dt, const Vmm &vmm_out, const Xbyak::Address &addr) {
+    if (!utils::one_of(dt, data_type::f8_e4m3, data_type::f8_e5m2)) {
+        assert(!"unsupported data type");
+        return;
+    }
+
+    if (dt == data_type::f8_e4m3)
+        vcvthf82ph(vmm_out, addr);
+    else if (dt == data_type::f8_e5m2) {
+        vpmovzxbw(vmm_out, addr);
+        vpsllw(vmm_out, vmm_out, 8);
+    }
+}
 
 template <typename Vmm>
 void jit_brgemm_matmul_copy_a_transposed_impl_t<Vmm>::transpose_f8(
@@ -966,6 +1012,13 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Xbyak::Zmm>::transpose_bf16(
             vmovups(zmm_src0 | kFFFF | T_z, src_addr_0);
             vmovups(zmm_src1 | kFFFF | T_z, src_addr_1);
             vcvtne2ps2bf16(zmm_src0, zmm_src1, zmm_src0);
+        } else if (req_cvtf82f16_) {
+            auto src1 = src_ymm(idx1);
+            f8_to_f16_upconvert(
+                    conf_->orig_src_dt, zmm_src0 | kFFFF | T_z, src_addr_0);
+            f8_to_f16_upconvert(
+                    conf_->orig_src_dt, zmm_src1 | kFFFF | T_z, src_addr_1);
+            vinsertf64x4(zmm_src0, zmm_src0, src1, 1);
         } else {
             auto src1 = src_ymm(idx1);
             vmovdqu16(zmm_src0 | kFFFF | T_z, src_addr_0);
@@ -992,6 +1045,9 @@ void jit_brgemm_matmul_copy_a_transposed_impl_t<Xbyak::Zmm>::transpose_bf16(
         if (is_bf32) {
             vmovups(zmm_src0 | kFFFF | T_z, src_addr);
             vcvtneps2bf16(Ymm(zmm_src0.getIdx()), zmm_src0);
+        } else if (req_cvtf82f16_) {
+            f8_to_f16_upconvert(
+                    conf_->orig_src_dt, zmm_src0 | kFFFF | T_z, src_addr);
         } else
             vmovdqu16(zmm_src0 | kFFFF | T_z, src_addr);
         vpermw(zmm_src0, vidx5, zmm_src0);
@@ -2377,13 +2433,14 @@ protected:
     * @return The potentially masked vector register (original if no masking needed)
     */
     template <typename Vmm>
-    Vmm maybe_mask(Vmm vmm, bool is_tail, bool is_int4 = false) {
+    Vmm maybe_mask(Vmm vmm, bool is_tail, bool is_int4 = false,
+            bool skip_unmask = false) {
         // Transposed kernel uses the same kTail mask for both cases
         const auto tail_mask
                 = is_int4 && !conf_->transposed_B ? kTail_int4 : kTail;
         const auto unmask_tail
                 = one_of(conf_->wei_dt, data_type::bf16, data_type::f16)
-                && !conf_->transposed_B;
+                && !conf_->transposed_B && !skip_unmask;
         if (isa_has_masks(conf_->isa))
             return is_tail ? vmm | tail_mask | T_z
                     // bf16 and f16 requires masking for tail
@@ -2686,6 +2743,34 @@ protected:
         // should be unreachable
         else
             assert(!"Unable to shift input for zero-point");
+    }
+
+    /**
+    / @brief Converts float8 data types to float16 format
+    * 
+    * @tparam Vmm Vector register type (Zmm, Ymm, etc.)
+    * @param dt Input data type of the values to be converted
+    * @param vmm_in Vector register containing data to be converted
+    * @param op Source memory operand to load from
+    * @param is_tail Flag indicating if tail processing is needed
+    * @param skip_unmask Flag indicating if unmask tail is needed
+    */
+    template <typename Vmm>
+    void f8_to_f16_upconvert(data_type_t dt, const Vmm &vmm_in,
+            const Xbyak::Operand &op, const bool is_tail = false,
+            const bool skip_unmask = false) {
+        if (!one_of(dt, data_type::f8_e4m3, data_type::f8_e5m2)) {
+            assert(!"unsupported data type");
+            return;
+        }
+
+        const auto vmm_masked = maybe_mask(vmm_in, is_tail, false, skip_unmask);
+        if (dt == data_type::f8_e4m3)
+            vcvthf82ph(vmm_masked, op);
+        else {
+            vpmovzxbw(vmm_masked, op);
+            vpsllw(vmm_masked, vmm_masked, 8);
+        }
     }
 
     /**
@@ -3975,6 +4060,7 @@ struct jit_brgemm_matmul_copy_b_bf16_t
         , is_dynamic_stride(is_runtime_value(src_stride))
         , is_dynamic_N(conf->is_runtime_N)
         , do_N_loop(conf->LDB < conf->N_blk)
+        , req_cvtf82f16(conf->is_f8 && conf->isa == avx10_2)
         , req_cvtps2bf16(conf->is_bf32 || conf->is_bf16_with_int_wei)
         , req_zp_b_shift(conf->has_zero_point_b && conf->with_wei_decompression)
         , req_apply_wei_scales(conf->apply_scales_in_buffer_b)
@@ -4004,6 +4090,7 @@ private:
     const bool is_dynamic_stride;
     const bool is_dynamic_N;
     const bool do_N_loop;
+    const bool req_cvtf82f16;
     const bool req_cvtps2bf16;
     const bool req_zp_b_shift;
     const bool req_apply_wei_scales;
@@ -4156,14 +4243,18 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
             else
                 uni_vmovups(src_load, load_addr);
             load_value(src_reg, src_reg, vmm_permd, conf_->orig_wei_dt, false);
+        } else if (req_cvtf82f16) {
+            f8_to_f16_upconvert(
+                    conf_->orig_wei_dt, src_reg, load_addr, is_tail);
         } else {
             load_value(
                     src_reg, load_addr, vmm_permd, conf_->orig_wei_dt, is_tail);
         }
         load_zero_point(n);
         load_scales(n);
-        decompress_and_downcvt_reg(src_reg, vmm_zp_b_shift, vmm_wei_scales,
-                conf_->orig_wei_dt, conf_->wei_dt);
+        if (!req_cvtf82f16)
+            decompress_and_downcvt_reg(src_reg, vmm_zp_b_shift, vmm_wei_scales,
+                    conf_->orig_wei_dt, conf_->wei_dt);
     };
 
     /** Stores half of the block using mask for the case when vnni_granularity == 2 */
@@ -4821,6 +4912,10 @@ struct jit_brgemm_matmul_copy_b_transposed_t
         , use_bf16_instructions_(is_subset(conf_->isa, avx512_core_bf16)
                   && conf_->orig_wei_dt == data_type::bf16
                   && conf_->wei_dt == data_type::f32)
+        , req_cvtf82f16_(conf_->isa == avx10_2
+                  && conf_->wei_dt == data_type::f16
+                  && utils::one_of(conf_->orig_wei_dt, data_type::f8_e4m3,
+                          data_type::f8_e5m2))
         , max_tmp_idx(16
                   - (avx512_core_dot_product_
                                   ? 8
@@ -4880,6 +4975,7 @@ private:
     const bool avx512_core_dot_product_;
     const bool use_fp16_instructions_;
     const bool use_bf16_instructions_;
+    const bool req_cvtf82f16_;
     const int max_tmp_idx;
 
     const dim_t src_stride_, tr_src_stride_;
@@ -5566,6 +5662,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::copy_row_x_col(
             // Upconvert: load 16 bits and move them 16 bits left.
             uni_vpmovzxwd(src_masked_reg, addr);
             uni_vpslld(src_masked_reg, src_masked_reg, 16);
+        } else if (req_cvtf82f16_) {
+            f8_to_f16_upconvert(
+                    conf_->orig_wei_dt, src_masked_reg, addr, is_tail);
         } else if (conf_->with_int8_grouped_quantization && is_src_int4_) {
             // Int8 grouped quantization with int4 weights:
             // Load packed int4 data into Ymm (half of Zmm), then
@@ -6296,6 +6395,7 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
         , src_stride_(
                   (conf->LDB * k_blk_step * typesize_) / src_elems_per_byte_)
         , tr_src_stride_(conf_->LDB * k_blk_step * tr_typesize_)
+        , req_cvtf82f16_(conf_->is_f8 && conf_->isa == avx10_2)
         , req_zp_b_shift_(
                   conf_->has_zero_point_b && conf_->with_wei_decompression)
         , req_apply_wei_scales_(conf_->apply_scales_in_buffer_b)
@@ -6326,6 +6426,7 @@ private:
     const bool is_src_int4_;
     const int src_elems_per_byte_;
     const dim_t src_stride_, tr_src_stride_;
+    const bool req_cvtf82f16_;
     const bool req_zp_b_shift_;
     const bool req_apply_wei_scales_;
     const int reserved_regs_;
@@ -6518,20 +6619,26 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
         const auto src_vmm1 = get_vmm(blk, 1);
         const dim_t offset = k_blk * src_stride_
                 + (n * k_blk_step * typesize_) / src_elems_per_byte_;
-        const auto stride = (n_blk_step * typesize_) / src_elems_per_byte_;
+        const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
         auto load_addr0 = maybe_EVEX_compress_addr(reg_src, offset);
         auto load_addr1 = maybe_EVEX_compress_addr(reg_src, offset + stride);
 
         const bool is_n_tail = ncolumns - n < n_blk_step;
         const bool is_k_tail = nrows - k < k_blk_step;
 
-        load_value(src_vmm0, load_addr0, vmm_permd, conf_->orig_wei_dt);
-        load_value(src_vmm1, load_addr1, vmm_permd, conf_->orig_wei_dt);
+        if (req_cvtf82f16_)
+            f8_to_f16_upconvert(
+                    conf_->orig_wei_dt, src_vmm0, load_addr0, false, true);
+        else {
+            load_value(src_vmm0, load_addr0, vmm_permd, conf_->orig_wei_dt);
+            load_value(src_vmm1, load_addr1, vmm_permd, conf_->orig_wei_dt);
+        }
         get_wei_scales(n, is_n_tail, is_k_tail);
         get_zero_points(n, is_n_tail, is_k_tail);
-        decompress_and_downcvt_2reg(src_vmm0, src_vmm1, vmm_zp_b_val0,
-                vmm_zp_b_val1, vmm_wei_scales0, vmm_wei_scales1,
-                conf_->orig_wei_dt, conf_->wei_dt);
+        if (!req_cvtf82f16_)
+            decompress_and_downcvt_2reg(src_vmm0, src_vmm1, vmm_zp_b_val0,
+                    vmm_zp_b_val1, vmm_wei_scales0, vmm_wei_scales1,
+                    conf_->orig_wei_dt, conf_->wei_dt);
     };
 
     maybe_update_strides(nrows);
@@ -7007,7 +7114,8 @@ status_t create_brgemm_matmul_copy_b(
     } else {
         if ((conf->is_bf16_with_int_wei
                     || (conf->is_f16_with_int_wei
-                            && conf->isa != avx512_core_fp16))
+                            && conf->isa != avx512_core_fp16)
+                    || (conf->is_f8 && conf->isa == avx10_2))
                 && conf->blocked_B) {
             if (is_superset(conf->isa, avx512_core))
                 CHECK(safe_ptr_assign(copy_ker,

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -2746,7 +2746,7 @@ protected:
     }
 
     /**
-    / @brief Converts float8 data types to float16 format
+    * @brief Converts float8 data types to float16 format
     * 
     * @tparam Vmm Vector register type (Zmm, Ymm, etc.)
     * @param dt Input data type of the values to be converted
@@ -4060,7 +4060,9 @@ struct jit_brgemm_matmul_copy_b_bf16_t
         , is_dynamic_stride(is_runtime_value(src_stride))
         , is_dynamic_N(conf->is_runtime_N)
         , do_N_loop(conf->LDB < conf->N_blk)
-        , req_cvtf82f16(conf->is_f8 && conf->isa == avx10_2)
+        , req_cvtf82f16(one_of(conf->orig_wei_dt, data_type::f8_e4m3,
+                                data_type::f8_e5m2)
+                  && conf->wei_dt == data_type::f16 && conf->isa == avx10_2)
         , req_cvtps2bf16(conf->is_bf32 || conf->is_bf16_with_int_wei)
         , req_zp_b_shift(conf->has_zero_point_b && conf->with_wei_decompression)
         , req_apply_wei_scales(conf->apply_scales_in_buffer_b)
@@ -6395,7 +6397,9 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
         , src_stride_(
                   (conf->LDB * k_blk_step * typesize_) / src_elems_per_byte_)
         , tr_src_stride_(conf_->LDB * k_blk_step * tr_typesize_)
-        , req_cvtf82f16_(conf_->is_f8 && conf_->isa == avx10_2)
+        , req_cvtf82f16_(one_of(conf->orig_wei_dt, data_type::f8_e5m2,
+                                 data_type::f8_e4m3)
+                  && conf_->wei_dt == data_type::f16 && conf_->isa == avx10_2)
         , req_zp_b_shift_(
                   conf_->has_zero_point_b && conf_->with_wei_decompression)
         , req_apply_wei_scales_(conf_->apply_scales_in_buffer_b)
@@ -6455,11 +6459,14 @@ private:
     Vmm vmm_wei_scales1 = Vmm(5);
 
     Vmm get_vmm(const int blk, const int idx) {
+        // fp8->f16 path needs only 1 VMM per block
+        // so that the full register pool is available for loop unrolling.
         const int max_isa_regs = isa_num_vregs(conf_->isa);
-        const int max_unroll = (max_isa_regs - reserved_regs_) / k_blk_step;
-        assert(idx >= 0 && idx < k_blk_step && blk >= 0);
+        const int blk_sz = req_cvtf82f16_ ? 1 : k_blk_step;
+        const int max_unroll = (max_isa_regs - reserved_regs_) / blk_sz;
+        assert(idx >= 0 && idx < blk_sz && blk >= 0);
         const auto reg_idx
-                = max_unroll * ((idx + 1) % k_blk_step) + blk + reserved_regs_;
+                = max_unroll * ((idx + 1) % blk_sz) + blk + reserved_regs_;
         assert(reg_idx >= reserved_regs_ && reg_idx < max_isa_regs);
         return Vmm(reg_idx);
     }
@@ -6608,7 +6615,9 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
         }
     }
 
-    static constexpr int blk_sz = k_blk_step;
+    // fp8->f16: only 1 VMM per block needed(not 2-register packing)
+    // and the full register pool is used
+    const int blk_sz = req_cvtf82f16_ ? 1 : k_blk_step;
     const int max_regs_available = isa_num_vregs(conf_->isa) - reserved_regs_;
     const int max_unroll = max_regs_available / blk_sz;
 
@@ -6616,29 +6625,30 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
     auto load = [this, nrows, ncolumns](int blk, int k, int n) {
         const int k_blk = k / k_blk_step;
         const auto src_vmm0 = get_vmm(blk, 0);
-        const auto src_vmm1 = get_vmm(blk, 1);
         const dim_t offset = k_blk * src_stride_
                 + (n * k_blk_step * typesize_) / src_elems_per_byte_;
-        const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
         auto load_addr0 = maybe_EVEX_compress_addr(reg_src, offset);
-        auto load_addr1 = maybe_EVEX_compress_addr(reg_src, offset + stride);
 
         const bool is_n_tail = ncolumns - n < n_blk_step;
         const bool is_k_tail = nrows - k < k_blk_step;
 
-        if (req_cvtf82f16_)
+        if (req_cvtf82f16_) {
             f8_to_f16_upconvert(
                     conf_->orig_wei_dt, src_vmm0, load_addr0, false, true);
-        else {
+        } else {
+            const auto src_vmm1 = get_vmm(blk, 1);
+            const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
+            auto load_addr1
+                    = maybe_EVEX_compress_addr(reg_src, offset + stride);
             load_value(src_vmm0, load_addr0, vmm_permd, conf_->orig_wei_dt);
             load_value(src_vmm1, load_addr1, vmm_permd, conf_->orig_wei_dt);
-        }
-        get_wei_scales(n, is_n_tail, is_k_tail);
-        get_zero_points(n, is_n_tail, is_k_tail);
-        if (!req_cvtf82f16_)
+
+            get_wei_scales(n, is_n_tail, is_k_tail);
+            get_zero_points(n, is_n_tail, is_k_tail);
             decompress_and_downcvt_2reg(src_vmm0, src_vmm1, vmm_zp_b_val0,
                     vmm_zp_b_val1, vmm_wei_scales0, vmm_wei_scales1,
                     conf_->orig_wei_dt, conf_->wei_dt);
+        }
     };
 
     maybe_update_strides(nrows);

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -4058,7 +4058,9 @@ struct jit_brgemm_matmul_copy_b_bf16_t
         , is_dynamic_stride(is_runtime_value(src_stride))
         , is_dynamic_N(conf->is_runtime_N)
         , do_N_loop(conf->LDB < conf->N_blk)
-        , req_cvtf82f16(conf->is_f8 && conf->isa == avx10_2)
+        , req_cvtf82f16(one_of(conf->orig_wei_dt, data_type::f8_e4m3,
+                                data_type::f8_e5m2)
+                  && conf->wei_dt == data_type::f16 && conf->isa == avx10_2)
         , req_cvtps2bf16(conf->is_bf32 || conf->is_bf16_with_int_wei)
         , req_zp_b_shift(conf->has_zero_point_b && conf->with_wei_decompression)
         , req_apply_wei_scales(conf->apply_scales_in_buffer_b)
@@ -6396,7 +6398,9 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
         , src_stride_(
                   (conf->LDB * k_blk_step * typesize_) / src_elems_per_byte_)
         , tr_src_stride_(conf_->LDB * k_blk_step * tr_typesize_)
-        , req_cvtf82f16_(conf_->is_f8 && conf_->isa == avx10_2)
+        , req_cvtf82f16_(one_of(conf->orig_wei_dt, data_type::f8_e5m2,
+                                 data_type::f8_e4m3)
+                  && conf_->wei_dt == data_type::f16 && conf_->isa == avx10_2)
         , req_zp_b_shift_(
                   conf_->has_zero_point_b && conf_->with_wei_decompression)
         , req_apply_wei_scales_(conf_->apply_scales_in_buffer_b)
@@ -6613,7 +6617,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
 
     // fp8->f16: only 1 VMM per block needed(not 2-register packing)
     // and the full register pool is used
-    static int blk_sz = req_cvtf82f16_ ? 1 : k_blk_step;
+    const int blk_sz = req_cvtf82f16_ ? 1 : k_blk_step;
     const int max_regs_available = isa_num_vregs(conf_->isa) - reserved_regs_;
     const int max_unroll = max_regs_available / blk_sz;
 
@@ -6628,10 +6632,10 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::copy_block(
         const bool is_n_tail = ncolumns - n < n_blk_step;
         const bool is_k_tail = nrows - k < k_blk_step;
 
-        if (req_cvtf82f16_)
+        if (req_cvtf82f16_) {
             f8_to_f16_upconvert(
                     conf_->orig_wei_dt, src_vmm0, load_addr0, false, true);
-        else {
+        } else {
             const auto src_vmm1 = get_vmm(blk, 1);
             const dim_t stride = (n_blk_step * typesize_) / src_elems_per_byte_;
             auto load_addr1

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -848,8 +848,8 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
-    if (is_int8() || is_f8() || is_bf16_fp8() || is_f16_fp8()
-            || with_int8_grouped_quantization()) {
+    if (is_int8() || (is_f8() && bgmmc.isa != avx10_2) || is_bf16_fp8()
+            || is_f16_fp8() || with_int8_grouped_quantization()) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c4b : BA16a64b4a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c4b : BA16a48b4a;
@@ -865,7 +865,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
             || is_f32_bf16() || is_f16_with_int_wei() || is_f32_with_int_wei();
 
     if ((prefer_amx_or_avx2_vnni_2 && is_amx_or_avx2_vnni_2) || is_bf16()
-            || is_bf16_with_int_wei()) {
+            || is_bf16_with_int_wei() || (is_f8() && bgmmc.isa == avx10_2)) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c2b : BA16a64b2a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c2b : BA16a48b2a;
@@ -1722,6 +1722,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         VCONDCHECK_BG(bgmmc.is_amx, VERBOSE_ISA_SPARSE_ENCODING_MISMATCH);
         VCONDCHECK_BG(bgmmc.wei_dt == s8, VERBOSE_UNSUPPORTED_DT);
     }
+    bgmmc.is_f8 = bm_conf_utils.is_f8();
     bgmmc.is_bf32 = bm_conf_utils.is_bf32();
     bgmmc.is_tf32 = bm_conf_utils.is_tf32();
     bgmmc.is_bf16_with_int_wei = bm_conf_utils.is_bf16_with_int_wei();
@@ -1771,7 +1772,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         // Note 3: Since `use_buffer_b()` depends on `bgmmc.wei_tag`, which is
         // set later in the code due to its dependencies, the update of data
         // types to f32 happens below in ANCHOR: `CONVERT_F32_XF16_DATA_TYPES`.
-    } else if (bgmmc.is_f16_with_int_wei && bgmmc.isa != avx512_core_fp16) {
+    } else if ((bgmmc.is_f16_with_int_wei && bgmmc.isa != avx512_core_fp16)
+            || (bgmmc.is_f8 && bgmmc.isa == avx10_2)) {
         bgmmc.src_dt = f16;
         bgmmc.wei_dt = f16;
         bgmmc.tr_a_dt_sz = types::data_type_size(f16);
@@ -2235,6 +2237,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                     || ((bm_conf_utils.is_f16()
                                 || bm_conf_utils.is_f16_with_int_wei())
                             && isa == avx512_core_fp16)
+                    || (bm_conf_utils.is_f8() && isa == avx10_2)
                     || (bgmmc.wei_zp_type != brgemm_broadcast_t::none
                             && !bm_conf_utils.with_weights_decompression())
                     || bgmmc.transposed_A);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -284,7 +284,8 @@ status_t check_isa_with_datatype(
                     is_superset(isa, avx512_core_amx_fp16)
                             || is_superset(isa, avx10_2))
             && IMPLICATION(bm_conf_utils.is_bf8(),
-                    is_superset(isa, avx512_core_amx_fp16))
+                    is_superset(isa, avx512_core_amx_fp16)
+                            || is_superset(isa, avx10_2))
             && IMPLICATION(
                     bm_conf_utils.is_f4_via_convert(), one_of(isa, avx10_2));
     return ok ? status::success : status::unimplemented;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -842,8 +842,8 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
-    if (is_int8() || is_f8() || is_bf16_fp8() || is_f16_fp8()
-            || with_int8_grouped_quantization()) {
+    if (is_int8() || (is_f8() && bgmmc.isa != avx10_2) || is_bf16_fp8()
+            || is_f16_fp8() || with_int8_grouped_quantization()) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c4b : BA16a64b4a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c4b : BA16a48b4a;
@@ -859,7 +859,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
             || is_f32_bf16() || is_f16_with_int_wei() || is_f32_with_int_wei();
 
     if ((prefer_amx_or_avx2_vnni_2 && is_amx_or_avx2_vnni_2) || is_bf16()
-            || is_bf16_with_int_wei()) {
+            || is_bf16_with_int_wei() || (is_f8() && bgmmc.isa == avx10_2)) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c2b : BA16a64b2a;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c2b : BA16a48b2a;
@@ -1885,6 +1885,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         VCONDCHECK_BG(bgmmc.is_amx, VERBOSE_ISA_SPARSE_ENCODING_MISMATCH);
         VCONDCHECK_BG(bgmmc.wei_dt == s8, VERBOSE_UNSUPPORTED_DT);
     }
+    bgmmc.is_f8 = bm_conf_utils.is_f8();
     bgmmc.is_bf32 = bm_conf_utils.is_bf32();
     bgmmc.is_bf16_with_int_wei = bm_conf_utils.is_bf16_with_int_wei();
     bgmmc.is_f16_with_int_wei = bm_conf_utils.is_f16_with_int_wei();
@@ -1933,7 +1934,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         // Note 3: Since `use_buffer_b()` depends on `bgmmc.wei_tag`, which is
         // set later in the code due to its dependencies, the update of data
         // types to f32 happens below in ANCHOR: `CONVERT_F32_XF16_DATA_TYPES`.
-    } else if (bgmmc.is_f16_with_int_wei && bgmmc.isa != avx512_core_fp16) {
+    } else if ((bgmmc.is_f16_with_int_wei && bgmmc.isa != avx512_core_fp16)
+            || (bgmmc.is_f8 && bgmmc.isa == avx10_2)) {
         bgmmc.src_dt = f16;
         bgmmc.wei_dt = f16;
         bgmmc.tr_a_dt_sz = types::data_type_size(f16);
@@ -2405,6 +2407,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                     || ((bm_conf_utils.is_f16()
                                 || bm_conf_utils.is_f16_with_int_wei())
                             && isa == avx512_core_fp16)
+                    || (bm_conf_utils.is_f8() && isa == avx10_2)
                     || (bgmmc.wei_zp_type != brgemm_broadcast_t::none
                             && !bm_conf_utils.with_weights_decompression())
                     || bgmmc.transposed_A);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -234,6 +234,7 @@ struct brgemm_matmul_conf_t {
     bool is_amx;
 
     int required_k_granularity;
+    bool is_f8 = false;
     bool is_bf32 = false;
     bool is_bf16_with_int_wei = false;
     bool is_f16_with_int_wei = false;
@@ -388,7 +389,7 @@ struct brgemm_matmul_conf_utils_t {
                 && !bgmmc.blocked_B;
         bool use_copy_buffer = IMPLICATION(
                 this->is_f32(), use_heuristic && (big_LDB && is_pow2));
-        return is_avx2_simd_tail
+        return is_avx2_simd_tail || (this->is_f8() && bgmmc.isa == avx10_2)
                 || (this->is_f16() && bgmmc.isa == avx512_core_fp16)
                 || (use_copy_buffer && this->check_is_plain(bgmmc.wei_tag))
                 || this->check_is_transposed(bgmmc.wei_tag)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -237,6 +237,7 @@ struct brgemm_matmul_conf_t {
     bool is_amx;
 
     int required_k_granularity;
+    bool is_f8 = false;
     bool is_bf32 = false;
     bool is_bf16_with_int_wei = false;
     bool is_f16_with_int_wei = false;
@@ -389,7 +390,7 @@ struct brgemm_matmul_conf_utils_t {
                 && !bgmmc.blocked_B;
         bool use_copy_buffer = IMPLICATION(
                 this->is_f32(), use_heuristic && (big_LDB && is_pow2));
-        return is_avx2_simd_tail
+        return is_avx2_simd_tail || (this->is_f8() && bgmmc.isa == avx10_2)
                 || (this->is_f16() && bgmmc.isa == avx512_core_fp16)
                 || (use_copy_buffer && this->check_is_plain(bgmmc.wei_tag))
                 || this->check_is_transposed(bgmmc.wei_tag)

--- a/tests/benchdnn/inputs/brgemm/harness_brgemm_f8
+++ b/tests/benchdnn/inputs/brgemm/harness_brgemm_f8
@@ -19,3 +19,14 @@
 --bs=1
 --batch=shapes_2d_no_tail_int8
 --batch=shapes_2d_tail_n_int8
+
+# f16 inputs with f8 output -- requires native f8 ISA (avx10_2+)
+# Add tests for matmul with pre-converted f8->f16
+--reset
+--dt=f16:f16:f8_e5m2,\
+     f16:f16:f8_e4m3
+--bia_dt=undef,f32,f8_e5m2,f8_e4m3
+--beta=0,1
+--attr-post-ops=,sum:2,relu
+--attr-scales=,dst:common:5
+--batch=option_set_bf16

--- a/tests/benchdnn/inputs/brgemm/harness_brgemm_f8
+++ b/tests/benchdnn/inputs/brgemm/harness_brgemm_f8
@@ -19,3 +19,12 @@
 --bs=1
 --batch=shapes_2d_no_tail_int8
 --batch=shapes_2d_tail_n_int8
+
+# f16 inputs with f8 output -- requires native f8 ISA (avx10_2+)
+--reset
+--dt=f16:f16:f8_e5m2,\
+     f16:f16:f8_e4m3
+--bia_dt=undef,f32,f8_e5m2,f8_e4m3
+--beta=0,1
+--attr-post-ops=,sum:2,relu
+--batch=option_set_bf16


### PR DESCRIPTION
The patch improves fp8 performance on NVL from:
1. Change weights format(vnni block from 4 to 2) for conv/deconv
2. Convert fp8 to f16 in brgemm copy kernel for matmul/ip, and add tests(f16:f16:fp8) to brgemm
3. Add buffer to brgemm kernel to store converted data type(fp8->f16)

It also enables f8_e5m2 support for all primitives on NVL.
[nvl_28C_3.4Ghz_ww30_5.xlsx](https://github.com/user-attachments/files/30719141/nvl_28C_3.4Ghz_ww30_5.xlsx)

[CI test](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f19757d1-52f6-f13f-b851-d4f5ef20c6a0)
