### PR TITLE
xe: sdpa: enable layout aware logsumexp

### DIFF
--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -752,6 +752,7 @@ size_t get_desc_hash(const sdpa_desc_t &desc) {
     seed = hash_combine(seed, desc.vs_zero_points.get_hash());
     seed = hash_combine(seed, get_md_hash(desc.dS_desc));
     seed = hash_combine(seed, get_md_hash(desc.dst_desc));
+    seed = hash_combine(seed, get_md_hash(desc.stats_desc));
     seed = hash_combine(seed, get_md_hash(desc.diff_dst_desc));
     seed = hash_combine(seed, get_md_hash(desc.diff_q_desc));
     seed = hash_combine(seed, get_md_hash(desc.diff_k_desc));

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -612,6 +612,7 @@ void serialize(serialization_stream_t &sstream, const sdpa_desc_t &desc) {
     desc.vs_zero_points.serialize(sstream);
     serialize(sstream, desc.dS_desc);
     serialize(sstream, desc.dst_desc);
+    serialize(sstream, desc.stats_desc);
     serialize(sstream, desc.diff_dst_desc);
     serialize(sstream, desc.diff_q_desc);
     serialize(sstream, desc.diff_k_desc);

--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -32,16 +32,17 @@ status_t sdpa_primitive_desc_create(
         const memory_desc_t *mask_desc, const memory_desc_t *scale_desc,
         bool invert_scale, dim_t kv_head_number, int attn_mask_type,
         alg_kind_t softmax_alg, prop_kind_t prop, const primitive_attr_t *attr,
-        const primitive_attr_t *kq_attr, const primitive_attr_t *vs_attr) {
+        const primitive_attr_t *kq_attr, const primitive_attr_t *vs_attr,
+        const memory_desc_t *stats_desc) {
     CHECK(sdpa_desc_check(query_desc, key_desc, value_desc, dst_desc, mask_desc,
             engine, attr, kq_attr, vs_attr));
     CHECK(sdpa_attr_check(query_desc, key_desc, value_desc, dst_desc, engine,
             attr, kq_attr, vs_attr));
 
     sdpa_desc_t sdpa_desc = create_sdpa_desc(query_desc, key_desc, value_desc,
-            dst_desc, mask_desc, scale_desc, invert_scale, kv_head_number,
-            static_cast<attn_mask_type_t>(attn_mask_type), softmax_alg, prop,
-            kq_attr, vs_attr);
+            dst_desc, mask_desc, scale_desc, stats_desc, invert_scale,
+            kv_head_number, static_cast<attn_mask_type_t>(attn_mask_type),
+            softmax_alg, prop, kq_attr, vs_attr);
     return primitive_desc_create(primitive_desc_iface, engine,
             (const op_desc_t *)&sdpa_desc, nullptr, attr);
 }
@@ -57,11 +58,11 @@ status_t sdpa_primitive_desc_create(
         const memory_desc_t *diff_dst_desc, const memory_desc_t *dS_desc,
         bool invert_scale, dim_t kv_head_number, int attn_mask_type,
         alg_kind_t softmax_alg, const primitive_attr_t *attr,
-        const primitive_desc_iface_t *hint_fwd_pd = nullptr) {
+        const primitive_desc_iface_t *hint_fwd_pd) {
     CHECK(sdpa_desc_check(query_desc, key_desc, value_desc, dst_desc, mask_desc,
             diff_query_desc, diff_key_desc, diff_value_desc, diff_dst_desc,
             engine, attr));
-    CHECK(sdpa_attr_check(engine, attr, dst_desc, key_desc));
+    CHECK(sdpa_attr_check(dst_desc, key_desc, engine, attr));
 
     sdpa_desc_t sdpa_desc = create_sdpa_desc(query_desc, key_desc, value_desc,
             dst_desc, mask_desc, scale_desc, diff_query_desc, diff_key_desc,

--- a/src/common/sdpa_test_iface.cpp
+++ b/src/common/sdpa_test_iface.cpp
@@ -32,7 +32,8 @@ status_t sdpa_primitive_desc_create(
         const memory_desc_t *mask_desc, const memory_desc_t *scale_desc,
         bool invert_scale, dim_t kv_head_number, int attn_mask_type,
         alg_kind_t softmax_alg, prop_kind_t prop, const primitive_attr_t *attr,
-        const primitive_attr_t *kq_attr, const primitive_attr_t *vs_attr) {
+        const primitive_attr_t *kq_attr, const primitive_attr_t *vs_attr,
+        const memory_desc_t *stats_desc) {
     CHECK(sdpa_desc_check(query_desc, key_desc, value_desc, dst_desc, mask_desc,
             engine, attr, kq_attr, vs_attr));
     CHECK(sdpa_attr_check(query_desc, key_desc, value_desc, dst_desc, engine,
@@ -41,7 +42,7 @@ status_t sdpa_primitive_desc_create(
     sdpa_desc_t sdpa_desc = create_sdpa_desc(query_desc, key_desc, value_desc,
             dst_desc, mask_desc, scale_desc, invert_scale, kv_head_number,
             static_cast<attn_mask_type_t>(attn_mask_type), softmax_alg, prop,
-            kq_attr, vs_attr);
+            kq_attr, vs_attr, stats_desc);
     return primitive_desc_create(primitive_desc_iface, engine,
             (const op_desc_t *)&sdpa_desc, nullptr, attr);
 }

--- a/src/common/sdpa_test_iface.hpp
+++ b/src/common/sdpa_test_iface.hpp
@@ -27,18 +27,19 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
         dnnl_alg_kind_t softmax_alg, dnnl_prop_kind_t prop,
         const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
-        const_dnnl_primitive_attr_t vs_attr);
+        const_dnnl_primitive_attr_t vs_attr,
+        const_dnnl_memory_desc_t stats_desc = nullptr);
 
 dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         dnnl_primitive_desc_t *primitive_desc_iface, dnnl_engine_t engine,
         const_dnnl_memory_desc_t query_desc, const_dnnl_memory_desc_t key_desc,
         const_dnnl_memory_desc_t value_desc, const_dnnl_memory_desc_t dst_desc,
+        const_dnnl_memory_desc_t mask_desc, const_dnnl_memory_desc_t scale_desc,
         const_dnnl_memory_desc_t diff_query_desc,
         const_dnnl_memory_desc_t diff_key_desc,
         const_dnnl_memory_desc_t diff_value_desc,
         const_dnnl_memory_desc_t diff_dst_desc,
-        const_dnnl_memory_desc_t dS_desc, const_dnnl_memory_desc_t mask_desc,
-        const_dnnl_memory_desc_t scale_desc, bool invert_scale,
+        const_dnnl_memory_desc_t dS_desc, bool invert_scale,
         dnnl_dim_t kv_head_number, int attn_mask_type,
         dnnl_alg_kind_t softmax_alg, const_dnnl_primitive_attr_t attr,
         const dnnl_primitive_desc *hint_fwd_pd);

--- a/src/common/sdpa_test_iface.hpp
+++ b/src/common/sdpa_test_iface.hpp
@@ -27,7 +27,8 @@ dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         bool invert_scale, dnnl_dim_t kv_head_number, int attn_mask_type,
         dnnl_alg_kind_t softmax_alg, dnnl_prop_kind_t prop,
         const_dnnl_primitive_attr_t attr, const_dnnl_primitive_attr_t kq_attr,
-        const_dnnl_primitive_attr_t vs_attr);
+        const_dnnl_primitive_attr_t vs_attr,
+        const_dnnl_memory_desc_t stats_desc = nullptr);
 
 dnnl_status_t DNNL_API sdpa_primitive_desc_create(
         dnnl_primitive_desc_t *primitive_desc_iface, dnnl_engine_t engine,

--- a/src/common/sdpa_types.hpp
+++ b/src/common/sdpa_types.hpp
@@ -87,6 +87,7 @@ struct sdpa_desc_t : public op_desc_t {
     memory_desc_t dS_desc;
 
     memory_desc_t dst_desc;
+    memory_desc_t stats_desc;
     memory_desc_t diff_dst_desc;
     memory_desc_t diff_q_desc;
     memory_desc_t diff_k_desc;
@@ -120,6 +121,7 @@ struct sdpa_desc_t : public op_desc_t {
     const memory_desc_t *qry_md() const { return &q_desc; }
     const memory_desc_t *key_md() const { return &k_desc; }
     const memory_desc_t *val_md() const { return &v_desc; }
+    const memory_desc_t *stats_md() const { return &stats_desc; }
     const memory_desc_t *attn_mask_md() const { return &attn_mask_desc; }
     const memory_desc_t *scale_md() const { return &scale_desc; }
     const memory_desc_t *diff_qry_md() const { return &diff_q_desc; }

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -239,9 +239,9 @@ static inline status_t sdpa_attr_check(const memory_desc_t *q_desc,
     return status::success;
 }
 
-static inline status_t sdpa_attr_check(const engine_t *engine,
-        const primitive_attr_t *attr, const memory_desc_t *dst_desc,
-        const memory_desc_t *k_desc) {
+static inline status_t sdpa_attr_check(const memory_desc_t *dst_desc,
+        const memory_desc_t *k_desc, const engine_t *engine,
+        const primitive_attr_t *attr) {
     using smask_t = primitive_attr_t::skip_mask_t;
 
     if (attr == nullptr) return status::success;
@@ -263,7 +263,8 @@ static inline status_t sdpa_attr_check(const engine_t *engine,
 static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
         const memory_desc_t *k_md, const memory_desc_t *v_md,
         const memory_desc_t *dst_md, const memory_desc_t *attn_mask_md,
-        const memory_desc_t *scale_md, bool invert_scale, dim_t kv_head_number,
+        const memory_desc_t *scale_md, const memory_desc_t *stats_md,
+        bool invert_scale, dim_t kv_head_number,
         attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
         prop_kind_t prop, const primitive_attr_t *kq_attr,
         const primitive_attr_t *vs_attr) {
@@ -291,6 +292,7 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     sdpa_desc.dst_desc = *dst_md;
     if (attn_mask_md) sdpa_desc.attn_mask_desc = *attn_mask_md;
     sdpa_desc.scale_desc = *scale_md;
+    if (stats_md) sdpa_desc.stats_desc = *stats_md;
     sdpa_desc.invert_scale = invert_scale;
     sdpa_desc.kv_head_number = kv_head_number;
     sdpa_desc.mask_type = attn_mask_type;
@@ -348,8 +350,8 @@ static inline status_t create_sdpa_pd(
             kq_attr, vs_attr));
 
     auto sdpa_desc = create_sdpa_desc(q_md, k_md, v_md, dst_md, attn_mask_md,
-            scale_md, invert_scale, kv_head_number, attn_mask_type, softmax_alg,
-            prop, kq_attr, vs_attr);
+            scale_md, /* stats_md = */ nullptr, invert_scale, kv_head_number,
+            attn_mask_type, softmax_alg, prop, kq_attr, vs_attr);
 
     primitive_attr_t sdpa_attr = attr ? *attr : default_attr();
 
@@ -366,10 +368,10 @@ static inline status_t create_sdpa_pd(
         std::shared_ptr<primitive_desc_t> &sdpa_pd_, engine_t *engine,
         const memory_desc_t *q_md, const memory_desc_t *k_md,
         const memory_desc_t *v_md, const memory_desc_t *dst_md,
+        const memory_desc_t *attn_mask_md, const memory_desc_t *scale_md,
         const memory_desc_t *diff_q_md, const memory_desc_t *diff_k_md,
         const memory_desc_t *diff_v_md, const memory_desc_t *diff_dst_md,
-        const memory_desc_t *dS_md, const memory_desc_t *attn_mask_md,
-        const memory_desc_t *scale_md, bool invert_scale, dim_t kv_head_number,
+        const memory_desc_t *dS_md, bool invert_scale, dim_t kv_head_number,
         attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
         const primitive_attr_t *attr, const primitive_desc_t *hint_fwd_pd,
         const primitive_attr_t *kq_attr = nullptr,

--- a/src/common/sdpa_utils.hpp
+++ b/src/common/sdpa_utils.hpp
@@ -266,7 +266,8 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
         const memory_desc_t *scale_md, bool invert_scale, dim_t kv_head_number,
         attn_mask_type_t attn_mask_type, alg_kind_t softmax_alg,
         prop_kind_t prop, const primitive_attr_t *kq_attr,
-        const primitive_attr_t *vs_attr) {
+        const primitive_attr_t *vs_attr,
+        const memory_desc_t *stats_md = nullptr) {
     auto sdpa_desc = sdpa_desc_t();
     sdpa_desc.primitive_kind = primitive_kind::sdpa;
     sdpa_desc.q_desc = *q_md;
@@ -289,6 +290,7 @@ static inline sdpa_desc_t create_sdpa_desc(const memory_desc_t *q_md,
     }
     sdpa_desc.v_desc = *v_md;
     sdpa_desc.dst_desc = *dst_md;
+    if (stats_md) sdpa_desc.stats_desc = *stats_md;
     if (attn_mask_md) sdpa_desc.attn_mask_desc = *attn_mask_md;
     sdpa_desc.scale_desc = *scale_md;
     sdpa_desc.invert_scale = invert_scale;

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -1033,6 +1033,7 @@ inline bool operator==(const sdpa_desc_t &lhs, const sdpa_desc_t &rhs) {
             && COMPARE_DESC_MEMBERS(vs_zero_points)
             && COMPARE_DESC_MEMBERS(dS_desc)
             && COMPARE_DESC_MEMBERS(dst_desc)
+            && COMPARE_DESC_MEMBERS(stats_desc)
             && COMPARE_DESC_MEMBERS(diff_dst_desc)
             && COMPARE_DESC_MEMBERS(diff_q_desc)
             && COMPARE_DESC_MEMBERS(diff_k_desc)

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -733,7 +733,11 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(impl::engine_t *engine) {
     problem_ktq.B.layout = MatrixLayout::Pr;
     problem_ktq.C.layout = MatrixLayout::N;
 
-    problem_ktq.A.setAlignment(micro::alignmentForLD(int(ldk)));
+    constexpr int ktq_nondense_align = 2;
+    problem_ktq.A.setAlignment(key_mdw.is_dense()
+                    ? micro::alignmentForLD(int(ldk))
+                    : std::min(ktq_nondense_align,
+                              micro::alignmentForLD(int(ldk))));
     problem_ktq.B.setAlignment(64); // S is packed in SLM
     if (use_systolic_ukernel()) { problem_ktq.B.crosspack = 16; }
 

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -345,6 +345,28 @@ struct micro_fwd_t : public primitive_t {
                     "fused SDPA FWD with device dropout not supported "
                     "for xe_hpg");
 
+            if (desc()->prop_kind == prop_kind::forward_training) {
+                const memory_desc_wrapper stats_mdw(desc()->stats_md());
+                if (!stats_mdw.is_zero()) {
+                    bool dense = stats_mdw.is_plain();
+                    if (dense) {
+                        const auto &strides = stats_mdw.strides();
+                        const auto *sdims = stats_mdw.dims();
+                        dim_t expected = 1;
+                        for (int i = stats_mdw.ndims() - 1; i >= 0; --i) {
+                            if (strides[i] != expected) {
+                                dense = false;
+                                break;
+                            }
+                            expected *= (sdims[i] > 0 ? sdims[i] : 1);
+                        }
+                    }
+                    VDISPATCH_SDPA(dense,
+                            "fused sdpa training requires densely packed "
+                            "softmax stats");
+                }
+            }
+
             CHECK(init_conf_microkernels(engine));
             CHECK(init_conf(engine));
 

--- a/src/graph/backend/dnnl/executables/sdpa.cpp
+++ b/src/graph/backend/dnnl/executables/sdpa.cpp
@@ -91,12 +91,16 @@ sdpa_executable_t::sdpa_executable_t(std::shared_ptr<op_t> &op,
     const auto prop
             = is_training_ ? dnnl_forward_training : dnnl_forward_inference;
 
+    dnnl::memory::desc md_stats;
+    if (is_training_)
+        md_stats = make_dnnl_memory_desc(op->get_output_logical_tensor(2));
+
     dnnl_primitive_desc_t pd = nullptr;
     auto ret = sdpa_primitive_desc_create(&pd, p_engine.get(), md_q.get(),
             md_k.get(), md_v.get(), md_dst.get(), md_mask.get(), md_scale.get(),
             is_invert_scale_, kv_head_number, mask_type_,
             static_cast<dnnl_alg_kind_t>(softmax_alg), prop, attr.get(),
-            qk_attr.get(), vs_attr.get());
+            qk_attr.get(), vs_attr.get(), md_stats.get());
 
     if (pd && ret == dnnl_success) {
         pd_.reset(pd);

--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -1818,39 +1818,28 @@ status_t layout_propagator_for_sdpa(std::shared_ptr<op_t> &op,
     if (op->get_attr<bool>(op_attr::is_training)) {
         value_ptr stats_val = op->get_output_value(output_idx);
         const logical_tensor_t &stats_lt = stats_val->get_logical_tensor();
-        dnnl::memory::desc stats_md;
-        // For GQA, we need to check the layout of the dnnl_reshape output
-        // following dnnl_sdpa, which is given by the user.
+        const auto stats_dims = ltw(stats_lt).vdims();
+        const auto dense_strides = get_dense_strides(stats_dims);
+        auto stats_strides = dense_strides;
         if (!stats_val->get_consumers().empty()) {
             const auto &consumer_op = stats_val->get_consumers()[0].get_op();
             const logical_tensor_t &consumer_out
                     = consumer_op.get_output_logical_tensor(0);
             if (consumer_op.get_kind() == op_kind::_reshape
                     && ltw(consumer_out).ndims() == 5
-                    && ltw(consumer_out).is_strided()) {
+                    && ltw(consumer_out).is_strided()
+                    && stats_dims.size() == 4) {
                 const auto &ori_strides = ltw(consumer_out).vstrides();
-                std::vector<dim_t> strides = {ori_strides[0], ori_strides[2],
-                        ori_strides[3], ori_strides[4]};
-                stats_md = {ltw(stats_lt).vdims(),
-                        static_cast<dnnl::memory::data_type>(
-                                ltw(stats_lt).data_type()),
-                        strides};
-            } else {
-                // Set default output layout format for sdpa as acbd if user
-                // doesn't specify the layout since no reorder will be required.
-                stats_md = {ltw(stats_lt).vdims(),
-                        static_cast<dnnl::memory::data_type>(
-                                ltw(out_lt).data_type()),
-                        dnnl::memory::format_tag::acbd};
+                stats_strides = {ori_strides[0], ori_strides[2], ori_strides[3],
+                        ori_strides[4]};
             }
-        } else {
-            expected_md = {ltw(out_lt).vdims(),
-                    static_cast<dnnl::memory::data_type>(
-                            ltw(out_lt).data_type()),
-                    dnnl::memory::format_tag::acbd};
         }
-
+        const dnnl::memory::desc stats_md {stats_dims,
+                static_cast<dnnl::memory::data_type>(ltw(stats_lt).data_type()),
+                stats_strides};
         status = fill_layout_info(stats_val, stats_md);
+        VCHECK_LAYOUT_PROPAGATOR(status == status::success, status,
+                "sdpa: failed to fill layout info for the softmax stats");
     }
     return status;
 }
@@ -1960,9 +1949,9 @@ status_t layout_propagator_for_sdpa_bwd(std::shared_ptr<op_t> &op,
 
         std::shared_ptr<primitive_desc_t> sdpa_bwd_pd;
         status = create_sdpa_pd(sdpa_bwd_pd, p_engine.get(), md_q.get(),
-                md_k.get(), md_v.get(), md_dst.get(), md_diff_q.get(),
-                md_diff_k.get(), md_diff_v.get(), md_diff_dst.get(),
-                md_dS.get(), md_attn_mask.get(), md_scale.get(),
+                md_k.get(), md_v.get(), md_dst.get(), md_attn_mask.get(),
+                md_scale.get(), md_diff_q.get(), md_diff_k.get(),
+                md_diff_v.get(), md_diff_dst.get(), md_dS.get(),
                 is_invert_scale, kv_head_number, mask_type, softmax_alg,
                 attr.get(), hint_fwd_pd.get(), qk_attr.get(), vs_attr.get());
         VCHECK_LAYOUT_PROPAGATOR(status == status::success, status,

--- a/src/graph/backend/dnnl/layout_propagator.cpp
+++ b/src/graph/backend/dnnl/layout_propagator.cpp
@@ -1818,39 +1818,28 @@ status_t layout_propagator_for_sdpa(std::shared_ptr<op_t> &op,
     if (op->get_attr<bool>(op_attr::is_training)) {
         value_ptr stats_val = op->get_output_value(output_idx);
         const logical_tensor_t &stats_lt = stats_val->get_logical_tensor();
-        dnnl::memory::desc stats_md;
-        // For GQA, we need to check the layout of the dnnl_reshape output
-        // following dnnl_sdpa, which is given by the user.
+        const auto stats_dims = ltw(stats_lt).vdims();
+        const auto dense_strides = get_dense_strides(stats_dims);
+        auto stats_strides = dense_strides;
         if (!stats_val->get_consumers().empty()) {
             const auto &consumer_op = stats_val->get_consumers()[0].get_op();
             const logical_tensor_t &consumer_out
                     = consumer_op.get_output_logical_tensor(0);
             if (consumer_op.get_kind() == op_kind::_reshape
                     && ltw(consumer_out).ndims() == 5
-                    && ltw(consumer_out).is_strided()) {
+                    && ltw(consumer_out).is_strided()
+                    && stats_dims.size() == 4) {
                 const auto &ori_strides = ltw(consumer_out).vstrides();
-                std::vector<dim_t> strides = {ori_strides[0], ori_strides[2],
-                        ori_strides[3], ori_strides[4]};
-                stats_md = {ltw(stats_lt).vdims(),
-                        static_cast<dnnl::memory::data_type>(
-                                ltw(stats_lt).data_type()),
-                        strides};
-            } else {
-                // Set default output layout format for sdpa as acbd if user
-                // doesn't specify the layout since no reorder will be required.
-                stats_md = {ltw(stats_lt).vdims(),
-                        static_cast<dnnl::memory::data_type>(
-                                ltw(out_lt).data_type()),
-                        dnnl::memory::format_tag::acbd};
+                stats_strides = {ori_strides[0], ori_strides[2], ori_strides[3],
+                        ori_strides[4]};
             }
-        } else {
-            expected_md = {ltw(out_lt).vdims(),
-                    static_cast<dnnl::memory::data_type>(
-                            ltw(out_lt).data_type()),
-                    dnnl::memory::format_tag::acbd};
         }
-
+        const dnnl::memory::desc stats_md {stats_dims,
+                static_cast<dnnl::memory::data_type>(ltw(stats_lt).data_type()),
+                stats_strides};
         status = fill_layout_info(stats_val, stats_md);
+        VCHECK_LAYOUT_PROPAGATOR(status == status::success, status,
+                "sdpa: failed to fill layout info for the softmax stats");
     }
     return status;
 }

--- a/tests/benchdnn/sdpa/sdpa.cpp
+++ b/tests/benchdnn/sdpa/sdpa.cpp
@@ -120,8 +120,6 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
         auto diff_dst_d
                 = create_md(prb->ndims, prb->dst_dims, dst_dt, prb->dtag);
 
-        // Follow the implementation parameter order (mask/scale before
-        // diff descs) which differs from the .hpp declaration.
         TIME_C_PD(DNN_SAFE_STATUS(sdpa_primitive_desc_create(&init_pd_args.pd,
                 init_pd_args.engine, q_d, k_d, v_d, dst_d, mask_ptr, scale_d,
                 diff_q_d, diff_k_d, diff_v_d, diff_dst_d,


### PR DESCRIPTION
# Description

This PR enables layout aware stats. The stats tensor is shared between fwd and bwd fused SDPA kernels and previously assumed a dense layout matching the DST tensor. Although the batching calculation works for abcd layouts, it would result in permuted outputs for externally requested acbd layouts.  
The batching calculation has been updated to be directly derived from DST strides. The graph portion now forwards the exact matching strides(for GQA as well) while fixing a mismatching data type in the else condition since stats is strictly f32.

Fixes MFDNN-14991.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?