### PR TITLE
x64: lrn + prelu: fix implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/lrn/jit_uni_lrn.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn.cpp
@@ -37,7 +37,7 @@ static dnnl_dim_t compute_n_summands(
         dnnl_dim_t size, int ndims, const dnnl_alg_kind_t &alg_kind) {
     return alg_kind == alg_kind::lrn_across_channels
             ? size
-            : std::pow(size, ndims - 2);
+            : static_cast<dnnl_dim_t>(std::pow(size, ndims - 2));
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
@@ -54,11 +54,11 @@ template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_lrn_fwd_t<isa, d_type>::init(engine_t *engine) {
     using namespace alg_kind;
 
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
+    const int C = static_cast<int>(pd()->C());
+    const int H = static_cast<int>(pd()->H());
+    const int W = static_cast<int>(pd()->W());
     const int ndims = memory_desc_wrapper(pd()->src_md()).ndims();
-    const int ls = pd()->desc()->local_size;
+    const int ls = static_cast<int>(pd()->desc()->local_size);
     const float K = pd()->desc()->lrn_k;
     const auto pk = pd()->desc()->prop_kind;
     const auto ak = pd()->desc()->alg_kind;
@@ -109,10 +109,10 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::execute_forward(
     auto ws = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_WORKSPACE, status);
     CHECK(status);
 
-    const int N = pd()->MB();
-    const int C = pd()->C();
-    const int HW = pd()->H() * pd()->W();
-    const int ls = pd()->desc()->local_size;
+    const dim_t N = pd()->MB();
+    const dim_t C = pd()->C();
+    const dim_t HW = pd()->H() * pd()->W();
+    const dim_t ls = pd()->desc()->local_size;
 
     const auto ak = pd()->desc()->alg_kind;
     const auto dat_tag = pd()->dat_tag_;
@@ -196,7 +196,7 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     dat_tag_ = memory_desc_matches_one_of_tag(
             *src_md(), nChw16c, nChw8c, nchw, nhwc);
 
-    const int HW = src_d.dims()[2] * src_d.dims()[3];
+    const dim_t HW = src_d.dims()[2] * src_d.dims()[3];
 
     const bool args_ok_across = true && desc()->alg_kind == lrn_across_channels
             && desc()->local_size == 5 && one_of(dat_tag_, nChw8c, nchw, nhwc)
@@ -245,10 +245,10 @@ jit_uni_lrn_bwd_t<isa, d_type>::~jit_uni_lrn_bwd_t() = default;
 template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_lrn_bwd_t<isa, d_type>::init(engine_t *engine) {
     using namespace alg_kind;
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
-    const int &ls = pd()->desc()->local_size;
+    const int C = static_cast<int>(pd()->C());
+    const int H = static_cast<int>(pd()->H());
+    const int W = static_cast<int>(pd()->W());
+    const int ls = static_cast<int>(pd()->desc()->local_size);
     const auto &ak = pd()->desc()->alg_kind;
     const int ndims = memory_desc_wrapper(pd()->src_md()).ndims();
     const float A = pd()->desc()->lrn_alpha / compute_n_summands(ls, ndims, ak);
@@ -290,10 +290,10 @@ status_t jit_uni_lrn_bwd_t<isa, d_type>::execute_backward(
     auto diff_src = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_DIFF_SRC, status);
     CHECK(status);
 
-    const int N = pd()->MB();
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
+    const dim_t N = pd()->MB();
+    const dim_t C = pd()->C();
+    const dim_t H = pd()->H();
+    const dim_t W = pd()->W();
     const auto ak = pd()->desc()->alg_kind;
     const auto &dat_tag = pd()->dat_tag_;
 

--- a/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
@@ -36,11 +36,11 @@ public:
         , ker_last_(nullptr)
         , N_(pd->MB())
         , C_(pd->C())
-        , H_(pd->H())
-        , W_(pd->W())
+        , H_(static_cast<int>(pd->H()))
+        , W_(static_cast<int>(pd->W()))
         , use_h_parallelism_(H_ > 28 ? 1 : 0) {
 
-        const int local_size = pd->desc()->local_size;
+        const int local_size = static_cast<int>(pd->desc()->local_size);
         const float alpha = pd->desc()->lrn_alpha / local_size;
         const float beta = pd->desc()->lrn_beta;
         const auto pk = pd->desc()->prop_kind;
@@ -90,13 +90,13 @@ public:
 
         parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
             size_t start {0}, end {0};
-            const int C16 = C_ / vsize_;
+            const dim_t C16 = C_ / vsize_;
             const size_t work_amount
                     = use_h_parallelism_ ? N_ * C16 * H_ : N_ * C16;
 
             balance211(work_amount, nthr, ithr, start, end);
             if (use_h_parallelism_) {
-                int n {0}, c16 {0}, h {0};
+                dim_t n {0}, c16 {0}, h {0};
                 nd_iterator_init(start, n, N_, c16, C16, h, H_);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset = n * C_ * H_ * W_
@@ -123,7 +123,7 @@ public:
                     nd_iterator_step(n, N_, c16, C16, h, H_);
                 }
             } else {
-                int n {0}, c16 {0};
+                dim_t n {0}, c16 {0};
                 nd_iterator_init(start, n, N_, c16, C16);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset
@@ -160,8 +160,8 @@ private:
     std::unique_ptr<lrn::jit_avx512_common_lrn_kernel_fwd_blocked_t<d_type>>
             ker_, ker_first_, ker_last_;
     static constexpr int vsize_ = 16;
-    const int N_;
-    const int C_;
+    const dim_t N_;
+    const dim_t C_;
     const int H_;
     const int W_;
     const int use_h_parallelism_;
@@ -176,11 +176,11 @@ public:
         , ker_last_(nullptr)
         , N_(pd->MB())
         , C_(pd->C())
-        , H_(pd->H())
-        , W_(pd->W())
+        , H_(static_cast<int>(pd->H()))
+        , W_(static_cast<int>(pd->W()))
         , use_h_parallelism_(H_ > 28 ? 1 : 0) {
 
-        const int local_size = pd->desc()->local_size;
+        const int local_size = static_cast<int>(pd->desc()->local_size);
         const float alpha = pd->desc()->lrn_alpha / local_size;
         const float beta = pd->desc()->lrn_beta;
 
@@ -229,13 +229,13 @@ public:
 
         parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
             size_t start {0}, end {0};
-            const int C16 = C_ / vsize_;
+            const dim_t C16 = C_ / vsize_;
             const size_t work_amount
                     = use_h_parallelism_ ? N_ * C16 * H_ : N_ * C16;
 
             balance211(work_amount, nthr, ithr, start, end);
             if (use_h_parallelism_) {
-                int n {0}, c16 {0}, h {0};
+                dim_t n {0}, c16 {0}, h {0};
                 nd_iterator_init(start, n, N_, h, H_, c16, C16);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset = n * C_ * H_ * W_
@@ -263,7 +263,7 @@ public:
                     nd_iterator_step(n, N_, h, H_, c16, C16);
                 }
             } else {
-                int n {0}, c16 {0};
+                dim_t n {0}, c16 {0};
                 nd_iterator_init(start, n, N_, c16, C16);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset
@@ -301,8 +301,8 @@ private:
     std::unique_ptr<lrn::jit_avx512_common_lrn_kernel_bwd_blocked_t<d_type>>
             ker_, ker_first_, ker_last_;
     static constexpr int vsize_ = 16;
-    const int N_;
-    const int C_;
+    const dim_t N_;
+    const dim_t C_;
     const int H_;
     const int W_;
     const int use_h_parallelism_;

--- a/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
@@ -32,11 +32,11 @@ class lrn_avx512_nhwc_executor_fwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_fwd_t(const PD_T *pd)
         : ker_(utils::make_unique<
-                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(pd->C(),
-                  pd->desc()->prop_kind,
+                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(
+                  static_cast<unsigned>(pd->C()), pd->desc()->prop_kind,
                   pd->desc()->lrn_alpha / pd->desc()->local_size,
                   pd->desc()->lrn_beta, pd->desc()->lrn_k,
-                  pd->desc()->local_size))
+                  static_cast<int>(pd->desc()->local_size)))
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())
@@ -88,9 +88,11 @@ class lrn_avx512_nhwc_executor_bwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_bwd_t(const PD_T *pd)
         : ker_ {utils::make_unique<
-                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(pd->C(),
+                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(
+                  static_cast<unsigned>(pd->C()),
                   pd->desc()->lrn_alpha / pd->desc()->local_size,
-                  pd->desc()->lrn_beta, pd->desc()->local_size)}
+                  pd->desc()->lrn_beta,
+                  static_cast<int>(pd->desc()->local_size))}
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())

--- a/src/cpu/x64/prelu/jit_prelu_backward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_backward.cpp
@@ -217,7 +217,7 @@ status_t jit_prelu_bwd_t::execute(const exec_ctx_t &ctx) const {
                 weights_diff_scratchpad, C_cache_line_aligned, nthr);
 
         if (bcast == prelu::bcast::per_oc_blocked) {
-            const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+            const dim_t C_blocks = utils::div_up(C, simd_w);
             work_amount = MB * C_blocks;
             parallel_nd_ext(nthr, MB, C_blocks,
                     [=](int ithr, int, dim_t mb, dim_t c_blk) {
@@ -283,7 +283,7 @@ void jit_prelu_bwd_t::scratchpad_to_diff_weights_reduction(float *scratchpad,
     const auto reduction_kernel = reduction_kernel_.get();
     const auto &simd_w = reduction_kernel_->simd_w();
     const bool tail_exists = C % simd_w;
-    const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+    const dim_t C_blocks = utils::div_up(C, simd_w);
 
     parallel_nd(C_blocks, [=](dim_t c_blk) {
         const auto blk_offset = c_blk * simd_w;

--- a/src/cpu/x64/prelu/jit_prelu_forward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_forward.cpp
@@ -181,7 +181,7 @@ status_t jit_prelu_fwd_t::execute(const exec_ctx_t &ctx) const {
             });
         } else if (bcast == prelu::bcast::per_oc_blocked) {
             const auto simd_w = kernel->simd_w();
-            const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+            const dim_t C_blocks = utils::div_up(C, simd_w);
 
             parallel_nd(MB, C_blocks, [=](dim_t mb, dim_t c_blk) {
                 jit_prelu_forward_kernel_t::call_params_t params;


### PR DESCRIPTION
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
The area of this PR is LRN & PRELU only.

The discussion for reference: https://github.com/uxlfoundation/oneDNN/pull/5486
