### PR TITLE
[GPU] Properly handle atomic load cache policy

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/matrix_access.cxx
@@ -31,7 +31,7 @@ enum class AccessClass {Read, Write, Atomic};
 static DataSizeLSC getDataSizeLSC(int ebytes, bool pad32);
 static DataSpecLSC getDataSpecLSC(AccessType access, const RegisterBlock &block);
 static DataSpecLSC getDataSpecLSC(const MatrixAddressing &atype, const MatrixAddressingStrategy &astrategy,
-                                  const RegisterBlock &block, AccessClass aclass);
+                                  const RegisterBlock &block, AccessClass aclass, bool atomic = false);
 static inline GRFDisp getAddress(GRF r, const RegisterBlock &block, const MatrixAddressingStrategy &astrategy);
 
 // Output code for prefetching a matrix chunk (XeHPG+).
@@ -103,10 +103,9 @@ void Generator<hw>::loadMatrixBlock(const Register &dest, const RegisterBlock &b
         case AccessType::Block:
         case AccessType::Scattered:
         case AccessType::ChannelScattered: {
-            auto spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Read);
+            auto spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Read, astrategy.atomic);
             if(hw >= HW::Xe3p) spec |= Overfetch;
             if (astrategy.atomic && hw >= HW::Xe2) {
-                spec = getDataSpecLSC(atype, astrategy, block, AccessClass::Atomic);
                 atomic(AtomicOp::load, mod, dest, spec, astrategy.base, getAddress(addr, block, astrategy));
             } else if (block.descAssigned) {
                 MessageDescriptor desc;
@@ -721,10 +720,10 @@ static DataSpecLSC getDataSpecLSC(AccessType access, const RegisterBlock &block)
 }
 
 static DataSpecLSC getDataSpecLSC(const MatrixAddressing &atype, const MatrixAddressingStrategy &astrategy,
-                                  const RegisterBlock &block, AccessClass aclass)
+                                  const RegisterBlock &block, AccessClass aclass, bool atomic)
 {
     auto caching = (aclass == AccessClass::Read) ? astrategy.cachingR : astrategy.cachingW;
-    if (aclass == AccessClass::Atomic)
+    if (aclass == AccessClass::Atomic || atomic)
         caching = makeL1Uncacheable(caching);
     return getDataSpecLSC(block.implAccessType(atype, astrategy), block) | caching;
 }


### PR DESCRIPTION
# Description

Refactor fix in #4784  so that unsupported atomic reads are masked out of cache setting, but the proper Read mode setting is applied to the extent it is supported. 

This was a source of performance degradation when testing [MFDNN-15182](https://jira.devtools.intel.com/browse/MFDNN-15182), although I'm not able to reproduce the perf improvement in isolation testing vs main [PERF](https://ecmd.jf.intel.com/commander/link/jobDetails/jobs/f1823cec-2b86-f157-9397-d4f5ef20c6a0) it is likely dependent on other upstream GEMMstone changes pending downstream.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?
