### PR TITLE
aarch64: brgemm: introduce a bfmmla kernel path

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -386,6 +386,11 @@ status_t brgemm_desc_set_attr(
             && brg->layout != brgemm_row_major)
         return status::unimplemented;
 
+    if (brgattr.use_mmla_packed_a && !brgattr.use_mmla)
+        return status::unimplemented;
+
+    if (brgattr.use_mmla) CHECK(validate_mmla_compute(*brg));
+
     brg->brgattr = brgattr;
 
     if (brgattr.fpmath_mode != fpmath_mode::strict) maybe_try_bf32(brg);
@@ -398,7 +403,8 @@ status_t brgemm_desc_set_attr(
                     || brgattr.hint_load_nt_A != brgemm_hint_nt_undef
                     || brgattr.hint_load_nt_B != brgemm_hint_nt_undef);
     if (brgattr.use_uker || hint_blocking_set || brgattr.bd_mask_level
-            || brgattr.fpmath_mode != fpmath_mode::strict || max_vpad > 0) {
+            || brgattr.fpmath_mode != fpmath_mode::strict || max_vpad > 0
+            || brgattr.use_mmla) {
         if (brg->is_dgmm)
             CHECK(brdgmm_blocking(brg));
         else
@@ -413,6 +419,20 @@ status_t brgemm_desc_set_attr(
         if ((max_vpad > min_bd_block)) return status::unimplemented;
     }
 
+    if (brgattr.use_mmla) {
+        constexpr int max_mmla_acc_regs = 24;
+        constexpr int max_mmla_bd_block = 12;
+        const int compute_ld_blocks = brg->ld_block2;
+        const int acc_regs = rnd_up(brg->bd_block, brgemm_utils::mmla_bd_blk())
+                * compute_ld_blocks;
+        if (brg->rd_block != brgemm_utils::mmla_rd_block()
+                || brg->bd_block > max_mmla_bd_block
+                || !is_mmla_ld_blocks_supported(compute_ld_blocks)
+                || acc_regs > max_mmla_acc_regs)
+            return status::unimplemented;
+        return status::unimplemented;
+    }
+
     brg->LDA2 = (brgattr.LDA2 != 0) ? brgattr.LDA2 : brg->LDA;
     brg->LDB2 = (brgattr.LDB2 != 0) ? brgattr.LDB2 : brg->LDB;
     brg->LDC2_M = (brgattr.LDC2_M != 0) ? brgattr.LDC2_M : brg->LDC;
@@ -421,7 +441,7 @@ status_t brgemm_desc_set_attr(
     brg->is_blocked = (brg->LDA2 != brg->LDA || brg->LDB2 != brg->LDB
             || brg->LDC2_M != brg->LDC || brg->LDC2_N != brg->ld_block);
 
-    if (!IMPLICATION(brg->is_blocked, brg->layout = brgemm_row_major))
+    if (!IMPLICATION(brg->is_blocked, brg->layout == brgemm_row_major))
         return status::invalid_arguments;
 
     brg->prfA = brgattr.hint_prfA;
@@ -550,6 +570,8 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(brgattr.bd_mask_level);
     CMP_BRGEMM_FIELD(brgattr.use_uker);
     CMP_BRGEMM_FIELD(brgattr.use_interleave_stores);
+    CMP_BRGEMM_FIELD(brgattr.use_mmla);
+    CMP_BRGEMM_FIELD(brgattr.use_mmla_packed_a);
     CMP_BRGEMM_FIELD(brgattr.b_is_vnni);
     CMP_BRGEMM_FIELD(brgattr.fpmath_mode);
     CMP_BRGEMM_FIELD(brgattr.LDA2);

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -430,7 +430,6 @@ status_t brgemm_desc_set_attr(
                 || !is_mmla_ld_blocks_supported(compute_ld_blocks)
                 || acc_regs > max_mmla_acc_regs)
             return status::unimplemented;
-        return status::unimplemented;
     }
 
     brg->LDA2 = (brgattr.LDA2 != 0) ? brgattr.LDA2 : brg->LDA;

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -150,6 +150,11 @@ struct DNNL_API brgemm_attr_t {
     // use_interleave_stores is a value that determines whether to use the
     // interleave stores or not
     bool use_interleave_stores;
+    // use_mmla requests the mmla compute path explicitly
+    // currently supported mmla is only bf16 mmla
+    bool use_mmla;
+    // use_mmla_packed_a expects A to use the mmla pack
+    bool use_mmla_packed_a;
     impl::fpmath_mode_t fpmath_mode = fpmath_mode::strict;
     bool b_is_vnni {false};
     // Second level leading dimension describing distance between 16-line

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -93,6 +93,14 @@ void maybe_try_bf32(brgemm_desc_t *brg) {
     //
 }
 
+// only bf16 mmla is currently supported
+status_t validate_mmla_compute(const brgemm_desc_t &brg) {
+    const bool is_valid = brg.is_bf16 && !brg.is_bf16_emu && !brg.is_dgmm
+            && brg.is_row_major()
+            && utils::one_of(brg.isa_impl, sve_128, sve_256);
+    return is_valid ? status::success : status::unimplemented;
+}
+
 status_t set_isa_impl(brgemm_desc_t *brg) {
     auto is_isa_ok = [&](cpu_isa_t isa) {
         return mayiuse(isa) &&
@@ -168,6 +176,21 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     return max_bcast_block;
 }
 
+int default_mmla_ld_block2(const brgemm_desc_t *brg) {
+    constexpr int heur_max_acc_regs = 24;
+    constexpr int heur_min_ld_block2 = 3;
+    constexpr int heur_max_ld_block2 = 6;
+
+    if (brg->bcast_dim <= 2) return 12;
+    if (!brg->brgattr.use_mmla_packed_a && brg->bcast_dim > 8) return 4;
+
+    const int bd_block = nstl::min(brg->bcast_dim, 8);
+    const int bd_pairs = utils::div_up(bd_block, mmla_bd_blk());
+    const int max_ld_block2 = heur_max_acc_regs / (2 * bd_pairs);
+    return nstl::min(
+            heur_max_ld_block2, nstl::max(heur_min_ld_block2, max_ld_block2));
+}
+
 inline size_t data_type_vnni_granularity(data_type_t data_type) {
     using namespace data_type;
     switch (data_type) {
@@ -182,6 +205,7 @@ inline size_t data_type_vnni_granularity(data_type_t data_type) {
     }
     return size_t(0); /* should not be reachable */
 }
+
 status_t brgemm_blocking(brgemm_desc_t *brg) {
 
     CHECK(set_isa_impl(brg));
@@ -189,37 +213,70 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
     assert(!brg->is_dgmm); // should not be called from brdgmm
     set_brg_vmm(brg);
 
+    const bool use_mmla = brg->brgattr.use_mmla;
     brg->ld_block = simd_elems(brg->dt_c, brg->isa_impl);
-    brg->ldb = brg->load_dim / brg->ld_block;
+    brg->ldb = use_mmla ? utils::div_up(brg->load_dim, brg->ld_block)
+                        : brg->load_dim / brg->ld_block;
     brg->ldb_tail = brg->load_dim % brg->ld_block;
 
-    int adj_ld_block2 = calculate_ldb_params(brg, 4);
-    int max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-
-    // reduce 'ld_block2' to allow a larger 'bd_block'
+    const int min_block = 1;
     const int max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
-    if (max_bcast_block < max_vpad) {
-        adj_ld_block2 = calculate_ldb_params(brg, 2);
-        max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
+    const int mmla_max_bd_block = 8;
+
+    auto calc_max_bcast_block = [&](int try_ld_block2) {
+        const int adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
+        return calculate_max_bcast_block(brg, adj_ld_block2);
+    };
+
+    if (use_mmla) {
+        const int ld_block2 = brg->brgattr.hint_ld_block2 != 0
+                ? brg->brgattr.hint_ld_block2
+                : default_mmla_ld_block2(brg);
+        calculate_ldb_params(brg, ld_block2);
+        auto set_mmla_blocking = [&]() {
+            brg->bdb = brg->bcast_dim / brg->bd_block;
+            brg->bdb_tail = brg->bcast_dim % brg->bd_block;
+            brg->rd_block = mmla_rd_block();
+            brg->rdb = brg->reduce_dim / brg->rd_block;
+            brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+            brg->is_M_tail = false;
+        };
+        brg->bd_block = brg->brgattr.hint_bd_block != 0
+                ? brg->brgattr.hint_bd_block
+                : (brg->brgattr.use_mmla_packed_a
+                                          || brg->bcast_dim <= mmla_max_bd_block
+                                  ? nstl::min(brg->bcast_dim, mmla_max_bd_block)
+                                  : nstl::min(brg->bcast_dim, 6));
+        set_mmla_blocking();
+        return status::success;
     }
 
-    const int min_block = 1;
+    int max_bcast_block = calc_max_bcast_block(4);
+    if (max_bcast_block < max_vpad) {
+        max_bcast_block = calc_max_bcast_block(2);
+    }
+
     float best_bd_block_eff = 0.f;
     brg->bd_block = 1;
     for (int bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
+        const int min_bd_block = brg->bcast_dim % bd_block != 0
+                ? brg->bcast_dim % bd_block
+                : bd_block;
+        if (max_vpad > min_bd_block) continue;
+
         const auto bd_block_disb = static_cast<float>(brg->bcast_dim)
                 / rnd_up(brg->bcast_dim, bd_block);
         const auto brgemm_microkernel_eff
-                = (static_cast<float>(adj_ld_block2) * bd_block)
-                / (((adj_ld_block2) + bd_block) * max_bcast_block);
+                = (static_cast<float>(brg->ld_block2) * bd_block)
+                / (((brg->ld_block2) + bd_block) * max_bcast_block);
         const auto bd_block_eff = bd_block_disb * brgemm_microkernel_eff;
 
         float block_foot_print = static_cast<float>(brg->typesize_A)
                 * (bd_block * brg->reduce_dim);
         if (block_foot_print <= static_cast<float>(
                     platform::get_per_core_cache_size(1))
-                && (bd_block_eff > best_bd_block_eff)) {
+                && bd_block_eff > best_bd_block_eff) {
             brg->bd_block = bd_block;
             best_bd_block_eff = bd_block_eff;
         }

--- a/src/cpu/aarch64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2024-2025 Arm Ltd. and affiliates
+* Copyright 2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,6 +34,31 @@ status_t init_kernel_datatype(
         brgemm_desc_t *brg, data_type_t dt_a, data_type_t dt_b);
 
 namespace brgemm_utils {
+inline constexpr int mmla_bd_blk() {
+    return 2;
+}
+inline constexpr int mmla_ld_blk() {
+    return 2;
+}
+inline constexpr int mmla_rd_chunk_bytes() {
+    return 8;
+}
+inline constexpr int mmla_rd_block() {
+    return 8;
+}
+
+inline constexpr int mmla_rd_chunk_elems(int dt_a_sz) {
+    return mmla_rd_chunk_bytes() / dt_a_sz;
+}
+inline constexpr int mmla_rd_chunks_per_block(int dt_a_sz) {
+    return mmla_rd_block() / mmla_rd_chunk_elems(dt_a_sz);
+}
+
+status_t validate_mmla_compute(const brgemm_desc_t &brg);
+
+inline bool is_mmla_ld_blocks_supported(dim_t ld_blocks) {
+    return ld_blocks >= 1 && ld_blocks <= 12;
+}
 
 bool can_dispatch_uker(const brgemm_desc_t *brg);
 

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -23,6 +23,7 @@
 #include "common/utils.hpp"
 
 #include "cpu/aarch64/brgemm/brgemm_types.hpp"
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
 #include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
@@ -67,6 +68,9 @@ struct jit_brgemm_kernel_t : public jit_generator_t {
         : jit_generator_t(nullptr, MAX_CODE_SIZE, true, sve_512)
         , brg(abrg)
         , postops_injector_(nullptr)
+        , use_mmla(abrg.brgattr.use_mmla)
+        , use_mmla_packed_a(abrg.brgattr.use_mmla_packed_a)
+        , use_gemv_path(abrg.is_gemv && !abrg.brgattr.use_mmla)
         , max_effective_vregs(
                   max_vregs - ((brg.is_int8 && !brg.has_int8_vnni) ? 2 : 0)) {
 
@@ -75,7 +79,10 @@ struct jit_brgemm_kernel_t : public jit_generator_t {
         assert(!utils::one_of(brg.isa_impl, isa_all, isa_undef));
         const int is_ldb2_tail = brg.ldb2_tail ? 1 : 0;
         const int is_ldb_tail = brg.ldb_tail ? 1 : 0;
-        is_ldb_loop_ = brg.ldb2 + is_ldb2_tail + is_ldb_tail > 1;
+        const int n_ldb_loops = use_mmla
+                ? brg.ldb2 + is_ldb2_tail
+                : brg.ldb2 + is_ldb2_tail + is_ldb_tail;
+        is_ldb_loop_ = n_ldb_loops > 1;
 
         if (brg.with_eltwise || brg.with_binary || brg.with_sum) {
 
@@ -220,14 +227,33 @@ private:
     bool is_ldb_loop_ = false;
     bool with_binary_non_scalar_bcast_ = false;
     constexpr static int max_vregs = 32;
+    const bool use_mmla;
+    const bool use_mmla_packed_a;
+    const bool use_gemv_path;
     const int max_effective_vregs;
 
+    int mmla_bd_blk() const { return brgemm_utils::mmla_bd_blk(); }
+    int mmla_ld_regs_per_block() const { return brgemm_utils::mmla_ld_blk(); }
+    int mmla_rd_chunk_elems() const {
+        return brgemm_utils::mmla_rd_chunk_elems(brg.typesize_A);
+    }
+    int mmla_rd_chunks_per_block() const {
+        return brgemm_utils::mmla_rd_chunks_per_block(brg.typesize_A);
+    }
+    int mmla_rd_block() const { return brgemm_utils::mmla_rd_block(); }
     PReg rd_tail_mask = PReg(2);
     PReg ld_tail_mask = PReg(3);
 
     ZReg accm(int ld_block, int bd, int ld) const {
         // Starts at the highest (e.g. 31), descending and using ld_block * bd_block registers as accumulators
         return ZReg(max_effective_vregs - 1 - (bd * ld_block + ld));
+    }
+    ZReg accm_mmla(int ld_block, int bd_pair, int ld4) const {
+        return accm(ld_block, mmla_bd_blk() * bd_pair + (ld4 % mmla_bd_blk()),
+                ld4 / mmla_bd_blk());
+    }
+    int mmla_bd_pairs(int bd_block) const {
+        return div_up(bd_block, mmla_bd_blk());
     }
 
     ZReg bcst(int bd = 0) const {
@@ -298,8 +324,8 @@ private:
 
     void store_accumulators(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_ld_tail, bool skip_accumulation);
-    void store_accumulators_without_post_ops(
-            int bd_block, int ld_block, bool is_ld_tail);
+    void store_accumulators_without_post_ops(int bd_block, int ld_block,
+            bool is_ld_tail, bool mmla_deinterleave_on_store = false);
     void store_accumulators_apply_post_ops(int bd_block, int ld_block,
             int ldb_and_bdb_offset, bool is_ld_tail);
     void apply_compensation(int bd_block, int ld_block, bool is_ld_tail);
@@ -328,13 +354,28 @@ private:
             const PReg &mask, const XReg &reg_stride_bytes,
             const int32_t stride_bytes, const int32_t n, const data_type_t dt);
 
+    void mmla_deinterleave_accumulators(int bd_block, int ld_block2);
+    int mmla_rd_chunk_B_offset(int ld_blocks) const noexcept;
+    int mmla_rdb_B_offset(int ld_blocks) const noexcept;
+    void mmla_load_packed_a(int rd_chunk, int bd_pair, const ZReg &z_a,
+            const ZReg &z_a_tmp, int bd_block, bool row0_valid,
+            bool row1_valid);
+    void mmla_load_plain_a(int rd_chunk, int bd_pair, const ZReg &z_a,
+            const ZReg &z_a_tmp, int rd_tail, bool row0_valid, bool row1_valid);
+    void mmla_load_b(const XReg &b_base, int ld, int z_idx);
+
     // FMLA/DOT
     void dot_product(ZReg v_acc, ZReg v_a, ZReg v_b);
     // FMLA/DOT with indexed b vector
     void dot_product(ZReg v_acc, ZReg v_a, ZReg v_b, const int16_t index);
 
+    // MMLA
+    void mmla(ZReg v_acc, ZReg v_a, ZReg v_b);
+
     void gemm_microkernel(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_rd_tail, bool is_ld_tail, int vpad, int rows_for_rd_tail);
+    void gemm_microkernel_mmla(bool is_bdb_tail, int ld_block,
+            int b_panel_ld_block, bool is_rd_tail, bool advance_a_b, int vpad);
     // GEMV microkernel is distinct from GEMM in that it loads vectors from A and B
     // and assumes that we will sum all the elements after the microkernel
     void gemv_microkernel(
@@ -354,8 +395,8 @@ private:
     int D_offset(int bd, int ld) const noexcept;
     int po_offset(int bd, int ld) const noexcept;
 
-    int rdb_A_offset() const noexcept;
-    int rdb_B_offset() const noexcept;
+    int rdb_A_offset(int bd_block) const noexcept;
+    int rdb_B_offset(int ld_block2) const noexcept;
 
     int ldb_B_offset(int ld_block2, bool is_tail = false) const noexcept;
     int ldb_C_offset(int ld_block2, bool is_tail = false) const noexcept;
@@ -390,7 +431,7 @@ int jit_brgemm_kernel_t::A_offset(int bd, int rd) const noexcept {
     return brg.typesize_A * (bd * brg.LDA + rd);
 }
 int jit_brgemm_kernel_t::B_offset(int ld, int rd) const noexcept {
-    if (brg.is_gemv) {
+    if (use_gemv_path) {
         return (ld + rd * brg.ld_block2) * brg.typesize_B;
     } else {
         const int data_vnni_granularity = brg.ld_step;
@@ -401,14 +442,14 @@ int jit_brgemm_kernel_t::B_offset(int ld, int rd) const noexcept {
     }
 }
 int jit_brgemm_kernel_t::C_offset(int bd, int ld) const noexcept {
-    if (brg.is_gemv) {
+    if (use_gemv_path) {
         return (ld + bd * brg.ld_block2) * brg.typesize_C;
     } else {
         return brg.typesize_C * (bd * brg.LDC + ld * brg.ld_block);
     }
 }
 int jit_brgemm_kernel_t::D_offset(int bd, int ld) const noexcept {
-    if (brg.is_gemv) {
+    if (use_gemv_path) {
         return (ld + bd * brg.ld_block2) * brg.typesize_D;
     } else {
         return brg.typesize_D * (bd * brg.LDD + ld * brg.ld_block);
@@ -418,15 +459,37 @@ int jit_brgemm_kernel_t::po_offset(int bd, int ld) const noexcept {
     return bd * brg.LDD + ld * brg.ld_block;
 }
 
-int jit_brgemm_kernel_t::rdb_A_offset() const noexcept {
+int jit_brgemm_kernel_t::mmla_rd_chunk_B_offset(int ld_blocks) const noexcept {
+    return ld_blocks * mmla_ld_regs_per_block()
+            * static_cast<int>(simd_bytes(brg.isa_impl));
+}
+
+int jit_brgemm_kernel_t::mmla_rdb_B_offset(int ld_blocks) const noexcept {
+    return mmla_rd_chunk_B_offset(ld_blocks) * mmla_rd_chunks_per_block();
+}
+
+int jit_brgemm_kernel_t::rdb_A_offset(int bd_block) const noexcept {
+    if (use_mmla) {
+        if (use_mmla_packed_a)
+            return brg.typesize_A * mmla_bd_blk() * mmla_rd_block();
+        return brg.typesize_A * mmla_rd_block();
+    }
+
     return brg.typesize_A * brg.rd_block;
 }
-int jit_brgemm_kernel_t::rdb_B_offset() const noexcept {
+int jit_brgemm_kernel_t::rdb_B_offset(int ld_block2) const noexcept {
+    if (use_mmla) return mmla_rdb_B_offset(ld_block2);
+
     return brg.typesize_B * brg.rd_block * brg.LDB;
 }
 
 int jit_brgemm_kernel_t::ldb_B_offset(
         int ld_block2, bool is_tail) const noexcept {
+    if (use_mmla) {
+        return mmla_rdb_B_offset(ld_block2)
+                * div_up(brg.reduce_dim, mmla_rd_block());
+    }
+
     return (is_tail) ? brg.typesize_B * brg.ldb_tail * brg.ld_step
                      : brg.typesize_B * ld_block2 * brg.ld_block * brg.ld_step;
 }
@@ -446,6 +509,10 @@ int jit_brgemm_kernel_t::ldb_po_offset(
 }
 
 int jit_brgemm_kernel_t::bdb_A_offset(int bd_block2) const noexcept {
+    if (use_mmla && use_mmla_packed_a)
+        return bd_block2 * rnd_up(brg.reduce_dim, mmla_rd_chunk_elems())
+                * brg.bd_block * brg.typesize_A;
+
     return brg.typesize_A * bd_block2 * brg.bd_block * brg.LDA;
 }
 int jit_brgemm_kernel_t::bdb_C_offset(int bd_block2) const noexcept {
@@ -682,9 +749,9 @@ void jit_brgemm_kernel_t::read_params() {
 
     ldr(reg_C, ptr(param1, GET_OFF(ptr_C)));
     ldr(reg_D, ptr(param1, GET_OFF(ptr_D)));
-    ldr(reg_BS, ptr(param1, GET_OFF(BS)));
+    if (brg.brgattr.max_bs > 1) ldr(reg_BS, ptr(param1, GET_OFF(BS)));
 
-    mov_imm(reg_stride_bytes_A, brg.typesize_A * brg.LDA);
+    if (!use_mmla) mov_imm(reg_stride_bytes_A, brg.typesize_A * brg.LDA);
 
     // ptr_buf is re-used for passing compensations for
     // brg.req_s8s8_compensation case
@@ -752,15 +819,17 @@ void jit_brgemm_kernel_t::read_params() {
 void jit_brgemm_kernel_t::zero_accumulators(int bd_block2, bool is_bdb_tail,
         int ld_block2, bool is_ld_tail, bool skip_accumulation) {
     int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const int acc_bd_block
+            = use_mmla ? rnd_up(bd_block, mmla_bd_blk()) : bd_block;
     const bool need_to_apply_beta = brg.beta != 0.f;
     int base_offset = 0;
     auto x_addr = reg_aux_C;
-    for_(int bd = 0; bd < bd_block; bd++)
+    for_(int bd = 0; bd < acc_bd_block; bd++)
     for (int ld = 0; ld < ld_block2; ld++) {
         auto zmm = accm(ld_block2, bd, ld);
         // This part is moved here from apply_alpha_beta function so that fadd instruction can be avoided.
         // This is also required only when K is blocked.
-        if (need_to_apply_beta && !brg.is_gemv) {
+        if (need_to_apply_beta && !brg.is_gemv && !use_mmla) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
             const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
 
@@ -790,7 +859,9 @@ void jit_brgemm_kernel_t::zero_accumulators(int bd_block2, bool is_bdb_tail,
 void jit_brgemm_kernel_t::apply_alpha_beta(
         int bd_block, int ld_block2, bool is_ld_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
+    const bool apply_beta = brg.beta != 0.f;
     const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
+    const bool apply_beta_after_norm = apply_beta && use_mmla;
 
     auto vmm_alpha = z_tmp_1();
     if (apply_alpha) {
@@ -798,11 +869,35 @@ void jit_brgemm_kernel_t::apply_alpha_beta(
         mov_imm(wreg_tmp, float2int(static_cast<float>(brg.alpha)));
         dup(vmm_alpha.s, wreg_tmp);
     }
+    auto vmm_beta = z_tmp_3();
+    if (apply_beta_after_norm && brg.beta != 1.f) {
+        auto wreg_tmp = WReg(reg_tmp_gpr.getIdx());
+        mov_imm(wreg_tmp, float2int(static_cast<float>(brg.beta)));
+        dup(vmm_beta.s, wreg_tmp);
+    }
+    int base_offset = 0;
+    auto x_addr = reg_aux_C;
     for_(int bd = 0; bd < bd_block; bd++)
     for (int ld = 0; ld < ld_block2; ld++) {
         auto vmm = accm(ld_block2, bd, ld);
         if (dq2ps_required) { scvtf(vmm.s, P_ALL_ONE / T_m, vmm.s); }
         if (apply_alpha) { fmul(vmm.s, vmm.s, vmm_alpha.s); }
+        if (apply_beta_after_norm) {
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+            const int offset = C_offset(bd, ld);
+            auto vmm_c = z_tmp_2();
+
+            if (!use_mul_vl(offset - base_offset, 4, cpu_sveLen)) {
+                add_vl_or_imm(reg_tmp_, x_addr, offset - base_offset, X_TMP_0);
+                base_offset = offset;
+                x_addr = reg_tmp_;
+            }
+            LD_MUL_VL(ld1w, vmm_c.s, k_mask, x_addr, offset - base_offset, 4);
+
+            if (brg.beta != 1.f) { fmul(vmm_c.s, vmm_c.s, vmm_beta.s); }
+            fadd(vmm.s, vmm.s, vmm_c.s);
+        }
     }
 }
 
@@ -825,7 +920,8 @@ void jit_brgemm_kernel_t::apply_post_ops(
                 rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_aux_D);
                 rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
                         vmm_idx, D_offset(bd, ld));
-                if (is_ld_tail) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
+                if (is_ld_tail && ld + 1 == ld_block2)
+                    rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
             }
         }
     }
@@ -898,8 +994,6 @@ static inline bool isa_has_masks(cpu_isa_t isa) {
 void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
         int bd_block, int ld_block2, int ldb_and_bdb_offset, bool is_ld_tail) {
 
-    auto k_mask = (!is_ld_tail) ? P_ALL_ONE : ld_tail_mask;
-
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are already converted to ps in apply_alpha_beta()
     const bool alpha_or_beta_applicable = brg.alpha != 1.0f || brg.beta != 0.f;
@@ -925,6 +1019,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                     offset = (ld + bd * ld_block2) * sizeof(float);
                     add_imm(addr, reg_aux_scales, offset, X_TMP_0);
                     const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                    const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
                     auto vmm_scales = z_tmp_1();
                     if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
                         ld1w(vmm_scales.s, k_mask / T_z, ptr(addr));
@@ -948,6 +1043,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                 const auto addr = X_DEFAULT_ADDR;
                 add_imm(addr, reg_aux_scales, scales_offset(ld), X_TMP_0);
                 const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
                 auto vmm_scales = z_tmp_1();
                 if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
                     ld1w(vmm_scales.s, k_mask / T_z, ptr(addr));
@@ -1000,7 +1096,9 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                         base_offset = offset;
                         x_addr = reg_tmp_;
                     }
-                    cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_ld_tail, false,
+                    const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                    const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+                    cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_tail, false,
                             k_mask, offset, base_offset);
                     auto zmm = accm(ld_block2, bd, ld);
                     fadd(zmm.s, zmm.s, zmm_bias.s);
@@ -1022,7 +1120,9 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                     base_offset = offset;
                     x_addr = reg_tmp_;
                 }
-                cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_ld_tail, false, k_mask,
+                const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+                cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_tail, false, k_mask,
                         offset, base_offset);
 
                 for (int bd = 0; bd < bd_block; bd++) {
@@ -1057,10 +1157,11 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
         if (brg.zp_type_c == brgemm_broadcast_t::per_tensor) {
             add_imm(X_DEFAULT_ADDR, reg_aux_zp_c_values, 0, X_TMP_0);
             ld1rw(z_tmp_2().s, P_ALL_ONE, ptr(X_DEFAULT_ADDR));
-            scvtf(vmm_zp_c.s, k_mask / T_m, z_tmp_2().s);
+            scvtf(vmm_zp_c.s, P_ALL_ONE / T_m, z_tmp_2().s);
         }
         for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
                 int zp_c_off = zp_c_values_offset(ld);
                 add_imm(X_DEFAULT_ADDR, reg_aux_zp_c_values, zp_c_off, X_TMP_0);
@@ -1084,6 +1185,8 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                 zmm_lbound, zmm_ubound, reg_tmp_gpr, data_type::f32, brg.dt_d);
         for (int bd = 0; bd < bd_block; bd++) {
             for (int ld = 0; ld < ld_block2; ld++) {
+                const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
                 auto zmm = accm(ld_block2, bd, ld);
                 saturate_f32(zmm, zmm_lbound, zmm_ubound, brg.dt_d, k_mask);
                 frinti(zmm.s, k_mask, zmm.s);
@@ -1098,6 +1201,8 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
     for (int bd = 0; bd < bd_block; bd++) {
         for (int ld = 0; ld < ld_block2; ld++) {
             auto zmm = accm(ld_block2, bd, ld);
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             const int offset = D_offset(bd, ld);
             if (!use_mul_vl(offset - base_offset,
                         types::data_type_size(brg.dt_d), cpu_sveLen)) {
@@ -1138,7 +1243,6 @@ void jit_brgemm_kernel_t::apply_compensation(
         int bd_block, int ld_block2, bool is_ld_tail) {
     // apply compensation to accumulated values
     // to avoid the loss of accuracy when converting s32 to f32
-    auto k_mask = (!is_ld_tail) ? P_ALL_ONE : ld_tail_mask;
 
     if (!brg.req_cal_comp_pads && brg.zp_type_a != brgemm_broadcast_t::none) {
         auto vmm_zp_a_val = z_tmp_2();
@@ -1151,6 +1255,7 @@ void jit_brgemm_kernel_t::apply_compensation(
         ldr(reg_aux_zp_comp_a, ptr(X_DEFAULT_ADDR));
         for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             auto vmm_zp_comp_a = z_tmp_1();
             int zp_comp_a_off = zp_comp_a_offset(ld);
             // apply src zero points value to the accumulated values
@@ -1189,11 +1294,11 @@ void jit_brgemm_kernel_t::apply_compensation(
             auto vmm_comp = z_tmp_1();
             int comp_offset = compensations_offset(ld);
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             if (IMPLICATION(is_tail, is_superset(brg.isa_impl, sve_512))) {
-                const auto mask = is_tail ? k_mask : P_ALL_ONE;
                 add_imm(X_DEFAULT_ADDR, reg_aux_compensation, comp_offset,
                         X_TMP_1);
-                ld1w(vmm_comp.s, mask / T_z, ptr(X_DEFAULT_ADDR));
+                ld1w(vmm_comp.s, k_mask / T_z, ptr(X_DEFAULT_ADDR));
             } else {
                 not_(P_TMP.b, P_ALL_ONE, P_NOT_256.b);
                 cmplt(P_TMP.s, P_TMP / T_z, z_tail_mask().s, 0);
@@ -1210,8 +1315,8 @@ void jit_brgemm_kernel_t::apply_compensation(
     }
 }
 
-void jit_brgemm_kernel_t::store_accumulators_without_post_ops(
-        int bd_block, int ld_block2, bool is_ld_tail) {
+void jit_brgemm_kernel_t::store_accumulators_without_post_ops(int bd_block,
+        int ld_block2, bool is_ld_tail, bool mmla_deinterleave_on_store) {
 
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are converted to ps in apply_alpha_beta()
@@ -1238,22 +1343,55 @@ void jit_brgemm_kernel_t::store_accumulators_without_post_ops(
     auto x_addr = reg_aux_C;
     int base_offset = 0;
 
-    auto scalar_reg = SReg(0);
-
-    for (int bd = 0; bd < bd_block; bd++) {
-        for (int ld = 0; ld < ld_block2; ld++) {
-            auto zmm = accm(ld_block2, bd, ld);
-            const auto mask = is_ld_tail ? ld_tail_mask : P_ALL_ONE;
+    if (mmla_deinterleave_on_store) {
+        const auto store_acc = [&](const ZReg &zmm, int bd, int ld) {
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             const int offset = C_offset(bd, ld);
             if (!use_mul_vl(offset - base_offset, 4, cpu_sveLen)) {
                 add_vl_or_imm(reg_tmp_, x_addr, offset - base_offset, X_TMP_0);
                 base_offset = offset;
                 x_addr = reg_tmp_;
             }
-            if (brg.is_gemv && brg.beta == 0.f) {
+            ST_MUL_VL(st1w, zmm.s, mask, x_addr, offset - base_offset, 4);
+        };
+
+        for (int bd_pair = 0; bd_pair < mmla_bd_pairs(bd_block); bd_pair++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
+                auto zmm_even = accm_mmla(ld_block2, bd_pair, 2 * ld);
+                auto zmm_odd = accm_mmla(ld_block2, bd_pair, 2 * ld + 1);
+                uzp1(ZReg(ld).d, zmm_even.d, zmm_odd.d);
+                uzp2(zmm_odd.d, zmm_even.d, zmm_odd.d);
+            }
+            const int bd = mmla_bd_blk() * bd_pair;
+            for (int ld = 0; ld < ld_block2; ld++)
+                store_acc(ZReg(ld), bd, ld);
+            if ((bd + 1) < bd_block) {
+                for (int ld = 0; ld < ld_block2; ld++)
+                    store_acc(accm_mmla(ld_block2, bd_pair, 2 * ld + 1), bd + 1,
+                            ld);
+            }
+        }
+        return;
+    }
+
+    auto scalar_reg = SReg(0);
+
+    for (int bd = 0; bd < bd_block; bd++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
+            auto zmm = accm(ld_block2, bd, ld);
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+            const int offset = C_offset(bd, ld);
+            if (!use_mul_vl(offset - base_offset, 4, cpu_sveLen)) {
+                add_vl_or_imm(reg_tmp_, x_addr, offset - base_offset, X_TMP_0);
+                base_offset = offset;
+                x_addr = reg_tmp_;
+            }
+            if (use_gemv_path && brg.beta == 0.f) {
                 faddv(scalar_reg, P_ALL_ONE, zmm.s);
                 STR_IMM(scalar_reg, x_addr, (offset - base_offset));
-            } else if (brg.is_gemv && brg.beta != 0.f) {
+            } else if (use_gemv_path && brg.beta != 0.f) {
                 LDR_IMM(scalar_reg, x_addr, (offset - base_offset));
                 fadda(scalar_reg, P_ALL_ONE, zmm.s);
                 STR_IMM(scalar_reg, x_addr, (offset - base_offset));
@@ -1274,6 +1412,13 @@ void jit_brgemm_kernel_t::store_accumulators(int bd_block2, bool is_bdb_tail,
             brg.req_s8s8_compensation, has_zero_points);
     const bool need_to_apply_alpha_beta = brg.beta != 0.f || brg.alpha != 1.f;
     int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const bool mmla_deinterleave_on_store = use_mmla
+            && brg.dt_c == data_type::f32 && brg.dt_d == data_type::f32
+            && ld_block2 <= 6 && !need_to_apply_alpha_beta
+            && !are_post_ops_applicable;
+
+    if (use_mmla && !mmla_deinterleave_on_store)
+        mmla_deinterleave_accumulators(bd_block, ld_block2);
 
     if (brg.is_int8 && (brg.req_s8s8_compensation || has_zero_points)) {
         Label label_store_without_comp;
@@ -1294,13 +1439,16 @@ void jit_brgemm_kernel_t::store_accumulators(int bd_block2, bool is_bdb_tail,
         LDR_IMM(reg_do_post_ops, sp, reg_do_post_ops_offs_);
         cmp_imm(reg_do_post_ops, 0, X_TMP_0);
         b(EQ, label_store_without_post_ops);
-        if (brg.is_gemv) { sum_into_one_lane(bd_block, ld_block2, is_ld_tail); }
+        if (use_gemv_path) {
+            sum_into_one_lane(bd_block, ld_block2, is_ld_tail);
+        }
         store_accumulators_apply_post_ops(bd_block, ld_block2, 0, is_ld_tail);
         bl(label_done);
 
         L(label_store_without_post_ops);
     }
-    store_accumulators_without_post_ops(bd_block, ld_block2, is_ld_tail);
+    store_accumulators_without_post_ops(
+            bd_block, ld_block2, is_ld_tail, mmla_deinterleave_on_store);
     L(label_done);
 }
 
@@ -1412,6 +1560,19 @@ void jit_brgemm_kernel_t::set_A_B_matrices() {
     add(reg_aux_B, reg_aux_B, reg_b_offset);
 }
 
+void jit_brgemm_kernel_t::mmla_deinterleave_accumulators(
+        int bd_block, int ld_block2) {
+    for (int bd_pair = 0; bd_pair < mmla_bd_pairs(bd_block); bd_pair++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
+            auto zmm_even = accm_mmla(ld_block2, bd_pair, 2 * ld);
+            auto zmm_odd = accm_mmla(ld_block2, bd_pair, 2 * ld + 1);
+            uzp1(z_tmp_1().d, zmm_even.d, zmm_odd.d);
+            uzp2(zmm_odd.d, zmm_even.d, zmm_odd.d);
+            mov(zmm_even.d, z_tmp_1().d);
+        }
+    }
+}
+
 void jit_brgemm_kernel_t::dot_product(ZReg v_acc, ZReg v_a, ZReg v_b) {
     if (brg.is_f32) {
         fmla(v_acc.s, P_ALL_ONE / T_m, v_a.s, v_b.s);
@@ -1459,6 +1620,14 @@ void jit_brgemm_kernel_t::dot_product(
             assert(!"unsupported\n");
     } else {
         assert(!"unsupported\n");
+    }
+}
+
+void jit_brgemm_kernel_t::mmla(ZReg v_acc, ZReg v_a, ZReg v_b) {
+    if (brg.is_bf16) {
+        bfmmla(v_acc.s, v_a.h, v_b.h);
+    } else {
+        assert(!"unsupported");
     }
 }
 
@@ -1603,6 +1772,205 @@ void jit_brgemm_kernel_t::load_quadword_for_bcast(const ZReg &dst,
     }
     // Note that we could use ld1rq* register + register, but it is quite complicated and
     // slower on V1. Perf uplift (~0.5%) on V2 did not justify complexity
+}
+
+void jit_brgemm_kernel_t::mmla_load_packed_a(int rd_chunk, int bd_pair,
+        const ZReg &z_a, const ZReg &z_a_tmp, int bd_block, bool row0_valid,
+        bool row1_valid) {
+    const XReg base = (rd_chunk == 0 && bd_pair == 0) ? reg_aux_A : reg_tmp_;
+    if (row0_valid && row1_valid) {
+        ld1rqh(z_a.h, P_ALL_ONE / T_z, ptr(base));
+    } else if (row0_valid) {
+        ld1rd(z_a.d, P_ALL_ONE / T_z, ptr(base));
+        eor(z_a_tmp.d, z_a_tmp.d, z_a_tmp.d);
+        zip1(z_a.d, z_a.d, z_a_tmp.d);
+    } else if (row1_valid) {
+        eor(z_a.d, z_a.d, z_a.d);
+        ld1rd(z_a_tmp.d, P_ALL_ONE / T_z,
+                ptr(base, mmla_rd_chunk_elems() * brg.typesize_A));
+        zip1(z_a.d, z_a.d, z_a_tmp.d);
+    } else {
+        eor(z_a.d, z_a.d, z_a.d);
+    }
+    if (bd_pair != mmla_bd_pairs(bd_block) - 1) {
+        const int packed_a_pair_stride
+                = div_up(brg.reduce_dim, mmla_rd_chunk_elems()) * mmla_bd_blk()
+                * mmla_rd_chunk_elems() * brg.typesize_A;
+        add_imm(reg_tmp_, base, packed_a_pair_stride, X_TMP_0);
+    }
+}
+
+void jit_brgemm_kernel_t::mmla_load_plain_a(int rd_chunk, int bd_pair,
+        const ZReg &z_a, const ZReg &z_a_tmp, int rd_tail, bool row0_valid,
+        bool row1_valid) {
+    const int bd = mmla_bd_blk() * bd_pair;
+    const int rd_off = rd_chunk * mmla_rd_chunk_elems();
+    const int valid_rd_elems
+            = nstl::min(mmla_rd_chunk_elems(), rd_tail - rd_off);
+    const bool is_full_rd_chunk = valid_rd_elems == mmla_rd_chunk_elems();
+
+    const auto add_a_offset = [&](const XReg &dst, const XReg &src, int off) {
+        constexpr int add_imm12_max = (1 << 12) - 1;
+        if (off >= 0 && off <= add_imm12_max) {
+            add(dst, src, off);
+        } else if (off >= 0 && off % (1 << 12) == 0
+                && (off >> 12) <= add_imm12_max) {
+            add(dst, src, off >> 12, 12);
+        } else {
+            add_imm(dst, src, off, X_TMP_0);
+        }
+    };
+
+    if (!is_full_rd_chunk) set_preg(rd_tail_mask.h, valid_rd_elems, X_TMP_0);
+
+    const auto load_a_row = [&](const ZReg &z, bool row_valid, int row) {
+        if (!row_valid) {
+            eor(z.d, z.d, z.d);
+            return;
+        }
+
+        const int off = A_offset(row, rd_off);
+        if (is_full_rd_chunk && off <= 504 && off % 8 == 0) {
+            ld1rd(z.d, P_ALL_ONE / T_z, ptr(reg_aux_A, off));
+        } else {
+            add_a_offset(X_TMP_1, reg_aux_A, off);
+            if (is_full_rd_chunk) {
+                ld1rd(z.d, P_ALL_ONE / T_z, ptr(X_TMP_1));
+            } else {
+                ld1h(z.h, rd_tail_mask / T_z, ptr(X_TMP_1));
+                dup(z.d, z.d[0]);
+            }
+        }
+    };
+
+    load_a_row(z_a, row0_valid, bd);
+    load_a_row(z_a_tmp, row1_valid, bd + 1);
+    zip1(z_a.d, z_a.d, z_a_tmp.d);
+}
+
+void jit_brgemm_kernel_t::mmla_load_b(const XReg &b_base, int ld, int z_idx) {
+    const int ld_off = ld * mmla_ld_regs_per_block();
+    if (ld_off + 1 <= 7) {
+        ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(b_base, ld_off, MUL_VL));
+        ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z,
+                ptr(b_base, ld_off + 1, MUL_VL));
+    } else {
+        const int simd_size = static_cast<int>(simd_bytes(brg.isa_impl));
+        add_vl_or_imm(reg_tmp_, b_base, ld_off * simd_size, X_TMP_0);
+        ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(reg_tmp_));
+        ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z, ptr(reg_tmp_, 1, MUL_VL));
+    }
+}
+
+void jit_brgemm_kernel_t::gemm_microkernel_mmla(bool is_bdb_tail, int ld_block2,
+        int b_panel_ld_block2, bool is_rd_tail, bool advance_a_b, int vpad) {
+    const int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const int bd_b = nstl::max(0, vpad);
+    const int bd_e = nstl::min(bd_block, bd_block + vpad);
+    if (bd_b >= bd_e) return;
+
+    const int bd_pair_count = mmla_bd_pairs(bd_block);
+    const int rd_tail = is_rd_tail ? brg.rdb_tail : mmla_rd_block();
+    // mmla traverses the rd dimension in 64-bit chunks
+    const int rd_chunks = is_rd_tail ? div_up(rd_tail, mmla_rd_chunk_elems())
+                                     : mmla_rd_chunks_per_block();
+
+    const int tmp_reg_count
+            = max_effective_vregs - mmla_bd_blk() * bd_pair_count * ld_block2;
+    const int all_a_reg_count = rd_chunks * bd_pair_count;
+    const bool all_a_in_regs
+            = all_a_reg_count + mmla_ld_regs_per_block() <= tmp_reg_count;
+    const int tmp_reg_0 = all_a_in_regs ? all_a_reg_count : bd_pair_count;
+    const int ld_blocks = nstl::min(
+            ld_block2, (tmp_reg_count - tmp_reg_0) / mmla_ld_regs_per_block());
+
+    const auto prepare_packed_a_base = [&](int rd_chunk) {
+        if (rd_chunk == 0) return;
+        const int a_offset = rd_chunk * mmla_bd_blk() * mmla_rd_chunk_elems()
+                * brg.typesize_A;
+        add_imm(reg_tmp_, reg_aux_A, a_offset, X_TMP_0);
+    };
+
+    const auto load_a = [&](int rd_chunk, int bd_pair, const ZReg &z_a,
+                                const ZReg &z_a_tmp) {
+        const int bd = mmla_bd_blk() * bd_pair;
+        const bool row0_valid = bd_b <= bd && bd < bd_e;
+        const bool row1_valid = bd_b <= bd + 1 && bd + 1 < bd_e;
+        if (!use_mmla_packed_a) {
+            mmla_load_plain_a(rd_chunk, bd_pair, z_a, z_a_tmp, rd_tail,
+                    row0_valid, row1_valid);
+        } else {
+            mmla_load_packed_a(rd_chunk, bd_pair, z_a, z_a_tmp, bd_block,
+                    row0_valid, row1_valid);
+        }
+    };
+
+    const auto advance_after_rd_chunk = [&](int rd_chunk) {
+        const bool is_last_rd_chunk = (rd_chunk == rd_chunks - 1);
+        if (is_last_rd_chunk)
+            add_vl_or_imm(reg_aux_A, reg_aux_A,
+                    rdb_A_offset(bd_pair_count * mmla_bd_blk()), X_TMP_0);
+
+        const int b_rd_chunk_offset = mmla_rd_chunk_B_offset(b_panel_ld_block2);
+        const int b_advance = is_last_rd_chunk
+                ? mmla_rdb_B_offset(b_panel_ld_block2)
+                        - rd_chunk * b_rd_chunk_offset
+                : b_rd_chunk_offset;
+        add_vl_or_imm(reg_aux_B, reg_aux_B, b_advance, X_TMP_0);
+    };
+
+    if (all_a_in_regs) {
+        for (int rd_chunk = 0; rd_chunk < rd_chunks; ++rd_chunk) {
+            if (use_mmla_packed_a) prepare_packed_a_base(rd_chunk);
+            for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair) {
+                const int a_reg_idx = rd_chunk * bd_pair_count + bd_pair;
+                load_a(rd_chunk, bd_pair, ZReg(a_reg_idx), ZReg(tmp_reg_0));
+            }
+        }
+    }
+
+    for (int rd_chunk = 0; rd_chunk < rd_chunks; ++rd_chunk) {
+        const XReg b_base
+                = (rd_chunk == 0 || advance_a_b) ? reg_aux_B : X_TMP_4;
+        if (rd_chunk > 0 && !advance_a_b) {
+            add_vl_or_imm(X_TMP_4, reg_aux_B,
+                    rd_chunk * mmla_rd_chunk_B_offset(b_panel_ld_block2),
+                    X_TMP_0);
+        }
+
+        if (!all_a_in_regs) {
+            if (use_mmla_packed_a) prepare_packed_a_base(rd_chunk);
+            for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair)
+                load_a(rd_chunk, bd_pair, ZReg(bd_pair), ZReg(tmp_reg_0));
+        }
+
+        for (int ld_reg_idx = 0; ld_reg_idx < ld_blocks; ++ld_reg_idx) {
+            mmla_load_b(b_base, ld_reg_idx,
+                    tmp_reg_0 + mmla_ld_regs_per_block() * ld_reg_idx);
+        }
+
+        if (advance_a_b && ld_blocks == ld_block2)
+            advance_after_rd_chunk(rd_chunk);
+
+        for (int ld_idx = 0; ld_idx < ld_block2; ++ld_idx) {
+            const int ld_reg_idx = ld_idx % ld_blocks;
+            const int z_b = tmp_reg_0 + mmla_ld_regs_per_block() * ld_reg_idx;
+            for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair) {
+                const ZReg z_a = all_a_in_regs
+                        ? ZReg(rd_chunk * bd_pair_count + bd_pair)
+                        : ZReg(bd_pair);
+                mmla(accm_mmla(ld_block2, bd_pair, 2 * ld_idx), z_a, ZReg(z_b));
+                mmla(accm_mmla(ld_block2, bd_pair, 2 * ld_idx + 1), z_a,
+                        ZReg(z_b + 1));
+            }
+            const int next_ld = ld_idx + ld_blocks;
+            if (next_ld < ld_block2) {
+                mmla_load_b(b_base, next_ld, z_b);
+                if (advance_a_b && next_ld + 1 == ld_block2)
+                    advance_after_rd_chunk(rd_chunk);
+            }
+        }
+    }
 }
 
 void jit_brgemm_kernel_t::gemm_microkernel(int bd_block2, bool is_bdb_tail,
@@ -1782,6 +2150,8 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
     Label BS_loop_label;
 
     copy_post_ops_stack_values_to_aux(is_reg_tail);
+    const int b_panel_ld_block2
+            = use_mmla && is_reg_tail ? brg.ld_block2 : ld_block2;
 
     auto ld_loop_body = [=](int vpad) {
         set_A_B_matrices();
@@ -1795,8 +2165,7 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
 
         int rdb_val = brg.rdb;
         int rdb_tail = brg.rdb_tail;
-        MAYBE_UNUSED(rdb_tail);
-        if (brg.is_gemv) {
+        if (use_gemv_path) {
             rdb_val = (brg.rd_block * brg.rdb + brg.rdb_tail)
                     / (cpu_sveLen / sizeof(float));
             rdb_tail = (brg.rd_block * brg.rdb + brg.rdb_tail)
@@ -1810,7 +2179,10 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
             {
                 const bool is_rd_tail = false;
 
-                if (brg.is_gemv) {
+                if (use_mmla) {
+                    gemm_microkernel_mmla(is_bdb_tail, ld_block2,
+                            b_panel_ld_block2, is_rd_tail, true, vpad);
+                } else if (use_gemv_path) {
                     gemv_microkernel(is_bdb_tail, ld_block2, is_rd_tail, vpad);
                 } else {
                     if (n_bcast_1_load
@@ -1834,10 +2206,14 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                             is_rd_tail, is_ld_tail, vpad, rows_for_rd_tail);
                 }
 
-                add_vl_or_imm(reg_aux_A, reg_aux_A,
-                        brg.is_gemv ? cpu_sveLen : rdb_A_offset(), X_TMP_0);
-                add_vl_or_imm(reg_aux_B, reg_aux_B,
-                        brg.is_gemv ? cpu_sveLen : rdb_B_offset(), X_TMP_0);
+                if (!use_mmla) {
+                    int A_rdb_off = use_gemv_path ? cpu_sveLen
+                                                  : rdb_A_offset(bd_block);
+                    add_vl_or_imm(reg_aux_A, reg_aux_A, A_rdb_off, X_TMP_0);
+                    int B_rdb_off = use_gemv_path ? cpu_sveLen
+                                                  : rdb_B_offset(ld_block2);
+                    add_vl_or_imm(reg_aux_B, reg_aux_B, B_rdb_off, X_TMP_0);
+                }
 
                 subs(reg_rdb_loop, reg_rdb_loop, 1);
             }
@@ -1846,7 +2222,10 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
         if (rdb_tail != 0) {
             const bool is_rd_tail = true;
 
-            if (brg.is_gemv) {
+            if (use_mmla) {
+                gemm_microkernel_mmla(is_bdb_tail, ld_block2, b_panel_ld_block2,
+                        is_rd_tail, false, vpad);
+            } else if (use_gemv_path) {
                 // GEMV loads whole vector from left hand side
                 const int k_tail
                         = brg.LDA % simd_elems(data_type::f32, brg.isa_impl);
@@ -1996,7 +2375,7 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
         store_accumulators(bd_block2, is_bdb_tail, ld_block2, is_ld_tail,
                 skip_accumulation);
         if (is_ldb_loop_) {
-            if (!is_ld_tail) {
+            if (!is_ld_tail || use_mmla) {
                 ldb_regs_shift(ld_block2);
             } else {
                 ldb_regs_shift(1, true);
@@ -2012,27 +2391,44 @@ void jit_brgemm_kernel_t::bdb_loop() {
     auto do_ldb_loop = [=](int bd_block2, bool is_bdb_tail, bool check_top_vpad,
                                bool check_bottom_vpad, int rows_for_rd_tail,
                                bool skip_accumulation) {
-        if (brg.ldb2 > 0) {
-            const bool is_ld_reg_tail = false;
-            const bool is_ld_tail = false;
-            ldb_loop(bd_block2, is_bdb_tail, brg.ld_block2, brg.ldb2,
+        auto call_ldb_loop = [&](int ld_block2, int ldb_loop_length,
+                                     bool is_ld_reg_tail, bool is_ld_tail) {
+            ldb_loop(bd_block2, is_bdb_tail, ld_block2, ldb_loop_length,
                     is_ld_reg_tail, is_ld_tail, check_top_vpad,
                     check_bottom_vpad, rows_for_rd_tail, skip_accumulation);
+        };
+
+        if (use_mmla) {
+            if (brg.ldb2_tail > 0) {
+                if (brg.ldb2 > 0) {
+                    call_ldb_loop(brg.ld_block2, brg.ldb2, false, false);
+                }
+                const bool is_ld_reg_tail = brg.ldb2 > 0;
+                const bool is_ld_tail = brg.ldb_tail > 0;
+                call_ldb_loop(brg.ldb2_tail, 1, is_ld_reg_tail, is_ld_tail);
+            } else if (brg.ldb2 > 0) {
+                if (brg.ldb_tail > 0 && brg.ldb2 > 1) {
+                    call_ldb_loop(brg.ld_block2, brg.ldb2 - 1, false, false);
+                }
+                const bool is_ld_reg_tail = brg.ldb_tail > 0 && brg.ldb2 > 1;
+                const bool is_ld_tail = brg.ldb_tail > 0;
+                const int ldb_loop_length = is_ld_tail ? 1 : brg.ldb2;
+                call_ldb_loop(brg.ld_block2, ldb_loop_length, is_ld_reg_tail,
+                        is_ld_tail);
+            }
+            return;
+        }
+
+        if (brg.ldb2 > 0) {
+            call_ldb_loop(brg.ld_block2, brg.ldb2, false, false);
         }
         if (brg.ldb2_tail > 0) {
-            const bool is_ld_reg_tail = (brg.ldb2 == 0) ? false : true;
-            const bool is_ld_tail = false;
-            ldb_loop(bd_block2, is_bdb_tail, brg.ldb2_tail, 1, is_ld_reg_tail,
-                    is_ld_tail, check_top_vpad, check_bottom_vpad,
-                    rows_for_rd_tail, skip_accumulation);
+            const bool is_ld_reg_tail = brg.ldb2 != 0;
+            call_ldb_loop(brg.ldb2_tail, 1, is_ld_reg_tail, false);
         }
         if (brg.ldb_tail > 0) {
-            const bool is_ld_reg_tail
-                    = (brg.ldb2 == 0 && brg.ldb2_tail == 0) ? false : true;
-            const bool is_ld_tail = true;
-            ldb_loop(bd_block2, is_bdb_tail, 1, 1, is_ld_reg_tail, is_ld_tail,
-                    check_top_vpad, check_bottom_vpad, rows_for_rd_tail,
-                    skip_accumulation);
+            const bool is_ld_reg_tail = brg.ldb2 != 0 || brg.ldb2_tail != 0;
+            call_ldb_loop(1, 1, is_ld_reg_tail, true);
         }
     };
 
@@ -2043,26 +2439,24 @@ void jit_brgemm_kernel_t::bdb_loop() {
                 rows_for_rd_tail, skip_accumulation);
 
         add_imm(reg_C, reg_C,
-                brg.is_gemv ? brg.bd_block * brg.typesize_C
-                            : bdb_C_offset(bd_block2),
+                use_gemv_path ? brg.bd_block * brg.typesize_C
+                              : bdb_C_offset(bd_block2),
                 X_TMP_0);
         add_imm(reg_D, reg_D,
-                brg.is_gemv ? brg.bd_block * brg.typesize_D
-                            : bdb_D_offset(bd_block2),
+                use_gemv_path ? brg.bd_block * brg.typesize_D
+                              : bdb_D_offset(bd_block2),
                 X_TMP_0);
         add_imm(reg_a_offset, reg_a_offset, bdb_A_offset(bd_block2), X_TMP_0);
     };
 
-    int rows_for_rd_tail, bd_blocks_for_rd_tail;
-
-    rows_for_rd_tail = 0;
-    if (brg.rdb_tail != 0 && (brg.is_bf16 || brg.is_int8)) {
+    int rows_for_rd_tail = 0;
+    if (!use_mmla && brg.rdb_tail != 0 && (brg.is_bf16 || brg.is_int8)) {
         const auto rd_tail_size = brg.rdb_tail % brg.rd_step;
         rows_for_rd_tail = rd_tail_size
                 ? div_up(brg.rd_step - rd_tail_size, brg.reduce_dim)
                 : 0;
     }
-    bd_blocks_for_rd_tail
+    const int bd_blocks_for_rd_tail
             = div_up(nstl::max(0,
                              rows_for_rd_tail - brg.bdb_tail
                                      + brg.brgattr.max_bottom_vpad),
@@ -2224,7 +2618,6 @@ void jit_brgemm_kernel_t::generate() {
 
     mov(x7, x0);
     mov(x6, x1);
-    mov(x2, x2);
     mov(x1, x3);
     mov(x8, x4);
     mov(x9, x5);
@@ -2264,6 +2657,8 @@ brgemm_attr_t::brgemm_attr_t()
     , bd_mask_level(0)
     , use_uker(false)
     , use_interleave_stores(false)
+    , use_mmla(false)
+    , use_mmla_packed_a(false)
     , LDA2(0)
     , LDB2(0)
     , LDC2_M(0)

--- a/tests/benchdnn/CMakeLists.txt
+++ b/tests/benchdnn/CMakeLists.txt
@@ -1,5 +1,6 @@
 #===============================================================================
 # Copyright 2017 Intel Corporation
+# Copyright 2026 Arm Ltd. and affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -211,6 +212,10 @@ foreach(driver ${all_drivers})
             list(REMOVE_ITEM test_files_gpu "test_matmul_grouped_gpu")
             list(REMOVE_ITEM test_files_cpu "test_matmul_grouped_gpu")
             list(REMOVE_ITEM test_files_cpu "test_matmul_grouped")
+        endif()
+
+        if(driver STREQUAL "brgemm" AND NOT DNNL_TARGET_ARCH STREQUAL "AARCH64")
+            list(REMOVE_ITEM test_files_cpu "test_brgemm_mmla")
         endif()
 
         ## Filter out gpu, large cpu and invalid inputs from cpu

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -143,6 +143,10 @@ dnnl_status_t brgemm_attr_init(
         // PROCESS_KEY_VAL(bd_mask_level);
         PROCESS_KEY_VAL(use_uker);
         PROCESS_KEY_VAL(use_interleave_stores);
+#if defined(brg_aarch64)
+        PROCESS_KEY_VAL(use_mmla);
+        PROCESS_KEY_VAL(use_mmla_packed_a);
+#endif
         PROCESS_KEY_VAL(b_is_vnni);
         PROCESS_KEY_VAL(postops_only);
         PROCESS_KEY_VAL(hint_bd_block);
@@ -203,6 +207,53 @@ std::string prepare_wei_format_string(
 
     return wtag;
 }
+
+#if defined(brg_aarch64)
+// packing helpers to test mmla brgemm kernel
+constexpr const char *mmla_src_tag = "AB2a4b";
+
+int get_mmla_ld_block() {
+    using namespace namespace_impl;
+    const bool use_sve256 = dnnl_get_effective_cpu_isa()
+            >= cpu_isa_traits<sve_256>::user_option_val;
+
+    return use_sve256 ? cpu_isa_traits<sve_256>::vlen / sizeof(float)
+                      : cpu_isa_traits<sve_128>::vlen / sizeof(float);
+}
+
+std::string prepare_mmla_wei_format_string(int ld_blocks) {
+    return std::string("BA2a") + std::to_string(ld_blocks * get_mmla_ld_block())
+            + "b4a";
+}
+
+int pack_for_mmla(const prb_t *prb, data_kind_t kind, const char *src_ptr,
+        std::vector<uint16_t> &packed_mem, size_t &batch_elems,
+        const dims_t &dims, const dims_t &strides, const std::string &tag,
+        size_t batch_offset, res_t *res) {
+    const size_t batch_offset_elems = batch_offset / sizeof(uint16_t);
+    auto src_md = dnn_mem_t::init_md(
+            2, dims.data(), prb->get_dt(kind), "", strides);
+    auto dst_md = dnn_mem_t::init_md(2, dims.data(), prb->get_dt(kind), tag);
+    dnn_mem_t dst_size_mem(dst_md, get_test_engine(), /* prefill = */ false);
+
+    batch_elems = dst_size_mem.size() / sizeof(uint16_t);
+    packed_mem.assign(prb->batch_size * batch_elems, 0);
+
+    const auto *src = reinterpret_cast<const uint16_t *>(src_ptr);
+    for (int bs = 0; bs < prb->batch_size; bs++) {
+        auto *src_batch = const_cast<uint16_t *>(src + bs * batch_offset_elems);
+        auto *dst_batch = packed_mem.data() + bs * batch_elems;
+
+        auto src_mem = dnn_mem_t::create_from_host_ptr(
+                src_md, get_test_engine(), src_batch);
+        auto dst_mem = dnn_mem_t::create_from_host_ptr(
+                dst_md, get_test_engine(), dst_batch);
+        SAFE(dst_mem.reorder(src_mem, res), WARN);
+    }
+
+    return OK;
+}
+#endif
 
 namespace_impl::brgemm_batch_kind_t str2batch_kind(const std::string &str) {
     if (str == "addr")
@@ -297,6 +348,11 @@ struct kernel_args_t {
 #endif
         , scratchpad_size_(0)
         , generate_skip_accumulation_(false)
+#if defined(brg_aarch64)
+        , mmla_ld_block2_(1)
+        , use_mmla_(false)
+        , use_mmla_packed_a_(false)
+#endif
         , prb_(prb) {
     }
 
@@ -314,6 +370,11 @@ struct kernel_args_t {
 #endif
     size_t scratchpad_size_;
     bool generate_skip_accumulation_;
+#if defined(brg_aarch64)
+    int mmla_ld_block2_;
+    bool use_mmla_;
+    bool use_mmla_packed_a_;
+#endif
 
     // Input members
     const prb_t *prb_;
@@ -378,6 +439,11 @@ int init_kernel(kernel_args_t &kernel_args, res_t *res) {
 
     kernel_args.generate_skip_accumulation_
             = brgemm_attr.generate_skip_accumulation;
+#if defined(brg_aarch64)
+    kernel_args.mmla_ld_block2_ = brgemm_desc.ld_block2;
+    kernel_args.use_mmla_ = brgemm_desc.brgattr.use_mmla;
+    kernel_args.use_mmla_packed_a_ = brgemm_desc.brgattr.use_mmla_packed_a;
+#endif
 
     // Create BRGeMM kernel, analogous to primitive creation.
     // ctx_init can here be used to select core type on hetero ISA with TBB.
@@ -579,11 +645,24 @@ void init_memory_args(
     // memory. Thus, it requires two memories and we need to pass a memory
     // handle from bigger one (where LDB is an actual dim value) to smaller, but
     // there's some reorder bug resulting in an error.
+#if defined(brg_aarch64)
+    const bool pack_mmla_wei_per_batch
+            = kernel_args.use_mmla_ && prb->batch_size > 1;
+    const auto wtag = kernel_args.use_mmla_
+            ? prepare_mmla_wei_format_string(kernel_args.mmla_ld_block2_)
+            : prepare_wei_format_string(prb->wei_dt(), prb->get_ldb(),
+                      kernel_args.is_b_data_layout_vnni_);
+    dims_t plain_wei_strides = {prb->get_ldb(), 1};
+    auto wei_md = pack_mmla_wei_per_batch
+            ? dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), "",
+                      plain_wei_strides)
+            : dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), wtag);
+#else
     const auto wtag = prepare_wei_format_string(
             prb->wei_dt(), prb->get_ldb(), kernel_args.is_b_data_layout_vnni_);
-    BENCHDNN_PRINT(6, "wtag: %s\n", wtag.c_str());
-
     auto wei_md = dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), wtag);
+#endif
+    BENCHDNN_PRINT(6, "wtag: %s\n", wtag.c_str());
     kernel_args.original_wei_md_size_ = dnnl_memory_desc_get_size(wei_md);
 
     // Prepare and assign extra for wei_md when s8s8 compensation, or source
@@ -1083,17 +1162,47 @@ int doit(const prb_t *prb, res_t *res) {
             : nullptr;
 
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
+    size_t src_batch_offset = prb->get_src_batch_offset();
+    size_t wei_batch_offset = prb->get_wei_batch_offset();
+#if defined(brg_aarch64)
+    std::vector<uint16_t> packed_src;
+    std::vector<uint16_t> packed_wei;
+    if (kernel_args.use_mmla_ && kernel_args.use_mmla_packed_a_) {
+        size_t src_batch_elems = 0;
+        const dims_t src_dims = {prb->m, prb->k};
+        const dims_t src_strides = {prb->get_lda(), 1};
+        BENCHDNN_PRINT(6, "stag: %s\n", mmla_src_tag);
+        SAFE(pack_for_mmla(prb, SRC, src_ptr, packed_src, src_batch_elems,
+                     src_dims, src_strides, mmla_src_tag,
+                     prb->get_src_batch_offset(), res),
+                WARN);
+        src_ptr = reinterpret_cast<const char *>(packed_src.data());
+        src_batch_offset = src_batch_elems * sizeof(uint16_t);
+    }
+    if (kernel_args.use_mmla_ && prb->batch_size > 1) {
+        size_t wei_batch_elems = 0;
+        const dims_t wei_dims = {prb->k, prb->n};
+        const dims_t wei_strides = {prb->get_ldb(), 1};
+        SAFE(pack_for_mmla(prb, WEI, wei_ptr, packed_wei, wei_batch_elems,
+                     wei_dims, wei_strides,
+                     prepare_mmla_wei_format_string(
+                             kernel_args.mmla_ld_block2_),
+                     prb->get_wei_batch_offset(), res),
+                WARN);
+        wei_ptr = reinterpret_cast<const char *>(packed_wei.data());
+        wei_batch_offset = wei_batch_elems * sizeof(uint16_t);
+    }
+#endif
+
     std::vector<namespace_impl::brgemm_batch_element_t> v_batch_element(
             prb->batch_size);
     for (size_t i = 0; i < v_batch_element.size(); i++) {
         if (prb->batch_kind == "addr") {
-            v_batch_element[i].ptr.A
-                    = src_ptr + i * prb->get_src_batch_offset();
-            v_batch_element[i].ptr.B
-                    = wei_ptr + i * prb->get_wei_batch_offset();
+            v_batch_element[i].ptr.A = src_ptr + i * src_batch_offset;
+            v_batch_element[i].ptr.B = wei_ptr + i * wei_batch_offset;
         } else if (prb->batch_kind == "offs") {
-            v_batch_element[i].offset.A = i * prb->get_src_batch_offset();
-            v_batch_element[i].offset.B = i * prb->get_wei_batch_offset();
+            v_batch_element[i].offset.A = i * src_batch_offset;
+            v_batch_element[i].offset.B = i * wei_batch_offset;
         }
     }
 

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -146,6 +146,9 @@ dnnl_status_t brgemm_attr_init(
 #if defined(brg_x64)
         // ACE is an x64-only compute path.
         PROCESS_KEY_VAL(use_ace);
+#elif defined(brg_aarch64)
+        PROCESS_KEY_VAL(use_mmla);
+        PROCESS_KEY_VAL(use_mmla_packed_a);
 #endif
         PROCESS_KEY_VAL(b_is_vnni);
         PROCESS_KEY_VAL(postops_only);
@@ -207,6 +210,14 @@ std::string prepare_wei_format_string(
 
     return wtag;
 }
+
+#if !defined(DNNL_EXPERIMENTAL_UKERNEL) && defined(brg_aarch64)
+constexpr const char *mmla_src_tag = "AB2a4b";
+
+std::string prepare_mmla_wei_format_string(int ld_block, int ld_block2) {
+    return std::string("BA2a") + std::to_string(ld_block * ld_block2) + "b4a";
+}
+#endif
 
 namespace_impl::brgemm_batch_kind_t str2batch_kind(const std::string &str) {
     if (str == "addr")
@@ -290,10 +301,16 @@ struct kernel_args_t {
         :
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
         brgemm_kernel_(nullptr)
+#if defined(brg_x64)
         , palette()
-        , is_b_data_layout_vnni_(false)
         , need_tile_config_(false)
+#endif
+        , is_b_data_layout_vnni_(false)
         , original_wei_md_size_(0)
+#if defined(brg_aarch64)
+        , use_mmla_(false)
+        , use_mmla_packed_a_(false)
+#endif
 #else
         brgemm_(nullptr)
         , transform_(nullptr)
@@ -307,10 +324,17 @@ struct kernel_args_t {
     // Output members
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
     namespace_impl::brgemm_kernel_t *brgemm_kernel_;
+#if defined(brg_x64)
     char palette[/*dnnl::impl::cpu::x64::AMX_PALETTE_SIZE = */ 64];
-    bool is_b_data_layout_vnni_;
     bool need_tile_config_;
+#endif
+    bool is_b_data_layout_vnni_;
     size_t original_wei_md_size_;
+#if defined(brg_aarch64)
+    std::string mmla_wei_tag_;
+    bool use_mmla_;
+    bool use_mmla_packed_a_;
+#endif
 #else
     dnnl_brgemm_t brgemm_;
     dnnl_transform_t transform_;
@@ -322,6 +346,17 @@ struct kernel_args_t {
     // Input members
     const prb_t *prb_;
 };
+
+#if !defined(DNNL_EXPERIMENTAL_UKERNEL)
+std::string prepare_wei_format_string(
+        const prb_t *prb, const kernel_args_t &kernel_args) {
+#if defined(brg_aarch64)
+    if (kernel_args.use_mmla_) return kernel_args.mmla_wei_tag_;
+#endif
+    return prepare_wei_format_string(
+            prb->wei_dt(), prb->get_ldb(), kernel_args.is_b_data_layout_vnni_);
+}
+#endif
 
 int init_kernel(kernel_args_t &kernel_args, res_t *res) {
     const prb_t *prb = kernel_args.prb_;
@@ -372,6 +407,12 @@ int init_kernel(kernel_args_t &kernel_args, res_t *res) {
 
     brgemm_attr_t brgemm_attr;
     DNN_SAFE(brgemm_attr_init(&brgemm_attr, prb), WARN);
+#if defined(brg_aarch64)
+    if (brgemm_attr.use_mmla && prb->batch_size > 1) {
+        SAFE(check_dnnl_status(dnnl_unimplemented, prb, res), WARN);
+        return OK;
+    }
+#endif
     SAFE(check_dnnl_status(
                  brgemm_desc_set_attr(&brgemm_desc, brgemm_attr), prb, res),
             WARN);
@@ -382,6 +423,14 @@ int init_kernel(kernel_args_t &kernel_args, res_t *res) {
 
     kernel_args.generate_skip_accumulation_
             = brgemm_attr.generate_skip_accumulation;
+#if defined(brg_aarch64)
+    kernel_args.use_mmla_ = brgemm_desc.brgattr.use_mmla;
+    if (kernel_args.use_mmla_) {
+        kernel_args.mmla_wei_tag_ = prepare_mmla_wei_format_string(
+                brgemm_desc.ld_block, brgemm_desc.ld_block2);
+    }
+    kernel_args.use_mmla_packed_a_ = brgemm_desc.brgattr.use_mmla_packed_a;
+#endif
 
     // Create BRGeMM kernel, analogous to primitive creation.
     // ctx_init can here be used to select core type on hetero ISA with TBB.
@@ -560,12 +609,19 @@ void init_memory_args(
     const dnnl_dims_t src_dims = {prb->m, prb->k * prb->batch_size};
     const dnnl_dims_t wei_dims = {prb->k * prb->batch_size, prb->n};
 
+    std::string stag;
     dims_t src_strides = {prb->get_lda(), 1};
+#if !defined(DNNL_EXPERIMENTAL_UKERNEL) && defined(brg_aarch64)
+    if (kernel_args.use_mmla_ && kernel_args.use_mmla_packed_a_) {
+        stag = mmla_src_tag;
+        src_strides = {};
+    }
+#endif
     dims_t dst_strides = {prb->get_ldd(), 1};
     dims_t acc_strides = prb->use_dst_as_acc() ? dst_strides : dims_t();
 
     auto src_md = dnn_mem_t::init_md(
-            prb->ndims, src_dims, prb->src_dt(), "", src_strides);
+            prb->ndims, src_dims, prb->src_dt(), stag, src_strides);
 
     auto dst_md = dnn_mem_t::init_md(
             prb->ndims, prb->dst_dims.data(), prb->dst_dt(), "", dst_strides);
@@ -575,7 +631,7 @@ void init_memory_args(
             prb->acc_dt(), tag::abx, acc_strides);
 
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
-    // Create weights memory descriptor with VNNI-friendly format.
+    // Create weights memory descriptor with kernel-friendly format.
     // Note: LDB is not passed here. This is because it's super difficult to
     // incorporate stride on top of blocking - oneDNN API doesn't provide any
     // calls to support both options together. Submemory descriptor, which is
@@ -583,11 +639,9 @@ void init_memory_args(
     // memory. Thus, it requires two memories and we need to pass a memory
     // handle from bigger one (where LDB is an actual dim value) to smaller, but
     // there's some reorder bug resulting in an error.
-    const auto wtag = prepare_wei_format_string(
-            prb->wei_dt(), prb->get_ldb(), kernel_args.is_b_data_layout_vnni_);
-    BENCHDNN_PRINT(6, "wtag: %s\n", wtag.c_str());
-
+    const auto wtag = prepare_wei_format_string(prb, kernel_args);
     auto wei_md = dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), wtag);
+    BENCHDNN_PRINT(6, "wtag: %s\n", wtag.c_str());
     kernel_args.original_wei_md_size_ = dnnl_memory_desc_get_size(wei_md);
 
     // Prepare and assign extra for wei_md when s8s8 compensation, or source

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
@@ -4,13 +4,14 @@
 --bia_dt=undef,f32,bf16
 --beta=0,1
 --attr-post-ops=,sum:2,relu
---brgemm-attr=,use_uker:1
+--brgemm-attr=,use_uker:1,use_mmla:1,use_mmla:1+use_mmla_packed_a:1
 --batch=option_set_bf16
 
 # Separate cases for non-default alpha
 --reset
 --dt=bf16
 --alpha=2
+--brgemm-attr=,use_mmla:1,use_mmla:1+use_mmla_packed_a:1
 --batch=shapes_2d_no_tail_bf16
 
 # Skip-acc feature

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_mmla
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_mmla
@@ -1,0 +1,16 @@
+--reset
+
+--dt=bf16,bf16:bf16:f32
+--bia_dt=undef,f32,bf16
+--alpha=1,2
+--beta=0,1
+--attr-post-ops=,sum:2,relu
+--brgemm-attr=use_mmla:1,use_mmla:1+use_mmla_packed_a:1
+--batch=shapes_2d_no_tail_bf16
+--batch=shapes_2d_tail_n_bf16
+
+--batch=shapes_2d_tail_k_bf16
+--batch=shapes_2d_big_k_bf16
+
+--batch=shapes_2d_tail_k_tail_n_bf16
+--batch=shapes_2d_big_k_tail_n_bf16


### PR DESCRIPTION
# Description

This PR adds a new AArch64 bf16 MMLA BRGeMM path for SVE-enabled systems with BFMMLA support. The change introduces the required kernel generation, configuration, and benchdnn coverage while preserving existing BRGeMM behavior as the default via the `use_mmla` and `use_mmla_packed_a` flags in `brgemm_attr_t`.

This change does not itself enable the new BFMMLA path in any existing primitives that use BRGeMM. It is the first stage toward a performant bf16 ukernel implementation on AArch64, as well as faster `brgemm_conv` and `brgemm_matmul` implementations. It can also serve as a template for possible future expansion to use int8 SMMLA, UMMLA, and USMMLA instructions in the BRGeMM kernel.

To test the new path in benchdnn locally, use:
- Plain A/source (default):
  `./benchdnn --brgemm --mode=C --dt=bf16 --brgemm-attr=use_mmla:1 ...`

- Packed A/source:
  `./benchdnn --brgemm --mode=C --dt=bf16 --brgemm-attr=use_mmla:1+use_mmla_packed_a:1 ...`

Note that `use_mmla` must be enabled for `use_mmla_packed_a` to be valid, and `DNNL_EXPERIMENTAL_UKERNEL` must be `OFF`.

### Speedups vs BFDOT BRGeMM baseline (benchdnn --mode=p)

| MxK:KxN | SVE128 (plain_a) | SVE128 (packed_a) | SVE256 (plain_a) | SVE256 (packed_a) |
|---|---:|---:|---:|---:|
| 2x768:768x384 | 1.96x | 1.86x | 1.75x | 1.63x |
| 4x769:769x512 | 1.90x | 2.33x | 1.53x | 1.71x |
| 64x128:128x512 | 1.39x | 1.77x | 1.61x | 1.86x |
| 64x512:512x128 | 1.40x | 1.89x | 1.67x | 1.94x |
| 120x512:512x288 | 1.39x | 1.85x | 1.68x | 1.96x |
| 128x512:512x256 | 1.62x | 2.15x | 1.68x | 1.98x |
| 504x512:512x480 | 1.40x | 1.84x | 1.67x | 1.94x |
| 512x512:512x512 | 1.71x | 2.26x | 1.67x | 1.95x |

### Generated assembly examples (144x512:512x288)

<details>
<summary>Plain A (bf16:bf16:f32) </summary>

```text
...
100:    ld1rd	{z0.d}, p0/z, [x11]
104:    add	x24, x11, #0x400
108:    ld1rd	{z6.d}, p0/z, [x24]
10c:    zip1	z0.d, z0.d, z6.d
110:    add	x24, x11, #0x800
114:    ld1rd	{z1.d}, p0/z, [x24]
118:    add	x24, x11, #0xc00
11c:    ld1rd	{z6.d}, p0/z, [x24]
120:    zip1	z1.d, z1.d, z6.d
124:    add	x24, x11, #0x1, lsl #12
128:    ld1rd	{z2.d}, p0/z, [x24]
12c:    mov	x23, #0x1400
130:    add	x24, x11, x23
134:    ld1rd	{z6.d}, p0/z, [x24]
138:    zip1	z2.d, z2.d, z6.d
13c:    ld1rd	{z3.d}, p0/z, [x11, #8]
140:    add	x24, x11, #0x408
144:    ld1rd	{z6.d}, p0/z, [x24]
148:    zip1	z3.d, z3.d, z6.d
14c:    add	x24, x11, #0x808
150:    ld1rd	{z4.d}, p0/z, [x24]
154:    add	x24, x11, #0xc08
158:    ld1rd	{z6.d}, p0/z, [x24]
15c:    zip1	z4.d, z4.d, z6.d
160:    mov	x23, #0x1008
164:    add	x24, x11, x23
168:    ld1rd	{z5.d}, p0/z, [x24]
16c:    mov	x23, #0x1408
170:    add	x24, x11, x23
174:    ld1rd	{z6.d}, p0/z, [x24]
178:    zip1	z5.d, z5.d, z6.d
17c:    ld1h	{z6.h}, p0/z, [x10]
180:    ld1h	{z7.h}, p0/z, [x10, #1, mul vl]
184:    bfmmla	z31.s, z0.h, z6.h
188:    bfmmla	z27.s, z0.h, z7.h
18c:    bfmmla	z23.s, z1.h, z6.h
190:    bfmmla	z19.s, z1.h, z7.h
194:    bfmmla	z15.s, z2.h, z6.h
198:    bfmmla	z11.s, z2.h, z7.h
19c:    ld1h	{z6.h}, p0/z, [x10, #2, mul vl]
1a0:    ld1h	{z7.h}, p0/z, [x10, #3, mul vl]
1a4:    bfmmla	z30.s, z0.h, z6.h
1a8:    bfmmla	z26.s, z0.h, z7.h
1ac:    bfmmla	z22.s, z1.h, z6.h
1b0:    bfmmla	z18.s, z1.h, z7.h
1b4:    bfmmla	z14.s, z2.h, z6.h
1b8:    bfmmla	z10.s, z2.h, z7.h
1bc:    ld1h	{z6.h}, p0/z, [x10, #4, mul vl]
1c0:    ld1h	{z7.h}, p0/z, [x10, #5, mul vl]
1c4:    bfmmla	z29.s, z0.h, z6.h
1c8:    bfmmla	z25.s, z0.h, z7.h
1cc:    bfmmla	z21.s, z1.h, z6.h
1d0:    bfmmla	z17.s, z1.h, z7.h
1d4:    bfmmla	z13.s, z2.h, z6.h
1d8:    bfmmla	z9.s, z2.h, z7.h
1dc:    ld1h	{z6.h}, p0/z, [x10, #6, mul vl]
1e0:    ld1h	{z7.h}, p0/z, [x10, #7, mul vl]
1e4:    addvl	x10, x10, #8
1e8:    bfmmla	z28.s, z0.h, z6.h
1ec:    bfmmla	z24.s, z0.h, z7.h
1f0:    bfmmla	z20.s, z1.h, z6.h
1f4:    bfmmla	z16.s, z1.h, z7.h
1f8:    bfmmla	z12.s, z2.h, z6.h
1fc:    bfmmla	z8.s, z2.h, z7.h
200:    ld1h	{z6.h}, p0/z, [x10]
204:    ld1h	{z7.h}, p0/z, [x10, #1, mul vl]
208:    bfmmla	z31.s, z3.h, z6.h
20c:    bfmmla	z27.s, z3.h, z7.h
210:    bfmmla	z23.s, z4.h, z6.h
214:    bfmmla	z19.s, z4.h, z7.h
218:    bfmmla	z15.s, z5.h, z6.h
21c:    bfmmla	z11.s, z5.h, z7.h
220:    ld1h	{z6.h}, p0/z, [x10, #2, mul vl]
224:    ld1h	{z7.h}, p0/z, [x10, #3, mul vl]
228:    bfmmla	z30.s, z3.h, z6.h
22c:    bfmmla	z26.s, z3.h, z7.h
230:    bfmmla	z22.s, z4.h, z6.h
234:    bfmmla	z18.s, z4.h, z7.h
238:    bfmmla	z14.s, z5.h, z6.h
23c:    bfmmla	z10.s, z5.h, z7.h
240:    ld1h	{z6.h}, p0/z, [x10, #4, mul vl]
244:    ld1h	{z7.h}, p0/z, [x10, #5, mul vl]
248:    bfmmla	z29.s, z3.h, z6.h
24c:    bfmmla	z25.s, z3.h, z7.h
250:    bfmmla	z21.s, z4.h, z6.h
254:    bfmmla	z17.s, z4.h, z7.h
258:    bfmmla	z13.s, z5.h, z6.h
25c:    bfmmla	z9.s, z5.h, z7.h
260:    ld1h	{z6.h}, p0/z, [x10, #6, mul vl]
264:    ld1h	{z7.h}, p0/z, [x10, #7, mul vl]
268:    add	x11, x11, #0x10
26c:    addvl	x10, x10, #8
270:    bfmmla	z28.s, z3.h, z6.h
274:    bfmmla	z24.s, z3.h, z7.h
278:    bfmmla	z20.s, z4.h, z6.h
27c:    bfmmla	z16.s, z4.h, z7.h
280:    bfmmla	z12.s, z5.h, z6.h
284:    bfmmla	z8.s, z5.h, z7.h
288:    subs	x3, x3, #0x1
28c:    b.ne	0x100  // b.any
290:    ldr	x11, [sp, #32]
294:    uzp1	z0.d, z31.d, z27.d
298:    uzp2	z27.d, z31.d, z27.d
29c:    uzp1	z1.d, z30.d, z26.d
2a0:    uzp2	z26.d, z30.d, z26.d
2a4:    uzp1	z2.d, z29.d, z25.d
2a8:    uzp2	z25.d, z29.d, z25.d
2ac:    uzp1	z3.d, z28.d, z24.d
2b0:    uzp2	z24.d, z28.d, z24.d
2b4:    st1w	{z0.s}, p0, [x14]
2b8:    st1w	{z1.s}, p0, [x14, #1, mul vl]
2bc:    st1w	{z2.s}, p0, [x14, #2, mul vl]
2c0:    st1w	{z3.s}, p0, [x14, #3, mul vl]
2c4:    add	x16, x14, #0x480
2c8:    st1w	{z27.s}, p0, [x16]
2cc:    st1w	{z26.s}, p0, [x16, #1, mul vl]
2d0:    st1w	{z25.s}, p0, [x16, #2, mul vl]
2d4:    st1w	{z24.s}, p0, [x16, #3, mul vl]
2d8:    uzp1	z0.d, z23.d, z19.d
2dc:    uzp2	z19.d, z23.d, z19.d
2e0:    uzp1	z1.d, z22.d, z18.d
2e4:    uzp2	z18.d, z22.d, z18.d
2e8:    uzp1	z2.d, z21.d, z17.d
2ec:    uzp2	z17.d, z21.d, z17.d
2f0:    uzp1	z3.d, z20.d, z16.d
2f4:    uzp2	z16.d, z20.d, z16.d
2f8:    add	x16, x16, #0x480
2fc:    st1w	{z0.s}, p0, [x16]
300:    st1w	{z1.s}, p0, [x16, #1, mul vl]
304:    st1w	{z2.s}, p0, [x16, #2, mul vl]
308:    st1w	{z3.s}, p0, [x16, #3, mul vl]
30c:    add	x16, x16, #0x480
310:    st1w	{z19.s}, p0, [x16]
314:    st1w	{z18.s}, p0, [x16, #1, mul vl]
318:    st1w	{z17.s}, p0, [x16, #2, mul vl]
31c:    st1w	{z16.s}, p0, [x16, #3, mul vl]
320:    uzp1	z0.d, z15.d, z11.d
324:    uzp2	z11.d, z15.d, z11.d
328:    uzp1	z1.d, z14.d, z10.d
32c:    uzp2	z10.d, z14.d, z10.d
330:    uzp1	z2.d, z13.d, z9.d
334:    uzp2	z9.d, z13.d, z9.d
338:    uzp1	z3.d, z12.d, z8.d
33c:    uzp2	z8.d, z12.d, z8.d
340:    add	x16, x16, #0x480
344:    st1w	{z0.s}, p0, [x16]
348:    st1w	{z1.s}, p0, [x16, #1, mul vl]
34c:    st1w	{z2.s}, p0, [x16, #2, mul vl]
350:    st1w	{z3.s}, p0, [x16, #3, mul vl]
354:    add	x16, x16, #0x480
358:    st1w	{z11.s}, p0, [x16]
35c:    st1w	{z10.s}, p0, [x16, #1, mul vl]
360:    st1w	{z9.s}, p0, [x16, #2, mul vl]
364:    st1w	{z8.s}, p0, [x16, #3, mul vl]
368:    add	x14, x14, #0x80
36c:    add	x0, x0, #0x80
370:    mov	x23, #0x8000
374:    add	x6, x6, x23
378:    sub	x8, x8, #0x1
37c:    cmp	x8, #0x0
380:    b.gt	0x88
384:    mov	x23, #0x1b00
388:    add	x15, x15, x23
38c:    mov	x23, #0x1b00
390:    add	x11, x11, x23
394:    mov	x23, #0x1800
398:    add	x2, x2, x23
39c:    subs	x9, x9, #0x1
3a0:    b.gt	0x78
3a4:    add	sp, sp, #0xc0
3a8:    mov	x9, sp
3ac:    ld4	{v8.d-v11.d}[0], [x9], #32
3b0:    ld4	{v12.d-v15.d}[0], [x9], #32
3b4:    ldp	x16, x17, [x9], #16
3b8:    ldp	x19, x20, [x9], #16
3bc:    ldp	x21, x22, [x9], #16
3c0:    ldp	x23, x24, [x9], #16
3c4:    ldp	x25, x26, [x9], #16
3c8:    ldp	x27, x28, [x9], #16
3cc:    add	sp, sp, #0xa0
3d0:    ldp	x29, x30, [sp], #16
3d4:    ret
```

</details>

<details>
<summary>Packed A (bf16:bf16:f32)</summary>

```text
...
100:    ld1rqh	{z0.h}, p0/z, [x11]
104:    add	x16, x11, #0x800
108:    ld1rqh	{z1.h}, p0/z, [x16]
10c:    add	x16, x16, #0x800
110:    ld1rqh	{z2.h}, p0/z, [x16]
114:    add	x16, x16, #0x800
118:    ld1rqh	{z3.h}, p0/z, [x16]
11c:    ld1h	{z4.h}, p0/z, [x10]
120:    ld1h	{z5.h}, p0/z, [x10, #1, mul vl]
124:    ld1h	{z6.h}, p0/z, [x10, #2, mul vl]
128:    ld1h	{z7.h}, p0/z, [x10, #3, mul vl]
12c:    bfmmla	z31.s, z0.h, z4.h
130:    bfmmla	z28.s, z0.h, z5.h
134:    bfmmla	z25.s, z1.h, z4.h
138:    bfmmla	z22.s, z1.h, z5.h
13c:    bfmmla	z19.s, z2.h, z4.h
140:    bfmmla	z16.s, z2.h, z5.h
144:    bfmmla	z13.s, z3.h, z4.h
148:    bfmmla	z10.s, z3.h, z5.h
14c:    ld1h	{z4.h}, p0/z, [x10, #4, mul vl]
150:    ld1h	{z5.h}, p0/z, [x10, #5, mul vl]
154:    addvl	x10, x10, #6
158:    bfmmla	z30.s, z0.h, z6.h
15c:    bfmmla	z27.s, z0.h, z7.h
160:    bfmmla	z24.s, z1.h, z6.h
164:    bfmmla	z21.s, z1.h, z7.h
168:    bfmmla	z18.s, z2.h, z6.h
16c:    bfmmla	z15.s, z2.h, z7.h
170:    bfmmla	z12.s, z3.h, z6.h
174:    bfmmla	z9.s, z3.h, z7.h
178:    bfmmla	z29.s, z0.h, z4.h
17c:    bfmmla	z26.s, z0.h, z5.h
180:    bfmmla	z23.s, z1.h, z4.h
184:    bfmmla	z20.s, z1.h, z5.h
188:    bfmmla	z17.s, z2.h, z4.h
18c:    bfmmla	z14.s, z2.h, z5.h
190:    bfmmla	z11.s, z3.h, z4.h
194:    bfmmla	z8.s, z3.h, z5.h
198:    add	x16, x11, #0x10
19c:    ld1rqh	{z0.h}, p0/z, [x16]
1a0:    add	x16, x16, #0x800
1a4:    ld1rqh	{z1.h}, p0/z, [x16]
1a8:    add	x16, x16, #0x800
1ac:    ld1rqh	{z2.h}, p0/z, [x16]
1b0:    add	x16, x16, #0x800
1b4:    ld1rqh	{z3.h}, p0/z, [x16]
1b8:    ld1h	{z4.h}, p0/z, [x10]
1bc:    ld1h	{z5.h}, p0/z, [x10, #1, mul vl]
1c0:    ld1h	{z6.h}, p0/z, [x10, #2, mul vl]
1c4:    ld1h	{z7.h}, p0/z, [x10, #3, mul vl]
1c8:    bfmmla	z31.s, z0.h, z4.h
1cc:    bfmmla	z28.s, z0.h, z5.h
1d0:    bfmmla	z25.s, z1.h, z4.h
1d4:    bfmmla	z22.s, z1.h, z5.h
1d8:    bfmmla	z19.s, z2.h, z4.h
1dc:    bfmmla	z16.s, z2.h, z5.h
1e0:    bfmmla	z13.s, z3.h, z4.h
1e4:    bfmmla	z10.s, z3.h, z5.h
1e8:    ld1h	{z4.h}, p0/z, [x10, #4, mul vl]
1ec:    ld1h	{z5.h}, p0/z, [x10, #5, mul vl]
1f0:    addvl	x11, x11, #1
1f4:    addvl	x10, x10, #6
1f8:    bfmmla	z30.s, z0.h, z6.h
1fc:    bfmmla	z27.s, z0.h, z7.h
200:    bfmmla	z24.s, z1.h, z6.h
204:    bfmmla	z21.s, z1.h, z7.h
208:    bfmmla	z18.s, z2.h, z6.h
20c:    bfmmla	z15.s, z2.h, z7.h
210:    bfmmla	z12.s, z3.h, z6.h
214:    bfmmla	z9.s, z3.h, z7.h
218:    bfmmla	z29.s, z0.h, z4.h
21c:    bfmmla	z26.s, z0.h, z5.h
220:    bfmmla	z23.s, z1.h, z4.h
224:    bfmmla	z20.s, z1.h, z5.h
228:    bfmmla	z17.s, z2.h, z4.h
22c:    bfmmla	z14.s, z2.h, z5.h
230:    bfmmla	z11.s, z3.h, z4.h
234:    bfmmla	z8.s, z3.h, z5.h
238:    subs	x3, x3, #0x1
23c:    b.ne	0x100  // b.any
240:    ldr	x11, [sp, #32]
244:    uzp1	z0.d, z31.d, z28.d
248:    uzp2	z28.d, z31.d, z28.d
24c:    uzp1	z1.d, z30.d, z27.d
250:    uzp2	z27.d, z30.d, z27.d
254:    uzp1	z2.d, z29.d, z26.d
258:    uzp2	z26.d, z29.d, z26.d
25c:    st1w	{z0.s}, p0, [x14]
260:    st1w	{z1.s}, p0, [x14, #1, mul vl]
264:    st1w	{z2.s}, p0, [x14, #2, mul vl]
268:    add	x16, x14, #0x480
26c:    st1w	{z28.s}, p0, [x16]
270:    st1w	{z27.s}, p0, [x16, #1, mul vl]
274:    st1w	{z26.s}, p0, [x16, #2, mul vl]
278:    uzp1	z0.d, z25.d, z22.d
27c:    uzp2	z22.d, z25.d, z22.d
280:    uzp1	z1.d, z24.d, z21.d
284:    uzp2	z21.d, z24.d, z21.d
288:    uzp1	z2.d, z23.d, z20.d
28c:    uzp2	z20.d, z23.d, z20.d
290:    add	x16, x16, #0x480
294:    st1w	{z0.s}, p0, [x16]
298:    st1w	{z1.s}, p0, [x16, #1, mul vl]
29c:    st1w	{z2.s}, p0, [x16, #2, mul vl]
2a0:    add	x16, x16, #0x480
2a4:    st1w	{z22.s}, p0, [x16]
2a8:    st1w	{z21.s}, p0, [x16, #1, mul vl]
2ac:    st1w	{z20.s}, p0, [x16, #2, mul vl]
2b0:    uzp1	z0.d, z19.d, z16.d
2b4:    uzp2	z16.d, z19.d, z16.d
2b8:    uzp1	z1.d, z18.d, z15.d
2bc:    uzp2	z15.d, z18.d, z15.d
2c0:    uzp1	z2.d, z17.d, z14.d
2c4:    uzp2	z14.d, z17.d, z14.d
2c8:    add	x16, x16, #0x480
2cc:    st1w	{z0.s}, p0, [x16]
2d0:    st1w	{z1.s}, p0, [x16, #1, mul vl]
2d4:    st1w	{z2.s}, p0, [x16, #2, mul vl]
2d8:    add	x16, x16, #0x480
2dc:    st1w	{z16.s}, p0, [x16]
2e0:    st1w	{z15.s}, p0, [x16, #1, mul vl]
2e4:    st1w	{z14.s}, p0, [x16, #2, mul vl]
2e8:    uzp1	z0.d, z13.d, z10.d
2ec:    uzp2	z10.d, z13.d, z10.d
2f0:    uzp1	z1.d, z12.d, z9.d
2f4:    uzp2	z9.d, z12.d, z9.d
2f8:    uzp1	z2.d, z11.d, z8.d
2fc:    uzp2	z8.d, z11.d, z8.d
300:    add	x16, x16, #0x480
304:    st1w	{z0.s}, p0, [x16]
308:    st1w	{z1.s}, p0, [x16, #1, mul vl]
30c:    st1w	{z2.s}, p0, [x16, #2, mul vl]
310:    add	x16, x16, #0x480
314:    st1w	{z10.s}, p0, [x16]
318:    st1w	{z9.s}, p0, [x16, #1, mul vl]
31c:    st1w	{z8.s}, p0, [x16, #2, mul vl]
320:    add	x14, x14, #0x60
324:    add	x0, x0, #0x60
328:    mov	x23, #0x6000
32c:    add	x6, x6, x23
330:    sub	x8, x8, #0x1
334:    cmp	x8, #0x0
338:    b.gt	0x88
33c:    mov	x23, #0x2400
340:    add	x15, x15, x23
344:    mov	x23, #0x2400
348:    add	x11, x11, x23
34c:    mov	x23, #0x2000
350:    add	x2, x2, x23
354:    subs	x9, x9, #0x1
358:    b.gt	0x78
35c:    add	sp, sp, #0xc0
360:    mov	x9, sp
364:    ld4	{v8.d-v11.d}[0], [x9], #32
368:    ld4	{v12.d-v15.d}[0], [x9], #32
36c:    ldp	x16, x17, [x9], #16
370:    ldp	x19, x20, [x9], #16
374:    ldp	x21, x22, [x9], #16
378:    ldp	x23, x24, [x9], #16
37c:    ldp	x25, x26, [x9], #16
380:    ldp	x27, x28, [x9], #16
384:    add	sp, sp, #0xa0
388:    ldp	x29, x30, [sp], #16
38c:    ret
```

</details>

<details>
<summary>Packed A (bf16:bf16:bf16 + relu)</summary>

```text
...
100:    ld1rqh	{z0.h}, p0/z, [x11]
104:    add	x16, x11, #0x800
108:    ld1rqh	{z1.h}, p0/z, [x16]
10c:    add	x16, x16, #0x800
110:    ld1rqh	{z2.h}, p0/z, [x16]
114:    add	x16, x16, #0x800
118:    ld1rqh	{z3.h}, p0/z, [x16]
11c:    ld1h	{z4.h}, p0/z, [x10]
120:    ld1h	{z5.h}, p0/z, [x10, #1, mul vl]
124:    ld1h	{z6.h}, p0/z, [x10, #2, mul vl]
128:    ld1h	{z7.h}, p0/z, [x10, #3, mul vl]
12c:    bfmmla	z31.s, z0.h, z4.h
130:    bfmmla	z28.s, z0.h, z5.h
134:    bfmmla	z25.s, z1.h, z4.h
138:    bfmmla	z22.s, z1.h, z5.h
13c:    bfmmla	z19.s, z2.h, z4.h
140:    bfmmla	z16.s, z2.h, z5.h
144:    bfmmla	z13.s, z3.h, z4.h
148:    bfmmla	z10.s, z3.h, z5.h
14c:    ld1h	{z4.h}, p0/z, [x10, #4, mul vl]
150:    ld1h	{z5.h}, p0/z, [x10, #5, mul vl]
154:    addvl	x10, x10, #6
158:    bfmmla	z30.s, z0.h, z6.h
15c:    bfmmla	z27.s, z0.h, z7.h
160:    bfmmla	z24.s, z1.h, z6.h
164:    bfmmla	z21.s, z1.h, z7.h
168:    bfmmla	z18.s, z2.h, z6.h
16c:    bfmmla	z15.s, z2.h, z7.h
170:    bfmmla	z12.s, z3.h, z6.h
174:    bfmmla	z9.s, z3.h, z7.h
178:    bfmmla	z29.s, z0.h, z4.h
17c:    bfmmla	z26.s, z0.h, z5.h
180:    bfmmla	z23.s, z1.h, z4.h
184:    bfmmla	z20.s, z1.h, z5.h
188:    bfmmla	z17.s, z2.h, z4.h
18c:    bfmmla	z14.s, z2.h, z5.h
190:    bfmmla	z11.s, z3.h, z4.h
194:    bfmmla	z8.s, z3.h, z5.h
198:    add	x16, x11, #0x10
19c:    ld1rqh	{z0.h}, p0/z, [x16]
1a0:    add	x16, x16, #0x800
1a4:    ld1rqh	{z1.h}, p0/z, [x16]
1a8:    add	x16, x16, #0x800
1ac:    ld1rqh	{z2.h}, p0/z, [x16]
1b0:    add	x16, x16, #0x800
1b4:    ld1rqh	{z3.h}, p0/z, [x16]
1b8:    ld1h	{z4.h}, p0/z, [x10]
1bc:    ld1h	{z5.h}, p0/z, [x10, #1, mul vl]
1c0:    ld1h	{z6.h}, p0/z, [x10, #2, mul vl]
1c4:    ld1h	{z7.h}, p0/z, [x10, #3, mul vl]
1c8:    bfmmla	z31.s, z0.h, z4.h
1cc:    bfmmla	z28.s, z0.h, z5.h
1d0:    bfmmla	z25.s, z1.h, z4.h
1d4:    bfmmla	z22.s, z1.h, z5.h
1d8:    bfmmla	z19.s, z2.h, z4.h
1dc:    bfmmla	z16.s, z2.h, z5.h
1e0:    bfmmla	z13.s, z3.h, z4.h
1e4:    bfmmla	z10.s, z3.h, z5.h
1e8:    ld1h	{z4.h}, p0/z, [x10, #4, mul vl]
1ec:    ld1h	{z5.h}, p0/z, [x10, #5, mul vl]
1f0:    addvl	x11, x11, #2
1f4:    addvl	x10, x10, #6
1f8:    bfmmla	z30.s, z0.h, z6.h
1fc:    bfmmla	z27.s, z0.h, z7.h
200:    bfmmla	z24.s, z1.h, z6.h
204:    bfmmla	z21.s, z1.h, z7.h
208:    bfmmla	z18.s, z2.h, z6.h
20c:    bfmmla	z15.s, z2.h, z7.h
210:    bfmmla	z12.s, z3.h, z6.h
214:    bfmmla	z9.s, z3.h, z7.h
218:    bfmmla	z29.s, z0.h, z4.h
21c:    bfmmla	z26.s, z0.h, z5.h
220:    bfmmla	z23.s, z1.h, z4.h
224:    bfmmla	z20.s, z1.h, z5.h
228:    bfmmla	z17.s, z2.h, z4.h
22c:    bfmmla	z14.s, z2.h, z5.h
230:    bfmmla	z11.s, z3.h, z4.h
234:    bfmmla	z8.s, z3.h, z5.h
238:    subs	x3, x3, #0x1
23c:    b.ne	0x100  // b.any
240:    ldr	x11, [sp, #32]
244:    uzp1	z0.d, z31.d, z28.d
248:    uzp2	z28.d, z31.d, z28.d
24c:    mov	z31.d, z0.d
250:    uzp1	z0.d, z30.d, z27.d
254:    uzp2	z27.d, z30.d, z27.d
258:    mov	z30.d, z0.d
25c:    uzp1	z0.d, z29.d, z26.d
260:    uzp2	z26.d, z29.d, z26.d
264:    mov	z29.d, z0.d
268:    uzp1	z0.d, z25.d, z22.d
26c:    uzp2	z22.d, z25.d, z22.d
270:    mov	z25.d, z0.d
274:    uzp1	z0.d, z24.d, z21.d
278:    uzp2	z21.d, z24.d, z21.d
27c:    mov	z24.d, z0.d
280:    uzp1	z0.d, z23.d, z20.d
284:    uzp2	z20.d, z23.d, z20.d
288:    mov	z23.d, z0.d
28c:    uzp1	z0.d, z19.d, z16.d
290:    uzp2	z16.d, z19.d, z16.d
294:    mov	z19.d, z0.d
298:    uzp1	z0.d, z18.d, z15.d
29c:    uzp2	z15.d, z18.d, z15.d
2a0:    mov	z18.d, z0.d
2a4:    uzp1	z0.d, z17.d, z14.d
2a8:    uzp2	z14.d, z17.d, z14.d
2ac:    mov	z17.d, z0.d
2b0:    uzp1	z0.d, z13.d, z10.d
2b4:    uzp2	z10.d, z13.d, z10.d
2b8:    mov	z13.d, z0.d
2bc:    uzp1	z0.d, z12.d, z9.d
2c0:    uzp2	z9.d, z12.d, z9.d
2c4:    mov	z12.d, z0.d
2c8:    uzp1	z0.d, z11.d, z8.d
2cc:    uzp2	z8.d, z11.d, z8.d
2d0:    mov	z11.d, z0.d
2d4:    ldr	x3, [sp, #24]
2d8:    cmp	x3, #0x0
2dc:    b.eq	0x42c  // b.none
2e0:    str	x0, [sp, #-16]!
2e4:    adr	x0, 0x540
2e8:    fmaxnm	z8.s, p0/m, z8.s, #0.0
2ec:    fmaxnm	z9.s, p0/m, z9.s, #0.0
2f0:    fmaxnm	z10.s, p0/m, z10.s, #0.0
2f4:    fmaxnm	z11.s, p0/m, z11.s, #0.0
2f8:    fmaxnm	z12.s, p0/m, z12.s, #0.0
2fc:    fmaxnm	z13.s, p0/m, z13.s, #0.0
300:    fmaxnm	z14.s, p0/m, z14.s, #0.0
304:    fmaxnm	z15.s, p0/m, z15.s, #0.0
308:    fmaxnm	z16.s, p0/m, z16.s, #0.0
30c:    fmaxnm	z17.s, p0/m, z17.s, #0.0
310:    fmaxnm	z18.s, p0/m, z18.s, #0.0
314:    fmaxnm	z19.s, p0/m, z19.s, #0.0
318:    fmaxnm	z20.s, p0/m, z20.s, #0.0
31c:    fmaxnm	z21.s, p0/m, z21.s, #0.0
320:    fmaxnm	z22.s, p0/m, z22.s, #0.0
324:    fmaxnm	z23.s, p0/m, z23.s, #0.0
328:    fmaxnm	z24.s, p0/m, z24.s, #0.0
32c:    fmaxnm	z25.s, p0/m, z25.s, #0.0
330:    fmaxnm	z26.s, p0/m, z26.s, #0.0
334:    fmaxnm	z27.s, p0/m, z27.s, #0.0
338:    fmaxnm	z28.s, p0/m, z28.s, #0.0
33c:    fmaxnm	z29.s, p0/m, z29.s, #0.0
340:    fmaxnm	z30.s, p0/m, z30.s, #0.0
344:    fmaxnm	z31.s, p0/m, z31.s, #0.0
348:    ldr	x0, [sp], #16
34c:    bfcvt	z31.h, p0/m, z31.s
350:    st1h	{z31.s}, p0, [x0]
354:    bfcvt	z30.h, p0/m, z30.s
358:    st1h	{z30.s}, p0, [x0, #1, mul vl]
35c:    bfcvt	z29.h, p0/m, z29.s
360:    st1h	{z29.s}, p0, [x0, #2, mul vl]
364:    add	x16, x0, #0x240
368:    bfcvt	z28.h, p0/m, z28.s
36c:    st1h	{z28.s}, p0, [x16]
370:    bfcvt	z27.h, p0/m, z27.s
374:    st1h	{z27.s}, p0, [x16, #1, mul vl]
378:    bfcvt	z26.h, p0/m, z26.s
37c:    st1h	{z26.s}, p0, [x16, #2, mul vl]
380:    add	x16, x16, #0x240
384:    bfcvt	z25.h, p0/m, z25.s
388:    st1h	{z25.s}, p0, [x16]
38c:    bfcvt	z24.h, p0/m, z24.s
390:    st1h	{z24.s}, p0, [x16, #1, mul vl]
394:    bfcvt	z23.h, p0/m, z23.s
398:    st1h	{z23.s}, p0, [x16, #2, mul vl]
39c:    add	x16, x16, #0x240
3a0:    bfcvt	z22.h, p0/m, z22.s
3a4:    st1h	{z22.s}, p0, [x16]
3a8:    bfcvt	z21.h, p0/m, z21.s
3ac:    st1h	{z21.s}, p0, [x16, #1, mul vl]
3b0:    bfcvt	z20.h, p0/m, z20.s
3b4:    st1h	{z20.s}, p0, [x16, #2, mul vl]
3b8:    add	x16, x16, #0x240
3bc:    bfcvt	z19.h, p0/m, z19.s
3c0:    st1h	{z19.s}, p0, [x16]
3c4:    bfcvt	z18.h, p0/m, z18.s
3c8:    st1h	{z18.s}, p0, [x16, #1, mul vl]
3cc:    bfcvt	z17.h, p0/m, z17.s
3d0:    st1h	{z17.s}, p0, [x16, #2, mul vl]
3d4:    add	x16, x16, #0x240
3d8:    bfcvt	z16.h, p0/m, z16.s
3dc:    st1h	{z16.s}, p0, [x16]
3e0:    bfcvt	z15.h, p0/m, z15.s
3e4:    st1h	{z15.s}, p0, [x16, #1, mul vl]
3e8:    bfcvt	z14.h, p0/m, z14.s
3ec:    st1h	{z14.s}, p0, [x16, #2, mul vl]
3f0:    add	x16, x16, #0x240
3f4:    bfcvt	z13.h, p0/m, z13.s
3f8:    st1h	{z13.s}, p0, [x16]
3fc:    bfcvt	z12.h, p0/m, z12.s
400:    st1h	{z12.s}, p0, [x16, #1, mul vl]
404:    bfcvt	z11.h, p0/m, z11.s
408:    st1h	{z11.s}, p0, [x16, #2, mul vl]
40c:    add	x16, x16, #0x240
410:    bfcvt	z10.h, p0/m, z10.s
414:    st1h	{z10.s}, p0, [x16]
418:    bfcvt	z9.h, p0/m, z9.s
41c:    st1h	{z9.s}, p0, [x16, #1, mul vl]
420:    bfcvt	z8.h, p0/m, z8.s
424:    st1h	{z8.s}, p0, [x16, #2, mul vl]
428:    bl	0x4a8
42c:    st1w	{z31.s}, p0, [x14]
430:    st1w	{z30.s}, p0, [x14, #1, mul vl]
434:    st1w	{z29.s}, p0, [x14, #2, mul vl]
438:    add	x16, x14, #0x480
43c:    st1w	{z28.s}, p0, [x16]
440:    st1w	{z27.s}, p0, [x16, #1, mul vl]
444:    st1w	{z26.s}, p0, [x16, #2, mul vl]
448:    add	x16, x16, #0x480
44c:    st1w	{z25.s}, p0, [x16]
450:    st1w	{z24.s}, p0, [x16, #1, mul vl]
454:    st1w	{z23.s}, p0, [x16, #2, mul vl]
458:    add	x16, x16, #0x480
45c:    st1w	{z22.s}, p0, [x16]
460:    st1w	{z21.s}, p0, [x16, #1, mul vl]
464:    st1w	{z20.s}, p0, [x16, #2, mul vl]
468:    add	x16, x16, #0x480
46c:    st1w	{z19.s}, p0, [x16]
470:    st1w	{z18.s}, p0, [x16, #1, mul vl]
474:    st1w	{z17.s}, p0, [x16, #2, mul vl]
478:    add	x16, x16, #0x480
47c:    st1w	{z16.s}, p0, [x16]
480:    st1w	{z15.s}, p0, [x16, #1, mul vl]
484:    st1w	{z14.s}, p0, [x16, #2, mul vl]
488:    add	x16, x16, #0x480
48c:    st1w	{z13.s}, p0, [x16]
490:    st1w	{z12.s}, p0, [x16, #1, mul vl]
494:    st1w	{z11.s}, p0, [x16, #2, mul vl]
498:    add	x16, x16, #0x480
49c:    st1w	{z10.s}, p0, [x16]
4a0:    st1w	{z9.s}, p0, [x16, #1, mul vl]
4a4:    st1w	{z8.s}, p0, [x16, #2, mul vl]
4a8:    add	x14, x14, #0x30
4ac:    add	x0, x0, #0x18
4b0:    mov	x23, #0x3000
4b4:    add	x6, x6, x23
4b8:    sub	x8, x8, #0x1
4bc:    cmp	x8, #0x0
4c0:    b.gt	0x88
4c4:    mov	x23, #0x2400
4c8:    add	x15, x15, x23
4cc:    mov	x23, #0x1200
4d0:    add	x11, x11, x23
4d4:    mov	x23, #0x2000
4d8:    add	x2, x2, x23
4dc:    subs	x9, x9, #0x1
4e0:    b.gt	0x78
4e4:    add	sp, sp, #0xc0
4e8:    mov	x9, sp
4ec:    ld4	{v8.d-v11.d}[0], [x9], #32
4f0:    ld4	{v12.d-v15.d}[0], [x9], #32
4f4:    ldp	x16, x17, [x9], #16
4f8:    ldp	x19, x20, [x9], #16
4fc:    ldp	x21, x22, [x9], #16
500:    ldp	x23, x24, [x9], #16
504:    ldp	x25, x26, [x9], #16
508:    ldp	x27, x28, [x9], #16
50c:    add	sp, sp, #0xa0
510:    ldp	x29, x30, [sp], #16
514:    ret
...
```

</details>


All expected unit and benchdnn tests pass locally.