### PR TITLE
cpu: x64: matmul: fix extendable_k with padded src leading dimension

### DIFF
--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -1159,8 +1159,13 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
                 && (n_blk_ >= n_decomposition * 3)
                 && ((size_t)k_blk_ >= (64 / gemm_dt_sz) * 4);
 
+        // extendable_k reads A's K dimension rounded up to the tile
+        // granularity directly from memory, so it is only valid when A is
+        // contiguous along K (leading dimension equal to K). A padded LDA
+        // would make the kernel stride rows by the padded value while reading
+        // the extended K, corrupting the result.
         extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k()
-                && !use_fused_copy_a_;
+                && !use_fused_copy_a_ && get_actual_lda() == K;
 
     } else {
         is_a_nt_ = true;
@@ -1186,7 +1191,10 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
         need_prefetch_a_ = false;
         need_prefetch_b_ = ((n_per_thread / n_blk_) >= 2) && !use_buffer_b;
         use_fused_copy_a_ = false;
-        extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k();
+
+        // extendable_k requires A to be contiguous along K.
+        extendable_k_ = K % wei_k_blk != 0 && !skip_extendable_k()
+                && get_actual_lda() == K;
     }
 
     brgemm_batch_size_ = 1;


### PR DESCRIPTION
Fixes [MFDNN-15354](https://jira.devtools.intel.com/browse/MFDNN-15354)
The macro AMX blocking heuristic enabled extendable_k without checking that A is contiguous along K (LDA == K). extendable_k reads A's K dimension rounded up to the tile granularity directly from memory while striding rows by the leading dimension, so a padded src LDA corrupts the result. Add the LDA == K guard to both macro-path assignments, matching the micro path.
