### PR TITLE
x64: matmul: eliminate implicit narrowing conversions 

### DIFF
--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -168,7 +168,7 @@ template <typename src_dt>
 void pp_src_and_weights_zero_points(std::vector<int32_t> &src_comp,
         std::vector<int32_t> &wei_comp, dim_t M, dim_t N, dim_t K,
         const src_dt *src, dim_t src_s0, dim_t src_s1, const int8_t *wei,
-        dim_t wei_s0, dim_t wei_s1, int32_t *acc, int ldc,
+        dim_t wei_s0, dim_t wei_s1, int32_t *acc, dim_t ldc,
         int32_t src_zero_point, int32_t wei_zero_point) {
     if (wei_zero_point) {
         for_(dim_t m = 0; m < M; ++m)

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -44,9 +44,9 @@ void ref_matmul_t::pd_t::init_scratchpad() {
     if (dst_scales.is_dynamic()) {
         auto scratchpad = scratchpad_registry().registrar();
         const memory_desc_wrapper dst_d(dst_md());
-        dim_t group_size = dst_scales.get_group_size();
-        dim_t work_amount = dst_d.nelems() / group_size;
-        ntasks_ = std::min<dim_t>(nthr_, work_amount);
+        const dim_t group_size = dst_scales.get_group_size();
+        const dim_t work_amount = dst_d.nelems() / group_size;
+        ntasks_ = static_cast<int>(nstl::min<dim_t>(nthr_, work_amount));
         scratchpad.template book<float>(
                 key_matmul_dst_in_acc_dt, ntasks_ * group_size);
     }
@@ -320,8 +320,15 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                         d /= dst_scale;
                     }
                     if (dst_rnd_mode == rounding_mode::stochastic)
-                        d = math::stochastic_round_fwd(d, dst_off,
-                                dropout_seed_val, dst_d.data_type());
+                        // NOTE: dst_off is truncated to 32 bits here. For
+                        // tensors with > 2^32 elements, different offsets
+                        // may alias to the same random seed --
+                        // stochastic_round_fwd does not support a 64-bit
+                        // index space.
+                        d = math::stochastic_round_fwd(d,
+                                static_cast<uint32_t>(dst_off),
+                                static_cast<uint32_t>(dropout_seed_val),
+                                dst_d.data_type());
                     io::store_float_value(dst_d.data_type(), d, dst, dst_off);
                     utils::dim_iterator(
                             dst_d.dims(), dst_dims_idx, batch_ndims);
@@ -385,8 +392,15 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                     d *= dst_group_scale;
 
                     if (dst_rnd_mode == rounding_mode::stochastic)
-                        d = math::stochastic_round_fwd(d, dst_off,
-                                dropout_seed_val, dst_d.data_type());
+                        // NOTE: dst_off is truncated to 32 bits here. For
+                        // tensors with > 2^32 elements, different offsets
+                        // may alias to the same random seed --
+                        // stochastic_round_fwd does not support a 64-bit
+                        // index space.
+                        d = math::stochastic_round_fwd(d,
+                                static_cast<uint32_t>(dst_off),
+                                static_cast<uint32_t>(dropout_seed_val),
+                                dst_d.data_type());
                     io::store_float_value(dst_d.data_type(), d, dst, dst_off);
                     utils::dim_iterator(
                             dst_d.dims(), dst_dims_idx, batch_ndims);

--- a/src/cpu/matmul/ref_sparse_matmul.cpp
+++ b/src/cpu/matmul/ref_sparse_matmul.cpp
@@ -144,12 +144,12 @@ status_t ref_sparse_matmul_t::execute(const exec_ctx_t &ctx) const {
 }
 
 void ref_sparse_matmul_t::cvt_coo_indices_to_csr_pointers(
-        const int32_t *indices, int32_t *pointers, const int nnz,
-        const int nrows) const {
+        const int32_t *indices, int32_t *pointers, const dim_t nnz,
+        const dim_t nrows) const {
     parallel_nd(
             nnz, [=](dim_t i) { fetch_and_add(&pointers[indices[i] + 1], 1); });
     parallel(1, [=](int, int) {
-        for (int i = 0; i < nrows; ++i) {
+        for (dim_t i = 0; i < nrows; ++i) {
             pointers[i + 1] += pointers[i];
         }
     });

--- a/src/cpu/matmul/ref_sparse_matmul.hpp
+++ b/src/cpu/matmul/ref_sparse_matmul.hpp
@@ -141,7 +141,7 @@ struct ref_sparse_matmul_t : public primitive_t {
     // COO sparse encodings are converted to CSR format by
     // compressing the respective row indices into CSR pointers.
     void cvt_coo_indices_to_csr_pointers(const int32_t *indices,
-            int32_t *pointers, const int nnz, const int nrows) const;
+            int32_t *pointers, const dim_t nnz, const dim_t nrows) const;
 
     // Executes the matrix mutiplication, C = A x B where one of the input
     // matrices is dense. Operation indices are determined depending on

--- a/src/cpu/x64/jit_avx512_sparse_decompress_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_sparse_decompress_kernel.hpp
@@ -57,7 +57,8 @@ struct jit_avx512_sparse_decompress_kernel_t : public jit_generator_t {
         }
 
         blk_sz_ = a_outter_blk_sz_ * b_blk_sz_ * a_inner_blk_sz_;
-        nblks_to_decompress_ = bgmmc.K_blk * b_blk_sz_ / blk_sz_;
+        nblks_to_decompress_
+                = static_cast<int>(bgmmc.K_blk * b_blk_sz_ / blk_sz_);
     }
 
     void tile_configure(const char *palette) const { (*this)(palette); }

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -133,7 +133,7 @@ bool matmul_amx_blocking_params_macro_t::divs_are_acceptable() const {
                 = rnd_up(n_per_thread, n_tmul) < min_mn_elem && nthr_n_ > 1;
     }
 
-    bool unacceptable_b_div = nthr_b_ > (size_t)batch;
+    bool unacceptable_b_div = nthr_b_ > batch;
     if (nthr_k_ > 1 && calculate_compensations_in_copy_routines()) {
         // If we have to calculate compensations in copy routines,
         // we cannot split K dimension
@@ -202,12 +202,14 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         best_blocking.n_decomposition
                 = nstl::min(bgmmc.N, (dim_t)bgmmc.wei_n_blk);
         best_blocking.m_decomposition = bgmmc.M;
-        uint32_t n_per_core = div_up(bgmmc.N, bgmmc.nthr);
+        dim_t n_per_core = div_up(bgmmc.N, bgmmc.nthr);
         n_per_core = rnd_up(n_per_core, best_blocking.n_decomposition);
-        best_blocking.set_core_divs(1, 1, 1, div_up(bgmmc.N, n_per_core));
+        best_blocking.set_core_divs(
+                1, 1, 1, static_cast<int>(div_up(bgmmc.N, n_per_core)));
 
-        if (best_blocking.nthr_n_
-                < core_utilization_threshold * best_blocking.nthr) {
+        if (static_cast<float>(best_blocking.nthr_n_)
+                < core_utilization_threshold
+                        * static_cast<float>(best_blocking.nthr)) {
             return false;
         }
         best_blocking.m_blk_ = bgmmc.M;
@@ -235,13 +237,15 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.K <= best_blocking.wei_k_blk && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
-        best_blocking.set_core_divs(1, div_up(bgmmc.M, m_per_core), 1, 1);
+        const dim_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        best_blocking.set_core_divs(
+                1, static_cast<int>(div_up(bgmmc.M, m_per_core)), 1, 1);
         best_blocking.set_tmul_sizes();
         best_blocking.set_decomposition();
 
-        if (best_blocking.nthr_m_
-                < core_utilization_threshold * best_blocking.nthr) {
+        if (static_cast<float>(best_blocking.nthr_m_)
+                < core_utilization_threshold
+                        * static_cast<float>(best_blocking.nthr)) {
             return false;
         }
         best_blocking.m_blk_ = best_blocking.m_decomposition;
@@ -270,7 +274,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.N <= 32 && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        const dim_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
 
         best_blocking.m_per_thread = m_per_core;
         // in this case 2 full are preferable
@@ -284,10 +288,11 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         const size_t m_per_core_actual = rnd_up(
                 best_blocking.m_per_thread, best_blocking.m_decomposition);
         best_blocking.set_core_divs(
-                1, div_up(bgmmc.M, m_per_core_actual), 1, 1);
+                1, static_cast<int>(div_up(bgmmc.M, m_per_core_actual)), 1, 1);
 
-        if (best_blocking.nthr_m_
-                < core_utilization_threshold * best_blocking.nthr) {
+        if (static_cast<float>(best_blocking.nthr_m_)
+                < core_utilization_threshold
+                        * static_cast<float>(best_blocking.nthr)) {
             return false;
         }
 
@@ -327,8 +332,7 @@ bool matmul_amx_blocking_params_macro_t::find_best_blocking(
 
     if (maybe_small_dims_heuristics(bgmmc, best_blocking)) { return true; }
 
-    for (size_t nthr_to_check = bgmmc.nthr; nthr_to_check > 0;
-            nthr_to_check--) {
+    for (int nthr_to_check = bgmmc.nthr; nthr_to_check > 0; nthr_to_check--) {
         current_blocking.nthr_ = nthr_to_check;
 
         for (int b_div = 1; b_div <= current_blocking.nthr_; ++b_div) {
@@ -420,82 +424,92 @@ void matmul_amx_blocking_params_macro_t::calculate_layer_sizes(
         size_t strip_dst_size = m_decomposition * n_per_thread
                 * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
         // Amount of compute
-        layer_perf_characteristics.num_tmuls_per_strip = m_decomposition
-                * k_per_thread * n_per_thread / (m_tmul * k_tmul * n_tmul);
+        layer_perf_characteristics.num_tmuls_per_strip
+                = static_cast<float>(m_decomposition * k_per_thread
+                        * n_per_thread / (m_tmul * k_tmul * n_tmul));
         // Amount of strips in the execution
         layer_perf_characteristics.num_strip
-                = div_up(m_per_thread, m_decomposition);
+                = static_cast<float>(div_up(m_per_thread, m_decomposition));
         // B is blocked to the L2 in horizontal traversal, its loads are NT
         layer_perf_characteristics.nt_mat_l1_miss
-                = layer_perf_characteristics.b_size;
+                = static_cast<float>(layer_perf_characteristics.b_size);
         // Number of times A is reused from L1 in a strip
-        layer_perf_characteristics.l1_reuse = div_up(n_blk_, n_decomposition);
+        layer_perf_characteristics.l1_reuse
+                = static_cast<float>(div_up(n_blk_, n_decomposition));
 
         // In horizontal multiple cores load the same B to L2
         layer_perf_characteristics.strip_1_size_shared
-                = layer_perf_characteristics.b_size;
+                = static_cast<float>(layer_perf_characteristics.b_size);
         // In strip 1 there is no sharing of A since there are no prefetches
         size_t strip_1_size_private_a
                 = m_decomposition * k_per_thread * gemm_dt_sz;
         layer_perf_characteristics.strip_1_size_private
-                = strip_1_size_private_a + strip_dst_size;
+                = static_cast<float>(strip_1_size_private_a + strip_dst_size);
         // The cores that share B
-        layer_perf_characteristics.strip_1_share_coef = nthr_m_;
+        layer_perf_characteristics.strip_1_share_coef
+                = static_cast<float>(nthr_m_);
 
         // In the mid strips B is reused from L2 and
         // A is prefetched by multiple cores.
-        layer_perf_characteristics.strip_mid_size_shared = m_decomposition
-                * k_per_thread * gemm_dt_sz; // A size per strip
+        layer_perf_characteristics.strip_mid_size_shared
+                = static_cast<float>(m_decomposition * k_per_thread
+                        * gemm_dt_sz); // A size per strip
         // C is private to a core, since each core writes to a distinct buffer
-        layer_perf_characteristics.strip_mid_size_private = strip_dst_size;
+        layer_perf_characteristics.strip_mid_size_private
+                = static_cast<float>(strip_dst_size);
         // share_coeff - the cores that share A
         layer_perf_characteristics.strip_mid_share_coef
-                = std::max((size_t)1, nthr_n_);
+                = static_cast<float>(std::max(1, nthr_n_));
 
         // Calculate the number of cache lines to be processed in AVX postops
-        layer_perf_characteristics.num_postop_cache_lines
-                = m_decomposition * div_up(n_per_thread, n_tmul);
+        layer_perf_characteristics.num_postop_cache_lines = static_cast<float>(
+                m_decomposition * div_up(n_per_thread, n_tmul));
 
     } else {
         // Amount of C/D bytes that are written per core
         size_t strip_dst_size = n_decomposition * m_per_thread
                 * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
         // Amount of compute
-        layer_perf_characteristics.num_tmuls_per_strip = n_decomposition
-                * k_per_thread * m_per_thread / (m_tmul * k_tmul * n_tmul);
+        layer_perf_characteristics.num_tmuls_per_strip
+                = static_cast<float>(n_decomposition * k_per_thread
+                        * m_per_thread / (m_tmul * k_tmul * n_tmul));
         // Amount of strips in the execution
         layer_perf_characteristics.num_strip
-                = div_up(n_per_thread, n_decomposition);
+                = static_cast<float>(div_up(n_per_thread, n_decomposition));
         // A is blocked to the L2 in vertical traversal, its loads are NT
         layer_perf_characteristics.nt_mat_l1_miss
-                = layer_perf_characteristics.a_size;
+                = static_cast<float>(layer_perf_characteristics.a_size);
         // Number of times B is reused from L1 in a strip
-        layer_perf_characteristics.l1_reuse = div_up(m_blk_, m_decomposition);
+        layer_perf_characteristics.l1_reuse
+                = static_cast<float>(div_up(m_blk_, m_decomposition));
 
         // In vertical multiple cores load the same A to L2
         layer_perf_characteristics.strip_1_size_shared
-                = layer_perf_characteristics.a_size;
+                = static_cast<float>(layer_perf_characteristics.a_size);
         // In strip 1 there is no sharing of B since there are no prefetches
         size_t strip_1_size_private_b
                 = n_decomposition * k_per_thread * gemm_dt_sz;
         layer_perf_characteristics.strip_1_size_private
-                = strip_1_size_private_b + strip_dst_size;
+                = static_cast<float>(strip_1_size_private_b + strip_dst_size);
         // The cores that share A
-        layer_perf_characteristics.strip_1_share_coef = nthr_n_;
+        layer_perf_characteristics.strip_1_share_coef
+                = static_cast<float>(nthr_n_);
 
         // In the mid strips A is reused from L2 and
         // B is prefetched by multiple cores.
-        layer_perf_characteristics.strip_mid_size_shared = n_decomposition
-                * k_per_thread * gemm_dt_sz; // B size per strip
+        layer_perf_characteristics.strip_mid_size_shared
+                = static_cast<float>(n_decomposition * k_per_thread
+                        * gemm_dt_sz); // B size per strip
         // C is private to a core, since each core writes to a distinct buffer
-        layer_perf_characteristics.strip_mid_size_private = strip_dst_size;
+        layer_perf_characteristics.strip_mid_size_private
+                = static_cast<float>(strip_dst_size);
         // share_coeff - the cores that share B
         layer_perf_characteristics.strip_mid_share_coef
-                = std::max((size_t)1, nthr_m_);
+                = static_cast<float>(std::max(1, nthr_m_));
 
         // Calculate the number of cache lines to be processed in AVX postops
-        layer_perf_characteristics.num_postop_cache_lines
-                = m_per_thread * div_up(n_decomposition, n_tmul);
+        layer_perf_characteristics.num_postop_cache_lines = static_cast<float>(
+                m_per_thread * div_up(n_decomposition, n_tmul));
     }
 }
 
@@ -511,25 +525,29 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
             = layer_perf_characteristics.strip_mid_size_shared
             * (layer_perf_characteristics.l1_reuse - 1);
 
-    float c_elem_per_strip = m_blk_ * n_blk_;
+    float c_elem_per_strip = static_cast<float>(m_blk_ * n_blk_);
 
     // C post write miss in bytes = m_blk_ * (#n_decompositions in BRGEMM) * (#cache lines per n_decomposition) * 64
-    float c_post_write_miss = m_blk_ * div_up(n_blk_, n_decomposition)
-            * rnd_up(n_decomposition * c_dt_sz, 64);
+    float c_post_write_miss
+            = static_cast<float>(m_blk_ * div_up(n_blk_, n_decomposition)
+                    * rnd_up(n_decomposition * c_dt_sz, 64));
     // C post write total in bytes = m_blk_ * (#n_decompositions in BRGEMM) * (#writes per n_decomposition) * 64
-    float c_post_write_total = m_blk_ * div_up(n_blk_, n_decomposition)
-            * div_up(n_decomposition, 16) * 64;
+    float c_post_write_total
+            = static_cast<float>(m_blk_ * div_up(n_blk_, n_decomposition)
+                    * div_up(n_decomposition, 16) * 64);
     float c_post_write_hit = c_post_write_total - c_post_write_miss;
 
-    float c_post_read_c_tmp = c_elem_per_strip * acc_dt_sz;
+    float c_post_read_c_tmp = c_elem_per_strip * static_cast<float>(acc_dt_sz);
 
     float c_tmp_l1_cycles;
     if (k_blk_ == K) {
-        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+        c_tmp_l1_cycles = static_cast<float>(acc_dt_sz) * c_elem_per_strip
+                * static_cast<float>(k_chunk_size_)
                 / bw_interpolator.l1_load_hit_bw;
     } else {
         // TODO: modify wrt wsp
-        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+        c_tmp_l1_cycles = static_cast<float>(acc_dt_sz) * c_elem_per_strip
+                * static_cast<float>(k_chunk_size_)
                 / bw_interpolator.l1_store_miss_bw;
     }
 
@@ -555,7 +573,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
     } else {
         strip_mid_dram = layer_perf_characteristics.strip_mid_size_shared
                         / bw_interpolator.get_bw(
-                                layer_perf_characteristics.strip_mid_share_coef)
+                                static_cast<int>(layer_perf_characteristics
+                                                         .strip_mid_share_coef))
                 + layer_perf_characteristics.strip_mid_size_private
                         / bw_interpolator.get_bw(1);
 
@@ -566,7 +585,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
     }
 
     float strip_tmul = layer_perf_characteristics.num_tmuls_per_strip
-            * layer_perf_characteristics.num_cycles_per_tmul;
+            * static_cast<float>(
+                    layer_perf_characteristics.num_cycles_per_tmul);
     float avx_insts_per_cache_line
             = calculate_avx_insts_per_cache_line(layer_perf_characteristics);
     float strip_avx = avx_insts_per_cache_line
@@ -585,8 +605,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_1_cycles(
             && !layer_perf_characteristics.strip1_a_read_v) {
         // default for vertical and horizontal without b transform
         strip_1_cycles = layer_perf_characteristics.strip_1_size_shared
-                        / bw_interpolator.get_bw(
-                                layer_perf_characteristics.strip_1_share_coef)
+                        / bw_interpolator.get_bw(static_cast<int>(
+                                layer_perf_characteristics.strip_1_share_coef))
                 + layer_perf_characteristics.strip_1_size_private
                         / bw_interpolator.get_bw(1);
     } else if (layer_perf_characteristics.strip1_b_in_mlc_h
@@ -607,8 +627,9 @@ float matmul_amx_blocking_params_macro_t::calculate_reduction_cycles(
 
     if (nthr_k_ != 1) {
         if (c_size_per_core * 2 < L2_threshold() && batch == 1) {
-            float reduction_read_bytes = (M * rnd_up(N, 16) * acc_dt_sz)
-                    * ((nthr_k_ - 1)) / (nthr_m_ * nthr_n_);
+            float reduction_read_bytes
+                    = static_cast<float>((M * rnd_up(N, 16) * acc_dt_sz)
+                            * ((nthr_k_ - 1)) / (nthr_m_ * nthr_n_));
             float reduction_read_cycles;
             if (layer_perf_characteristics.a_size
                             + layer_perf_characteristics.b_size
@@ -621,8 +642,8 @@ float matmul_amx_blocking_params_macro_t::calculate_reduction_cycles(
                         = reduction_read_bytes / bw_interpolator.llc_bw;
             }
 
-            float reduction_write_bytes
-                    = (M * N * c_dt_sz) / (nthr_m_ * nthr_n_);
+            float reduction_write_bytes = static_cast<float>(
+                    (M * N * c_dt_sz) / (nthr_m_ * nthr_n_));
             float reduction_write_cycles
                     = reduction_write_bytes / bw_interpolator.get_bw(1);
             // Add reduction const overhead - measured
@@ -643,7 +664,7 @@ float matmul_amx_blocking_params_macro_t::calculate_avx_insts_per_cache_line(
         layer_perf_characteristics_t &layer_perf_characteristics) const {
     const float down_convert_inst = 4;
     float avx_insts_per_cache_line
-            = down_convert_inst + this->postops_inst_count;
+            = down_convert_inst + static_cast<float>(this->postops_inst_count);
 
     bool has_zp = this->src_zp_type != brgemm_broadcast_t::none
             || this->wei_zp_type != brgemm_broadcast_t::none
@@ -666,26 +687,26 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
 
     float b_transform_cycles_v = layer_perf_characteristics.strips_b_tranform_v
             ? layer_perf_characteristics.strip_mid_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_mid_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_mid_share_coef))
             : 0;
 
     float b_transform_cycles_h = layer_perf_characteristics.strip1_b_tranform_h
             ? layer_perf_characteristics.strip_1_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_1_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_1_share_coef))
             : 0;
 
     float a_read_cycles_v = layer_perf_characteristics.strip1_a_read_v
             ? layer_perf_characteristics.strip_1_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_1_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_1_share_coef))
             : 0;
 
     float a_read_cycles_h = layer_perf_characteristics.strips_a_read_h
             ? layer_perf_characteristics.strip_mid_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_mid_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_mid_share_coef))
             : 0;
 
     float strip_mid_cycles = calculate_strip_mid_cycles(
@@ -704,11 +725,13 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
     if (reduction_cycles < 0)
         return 0; //reduction is not feasible, so the score is 0
 
-    float total_macs = M * K * N * batch;
-    float total_cycles = (gemm_cycles + reduction_cycles) * b_per_thread;
+    float total_macs = static_cast<float>(M * K * N * batch);
+    float total_cycles = (gemm_cycles + reduction_cycles)
+            * static_cast<float>(b_per_thread);
 
     int macs_per_cycle_base = 1024;
-    float peak_macs_per_cycle = (macs_per_cycle_base / gemm_dt_sz) * nthr;
+    float peak_macs_per_cycle
+            = static_cast<float>((macs_per_cycle_base / gemm_dt_sz) * nthr);
     float peak_cycles = total_macs / peak_macs_per_cycle;
     return peak_cycles / total_cycles;
 }
@@ -800,7 +823,7 @@ std::set<dim_t> matmul_amx_blocking_params_macro_t::blk_candidates(
 size_t matmul_amx_blocking_params_macro_t::l2_matrix_usage(size_t k_chunk_size,
         size_t m_or_n_blk, size_t k_blk, bool is_horizontal,
         bool force_transform_matrix_to_l2) const {
-    int decomposition = is_horizontal ? m_decomposition : n_decomposition;
+    dim_t decomposition = is_horizontal ? m_decomposition : n_decomposition;
     size_t l1_matrix_size = 2 * decomposition
             * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz; // 2 for prefetch
@@ -846,13 +869,13 @@ size_t matmul_amx_blocking_params_macro_t::l2_matrix_and_c_usage(
     return l1_matrix_size + l2_matrix_size + c_size;
 }
 
-int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
+size_t matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
         size_t k_blk, size_t n_blk, bool is_horizontal) const {
-    int a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+    size_t a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz;
-    int b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+    size_t b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz;
-    int c_bw;
+    size_t c_bw;
 
     if ((l2_matrix_and_c_usage(k_chunk_size, is_horizontal ? n_blk : m_blk,
                  k_blk, is_horizontal)
@@ -867,7 +890,7 @@ int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
     return a_bw + b_bw + c_bw;
 }
 
-int matmul_amx_blocking_params_macro_t::compute(
+size_t matmul_amx_blocking_params_macro_t::compute(
         size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk) const {
     return m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * n_blk;
@@ -877,7 +900,8 @@ float matmul_amx_blocking_params_macro_t::ratio(size_t m_blk,
         size_t k_chunk_size, size_t k_blk, size_t n_blk,
         bool is_horizontal) const {
     return static_cast<float>(compute(m_blk, k_chunk_size, k_blk, n_blk))
-            / bw(m_blk, k_chunk_size, k_blk, n_blk, is_horizontal);
+            / static_cast<float>(
+                    bw(m_blk, k_chunk_size, k_blk, n_blk, is_horizontal));
 }
 
 float matmul_amx_blocking_params_macro_t::evaluate_single_core_blocking(
@@ -953,10 +977,9 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
     bool vertical_not_possible = force_horizontal;
 
     auto calc_horizontal = [&](size_t k_blk_h, dim_t min_k_chunk_size = 0) {
-        if (rnd_up(m_per_thread, m_decomposition) * (nthr_m_ - 1)
-                >= (size_t)M) {
+        if (rnd_up(m_per_thread, m_decomposition) * (nthr_m_ - 1) >= M) {
             horizontal_not_possible = true;
-        } else if (rnd_up(k_per_thread, k_blk_h) * (nthr_k_ - 1) >= (size_t)K) {
+        } else if (rnd_up(k_per_thread, k_blk_h) * (nthr_k_ - 1) >= K) {
             // Early exit: There is no possible division of work for nthr_k threads
             horizontal_not_possible = true;
         } else {
@@ -985,11 +1008,10 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             }
 
             if (rnd_up(n_per_thread, best_n_h * n_decomposition) * (nthr_n_ - 1)
-                    >= (size_t)N) {
+                    >= N) {
                 horizontal_not_possible = true;
             }
-            if (rnd_up(k_per_thread, best_k_h * k_blk_h) * (nthr_k_ - 1)
-                    >= (size_t)K) {
+            if (rnd_up(k_per_thread, best_k_h * k_blk_h) * (nthr_k_ - 1) >= K) {
                 // There is not enough work for nthr_k threads
                 horizontal_not_possible = true;
             }
@@ -1000,10 +1022,9 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
     calc_horizontal(k_blk_h);
 
     auto calc_vertical = [&](size_t k_blk_v, dim_t min_k_chunk_size = 0) {
-        if (rnd_up(n_per_thread, n_decomposition) * (nthr_n_ - 1)
-                >= (size_t)N) {
+        if (rnd_up(n_per_thread, n_decomposition) * (nthr_n_ - 1) >= N) {
             vertical_not_possible = true;
-        } else if (rnd_up(k_per_thread, k_blk_v) * (nthr_k_ - 1) >= (size_t)K) {
+        } else if (rnd_up(k_per_thread, k_blk_v) * (nthr_k_ - 1) >= K) {
             // Early exit: There is no possible division of work for nthr_k threads
             vertical_not_possible = true;
         } else {
@@ -1031,11 +1052,10 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             }
 
             if (rnd_up(m_per_thread, best_m_v * m_decomposition) * (nthr_m_ - 1)
-                    >= (size_t)M) {
+                    >= M) {
                 vertical_not_possible = true;
             }
-            if (rnd_up(k_per_thread, best_k_v * k_blk_v) * (nthr_k_ - 1)
-                    >= (size_t)K) {
+            if (rnd_up(k_per_thread, best_k_v * k_blk_v) * (nthr_k_ - 1) >= K) {
                 // There is not enough work for nthr_k threads
                 vertical_not_possible = true;
             }
@@ -1052,7 +1072,7 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             }
             bool repeat_loop_over_k = div_up(K, k_blk_v * best_k_v) != 1;
             bool critical_l2_set_issues_a
-                    = div_up((size_t)K, k_blk_v * best_k_v) != nthr_k_
+                    = div_up(K, k_blk_v * best_k_v) != nthr_k_
                     || (size_t)((l2_util_v * nthr_k_)) >= L2_threshold();
 
             if (repeat_loop_over_k && critical_l2_set_issues_a)
@@ -1095,7 +1115,8 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
         // If the number of cycles for postops per cache line is larger than
         // the number of AMX cycles per cache line, then the calculation is
         // postops bound.
-        return postops_inst_count / avx_ipc > div_up(k_blk, k_tmul);
+        return static_cast<float>(postops_inst_count) / avx_ipc
+                > static_cast<float>(div_up(k_blk, k_tmul));
     };
 
     if (is_horizontal) {
@@ -1272,7 +1293,8 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
     const bool runtime_dims
             = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;
     const int max_nthr_k = !runtime_dims && is_amx_xf16 && bgmmc.batch == 1
-            ? nstl::min(saturate(1, 7, bgmmc.nthr / 8), max_k_parallel_work)
+            ? nstl::min<int>(
+                      saturate<int>(1, 7, bgmmc.nthr / 8), max_k_parallel_work)
             : 1;
     int iter = 0;
     const int runtime_M_chunk = bgmmc.lda_big_pow2() ? 2 : 4;
@@ -1287,37 +1309,38 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
     for (int nthr_k = 1; nthr_k <= max_nthr_k; nthr_k++) {
         int nthr_bmn = bgmmc.nthr / nthr_k;
 
-        int num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
-        int num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
-        int k_parallel_work = nstl::min(max_k_parallel_work, nthr_k);
-        int num_parallel_work
+        dim_t num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
+        dim_t num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
+        dim_t k_parallel_work = nstl::min<dim_t>(max_k_parallel_work, nthr_k);
+        dim_t num_parallel_work
                 = bgmmc.batch * num_M_blk * num_N_blk * k_parallel_work;
         const bool a_lot_of_parallel_work_lvl2
                 = num_parallel_work > 16 * bgmmc.nthr;
-        const bool low_parallelism
-                = static_cast<float>(num_parallel_work) < 1.5f * bgmmc.nthr;
+        const bool low_parallelism = static_cast<float>(num_parallel_work)
+                < 1.5f * static_cast<float>(bgmmc.nthr);
         const bool maybe_low_blocking
                 = is_amx_int8 && bm_conf_utils.maybe_low_brg_blocking();
-        const int min_M_blk = !bgmmc.is_runtime_M
+        const dim_t min_M_blk = !bgmmc.is_runtime_M
                         && (maybe_low_blocking || low_parallelism)
                         && bgmmc.M_blk > 32
                 ? div_up(bgmmc.M_blk, 2)
                 : bgmmc.M_blk;
-        const int min_N_blk = !bgmmc.is_runtime_N && low_parallelism
+        const dim_t min_N_blk = !bgmmc.is_runtime_N && low_parallelism
                         && is_amx_xf16 && !bm_conf_utils.check_n_blk_fixed()
                         && bgmmc.N_blk > 32 && !runtime_dims
                         && !bgmmc.transposed_B // Transposed copy B kernel doesn't support adjusting N_blk
                 ? 32
                 : bgmmc.N_blk;
-        const int desired_M_chunk = bgmmc.is_runtime_M
+        const dim_t desired_M_chunk = bgmmc.is_runtime_M
                 ? runtime_M_chunk
-                : nstl::min(4, num_M_blk);
-        const int desired_N_chunk = bgmmc.is_runtime_N
+                : nstl::min<dim_t>(4, num_M_blk);
+        const dim_t desired_N_chunk = bgmmc.is_runtime_N
                 ? runtime_N_chunk
-                : nstl::min(a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
+                : nstl::min<dim_t>(
+                          a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
 
-        std::unordered_set<int> mblk_candidates;
-        for (int m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
+        std::unordered_set<dim_t> mblk_candidates;
+        for (dim_t m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
                 m_blk = m_blk > 1 ? div_up(m_blk, 2) : m_blk - 1) {
             if (IMPLICATION(maybe_low_blocking, m_blk != bgmmc.M_blk))
                 mblk_candidates.insert(m_blk);
@@ -1325,20 +1348,20 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
 
         if (!bgmmc.is_runtime_M && bgmmc.M > 16) {
             // Add multiple of 16 M block sizes for consideration
-            const int mul16_m_blk_max
-                    = nstl::min(rnd_dn(static_cast<int>(bgmmc.M), 16), 64);
-            const int mul16_m_blk_min = rnd_up(min_M_blk, 16);
-            for (int m_blk = mul16_m_blk_max; m_blk >= mul16_m_blk_min;
+            const dim_t mul16_m_blk_max
+                    = nstl::min<dim_t>(rnd_dn(bgmmc.M, (dim_t)16), 64);
+            const dim_t mul16_m_blk_min = rnd_up(min_M_blk, (dim_t)16);
+            for (dim_t m_blk = mul16_m_blk_max; m_blk >= mul16_m_blk_min;
                     m_blk -= 16) {
                 mblk_candidates.insert(m_blk);
             }
         }
 
         bool found_best_blocking = false;
-        for_(int n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
-        for_(int m_blk : mblk_candidates)
-        for_(int n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
-        for (int m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
+        for_(dim_t n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
+        for_(dim_t m_blk : mblk_candidates)
+        for_(dim_t n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
+        for (dim_t m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
             current_blocking.set_blocking_parameters(
                     nthr_k, n_blk, n_ch_sz, m_blk, m_ch_sz);
 
@@ -1348,11 +1371,11 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
             // TODO: Verify whether using a chunk count of 1 for runtime M and N is optimal for
             // this heuristic. The previous implementation inadvertently used DNNL_RUNTIME_DIM_VAL
             // for M and N in arithmetic, producing incorrect work_amount values.
-            int m_chunks
+            dim_t m_chunks
                     = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, m_blk * m_ch_sz);
-            int n_chunks
+            dim_t n_chunks
                     = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, n_blk * n_ch_sz);
-            int work_amount = bgmmc.batch * m_chunks * n_chunks;
+            dim_t work_amount = bgmmc.batch * m_chunks * n_chunks;
 
             bool skip_config = work_amount < nthr_bmn * 3
                     && work_amount % nthr_bmn != 0 && max_nthr_k == 1;
@@ -1381,8 +1404,8 @@ void matmul_amx_blocking_params_micro_t::update_k_blocking_dependent_params() {
     need_buf_c_ = is_buffer_c_required();
 }
 
-void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
-        int nthr_k, int n_blk, int n_chunk_size, int m_blk, int m_chunk_size) {
+void matmul_amx_blocking_params_micro_t::set_blocking_parameters(int nthr_k,
+        dim_t n_blk, dim_t n_chunk_size, dim_t m_blk, dim_t m_chunk_size) {
     nthr_k_ = nstl::max(1, nthr_k);
     nthr_mnb_ = nthr / nthr_k_;
     nthr_ = nthr_mnb_ * nthr_k_;
@@ -1475,26 +1498,33 @@ float matmul_amx_blocking_params_micro_t::get_thread_balance_scores() const {
     assert(!(is_runtime_M && is_runtime_N)
             && "single runtime dim is supported");
     // Ignore M sizes in thread balance computation as actual M size is unknown
-    if (is_runtime_M) return (float)N / rnd_up(N, n_chunk_elems_);
+    if (is_runtime_M)
+        return static_cast<float>(N)
+                / static_cast<float>(rnd_up(N, n_chunk_elems_));
     // Ignore N sizes in thread balance computation as actual N size is unknown
-    if (is_runtime_N) return (float)M / rnd_up(M, m_chunk_elems_);
+    if (is_runtime_N)
+        return static_cast<float>(M)
+                / static_cast<float>(rnd_up(M, m_chunk_elems_));
 
     const dim_t num_M_chunks = div_up(M, m_chunk_elems_);
     const dim_t num_N_chunks = div_up(N, n_chunk_elems_);
-    float mnb_parallel_score = batch * ((float)M / m_chunk_elems_)
-            * ((float)N / n_chunk_elems_)
-            / rnd_up(batch * num_M_chunks * num_N_chunks, nthr_mnb_)
-            * nthr_mnb_;
+    float mnb_parallel_score = static_cast<float>(batch)
+            * (static_cast<float>(M) / static_cast<float>(m_chunk_elems_))
+            * (static_cast<float>(N) / static_cast<float>(n_chunk_elems_))
+            / static_cast<float>(
+                    rnd_up(batch * num_M_chunks * num_N_chunks, nthr_mnb_))
+            * static_cast<float>(nthr_mnb_);
     float k_parallel_score = 1.0f;
     if (nthr_k_ > 1) {
         const dim_t num_K_chunks = div_up(K, k_chunk_elems_);
         const float parallel_reduction_penalty = 0.8f;
         k_parallel_score = parallel_reduction_penalty
-                * ((float)K / k_chunk_elems_) / rnd_up(num_K_chunks, nthr_k_)
-                * nthr_k_;
+                * (static_cast<float>(K) / static_cast<float>(k_chunk_elems_))
+                / static_cast<float>(rnd_up(num_K_chunks, nthr_k_))
+                * static_cast<float>(nthr_k_);
     }
 
-    return mnb_parallel_score * k_parallel_score / nthr;
+    return mnb_parallel_score * k_parallel_score / static_cast<float>(nthr);
 }
 
 // Returns score for current blocking parameters' values in range [0, 1]
@@ -1509,10 +1539,12 @@ float matmul_amx_blocking_params_micro_t::get_copied_data_reusage_scores()
     const dim_t desired_N_chunk_size = is_runtime_N
             ? effective_n_chunk_sz
             : nstl::min(N, effective_n_chunk_sz);
-    const float coef_M = nstl::min(
-            static_cast<float>(m_chunk_elems_) / desired_M_chunk_size, 1.0f);
-    const float coef_N = nstl::min(
-            static_cast<float>(n_chunk_elems_) / desired_N_chunk_size, 1.0f);
+    const float coef_M = nstl::min(static_cast<float>(m_chunk_elems_)
+                    / static_cast<float>(desired_M_chunk_size),
+            1.0f);
+    const float coef_N = nstl::min(static_cast<float>(n_chunk_elems_)
+                    / static_cast<float>(desired_N_chunk_size),
+            1.0f);
     return 0.5f * (coef_M + coef_N);
 }
 
@@ -1520,8 +1552,10 @@ float matmul_amx_blocking_params_micro_t::get_copied_data_reusage_scores()
 // for L2 utilization
 float matmul_amx_blocking_params_micro_t::get_L2_utilization_scores() const {
     const float relative_difference_with_L2
-            = fabsf((float)L2_threshold() - blocking_chunk_mem_size_)
-            / nstl::max(L2_threshold(), blocking_chunk_mem_size_);
+            = fabsf((float)L2_threshold()
+                      - static_cast<float>(blocking_chunk_mem_size_))
+            / static_cast<float>(
+                    nstl::max(L2_threshold(), blocking_chunk_mem_size_));
     return 1.0f - relative_difference_with_L2;
 }
 
@@ -1535,7 +1569,7 @@ float matmul_amx_blocking_params_micro_t::calculate_blocking_scores() const {
                 brgemm_batch_size_))
         return 0.0f;
 
-    const float nthr_coeff = nstl::min(nthr, 100);
+    const float nthr_coeff = static_cast<float>(nstl::min(nthr, 100));
     const float reusage_factor = 1.0f;
     // For runtume M the actual size is unknown, use independent on num_threads
     // balance factors

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -34,7 +34,7 @@ struct layer_perf_characteristics_t {
             nt_mat_l1_miss {0};
     float l1_reuse {0};
     float num_postop_cache_lines {0};
-    int num_cycles_per_tmul {0};
+    dim_t num_cycles_per_tmul {0};
 
     bool strip1_b_tranform_h {false};
     bool strips_b_tranform_v {false};
@@ -48,7 +48,9 @@ class bw_map_t {
 public:
     bw_map_t() = default;
 
-    float get_bw(int x) const { return linear_interpolation(multicore_bw, x); }
+    float get_bw(int x) const {
+        return linear_interpolation(multicore_bw, static_cast<float>(x));
+    }
 
     // All the following bandwidth measurements were taken on an
     // EMR machine with two NUMA domains, each containing 32 cores.
@@ -73,7 +75,7 @@ private:
     float linear_interpolation(
             const std::map<int, float> &points, float x) const {
         // Find the interval [x0, x1] where x0 <= x <= x1
-        auto it = points.lower_bound(x);
+        auto it = points.lower_bound(static_cast<int>(x));
         if (it == points.end()) {
             return points.rbegin()
                     ->second; // x is greater than the largest x in the map
@@ -91,7 +93,9 @@ private:
         float y1 = it1->second;
 
         // Perform linear interpolation
-        return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
+        return y0
+                + (y1 - y0) * (x - static_cast<float>(x0))
+                / static_cast<float>(x1 - x0);
     }
 };
 
@@ -99,10 +103,10 @@ class matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
 public:
     matmul_amx_blocking_params_t(const brgemm_matmul_conf_t &bgmmc)
         : brgemm_matmul_conf_t(bgmmc)
-        , nthr_m_(nstl::max(nthr_m, 1))
-        , nthr_n_(nstl::max(nthr_n, 1))
-        , nthr_k_(nstl::max(nthr_k, 1))
-        , nthr_b_(nstl::max(nthr_b, 1))
+        , nthr_m_(nstl::max<int>(nthr_m, 1))
+        , nthr_n_(nstl::max<int>(nthr_n, 1))
+        , nthr_k_(nstl::max<int>(nthr_k, 1))
+        , nthr_b_(nstl::max<int>(nthr_b, 1))
         , nthr_mnb_(nthr / nthr_k_)
         , nthr_(nthr_mnb_ * nthr_k_)
         , n_blk_(N_blk)
@@ -140,7 +144,7 @@ protected:
     virtual dim_t get_actual_lda() const;
 
     // Num threads for parallelism wrt K dimension
-    size_t nthr_m_ {0}, nthr_n_ {0}, nthr_k_ {0}, nthr_b_ {0};
+    int nthr_m_ {0}, nthr_n_ {0}, nthr_k_ {0}, nthr_b_ {0};
     // Num threads for parallelism wrt M, N and batch dimensions
     int nthr_mnb_ {0};
     int nthr_ {0};
@@ -218,9 +222,9 @@ private:
     size_t l2_matrix_and_c_usage(size_t k_chunk_size, size_t m_or_n_blk,
             size_t k_blk, bool is_horizontal) const;
     void set_core_divs(int nthr_b, int nthr_m, int nthr_k, int nthr_n);
-    int bw(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
+    size_t bw(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
             bool is_horizontal) const;
-    int compute(size_t m_blk, size_t k_chunk_size, size_t k_blk,
+    size_t compute(size_t m_blk, size_t k_chunk_size, size_t k_blk,
             size_t n_blk) const;
     float ratio(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
             bool is_horizontal) const;
@@ -260,8 +264,8 @@ public:
     matmul_amx_blocking_params_micro_t(const brgemm_matmul_conf_t &bgmmc)
         : matmul_amx_blocking_params_t(bgmmc) {}
 
-    void set_blocking_parameters(int nthr_k, int n_blk, int n_chunk_size,
-            int m_blk, int m_chunk_size);
+    void set_blocking_parameters(int nthr_k, dim_t n_blk, dim_t n_chunk_size,
+            dim_t m_blk, dim_t m_chunk_size);
 
     static void find_best_blocking(const brgemm_matmul_conf_t &bgmmc,
             const brgemm_matmul_conf_utils_t &bm_conf_utils,

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -47,7 +47,7 @@ using namespace nstl;
 using namespace data_type;
 namespace {
 
-int get_brg_batchsize(
+dim_t get_brg_batchsize(
         const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail, bool is_K_tail) {
     auto bs = is_K_tail  ? 1
             : is_bs_tail ? bgmmc.brgemm_batch_tail_size
@@ -57,7 +57,7 @@ int get_brg_batchsize(
 
 int get_brg_kernel_index(const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail,
         bool do_initialization, int m_ker_idx, int n_ker_idx, bool is_K_tail,
-        int bs, bool is_prefetching) {
+        dim_t bs, bool is_prefetching) {
     const int max_m_ker_idx
             = bgmmc.is_runtime_M ? max_num_dynamic_m_tails + 1 : 2;
     if (m_ker_idx >= max_m_ker_idx) return -1;
@@ -129,7 +129,7 @@ template <cpu_isa_t isa>
 int brgemm_matmul_t<isa>::pd_t::get_brg_kernel_idx(bool is_bs_tail,
         bool do_initialization, int m_ker_idx, int n_ker_idx, bool is_K_tail,
         bool is_prefetching) const {
-    int bs = get_brg_batchsize(bgmmc_, is_bs_tail, is_K_tail);
+    dim_t bs = get_brg_batchsize(bgmmc_, is_bs_tail, is_K_tail);
     return get_brg_kernel_index(bgmmc_, is_bs_tail, do_initialization,
             m_ker_idx, n_ker_idx, is_K_tail, bs, is_prefetching);
 }
@@ -399,7 +399,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                                                     : bgmmc_.N_tail);
         auto vK = (i_K) ? bgmmc_.K_tail : bgmmc_.K_blk;
 
-        int bs = get_brg_batchsize(bgmmc_, i_bs, i_K);
+        dim_t bs = get_brg_batchsize(bgmmc_, i_bs, i_K);
         int idx = get_brg_kernel_idx(i_bs, i_init, i_M, i_N, i_K, prefetching);
         if (idx < 0) continue;
 
@@ -592,8 +592,8 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
 }
 
 template <cpu_isa_t isa>
-bool brgemm_matmul_t<isa>::determine_prefetch(const int mb, const int m_end,
-        const int nb, const int n_end, const brgemm_matmul_conf_t &bgmmc,
+bool brgemm_matmul_t<isa>::determine_prefetch(const dim_t mb, const dim_t m_end,
+        const dim_t nb, const dim_t n_end, const brgemm_matmul_conf_t &bgmmc,
         const brg_matmul_exec_ctx_t &brgmm_ctx) const {
     // Prefetch if not the last BRGEMM in the chunk and
     // if the next BRGEMM is identical to the current one.
@@ -636,26 +636,26 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         const bool use_buffer_a
                 = bgmmc.use_buffer_a || bgmmc.use_buffer_a_tail_only;
         const bool is_amx = is_superset(isa, avx512_core_amx);
-        const int M_chunks = brgmm_ctx.get_M_chunks();
-        const int M_chunk_size = brgmm_ctx.get_M_chunk_size();
-        const int M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
+        const dim_t M_chunks = brgmm_ctx.get_M_chunks();
+        const dim_t M_chunk_size = brgmm_ctx.get_M_chunk_size();
+        const dim_t M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
 
-        const int K_chunks = brgmm_ctx.get_K_chunks();
-        const int K_chunk_size = brgmm_ctx.get_K_chunk_size();
-        const int K_chunk_tail = brgmm_ctx.get_K_chunk_tail();
+        const dim_t K_chunks = brgmm_ctx.get_K_chunks();
+        const dim_t K_chunk_size = brgmm_ctx.get_K_chunk_size();
+        const dim_t K_chunk_tail = brgmm_ctx.get_K_chunk_tail();
 
-        const int N_chunks = brgmm_ctx.get_N_chunks();
-        const int N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
+        const dim_t N_chunks = brgmm_ctx.get_N_chunks();
+        const dim_t N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
 
         const int ithr_bmn = brgmm_ctx.get_thread_idx_for_bmn_gemm(ithr);
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(brgmm_ctx.get_parallel_work_amount_gemm(),
                 brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn, start, end);
-        int kc_start {0}, kc_end {bgmmc.K_chunks};
+        dim_t kc_start {0}, kc_end {bgmmc.K_chunks};
         if (brgmm_ctx.parallel_reduction_is_used())
-            balance211((int)bgmmc.K_chunks, brgmm_ctx.get_num_threads_for_k(),
+            balance211(bgmmc.K_chunks, brgmm_ctx.get_num_threads_for_k(),
                     ithr_k, kc_start, kc_end);
 
         int prev_ker_idx = -1;
@@ -670,11 +670,11 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
+        dim_t b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
                 bt {0}, mt {0}, nt {0};
-        int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
-        int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
-        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        dim_t m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
+        dim_t n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
+        dim_t batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
         if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
@@ -702,9 +702,9 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             b = bt * batch_per_thread + b_per_t;
         };
 
-        int mc_prev = -1;
-        int nb_prev = -1;
-        int b_prev = -1;
+        dim_t mc_prev = -1;
+        dim_t nb_prev = -1;
+        dim_t b_prev = -1;
         const char *a_batch_ptr = nullptr;
         const char *b_batch_ptr = nullptr;
 
@@ -721,12 +721,12 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             const bool n_chunk_tail = nc == N_chunks - 1 && N_chunk_tail > 0;
             auto n_end = n_start
                     + (n_chunk_tail ? N_chunk_tail : bgmmc.N_chunk_size);
-            int kc_prev = -1;
+            dim_t kc_prev = -1;
             if (b != b_prev) {
                 a_batch_ptr = brgmm_ctx.get_data_A_batch_ptr(b);
                 b_batch_ptr = brgmm_ctx.get_data_B_batch_ptr(b);
             }
-            for_(int kc = kc_start; kc < kc_end; kc++)
+            for_(dim_t kc = kc_start; kc < kc_end; kc++)
             {
                 const bool k_chunk_tail
                         = kc == K_chunks - 1 && K_chunk_tail > 0;
@@ -734,7 +734,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                 auto kb_end = kb_start
                         + (k_chunk_tail ? K_chunk_tail : K_chunk_size);
 
-                for (int nb = n_start; nb < n_end; nb++) {
+                for (dim_t nb = n_start; nb < n_end; nb++) {
                     const bool bcast_across_all_batch_dims
                             = bgmmc.bcast_B_desc.bcast_across_all_batch_dims;
                     const bool skip_copy_b
@@ -743,14 +743,14 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                                               || bcast_across_all_batch_dims))
                             && !bgmmc.packed_sparse_weights;
 
-                    for (int mb = m_start; mb < m_end; mb++) {
+                    for (dim_t mb = m_start; mb < m_end; mb++) {
                         const bool skip_copy_a = mc_prev == mc && kc_prev == kc
                                 && (b_prev == b
                                         || bgmmc.bcast_A_desc
                                                    .bcast_across_all_batch_dims);
                         bool prefetch = determine_prefetch(
                                 mb, m_end, nb, n_end, bgmmc, brgmm_ctx);
-                        for (int kb = kb_start; kb < kb_end; kb++) {
+                        for (dim_t kb = kb_start; kb < kb_end; kb++) {
 
                             if (bgmmc.use_buffer_b && mb == m_start
                                     && !skip_copy_b)
@@ -788,8 +788,8 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::compute_kernel(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
-        const char *B_data_batch_ptr, int ithr, int b_idx, int m_blk_idx,
-        int n_blk_idx, int k_blk_idx, bool do_init, int &prev_ker_idx,
+        const char *B_data_batch_ptr, int ithr, dim_t b_idx, dim_t m_blk_idx,
+        dim_t n_blk_idx, dim_t k_blk_idx, bool do_init, int &prev_ker_idx,
         bool prefetch) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
     const auto addr_batch = brgmm_ctx.get_batch_elem_ptr(ithr);
@@ -804,8 +804,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
     const int n_ker_idx = brgmm_ctx.get_N_kernel_idx(n_blk_idx);
     const bool is_last_K_blk = brgmm_ctx.is_last_K_blk(k_blk_idx);
 
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
-    const int remaining_k_blks
+    const dim_t gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t remaining_k_blks
             = (bgmmc.use_buffer_a ? utils::rnd_up(bgmmc.K, bgmmc.K_blk)
                                   : bgmmc.K)
             - k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
@@ -837,7 +837,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
     brgmm_ctx.maybe_backup_dst_values_to_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
 
-    auto is_brg_amx = [&](const int brg_idx) {
+    auto is_brg_amx = [&](const dim_t brg_idx) {
         return is_superset(
                 pd()->get_brg_desc(brg_idx).isa_impl, avx512_core_amx);
     };
@@ -847,9 +847,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
     // compensation and the final-block epilogue go through the post-ops API.
     // The `do_only_*` flags map to {do_post_ops, do_apply_comp} as {0,1} (comp
     // only) and {1,1} (epilogue).
-    auto execute_brgemm = [&](const brgemm_kernel_t *kernel, const int brg_idx,
-                                  const int bs, const bool need_postops,
-                                  const bool is_tail) {
+    auto execute_brgemm = [&](const brgemm_kernel_t *kernel,
+                                  const dim_t brg_idx, const dim_t bs,
+                                  const bool need_postops, const bool is_tail) {
         const bool per_k_scales = bgmmc.is_src_scale_per_k
                 || (bgmmc.is_wei_scale_per_k
                         && !bgmmc.apply_scales_in_buffer_b);
@@ -990,10 +990,10 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::fill_per_mn_compensation(
-        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, int b_idx,
-        int m_blk_idx, int n_blk_idx, const char *A_data_batch_ptr,
-        const char *B_data_batch_ptr, int m_kernel_size, int n_kernel_size,
-        int k_blk_idx, bool is_tail) const {
+        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, dim_t b_idx,
+        dim_t m_blk_idx, dim_t n_blk_idx, const char *A_data_batch_ptr,
+        const char *B_data_batch_ptr, dim_t m_kernel_size, dim_t n_kernel_size,
+        dim_t k_blk_idx, bool is_tail) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
     if (!bgmmc.with_per_mn_compensation) return;
     assert(per_mn_comp_kernel_ != nullptr);
@@ -1098,8 +1098,8 @@ void brgemm_matmul_t<isa>::fill_per_mn_compensation(
 
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::maybe_reduce_A(
-        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, int gemm_batch,
-        int m_blk_idx, int n_blk_idx, int k_chunk_idx, bool do_init,
+        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, dim_t gemm_batch,
+        dim_t m_blk_idx, dim_t n_blk_idx, dim_t k_chunk_idx, bool do_init,
         bool has_K_tail, bool do_K_tail) const {
 
     if (!pd()->with_reduce()) return;
@@ -1127,7 +1127,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_A(
         const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(m_blk_idx);
 
         if (!do_K_tail) {
-            for (int gb = 0; gb < gemm_batch; gb++) {
+            for (dim_t gb = 0; gb < gemm_batch; gb++) {
                 p.ptr_in = (void *)addr_batch[gb].ptr.A;
 
                 const bool is_first = do_init && gb == 0;
@@ -1215,9 +1215,9 @@ void brgemm_matmul_t<isa>::maybe_reduce_and_convert_partial_results_A(
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
 
-        const int M_chunks = brgmm_ctx.get_M_chunks();
+        const dim_t M_chunks = brgmm_ctx.get_M_chunks();
 
-        int start_mc {0}, end_mc {0};
+        dim_t start_mc {0}, end_mc {0};
         balance211(M_chunks, brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn,
                 start_mc, end_mc);
         if (start_mc != end_mc && ithr_k == 0) {
@@ -1279,24 +1279,25 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
 
-        const int num_reduction_buffers = nstl::min(nthr_k, bgmmc.K_chunks);
+        const dim_t num_reduction_buffers
+                = nstl::min<dim_t>(nthr_k, bgmmc.K_chunks);
         brgemm_dynamic_values_t leading_dimensions(
                 bgmmc.LDA, bgmmc.LDB, brgmm_ctx.get_LDC(), brgmm_ctx.get_LDD());
         const dim_t M = brgmm_ctx.get_M();
-        const int M_chunks = brgmm_ctx.get_M_chunks();
-        const int M_chunk_size = brgmm_ctx.get_M_chunk_size();
-        const int M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
-        const int N_chunks = brgmm_ctx.get_N_chunks();
-        const int N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
+        const dim_t M_chunks = brgmm_ctx.get_M_chunks();
+        const dim_t M_chunk_size = brgmm_ctx.get_M_chunk_size();
+        const dim_t M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
+        const dim_t N_chunks = brgmm_ctx.get_N_chunks();
+        const dim_t N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
 
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(brgmm_ctx.get_parallel_work_amount_gemm(),
                 brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn, start, end);
-        int b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
+        dim_t b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
                 bt {0}, mt {0}, nt {0};
-        int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
-        int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
-        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        dim_t m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
+        dim_t n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
+        dim_t batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
         if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
@@ -1340,21 +1341,21 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
             auto nb_end_total = nb_start_total
                     + (n_chunk_tail ? N_chunk_tail : bgmmc.N_chunk_size);
 
-            int total_m_work = mb_end_total - mb_start_total;
-            int total_n_work = nb_end_total - nb_start_total;
-            int mn_start, mn_end;
+            dim_t total_m_work = mb_end_total - mb_start_total;
+            dim_t total_n_work = nb_end_total - nb_start_total;
+            dim_t mn_start, mn_end;
             balance211(total_m_work * total_n_work, bgmmc.nthr_k, ithr_k,
                     mn_start, mn_end);
 
-            int mb_in_chunk, nb_in_chunk;
+            dim_t mb_in_chunk, nb_in_chunk;
             nd_iterator_init(mn_start, mb_in_chunk, total_m_work, nb_in_chunk,
                     total_n_work);
             while (mn_start < mn_end) {
-                int mb = mc * M_chunk_size + mb_in_chunk;
-                int nb = nc * bgmmc.N_chunk_size + nb_in_chunk;
-                const int curr_M_blk = brgmm_ctx.get_M_kernel_size(mb);
+                dim_t mb = mc * M_chunk_size + mb_in_chunk;
+                dim_t nb = nc * bgmmc.N_chunk_size + nb_in_chunk;
+                const dim_t curr_M_blk = brgmm_ctx.get_M_kernel_size(mb);
                 const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(mb);
-                const int curr_N_blk = brgmm_ctx.get_N_kernel_size(nb);
+                const dim_t curr_N_blk = brgmm_ctx.get_N_kernel_size(nb);
                 char *buf_reduced_base
                         = brgmm_ctx.get_buf_C_par_reduction_ptr(0, mb, nb);
 
@@ -1437,7 +1438,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
-        int ithr, int m_blk_idx, int k_blk_idx) const {
+        int ithr, dim_t m_blk_idx, dim_t k_blk_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
 
     auto ctx = jit_brgemm_matmul_copy_a_t::ctx_t();
@@ -1445,8 +1446,9 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     const bool is_K_tail
             = brgmm_ctx.is_last_K_blk(k_blk_idx) && bgmmc.K_tail > 0;
 
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
-    const int gemm_batch_iters = bgmmc.use_buffer_a_tail_only ? 0 : gemm_batch;
+    const dim_t gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t gemm_batch_iters
+            = bgmmc.use_buffer_a_tail_only ? 0 : gemm_batch;
 
     const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
 
@@ -1465,12 +1467,12 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     const bool use_legacy_zp_a_path
             = !bgmmc.with_wei_decompression && !bgmmc.with_per_mn_compensation;
     int32_t neg_zp_b = use_legacy_zp_a_path ? brgmm_ctx.get_neg_zp_b() : 0;
-    int32_t neg_zp_ab_comp
-            = use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0;
+    int32_t neg_zp_ab_comp = static_cast<int32_t>(
+            use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0);
     ctx.zp_b_neg_val_ptr = &neg_zp_b;
     ctx.zp_ab_comp_ptr = &neg_zp_ab_comp;
 
-    for (int gb = 0; gb < gemm_batch_iters; gb++) {
+    for (dim_t gb = 0; gb < gemm_batch_iters; gb++) {
         const dim_t k = k_start + gb * bgmmc.K_blk;
         ctx.src = (void *)brgmm_ctx.get_data_A_mk_ptr(A_data_batch_ptr, m, k);
         ctx.tr_src = (void *)brgmm_ctx.get_buf_A_ptr(
@@ -1496,18 +1498,18 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *B_data_batch_ptr,
-        int ithr, int b_idx, int n_blk_idx, int k_blk_idx) const {
+        int ithr, dim_t b_idx, dim_t n_blk_idx, dim_t k_blk_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
 
     const dim_t k_start = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
     const bool is_K_tail
             = brgmm_ctx.is_last_K_blk(k_blk_idx) && bgmmc.K_tail > 0;
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
 
     const dim_t n = brgmm_ctx.get_N_idx(n_blk_idx, true);
 
     if (brgmm_ctx.packed_sparse_weights()) {
-        for (int gb = 0; gb < gemm_batch + is_K_tail; gb++) {
+        for (dim_t gb = 0; gb < gemm_batch + is_K_tail; gb++) {
             const dim_t k = k_start + gb * bgmmc.K_blk;
             auto p = jit_avx512_sparse_decompress_kernel_t::call_params_t();
             const char *B_data_ptr
@@ -1541,8 +1543,8 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
 
     // For the grouped Zero points/scales need to vary k-block size
     // For this case need to call copy kernel with unaligned (k, k_iters)
-    auto call_copy_kernel
-            = [&](dim_t k, int k_iters, int gb, bool aligned_blocks = false) {
+    auto call_copy_kernel = [&](dim_t k, dim_t k_iters, dim_t gb,
+                                    bool aligned_blocks = false) {
         ctx.src = (void *)brgmm_ctx.get_data_B_kn_ptr(B_data_batch_ptr, k, n);
         // Use k for buffer locating only when the block is unaligned
         if (aligned_blocks)
@@ -1601,7 +1603,7 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
             call_copy_kernel(k, k_end - k, gb);
         }
     } else { // Default case with k_blk blocking
-        for (int gb = 0; gb < gemm_batch; ++gb) {
+        for (dim_t gb = 0; gb < gemm_batch; ++gb) {
             const auto k = k_start + gb * bgmmc.K_blk;
             const auto k_iters = nstl::min(bgmmc.K_blk, bgmmc.K);
             call_copy_kernel(k, k_iters, gb, /*aligned_blocks=*/true);
@@ -1784,7 +1786,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             M_ = helper.M();
             M_chunks_ = M_ / bgmmc.M_chunk_elems;
             M_chunk_tail_elements_ = M_ % bgmmc.M_chunk_elems;
-            int tail = M_chunk_tail_elements_;
+            dim_t tail = M_chunk_tail_elements_;
             dim_t m_idx = M_ - tail;
             int tail_idx = 0;
             dim_t m_c_buf_idx = 0;
@@ -1809,7 +1811,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     tail_idx++;
                     continue;
                 }
-                int kernel_m_shift = nstl::max(tail_ker_size - tail, 0);
+                dim_t kernel_m_shift
+                        = nstl::max<dim_t>(tail_ker_size - tail, 0);
 
                 m_tail_processing_.push_back({m_idx, ker_idx, tail_ker_size,
                         kernel_m_shift, m_c_buf_idx});
@@ -1848,7 +1851,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             N_ = helper.N();
             N_chunks_ = N_ / bgmmc.N_chunk_elems;
             N_chunk_tail_elems_ = N_ % bgmmc.N_chunk_elems;
-            int tail = N_chunk_tail_elems_;
+            dim_t tail = N_chunk_tail_elems_;
             dim_t n_idx = N_ - tail;
             int tail_idx = 0;
             dim_t n_c_buf_idx = 0;
@@ -1873,7 +1876,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     tail_idx++;
                     continue;
                 }
-                int kernel_n_shift = nstl::max(tail_ker_size - tail, 0);
+                dim_t kernel_n_shift
+                        = nstl::max<dim_t>(tail_ker_size - tail, 0);
 
                 n_tail_processing_.push_back({n_idx, ker_idx, tail_ker_size,
                         kernel_n_shift, n_c_buf_idx});
@@ -1921,9 +1925,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         // create parallel work of amount that is divisible by nthr_m and nthr_n,
         // the chunks that do not exist will be ignored in gemm execution
         // In case of micro heuristics, nthr_m==nthr_n==nthr_b==1 (round up has no effect)
-        int m_chunks_per_thread = rnd_up(M_chunks_, bgmmc.nthr_m);
-        int n_chunks_per_thread = rnd_up(N_chunks_, bgmmc.nthr_n);
-        int b_per_thread = rnd_up(bgmmc.batch, bgmmc.nthr_b);
+        dim_t m_chunks_per_thread = rnd_up(M_chunks_, bgmmc.nthr_m);
+        dim_t n_chunks_per_thread = rnd_up(N_chunks_, bgmmc.nthr_n);
+        dim_t b_per_thread = rnd_up(bgmmc.batch, bgmmc.nthr_b);
         parallel_work_amount_gemm_
                 = b_per_thread * m_chunks_per_thread * n_chunks_per_thread;
 
@@ -1953,7 +1957,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         // For Eigen threadpool there is significant advantage to not spawn
         // useless threads.
         if (!dnnl_thr_syncable()) {
-            nthr_bmn_ = nstl::min(nthr_bmn_, parallel_work_amount_);
+            nthr_bmn_ = static_cast<int>(
+                    nstl::min<dim_t>(nthr_bmn_, parallel_work_amount_));
         }
 
         num_threads_used_ = nthr_k_ * nthr_bmn_;
@@ -1967,15 +1972,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     // NOTE: gb --> generalized batch, bb --> broadcast batch
-    int get_bb_idx(int gb_idx, const brgemm_matmul_bcast_desc_t &bd) const {
+    dim_t get_bb_idx(dim_t gb_idx, const brgemm_matmul_bcast_desc_t &bd) const {
         if (!bd.bcast_mask) // no broadcast
             return gb_idx;
 
         if (bd.bcast_across_all_batch_dims) return 0;
 
-        int gb_off_before_bcast = utils::rnd_dn(
+        dim_t gb_off_before_bcast = utils::rnd_dn(
                 gb_idx, bd.first_bcast_dim_to_last_batch_dim_prod);
-        int bb_idx = gb_off_before_bcast / (bd.bcast_dims_prod);
+        dim_t bb_idx = gb_off_before_bcast / (bd.bcast_dims_prod);
 
         dim_t cur_bcast_dims_prod = bd.bcast_dims_prod;
         int mask = 1 << (bgmmc_.batch_ndims - bd.first_bcast_dim - 1);
@@ -1983,7 +1988,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             if (bd.bcast_mask & mask) // broadcast
                 cur_bcast_dims_prod /= bd.batch_dims[d];
             else {
-                int cur_b = (gb_idx / bd.gb_off[d]) % bd.batch_dims[d];
+                dim_t cur_b = (gb_idx / bd.gb_off[d]) % bd.batch_dims[d];
                 bb_idx += cur_b * (bd.gb_off[d] / cur_bcast_dims_prod);
             }
             mask >>= 1;
@@ -1994,9 +1999,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Note: Minimize the calls to `X_batch_ptr` to reduce overhead.
     // Call it once the batch changes, later use get_data_mk_off
-    const char *get_data_A_batch_ptr(int b_idx) const {
+    const char *get_data_A_batch_ptr(dim_t b_idx) const {
         using namespace format_tag;
-        const int b = get_bb_idx(b_idx, bgmmc_.bcast_A_desc);
+        const dim_t b = get_bb_idx(b_idx, bgmmc_.bcast_A_desc);
         dim_t b_off = 0;
         if (one_of(bgmmc_.src_tag, acbd, adbc)
                 /* this is a special case when src can be represented
@@ -2025,11 +2030,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_data_B_kn_off(dim_t k, dim_t n) const {
-        const int wei_k_blk = bgmmc_.is_bf32 || bgmmc_.is_xf16_fp8
+        const dim_t wei_k_blk = bgmmc_.is_bf32 || bgmmc_.is_xf16_fp8
                 ? get_wei_k_blk(bgmmc_.orig_wei_dt)
                 : bgmmc_.wei_k_blk;
-        const int k_idx = bgmmc_.blocked_B ? k / wei_k_blk : k;
-        const int n_idx = bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n;
+        const dim_t k_idx = bgmmc_.blocked_B ? k / wei_k_blk : k;
+        const dim_t n_idx = bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n;
         const int int4_fac = bgmmc_.is_int4_weights ? 2 : 1;
         return (B_strides_[1] * k_idx + B_strides_[0] * n_idx
                        + get_data_B_off_within_block(k, n))
@@ -2048,7 +2053,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return b_ptr;
     }
 
-    dim_t get_data_B_batch_off(int b) const {
+    dim_t get_data_B_batch_off(dim_t b) const {
         using namespace format_tag;
         dim_t b_off = 0;
         if (one_of(bgmmc_.wei_tag, acbd, adbc)
@@ -2072,12 +2077,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return b_off;
     }
 
-    const char *get_data_B_batch_ptr(int b_idx) const {
-        const int b = get_bb_idx(b_idx, bgmmc_.bcast_B_desc);
+    const char *get_data_B_batch_ptr(dim_t b_idx) const {
+        const dim_t b = get_bb_idx(b_idx, bgmmc_.bcast_B_desc);
         return data_B_ptr_ + get_data_B_batch_off(b);
     }
 
-    const char *get_data_B_bitmask_ptr(int b, dim_t k, dim_t n) const {
+    const char *get_data_B_bitmask_ptr(dim_t b, dim_t k, dim_t n) const {
         assert(bgmmc_.packed_sparse_weights);
         const dim_t cur_data_B_off
                 = get_data_B_batch_off(b) + get_data_B_kn_off(k, n);
@@ -2085,7 +2090,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return data_B_bitmask_ptr_ + bitmask_off;
     }
 
-    char *get_data_C_ptr(int b, dim_t m, dim_t n) const {
+    char *get_data_C_ptr(dim_t b, dim_t m, dim_t n) const {
         return data_C_ptr_ + get_data_C_off(b, m, n);
     }
 
@@ -2094,17 +2099,17 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 + ithr * bgmmc_.brgemm_batch_element_per_thr_sz;
     }
 
-    void init_brgemm_batch_elements_values(int ithr, int brg_batch_start,
-            int brg_batch_iters, const char *A_data_batch_ptr,
-            const char *B_data_batch_ptr, int b_idx, int m_blk_idx,
-            int k_blk_idx, int n_blk_idx) const {
+    void init_brgemm_batch_elements_values(int ithr, dim_t brg_batch_start,
+            dim_t brg_batch_iters, const char *A_data_batch_ptr,
+            const char *B_data_batch_ptr, dim_t b_idx, dim_t m_blk_idx,
+            dim_t k_blk_idx, dim_t n_blk_idx) const {
         auto addr_batch = get_batch_elem_ptr(ithr);
 
         const dim_t m = get_M_idx(m_blk_idx, true);
         const dim_t n = n_blk_idx * bgmmc_.N_blk;
 
         for (int b_iter = 0; b_iter < brg_batch_iters; b_iter++) {
-            const int brg_batch_idx = brg_batch_start + b_iter;
+            const dim_t brg_batch_idx = brg_batch_start + b_iter;
             const dim_t k = k_blk_idx * bgmmc_.K_blk * bgmmc_.brgemm_batch_size
                     + brg_batch_idx * bgmmc_.K_blk;
             addr_batch[b_iter].ptr.A = bgmmc_.use_buffer_a
@@ -2119,22 +2124,23 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         }
     }
 
-    char *get_buf_A_ptr(int ithr, int m_blk_idx, int k_blk_idx, int gb) const {
+    char *get_buf_A_ptr(
+            int ithr, dim_t m_blk_idx, dim_t k_blk_idx, dim_t gb) const {
         if (!bgmmc_.use_buffer_a && !bgmmc_.use_buffer_a_tail_only)
             return nullptr;
 
-        int k_blk_local = bgmmc_.use_buffer_a_tail_only ? 0 : k_blk_idx;
+        dim_t k_blk_local = bgmmc_.use_buffer_a_tail_only ? 0 : k_blk_idx;
         k_blk_local = k_blk_local % get_K_chunk_size();
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
-            const int tail_idx = get_M_tail_block_idx(m_blk_idx);
-            const int curr_m_block_size
+            const dim_t tail_idx = get_M_tail_block_idx(m_blk_idx);
+            const dim_t curr_m_block_size
                     = m_tail_processing_[tail_idx].kernel_size;
             const dim_t curr_m_buf_shift
                     = m_tail_processing_[tail_idx].buf_dim_idx;
             const dim_t ld = bgmmc_.tr_a_dt_sz
                     * (bgmmc_.use_buffer_a_tail_only ? bgmmc_.wei_k_blk
                                                      : bgmmc_.LDA);
-            const int batch = bgmmc_.use_buffer_a_tail_only
+            const dim_t batch = bgmmc_.use_buffer_a_tail_only
                     ? 1
                     : bgmmc_.brgemm_batch_size;
             const dim_t offset = ithr * bgmmc_.buffer_a_per_thread_sz
@@ -2144,7 +2150,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             return buf_A_ptr_ + offset;
         }
 
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+        const dim_t m_blk_local = m_blk_idx % get_M_chunk_size();
         return buf_A_ptr_ + ithr * bgmmc_.buffer_a_per_thread_sz
                 + m_blk_local * bgmmc_.buffer_a_m_stride
                 + k_blk_local * bgmmc_.buffer_a_k_stride
@@ -2158,10 +2164,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     //     a block of memory per thread.
     //   `gb` defines an offset to a specific block over K inside a portion of
     //     blocks.
-    char *get_buf_B_ptr(int ithr, int k_blk_idx, int n_blk_idx, int gb) const {
+    char *get_buf_B_ptr(
+            int ithr, dim_t k_blk_idx, dim_t n_blk_idx, dim_t gb) const {
         UNUSED(n_blk_idx);
         if (!bgmmc_.use_buffer_b) return nullptr;
-        int k_blk_local = k_blk_idx % get_K_chunk_size();
+        dim_t k_blk_local = k_blk_idx % get_K_chunk_size();
         const auto offset = ithr * bgmmc_.buffer_b_per_thread_sz
                 + k_blk_local * bgmmc_.buffer_b_k_brg_stride
                 + gb * bgmmc_.buffer_b_gb_stride;
@@ -2190,7 +2197,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return buf_B_ptr_ + offset;
     }
 
-    char *get_buf_C_ptr(int ithr, int m_blk_idx, int n_blk_idx) const {
+    char *get_buf_C_ptr(int ithr, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (!bgmmc_.use_buffer_c) return nullptr;
 
         if (bgmmc_.nthr_k > 1) {
@@ -2200,8 +2207,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         char *buf_C_ptr_local
                 = buf_C_ptr_ + ithr * bgmmc_.buffer_c_per_thread_sz;
 
-        int n_blk_local = 0;
-        int m_blk_local = 0;
+        dim_t n_blk_local = 0;
+        dim_t m_blk_local = 0;
 
         if (bgmmc_.is_runtime_N || bgmmc_.is_runtime_M
                 || bgmmc_.K_chunk_elems < bgmmc_.K) {
@@ -2213,7 +2220,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         const bool runtime_N_tail = is_runtime_N_tail_chunk(n_blk_idx);
 
         if (runtime_M_tail || runtime_N_tail) {
-            const int curr_m_block_size = get_M_kernel_size(m_blk_idx);
+            const dim_t curr_m_block_size = get_M_kernel_size(m_blk_idx);
             const dim_t curr_m_buf_shift = runtime_M_tail
                     ? m_tail_processing_[get_M_tail_block_idx(m_blk_idx)]
                               .buf_dim_idx
@@ -2240,7 +2247,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     char *get_buf_C_par_reduction_ptr(
-            int ithr_k, int m_blk_idx, int n_blk_idx) const {
+            int ithr_k, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (bgmmc_.nthr_k <= 1) return nullptr;
 
         const dim_t m = m_blk_idx * bgmmc_.M_blk;
@@ -2259,12 +2266,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         if (!bgmmc_.blocked_B) return 0;
 
-        const int orig_wei_k_blk = bgmmc_.is_xf16_fp8
+        const dim_t orig_wei_k_blk = bgmmc_.is_xf16_fp8
                 ? get_wei_k_blk(bgmmc_.orig_wei_dt)
                 : bgmmc_.wei_k_blk;
         dim_t x0 = k % orig_wei_k_blk;
         dim_t x1 = n % bgmmc_.wei_n_blk;
-        const int orig_vnni_factor = bgmmc_.is_xf16_fp8
+        const dim_t orig_vnni_factor = bgmmc_.is_xf16_fp8
                 ? data_type_vnni_granularity(bgmmc_.orig_wei_dt)
                 : vnni_factor;
         dim_t offset
@@ -2273,7 +2280,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return bgmmc_.b_dt_sz * offset;
     }
 
-    dim_t get_data_C_off(int b, dim_t m, dim_t n) const {
+    dim_t get_data_C_off(dim_t b, dim_t m, dim_t n) const {
         using namespace format_tag;
         assert(bgmmc_.dst_tag != adbc);
         dim_t off = 0;
@@ -2296,14 +2303,14 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the user-provided reduce buffer, shifted by
     // the specified offset @p off.
-    char *get_data_reduce_ptr(int off) const {
+    char *get_data_reduce_ptr(dim_t off) const {
         if (!bgmmc_.with_reduce) return nullptr;
         return data_reduce_ptr_ + off * bgmmc_.reduce_dt_sz;
     }
 
     // Returns a pointer to the scratchpad reduce buffer for the
     // corresponding @p ithr, shifted by the specified offset @p off.
-    char *get_buf_reduce_ptr(int ithr, int off) const {
+    char *get_buf_reduce_ptr(int ithr, dim_t off) const {
         if (!bgmmc_.with_reduce) return nullptr;
         assert(bgmmc_.acc_dt == f32);
         const int ithr_k = get_thread_idx_for_k(ithr);
@@ -2318,7 +2325,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the scratchpad reduce buffer for the
     // corresponding index @p ibuf, shifted by the specified offset @p off.
-    char *get_buf_reduce_ptr_by_index(int ibuf, int off) const {
+    char *get_buf_reduce_ptr_by_index(int ibuf, dim_t off) const {
         if (!bgmmc_.with_reduce) return nullptr;
         const size_t _off = bgmmc_.M * ibuf + off;
         return buf_reduce_ptr_ + _off * bgmmc_.acc_dt_sz;
@@ -2330,10 +2337,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return bias_ptr_ + n * bgmmc_.bias_dt_sz;
     }
 
-    int32_t *get_s8s8_comp_ptr(int ithr, int b, int n_blk_idx) const {
+    int32_t *get_s8s8_comp_ptr(int ithr, dim_t b, dim_t n_blk_idx) const {
         if (!bgmmc_.s8s8_compensation_required) return nullptr;
 
-        const int n_blk_local = bgmmc_.use_buffer_b
+        const dim_t n_blk_local = bgmmc_.use_buffer_b
                 ? n_blk_idx % bgmmc_.N_chunk_size
                 : n_blk_idx;
         assert(!is_runtime_value(bgmmc_.s8s8_comp_b_str));
@@ -2493,10 +2500,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     int32_t *get_zp_a_compensation_ptr(
-            int ithr, int b_idx, int n_blk_idx) const {
+            int ithr, dim_t b_idx, dim_t n_blk_idx) const {
         if (!bgmmc_.has_zero_point_a) return nullptr;
 
-        const int n_blk_local = n_blk_idx % bgmmc_.N_chunk_size;
+        const dim_t n_blk_local = n_blk_idx % bgmmc_.N_chunk_size;
         int32_t *zp_comp = zero_point_a_compensations_ptr_
                 + ithr * bgmmc_.zp_a_comp_elems_per_thr
                 + n_blk_local * bgmmc_.zp_a_comp_shift_n;
@@ -2506,20 +2513,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             // locally just before usage. Using the single global scaling before
             // parallel section might produce significant overhead for small
             // problems running in multitreaded execution mode
-            const int base_offset = get_bb_idx(b_idx, bgmmc_.bcast_B_desc)
+            const dim_t base_offset = get_bb_idx(b_idx, bgmmc_.bcast_B_desc)
                             * rnd_up(bgmmc_.N, bgmmc_.wei_n_blk)
                     + n_blk_idx * bgmmc_.N_blk;
 
-            int curr_N_blk = get_N_kernel_size(n_blk_idx);
+            const dim_t curr_N_blk = get_N_kernel_size(n_blk_idx);
             PRAGMA_OMP_SIMD()
-            for (int b = 0; b < curr_N_blk; b++)
+            for (dim_t b = 0; b < curr_N_blk; b++)
                 zp_comp[b] = -get_neg_zp_a()
                         * reorder_zp_a_comp_ptr_[base_offset + b];
         }
         return zp_comp;
     }
 
-    int32_t *get_zp_b_compensation_result_ptr(int ithr, int m_blk_idx) const {
+    int32_t *get_zp_b_compensation_result_ptr(int ithr, dim_t m_blk_idx) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
 
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
@@ -2530,13 +2537,13 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     + ithr * bgmmc_.zp_b_comp_elems_per_thr + curr_m_buf_shift;
         }
 
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+        const dim_t m_blk_local = m_blk_idx % get_M_chunk_size();
         return zero_point_b_compensations_ptr_
                 + ithr * bgmmc_.zp_b_comp_elems_per_thr
                 + m_blk_local * bgmmc_.zp_b_comp_result_shift_m;
     }
 
-    int32_t *get_zp_b_compensation_buffer_ptr(int ithr, int m_blk_idx) const {
+    int32_t *get_zp_b_compensation_buffer_ptr(int ithr, dim_t m_blk_idx) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
 
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
@@ -2547,7 +2554,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     + bgmmc_.zp_b_comp_buffer_start + curr_m_buf_shift;
         }
 
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+        const dim_t m_blk_local = m_blk_idx % get_M_chunk_size();
         return get_zp_b_compensation_result_ptr(ithr, 0)
                 + bgmmc_.zp_b_comp_buffer_start
                 + m_blk_local * bgmmc_.zp_b_comp_buffer_shift_m;
@@ -2564,17 +2571,17 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     int get_base_brgemm_kernel_idx() const { return base_brg_ker_idx_; }
 
-    bool is_last_K_blk(int k_blk_idx) const {
+    bool is_last_K_blk(dim_t k_blk_idx) const {
         return k_blk_idx == bgmmc_.num_K_blocks - 1;
     }
 
-    int get_brgemm_batch_size(int k_chunk_idx) const {
+    dim_t get_brgemm_batch_size(dim_t k_chunk_idx) const {
         return is_last_K_blk(k_chunk_idx) ? last_brgemm_batch_size_
                                           : bgmmc_.brgemm_batch_size;
     }
 
-    int get_parallel_work_amount() const { return parallel_work_amount_; }
-    int get_parallel_work_amount_gemm() const {
+    dim_t get_parallel_work_amount() const { return parallel_work_amount_; }
+    dim_t get_parallel_work_amount_gemm() const {
         return parallel_work_amount_gemm_;
     }
     int get_num_threads_for_k() const { return nthr_k_; }
@@ -2605,15 +2612,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return num_threads_used_;
     }
     dim_t get_M() const { return M_; }
-    int get_M_chunks() const { return M_chunks_; }
-    int get_M_chunk_size() const { return bgmmc_.M_chunk_size; }
-    int get_M_chunk_tail() const { return M_chunk_tail_; }
+    dim_t get_M_chunks() const { return M_chunks_; }
+    dim_t get_M_chunk_size() const { return bgmmc_.M_chunk_size; }
+    dim_t get_M_chunk_tail() const { return M_chunk_tail_; }
 
-    int get_K_chunks() const { return K_chunks_; }
-    int get_K_chunk_size() const { return bgmmc_.K_chunk_size; }
-    int get_K_chunk_tail() const { return K_chunk_tail_; }
+    dim_t get_K_chunks() const { return K_chunks_; }
+    dim_t get_K_chunk_size() const { return bgmmc_.K_chunk_size; }
+    dim_t get_K_chunk_tail() const { return K_chunk_tail_; }
 
-    int get_M_kernel_idx(int m_block_idx) const {
+    int get_M_kernel_idx(dim_t m_block_idx) const {
         if (!is_M_tail_processing(m_block_idx))
             return 0;
         else if (!bgmmc_.is_runtime_M)
@@ -2624,7 +2631,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return m_tail_processing_[get_M_tail_block_idx(m_block_idx)].kernel_idx;
     }
 
-    int get_M_kernel_size(int m_block_idx) const {
+    dim_t get_M_kernel_size(dim_t m_block_idx) const {
         if (!is_M_tail_processing(m_block_idx))
             return bgmmc_.M_blk;
         else if (!bgmmc_.is_runtime_M)
@@ -2637,10 +2644,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_M_idx(
-            int m_block_idx, bool adjust_for_kernel_overlap = false) const {
+            dim_t m_block_idx, bool adjust_for_kernel_overlap = false) const {
         if (is_runtime_M_tail_chunk(m_block_idx)) {
-            const int tail_idx = get_M_tail_block_idx(m_block_idx);
-            const int shift = adjust_for_kernel_overlap
+            const dim_t tail_idx = get_M_tail_block_idx(m_block_idx);
+            const dim_t shift = adjust_for_kernel_overlap
                     ? m_tail_processing_[tail_idx].shift
                     : 0;
             return m_tail_processing_[tail_idx].idx - shift;
@@ -2649,11 +2656,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_N() const { return N_; }
-    int get_N_chunks() const { return N_chunks_; }
-    int get_N_chunk_tail() const { return N_chunk_tail_; }
-    int get_N_chunk_tail_elems() const { return N_chunk_tail_elems_; }
+    dim_t get_N_chunks() const { return N_chunks_; }
+    dim_t get_N_chunk_tail() const { return N_chunk_tail_; }
+    dim_t get_N_chunk_tail_elems() const { return N_chunk_tail_elems_; }
 
-    int get_N_kernel_idx(int n_block_idx) const {
+    int get_N_kernel_idx(dim_t n_block_idx) const {
         if (!is_N_tail_processing(n_block_idx))
             return 0;
         else if (!bgmmc_.is_runtime_N)
@@ -2664,7 +2671,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return n_tail_processing_[get_N_tail_block_idx(n_block_idx)].kernel_idx;
     }
 
-    int get_N_kernel_size(int n_block_idx) const {
+    dim_t get_N_kernel_size(dim_t n_block_idx) const {
         if (!is_N_tail_processing(n_block_idx))
             return bgmmc_.N_blk;
         else if (!bgmmc_.is_runtime_N)
@@ -2677,10 +2684,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_N_idx(
-            int n_block_idx, bool adjust_for_kernel_overlap = false) const {
+            dim_t n_block_idx, bool adjust_for_kernel_overlap = false) const {
         if (is_runtime_N_tail_chunk(n_block_idx)) {
-            const int tail_idx = get_N_tail_block_idx(n_block_idx);
-            const int shift = adjust_for_kernel_overlap
+            const dim_t tail_idx = get_N_tail_block_idx(n_block_idx);
+            const dim_t shift = adjust_for_kernel_overlap
                     ? n_tail_processing_[tail_idx].shift
                     : 0;
             return n_tail_processing_[tail_idx].idx - shift;
@@ -2695,20 +2702,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     // compute dst values for the same area. We need to backup/restore values
     // for overlapped area to avoid correctness issues.
     void maybe_backup_dst_values_to_buffer(
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx) const {
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (!copy_d_required(m_blk_idx, n_blk_idx)) return;
 
         const bool m_tail_overlapping = is_m_tail_overlap(m_blk_idx);
         dim_t m_start = m_tail_overlapping ? get_M_idx(m_blk_idx, true)
                                            : get_M_idx(m_blk_idx);
-        const int rows_to_copy = m_tail_overlapping
+        const dim_t rows_to_copy = m_tail_overlapping
                 ? m_tail_processing_[get_M_tail_block_idx(m_blk_idx)].shift
                 : get_M_kernel_size(m_blk_idx);
 
         const bool n_tail_overlapping = is_n_tail_overlap(n_blk_idx);
         dim_t n_start = n_tail_overlapping ? get_N_idx(n_blk_idx, true)
                                            : get_N_idx(n_blk_idx);
-        const int row_elems = n_tail_overlapping
+        const dim_t row_elems = n_tail_overlapping
                 ? n_tail_processing_[get_N_tail_block_idx(n_blk_idx)].shift
                 : get_N_kernel_size(n_blk_idx);
         const dim_t bytes_to_copy = bgmmc_.c_dt_sz * row_elems;
@@ -2727,20 +2734,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     void maybe_restore_dst_values_from_buffer(
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx) const {
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (!copy_d_required(m_blk_idx, n_blk_idx)) return;
 
         const bool m_tail_overlapping = is_m_tail_overlap(m_blk_idx);
         dim_t m_start = m_tail_overlapping ? get_M_idx(m_blk_idx, true)
                                            : get_M_idx(m_blk_idx);
-        const int rows_to_copy = m_tail_overlapping
+        const dim_t rows_to_copy = m_tail_overlapping
                 ? m_tail_processing_[get_M_tail_block_idx(m_blk_idx)].shift
                 : get_M_kernel_size(m_blk_idx);
 
         const bool n_tail_overlapping = is_n_tail_overlap(n_blk_idx);
         dim_t n_start = n_tail_overlapping ? get_N_idx(n_blk_idx, true)
                                            : get_N_idx(n_blk_idx);
-        const int row_elems = n_tail_overlapping
+        const dim_t row_elems = n_tail_overlapping
                 ? n_tail_processing_[get_N_tail_block_idx(n_blk_idx)].shift
                 : get_N_kernel_size(n_blk_idx);
         const dim_t bytes_to_copy = bgmmc_.c_dt_sz * row_elems;
@@ -2771,7 +2778,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     bool packed_sparse_weights() const { return bgmmc_.packed_sparse_weights; }
 
-    int get_current_K_pad(int current_K_iters) const {
+    dim_t get_current_K_pad(dim_t current_K_iters) const {
         if (bgmmc_.is_wei_zp_per_k || bgmmc_.is_wei_scale_per_k) return 0;
         if (current_K_iters % bgmmc_.wei_k_blk == 0) return 0;
         return (bgmmc_.extendable_k || bgmmc_.use_fused_copy_a)
@@ -2788,10 +2795,10 @@ private:
         // index of tail processing kernel, 0 is reserved for main block
         int kernel_idx;
         // block size of tail kernel
-        int kernel_size;
+        dim_t kernel_size;
         // shift wrt dimension index when kernel is applied w/ computational
         // overlapping with other kernel, dim_idx_to_apply_kernel = idx - shift
-        int shift;
+        dim_t shift;
         // if shift > 0 (computational overlapping case) we have to use buffer
         // for kernel dst to avoid result values spoiling, this value
         // represents dimensional idx for dst buffer
@@ -2814,7 +2821,7 @@ private:
     const char *data_B_bitmask_ptr_;
     // The size of a packed saprse block. E.g. the block
     // for a tag 'BA16a64b4a' is 4096.
-    int B_packed_sparse_block_size_;
+    dim_t B_packed_sparse_block_size_;
 
     char *data_C_ptr_;
     char *data_reduce_ptr_;
@@ -2847,33 +2854,33 @@ private:
     std::vector<const void *> post_ops_binary_rhs_arg_vec_;
 
     int base_brg_ker_idx_;
-    int vnni_factor;
+    dim_t vnni_factor;
 
     // parallelization parameters
-    int parallel_work_amount_;
-    int parallel_work_amount_gemm_;
+    dim_t parallel_work_amount_;
+    dim_t parallel_work_amount_gemm_;
     int nthr_, nthr_k_, nthr_bmn_, num_threads_used_;
     // Horizontal order means first process N (load) dim then M (bcast) dim.
     bool is_thread_chunks_exec_order_horizontal_;
-    int last_brgemm_batch_size_;
+    dim_t last_brgemm_batch_size_;
 
     dim_t M_;
-    int M_chunks_;
-    int M_chunk_tail_;
-    int M_chunk_tail_elements_;
-    int M_tail_block_start_;
+    dim_t M_chunks_;
+    dim_t M_chunk_tail_;
+    dim_t M_chunk_tail_elements_;
+    dim_t M_tail_block_start_;
 
     dim_t K_;
-    int K_chunks_;
-    int K_chunk_tail_;
-    int K_chunk_tail_elements_;
+    dim_t K_chunks_;
+    dim_t K_chunk_tail_;
+    dim_t K_chunk_tail_elements_;
 
     dim_t N_;
-    int N_chunks_;
-    int N_chunk_tail_;
-    int N_chunk_tail_elems_;
+    dim_t N_chunks_;
+    dim_t N_chunk_tail_;
+    dim_t N_chunk_tail_elems_;
 
-    int N_tail_block_start_;
+    dim_t N_tail_block_start_;
     dim_t A_strides_[3];
     dim_t A_ptr_shift_b_;
     dim_t copy_A_src_stride_;
@@ -2890,44 +2897,44 @@ private:
         return buf_D_ptr_ + bgmmc_.c_dt_sz * bgmmc_.M_blk * bgmmc_.N_blk * ithr;
     }
 
-    int get_M_tail_block_idx(int m_block_idx) const {
-        const int tail_idx = m_block_idx - M_tail_block_start_;
+    dim_t get_M_tail_block_idx(dim_t m_block_idx) const {
+        const dim_t tail_idx = m_block_idx - M_tail_block_start_;
         if (!bgmmc_.is_runtime_M) return tail_idx;
-        return tail_idx < (int)m_tail_processing_.size() ? tail_idx : -1;
+        return tail_idx < (dim_t)m_tail_processing_.size() ? tail_idx : -1;
     }
-    bool is_M_tail_processing(int m_block_idx) const {
+    bool is_M_tail_processing(dim_t m_block_idx) const {
         return get_M_tail_block_idx(m_block_idx) >= 0;
     }
-    bool is_runtime_M_tail_chunk(int m_block_idx) const {
+    bool is_runtime_M_tail_chunk(dim_t m_block_idx) const {
         return bgmmc_.is_runtime_M && is_M_tail_processing(m_block_idx);
     }
 
-    bool is_m_tail_overlap(int m_block_idx) const {
+    bool is_m_tail_overlap(dim_t m_block_idx) const {
         return is_runtime_M_tail_chunk(m_block_idx)
                 && m_tail_processing_[get_M_tail_block_idx(m_block_idx)].shift
                 > 0;
     }
 
-    int get_N_tail_block_idx(int n_block_idx) const {
-        const int tail_idx = n_block_idx - N_tail_block_start_;
+    dim_t get_N_tail_block_idx(dim_t n_block_idx) const {
+        const dim_t tail_idx = n_block_idx - N_tail_block_start_;
         if (!bgmmc_.is_runtime_N) return tail_idx;
-        return tail_idx < (int)n_tail_processing_.size() ? tail_idx : -1;
+        return tail_idx < (dim_t)n_tail_processing_.size() ? tail_idx : -1;
     }
-    bool is_N_tail_processing(int n_block_idx) const {
+    bool is_N_tail_processing(dim_t n_block_idx) const {
         return get_N_tail_block_idx(n_block_idx) >= 0;
     }
 
-    bool is_runtime_N_tail_chunk(int n_block_idx) const {
+    bool is_runtime_N_tail_chunk(dim_t n_block_idx) const {
         return bgmmc_.is_runtime_N && is_N_tail_processing(n_block_idx);
     }
 
-    bool is_n_tail_overlap(int n_block_idx) const {
+    bool is_n_tail_overlap(dim_t n_block_idx) const {
         return is_runtime_N_tail_chunk(n_block_idx)
                 && n_tail_processing_[get_N_tail_block_idx(n_block_idx)].shift
                 > 0;
     }
 
-    bool copy_d_required(int m_block_idx, int n_block_idx) const {
+    bool copy_d_required(dim_t m_block_idx, dim_t n_block_idx) const {
         if (!bgmmc_.with_sum) return false;
         return is_m_tail_overlap(m_block_idx) || is_n_tail_overlap(n_block_idx);
     }

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -63,7 +63,7 @@ struct brgemm_matmul_t : public primitive_t {
         int get_brg_kernel_idx(bool is_bs_tail, bool do_initialization,
                 int m_ker_idx, int n_ker_idx, bool is_K_tail,
                 bool is_prefetching) const;
-        const brgemm_desc_t &get_brg_desc(int idx) const {
+        const brgemm_desc_t &get_brg_desc(dim_t idx) const {
             return brg_descs_[idx];
         }
         const brgemm_matmul_conf_t &get_brgemm_matmul_conf() const {
@@ -91,29 +91,31 @@ private:
     status_t execute_body(const exec_ctx_t &ctx) const;
     void compute_kernel(const brg_matmul_exec_ctx_t &brgmm_ctx,
             const char *A_data_batch_ptr, const char *B_data_batch_ptr,
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx, int k_blk_idx,
-            bool do_init, int &prev_ker_idx, bool prefetch) const;
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx,
+            dim_t k_blk_idx, bool do_init, int &prev_ker_idx,
+            bool prefetch) const;
     void fill_per_mn_compensation(const brg_matmul_exec_ctx_t &brgmm_ctx,
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx,
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx,
             const char *A_data_batch_ptr, const char *B_data_batch_ptr,
-            int m_kernel_size, int n_kernel_size, int k_blk_idx,
+            dim_t m_kernel_size, dim_t n_kernel_size, dim_t k_blk_idx,
             bool is_tail) const;
 
-    bool determine_prefetch(const int mc, const int m_end, const int nc,
-            const int n_end, const brgemm_matmul_conf_t &bgmmc,
+    bool determine_prefetch(const dim_t mc, const dim_t m_end, const dim_t nc,
+            const dim_t n_end, const brgemm_matmul_conf_t &bgmmc,
             const brg_matmul_exec_ctx_t &brgmm_ctx) const;
 
     void copy_a_chunk_in_buffer(const brg_matmul_exec_ctx_t &brgmm_ctx,
-            const char *A_data_batch_ptr, int ithr, int m_blk_idx,
-            int k_blk_idx) const;
+            const char *A_data_batch_ptr, int ithr, dim_t m_blk_idx,
+            dim_t k_blk_idx) const;
     void copy_b_chunk_in_buffer(const brg_matmul_exec_ctx_t &brgmm_ctx,
-            const char *B_data_batch_ptr, int ithr, int b_idx, int n_blk_idx,
-            int k_blk_idx) const;
+            const char *B_data_batch_ptr, int ithr, dim_t b_idx,
+            dim_t n_blk_idx, dim_t k_blk_idx) const;
     void maybe_reduce_partial_results_and_apply_postops(
             const std::shared_ptr<brg_matmul_exec_ctx_t> &brgmm_ctx_ptr) const;
     void maybe_reduce_A(const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr,
-            int gemm_batch, int m_blk_idx, int n_blk_idx, int k_chunk_idx,
-            bool do_init, bool has_K_tail, bool do_K_tail) const;
+            dim_t gemm_batch, dim_t m_blk_idx, dim_t n_blk_idx,
+            dim_t k_chunk_idx, bool do_init, bool has_K_tail,
+            bool do_K_tail) const;
     void maybe_reduce_and_convert_partial_results_A(
             const std::shared_ptr<brg_matmul_exec_ctx_t> &brgmm_ctx_ptr) const;
     void accumulate(

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -43,9 +43,10 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
     jit_brgemm_matmul_copy_a_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
         , jit_generator_t(jit_name())
-        , typesize_(conf_->a_dt_sz)
-        , tr_typesize_(conf_->tr_a_dt_sz)
-        , vnni_granularity_(data_type_vnni_granularity(conf_->src_dt))
+        , typesize_(static_cast<int>(conf_->a_dt_sz))
+        , tr_typesize_(static_cast<int>(conf_->tr_a_dt_sz))
+        , vnni_granularity_(
+                  static_cast<int>(data_type_vnni_granularity(conf_->src_dt)))
         , k_step_(vlen_ / nstl::max(typesize_, tr_typesize_))
         , src_stride_(conf_->copy_A_src_stride)
         , tr_src_stride_((conf_->use_buffer_a_tail_only
@@ -265,8 +266,9 @@ void jit_brgemm_matmul_copy_a_impl_t<
 template <typename Vmm>
 void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
         bool is_K_tail, bool is_first_K_iter, bool is_last_K_iter) {
-    const int K_blk = is_K_tail ? conf_->K % conf_->K_blk
-                                : nstl::min(conf_->K, conf_->K_blk);
+    const int K_blk = static_cast<int>(is_K_tail
+                    ? conf_->K % conf_->K_blk
+                    : nstl::min<dim_t>(conf_->K, conf_->K_blk));
     const int k_tail = K_blk % k_step_;
     const int num_k_iters = K_blk / k_step_;
     const int num_acc = utils::saturate(1, (int)num_comp_acc_, num_k_iters);
@@ -295,7 +297,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
             const int k_idx = kb * k_loop_unroll_ + k;
             const size_t offset
                     = static_cast<size_t>(k_idx) * k_step_ * typesize_;
-            load_vmm(k, offset);
+            load_vmm(k, static_cast<int>(offset));
             maybe_compute_compensation(k_idx, get_vmm_copy(k));
         }
         if (allow_input_shift_for_s8s8 && conf_->s8s8_compensation_required) {
@@ -330,7 +332,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
                 const size_t offset
                         = (static_cast<size_t>(kb) * k_loop_unroll_ + k)
                         * k_step_ * tr_typesize_;
-                store_vmm(k, offset);
+                store_vmm(k, static_cast<int>(offset));
             }
         }
     }
@@ -3547,7 +3549,7 @@ private:
 
     Xbyak::Ymm get_ymm(int idx) { return get_vmm(0, idx); }
 
-    void load_ymm(int ymm_idx, size_t offset, bool is_tail, size_t tail_sz) {
+    void load_ymm(int ymm_idx, size_t offset, bool is_tail, int tail_sz) {
         Xbyak::Ymm vmm_src = Xbyak::Ymm(ymm_idx);
         if (is_tail) {
             load_bytes(vmm_src, reg_src, offset, tail_sz);
@@ -3566,8 +3568,8 @@ private:
             if (pass == 0 && ncolumns >= simd_w_) mov(reg_src_backup, reg_src);
             assert(one_of(pass, 0, 1));
             const dim_t tr_src_off_base = k * tr_src_stride_;
-            const int set_1_tr_src_offset
-                    = tr_src_off_base + pass * 2 * n_blk_step_;
+            const int set_1_tr_src_offset = static_cast<int>(
+                    tr_src_off_base + pass * 2 * n_blk_step_);
             const int row_start = k * k_blk_step_;
             const int row_end = nstl::min(row_start + k_blk_step_, nrows);
             if (!zeropad) {
@@ -3743,7 +3745,8 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         if (!is_dynamic_N_) mov(reg_N_blk, ncolumns);
 
         if (do_compute_compensation_) {
-            int n_iters = div_up(conf_->wei_n_blk, 16) * (is_ymm_ ? 2 : 1);
+            int n_iters = static_cast<int>(
+                    div_up(conf_->wei_n_blk, 16) * (is_ymm_ ? 2 : 1));
             for (int i = 0; i < n_iters; i++)
                 uni_vpxor(get_comp_acc(i), get_comp_acc(i), get_comp_acc(i));
             mov(reg_tmp, 1);
@@ -3771,7 +3774,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         if (do_compute_compensation_) {
             const bool req_s8s8_comp = conf_->s8s8_compensation_required;
             const bool req_zp_comp = conf_->has_zero_point_a;
-            int n_iters = div_up(conf_->wei_n_blk, 16);
+            int n_iters = static_cast<int>(div_up(conf_->wei_n_blk, 16));
             assert(IMPLICATION(req_zp_comp,
                     conf_->src_zp_type == brgemm_broadcast_t::per_tensor));
 
@@ -3965,9 +3968,9 @@ struct jit_brgemm_matmul_copy_b_bf16_t
 
     jit_brgemm_matmul_copy_b_bf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize(conf->b_dt_sz)
-        , tr_typesize(conf->tr_b_dt_sz)
-        , wei_scales_typesize(conf->wei_scales_dt_sz)
+        , typesize(static_cast<int>(conf->b_dt_sz))
+        , tr_typesize(static_cast<int>(conf->tr_b_dt_sz))
+        , wei_scales_typesize(static_cast<int>(conf->wei_scales_dt_sz))
         , src_stride(conf->copy_B_wei_stride)
         , tr_src_stride(conf_->LDB * k_blk_step * tr_typesize)
         , is_src_int4(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
@@ -4197,7 +4200,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
     if (is_dynamic_N || do_N_loop) {
         n_iters = ncolumns;
     } else {
-        n_iters = conf_->wei_n_blk;
+        n_iters = static_cast<int>(conf_->wei_n_blk);
     }
 
     for_(int k = 0; k < nrows; k += k_blk_step)
@@ -4315,7 +4318,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
     mov(ptr[rsp + reg_tr_src_offs], reg_tr_src);
     xor_(reg_copy_block_n_shift, reg_copy_block_n_shift);
 
-    int current_n_blk_step = do_N_loop ? conf_->LDB : n_blk_step;
+    int current_n_blk_step
+            = do_N_loop ? static_cast<int>(conf_->LDB) : n_blk_step;
 
     Label loop_row_start, loop_row_tail, loop_row_done;
     cmp(reg_dynamic_tail, current_n_blk_step);
@@ -4417,8 +4421,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
         // Otherwise default K-loop is used
         if (is_wei_grouped_over_k) {
             const int k_group_size = conf_->is_wei_zp_per_k
-                    ? conf_->wei_zp_k_gsize
-                    : conf_->wei_scales_k_gsize;
+                    ? static_cast<int>(conf_->wei_zp_k_gsize)
+                    : static_cast<int>(conf_->wei_scales_k_gsize);
             if (k_group_size < k_blk_step) {
                 if (zeropad) return;
                 copy_block(
@@ -4472,7 +4476,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
     };
 
     auto compute_K_loop = [&](bool is_N_tail) {
-        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        int ncolumns = is_N_tail ? static_cast<int>(conf_->N_tail)
+                                 : static_cast<int>(conf_->N_blk);
         // 'param1' register (rcx on Windows) re-written in compute_K_loop_body
         // so we need to read and keep 'current_K_pad' parameter in stack before
         // the call
@@ -4600,7 +4605,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
                 (k * src_stride_ + n * typesize_in_) / src_elems_per_byte_);
         if (is_tail && !isa_has_masks(conf_->isa)) {
             load_bytes(src_vmm, addr,
-                    (ncolumns % simd_w_) * typesize_in_ / src_elems_per_byte_);
+                    static_cast<int>((ncolumns % simd_w_) * typesize_in_
+                            / src_elems_per_byte_));
             load_value(src_vmm, src_vmm, vmm_permd, conf_->orig_wei_dt, false);
         } else
             load_value(src_vmm, addr, vmm_permd, conf_->orig_wei_dt, is_tail);
@@ -4624,7 +4630,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto addr = maybe_EVEX_compress_addr(reg_zp_ptr, offset);
         if (is_tail && !isa_has_masks(conf_->isa)) {
             load_bytes(vmm_zp_b_shift, addr,
-                    (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte);
+                    static_cast<int>(
+                            (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte));
             load_value(vmm_zp_b_shift, vmm_zp_b_shift, vmm_permd, zp_dt, false);
         } else
             load_value(vmm_zp_b_shift, addr, vmm_permd, zp_dt, is_tail);
@@ -4643,8 +4650,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto offset = n * scales_dt_sz;
         const auto addr = maybe_EVEX_compress_addr(reg_wei_scales, offset);
         if (is_tail && !isa_has_masks(conf_->isa)) {
-            load_bytes(
-                    vmm_wei_scales, addr, (ncolumns % simd_w_) * scales_dt_sz);
+            load_bytes(vmm_wei_scales, addr,
+                    static_cast<int>((ncolumns % simd_w_) * scales_dt_sz));
             load_scale_value(vmm_wei_scales, vmm_wei_scales, scales_dt, false);
         } else
             load_scale_value(vmm_wei_scales, addr, scales_dt, is_tail);
@@ -4698,7 +4705,9 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::compute_k_loop(int ncolumns) {
         jl(K_end_label, T_NEAR);
 
         copy_16_x_n_block(unroll, ncolumns);
-        add(reg_src, (unroll * src_stride_) / src_elems_per_byte_);
+        add(reg_src,
+                static_cast<dim_t>(
+                        (unroll * src_stride_) / src_elems_per_byte_));
         add(reg_tr_src, unroll * tr_src_stride_);
 
         sub(reg_K_iters, unroll);
@@ -4769,13 +4778,13 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::generate() {
         Label not_N_tail;
         cmp(reg_N_blk, conf_->N_tail);
         jne(not_N_tail, T_NEAR);
-        compute_k_loop(conf_->N_tail);
+        compute_k_loop(static_cast<int>(conf_->N_tail));
         jmp(done, T_NEAR);
 
         L(not_N_tail);
     }
 
-    compute_k_loop(conf_->N_blk);
+    compute_k_loop(static_cast<int>(conf_->N_blk));
     L(done);
 
     postamble();
@@ -4791,10 +4800,11 @@ struct jit_brgemm_matmul_copy_b_transposed_t
 
     jit_brgemm_matmul_copy_b_transposed_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize_(conf_->b_dt_sz)
-        , tr_typesize_(conf_->tr_b_dt_sz)
-        , wei_scales_typesize_(conf_->wei_scales_dt_sz)
-        , vnni_granularity_(data_type_vnni_granularity(conf_->wei_dt))
+        , typesize_(static_cast<int>(conf_->b_dt_sz))
+        , tr_typesize_(static_cast<int>(conf_->tr_b_dt_sz))
+        , wei_scales_typesize_(static_cast<int>(conf_->wei_scales_dt_sz))
+        , vnni_granularity_(
+                  static_cast<int>(data_type_vnni_granularity(conf_->wei_dt)))
         , k_blk_step_(vlen_ / tr_typesize_)
         , is_wei_grouped_over_k_(
                   conf_->is_wei_zp_per_k || conf_->is_wei_scale_per_k)
@@ -5354,7 +5364,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::init_tail_mask(
                 ? size_t(((size_t)1 << div_up(dt_step * columns_tail, 2)) - 1)
                 : size_t(((size_t)1 << dt_step * columns_tail) - 1);
         if (req_cvtps2xf16_)
-            kmovw(kTail, tail_mask);
+            kmovw(kTail, static_cast<uint32_t>(tail_mask));
         else
             kmovq(kTail, tail_mask);
     }
@@ -6048,7 +6058,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
     if (conf_->is_wei_scale_per_n) {
         const auto &scales_dt_sz = conf_->wei_scales_dt_sz;
         const auto offset = n_blk_step_ * scales_dt_sz;
-        add(reg_wei_scales, offset);
+        add(reg_wei_scales, static_cast<dim_t>(offset));
     }
 
     if (conf_->is_wei_zp_per_n) {
@@ -6064,9 +6074,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
         // compensation pointer. Only the stack-saved ZP pointer needs to
         // advance per N-block in that case.
         if (req_int8_zp_b_shift_)
-            add(qword[rsp + reg_zp_b_ptr_offs_], offset);
+            add(qword[rsp + reg_zp_b_ptr_offs_], static_cast<dim_t>(offset));
         else
-            add(reg_zp_ptr, offset);
+            add(reg_zp_ptr, static_cast<dim_t>(offset));
     }
 
     if (req_zp_comp_) add(reg_zp_comp_ptr, comp_shift_);
@@ -6214,7 +6224,8 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         }
 
         if (is_wei_grouped_over_k_ && grouped_k < k_blk_step_) {
-            compute_N_loop(grouped_k, is_first_K_iter, is_last_K_iter);
+            compute_N_loop(static_cast<int>(grouped_k), is_first_K_iter,
+                    is_last_K_iter);
             return;
         }
 
@@ -6223,13 +6234,15 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
             Label not_K_tail;
             cmp(reg_K_iters, k_blk);
             je(not_K_tail, T_NEAR);
-            compute_N_loop(K_tail_tail, is_first_K_iter, is_last_K_iter);
+            compute_N_loop(static_cast<int>(K_tail_tail), is_first_K_iter,
+                    is_last_K_iter);
             jmp(compute_body_done, T_NEAR);
 
             L(not_K_tail);
         }
 
-        compute_N_loop(K_blk_tail, is_first_K_iter, is_last_K_iter);
+        compute_N_loop(
+                static_cast<int>(K_blk_tail), is_first_K_iter, is_last_K_iter);
         L(compute_body_done);
     };
 
@@ -6290,9 +6303,9 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
 
     jit_brgemm_matmul_copy_b_cvt_bf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize_(conf->b_dt_sz)
-        , tr_typesize_(conf->tr_b_dt_sz)
-        , wei_scales_typesize_(conf_->wei_scales_dt_sz)
+        , typesize_(static_cast<int>(conf->b_dt_sz))
+        , tr_typesize_(static_cast<int>(conf->tr_b_dt_sz))
+        , wei_scales_typesize_(static_cast<int>(conf_->wei_scales_dt_sz))
         , is_src_int4_(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
         , src_elems_per_byte_(is_src_int4_ ? 2 : 1)
         , src_stride_(
@@ -6592,8 +6605,8 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         // Otherwise default K-loop is used
         if (is_wei_grouped_over_k_) {
             const int k_group_size = conf_->is_wei_zp_per_k
-                    ? conf_->wei_zp_k_gsize
-                    : conf_->wei_scales_k_gsize;
+                    ? static_cast<int>(conf_->wei_zp_k_gsize)
+                    : static_cast<int>(conf_->wei_scales_k_gsize);
             if (k_group_size == 1) {
                 if (zeropad) return;
                 copy_block(k_group_size, ncolumns, /*zeropad= */ false);
@@ -6659,7 +6672,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
 
     if (conf_->LDB2 != 0) {
         Label main_N_loop, main_N_loop_tail;
-        int tail = conf_->N % conf_->LDB;
+        int tail = static_cast<int>(conf_->N % conf_->LDB);
 
         if (tail != 0) {
             cmp(reg_N_blk, conf_->LDB);
@@ -6667,7 +6680,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         }
 
         L(main_N_loop);
-        compute_K_loop(conf_->LDB);
+        compute_K_loop(static_cast<int>(conf_->LDB));
         add(reg_src, conf_->LDB2 * typesize_);
         add(reg_tr_src, conf_->LDB2 * tr_typesize_);
 
@@ -6687,13 +6700,13 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
             Label main_N_blk;
             cmp(reg_N_blk, conf_->N_blk);
             je(main_N_blk, T_NEAR);
-            compute_K_loop(conf_->N_tail);
+            compute_K_loop(static_cast<int>(conf_->N_tail));
             jmp(done, T_NEAR);
 
             L(main_N_blk);
         }
 
-        compute_K_loop(conf_->N_blk);
+        compute_K_loop(static_cast<int>(conf_->N_blk));
     }
     L(done);
     postamble();
@@ -6761,8 +6774,8 @@ struct jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t
     jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
         , jit_generator_t(jit_name())
-        , typesize_(conf->b_dt_sz)
-        , tr_typesize_(conf->tr_b_dt_sz)
+        , typesize_(static_cast<int>(conf->b_dt_sz))
+        , tr_typesize_(static_cast<int>(conf->tr_b_dt_sz))
         , src_stride_(conf->LDB * k_blk_step * typesize_)
         , tr_src_stride_(conf->LDB * tr_k_blk_step * tr_typesize_)
         , cvt_helper_(this, conf) {}
@@ -6956,7 +6969,7 @@ private:
         assert(conf_->LDB2 != 0);
 
         Label main_N_loop, main_N_loop_tail;
-        int tail = conf_->N % conf_->LDB;
+        int tail = static_cast<int>(conf_->N % conf_->LDB);
 
         if (tail != 0) {
             cmp(reg_N_blk, conf_->LDB);
@@ -6964,7 +6977,7 @@ private:
         }
 
         L(main_N_loop);
-        compute_K_loop(conf_->LDB);
+        compute_K_loop(static_cast<int>(conf_->LDB));
         add(reg_src, conf_->B_strides[0]);
         add(reg_tr_src, conf_->LDB2 * tr_typesize_);
 

--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -72,7 +72,7 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     // drop all unit dims as they they will break the calculations. Removing
     // unit dims will not change the physical memory reorder problem.
     dims_t non_unit_dims {};
-    dim_t non_unit_dim = 0;
+    int non_unit_dim = 0;
     for (dim_t i = 0; i < src_md.ndims; i++) {
         if (src_md.dims[i] == 1) continue;
         non_unit_dims[non_unit_dim++] = src_md.dims[i];
@@ -147,8 +147,8 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
 
     // find first umatching stride by division
     dim_t lm_idx = -1;
-    int prev_M_src = src_over_dst[l_idx],
-        prev_1_over_M_dst = dst_over_src[l_idx];
+    dim_t prev_M_src = src_over_dst[l_idx],
+          prev_1_over_M_dst = dst_over_src[l_idx];
     // here we are checking to make sure all indexes are the same in src/dst
     // and dst/src arrays (comparing with prev_h_src and prev_h_dst). If its
     // different, then both src/dst and dst/src arrays should be different. In
@@ -175,8 +175,8 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     // Only case this might be possible is unit strides after batch.
     VDISPATCH_REORDER_IC(lm_idx != -1, VERBOSE_UNSUPPORTED_MEM_STRIDE);
 
-    int prev_1_over_K_src = src_over_dst[lm_idx],
-        prev_K_dst = dst_over_src[lm_idx];
+    dim_t prev_1_over_K_src = src_over_dst[lm_idx],
+          prev_K_dst = dst_over_src[lm_idx];
     // Here we make sure the last strides divs are the same. If not, then this
     // means that one of the l+m, l+m+1, ..., l+m+n indexes is not in the same
     // order as in src. For example in src, looking at memory view, it can be

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -83,12 +83,12 @@ int get_n_block_from_tag(format_tag_t matrix_b_tag) {
     }
 }
 
-int get_wei_k_blk(data_type_t wei_dt) {
+dim_t get_wei_k_blk(data_type_t wei_dt) {
     // Fixed outer block size.
-    const int k_outer_block = 16;
+    const dim_t k_outer_block = 16;
 
     // VNNI granularity determines the inner block size along K.
-    const int k_inner_block = data_type_vnni_granularity(wei_dt);
+    const dim_t k_inner_block = data_type_vnni_granularity(wei_dt);
 
     return k_outer_block * k_inner_block;
 }
@@ -627,7 +627,7 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             VCONDCHECK_BG(
                     IMPLICATION(bgmmc.is_xf16_fp8, blocked_B_layouts_allowed),
                     VERBOSE_UNSUPPORTED_TAG)
-            const int default_n_block = init_n_tag
+            const dim_t default_n_block = init_n_tag
                     ? get_default_n_block(format_tag::undef)
                     : bgmmc.N_blk;
             bgmmc.wei_tag = blocked_B_layouts_allowed && !bgmmc.is_runtime_N
@@ -708,7 +708,7 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
 }
 
 status_t brgemm_matmul_conf_utils_t::update_and_check_B_tag(memory_desc_t &B_md,
-        int n_blk_size, const matmul_helper_t &helper) const {
+        dim_t n_blk_size, const matmul_helper_t &helper) const {
     if (n_blk_fixed && n_blk_size != bgmmc.wei_n_blk)
         return status::unimplemented;
 
@@ -844,7 +844,7 @@ status_t brgemm_matmul_conf_utils_t::set_B_flags(memory_desc_t &B_md) const {
 }
 
 format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
-        int n_blk) const {
+        dim_t n_blk) const {
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
@@ -937,14 +937,14 @@ struct matmul_avx512_blocking_params_t {
     }
 
     const matmul_params_t &mp;
-    int m_chunks, m_blk, m_tail;
-    int n_chunks, n_blk, n_tail;
-    int batch_size, k_blk, k_tail;
+    dim_t m_chunks, m_blk, m_tail;
+    dim_t n_chunks, n_blk, n_tail;
+    dim_t batch_size, k_blk, k_tail;
     int nthr_k;
     const int nthr;
 
-    void update_params(int m_chunks_, int m_blk_, int n_chunks_, int n_blk_,
-            int batch_size_, int k_blk_, int nthr_k_) {
+    void update_params(dim_t m_chunks_, dim_t m_blk_, dim_t n_chunks_,
+            dim_t n_blk_, dim_t batch_size_, dim_t k_blk_, int nthr_k_) {
         m_chunks = m_chunks_;
         m_blk = m_blk_;
         m_tail = mp.M % m_blk;
@@ -962,7 +962,7 @@ struct matmul_avx512_blocking_params_t {
         size_t scalar = work < thread_block
                 ? thread_block - mod
                 : nstl::min(thread_block - mod, mod);
-        return static_cast<float>(scalar) / thread_block;
+        return static_cast<float>(scalar) / static_cast<float>(thread_block);
     }
 
     float get_imbalance() const {
@@ -973,20 +973,25 @@ struct matmul_avx512_blocking_params_t {
                 = calculate_spatial_disbalance(parallel_work, cur_nthr);
 
         const auto m_work = (m_blk * div_up(mp.M, m_blk)) % mp.M;
-        const float m_blk_disbalance = static_cast<float>(m_work) / mp.M;
+        const float m_blk_disbalance
+                = static_cast<float>(m_work) / static_cast<float>(mp.M);
 
         const auto num_n_blk = div_up(mp.N, n_blk);
         const auto par_n_chunks = div_up(num_n_blk, n_chunks);
         const float n_chunk_disbalance
-                = (static_cast<float>(par_n_chunks) * n_chunks - num_n_blk)
-                / num_n_blk;
+                = (static_cast<float>(par_n_chunks)
+                                  * static_cast<float>(n_chunks)
+                          - static_cast<float>(num_n_blk))
+                / static_cast<float>(num_n_blk);
 
         const float disbalance_nthr_k
                 = calculate_spatial_disbalance(mp.K, nthr_k * k_blk);
 
         const float thread_allocation_disb
                 = (cur_nthr * nthr_k) != static_cast<size_t>(nthr)
-                ? (static_cast<float>(nthr) - cur_nthr * nthr_k) / nthr
+                ? (static_cast<float>(nthr)
+                          - static_cast<float>(cur_nthr * nthr_k))
+                        / static_cast<float>(nthr)
                 : 0;
 
         const float score
@@ -1152,7 +1157,7 @@ void compute_gemv_k_blocking(dim_t K, int &k_blk, int &batch_size) {
 // only select m_blk >= min_m_blk.
 bool is_gemv_k_split_needed(const brgemm_matmul_conf_t &bgmmc,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
-        int min_m_blk, int nthr) {
+        dim_t min_m_blk, int nthr) {
     if (!bgmmc.is_gemv) return false;
     if (!one_of(bgmmc.gemv_strategy, gemv_strategy_t::n1_A_trans,
                 gemv_strategy_t::m1_B_plain))
@@ -1192,7 +1197,7 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
 
     dim_t min_m_chunks = div_up(matmul.M, max_m_blk);
 
-    int n_blk = bgmmc.N_blk;
+    dim_t n_blk = bgmmc.N_blk;
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1261,15 +1266,15 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         use_k_partitioning = use_k_partitioning && bm_conf_utils.is_f32();
 
         if (use_k_partitioning) {
-            auto least_prime_factor = [](int n) {
+            auto least_prime_factor = [](dim_t n) {
                 assert(n > 0);
-                if (n == 1) return 1;
-                for (int factor = 2; factor < n; factor++)
+                if (n == 1) return (dim_t)1;
+                for (dim_t factor = 2; factor < n; factor++)
                     if (n % factor == 0) return factor;
                 return n;
             };
 
-            int nthr_bmn = max_div(max_bmn_parallel, nthr);
+            int nthr_bmn = static_cast<int>(max_div(max_bmn_parallel, nthr));
             int nthr_k = nstl::max(nthr / nthr_bmn, 1);
             int nthr_remainder = nthr % nthr_bmn;
 
@@ -1374,7 +1379,7 @@ float compute_blocking_heuristic_avx2(brgemm_matmul_conf_t &bgmmc,
     int min_m_blk
             = static_cast<int>(nstl::min((dim_t)32, matmul.M)); // max_m_blk
 
-    int n_blk = bgmmc.N_blk;
+    dim_t n_blk = bgmmc.N_blk;
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1431,7 +1436,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     dim_t max_m_blk = nstl::min((dim_t)256, matmul.M);
     dim_t min_m_blk = nstl::min((dim_t)32, matmul.M);
 
-    int n_blk = bgmmc.N_blk;
+    dim_t n_blk = bgmmc.N_blk;
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1446,10 +1451,12 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     // for cases with low parallel work, reduce 'min_m_blk' to
     // increase potential parallelization balance.
     size_t max_parallel = matmul.batch * n_chunks;
-    const float req_additional_parallel = nthr / max_parallel;
+    const float req_additional_parallel
+            = static_cast<float>(nthr) / static_cast<float>(max_parallel);
     if (req_additional_parallel > 1) {
         min_m_blk = saturate<dim_t>(nstl::min((dim_t)16, max_m_blk), max_m_blk,
-                matmul.M / req_additional_parallel);
+                static_cast<dim_t>(static_cast<float>(matmul.M)
+                        / req_additional_parallel));
         max_parallel *= div_up(matmul.M, min_m_blk);
     } else if (bm_conf_utils.check_is_transposed(bgmmc.src_tag)
             && matmul.K >= 4096) {
@@ -1457,7 +1464,8 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     }
 
     bool low_parallel_work = max_parallel % nthr != 0
-            && (static_cast<float>(max_parallel) / nthr) < 2;
+            && (static_cast<float>(max_parallel) / static_cast<float>(nthr))
+                    < 2;
     if (low_parallel_work) {
         // Reduce n_blk size to increase parallel space
         // note: over reduction of n_blk size on 2d shapes when n_chunks == 1
@@ -1471,7 +1479,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     max_m_blk = nstl::max(max_m_blk, min_m_blk);
     for_(int nthr_k = start_nthr_k; nthr_k >= 1; --nthr_k)
     for_(int n_chunk_size = n_chunks_start; n_chunk_size >= 1; --n_chunk_size)
-    for (int m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
+    for (dim_t m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
         matmul_avx512_blocking_params_t cur_params(matmul, nthr);
         cur_params.update_params(
                 1, m_blk, n_chunk_size, n_blk, brgemm_bs, k_blk, nthr_k);
@@ -2609,7 +2617,7 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
             ? runtime_value_for(bgmmc.num_K_blocks)
             : div_up(bgmmc.K, bgmmc.K_blk * bgmmc.brgemm_batch_size);
 
-    const int last_chunck_batch_size
+    const dim_t last_chunck_batch_size
             = (nstl::max(bgmmc.K, bgmmc.K_blk)
                       - (bgmmc.K_chunks - 1) * bgmmc.K_chunk_elems)
             / bgmmc.K_blk;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -118,14 +118,14 @@ struct brgemm_matmul_conf_t {
     int ndims, batch_ndims;
     dim_t M, N, K, batch, batch_without_first_dim;
     dim_t M_blk, N_blk, K_blk, M_tail, N_tail, K_tail;
-    int M_chunk_size, N_chunk_size, K_chunk_size;
+    dim_t M_chunk_size, N_chunk_size, K_chunk_size;
     bool is_a_nt, is_b_nt, set_nt;
     bool need_prefetch_a, need_prefetch_b;
     bool use_fused_copy_a;
     dim_t LDA, LDB, LDC, LDD;
     dim_t LDB2;
-    int brgemm_batch_size, brgemm_batch_tail_size;
-    int wei_n_blk, wei_k_blk;
+    dim_t brgemm_batch_size, brgemm_batch_tail_size;
+    dim_t wei_n_blk, wei_k_blk;
     brgemm_batch_kind_t brg_type;
     bool is_macro_heuristics;
 
@@ -179,12 +179,12 @@ struct brgemm_matmul_conf_t {
     // from FP32 implementation)
     dim_t tr_a_dt_sz, tr_b_dt_sz;
 
-    int M_chunks;
-    int N_chunks;
-    int K_chunks;
-    int num_M_blocks;
-    int num_N_blocks;
-    int num_K_blocks;
+    dim_t M_chunks;
+    dim_t N_chunks;
+    dim_t K_chunks;
+    dim_t num_M_blocks;
+    dim_t num_N_blocks;
+    dim_t num_K_blocks;
     dim_t M_chunk_elems;
     dim_t N_chunk_elems;
     dim_t K_chunk_elems;
@@ -229,11 +229,11 @@ struct brgemm_matmul_conf_t {
     // were changed.
     bool adjust_a_strides = false;
 
-    int wsp_tile_per_thr_bytes;
-    int brgemm_batch_element_per_thr_sz;
+    dim_t wsp_tile_per_thr_bytes;
+    dim_t brgemm_batch_element_per_thr_sz;
     bool is_amx;
 
-    int required_k_granularity;
+    dim_t required_k_granularity;
     bool is_bf32 = false;
     bool is_bf16_with_int_wei = false;
     bool is_f16_with_int_wei = false;
@@ -491,13 +491,13 @@ struct brgemm_matmul_conf_utils_t {
     status_t set_or_check_B_tag(memory_desc_t &B_md,
             const dnnl::impl::cpu::matmul::matmul_helper_t &helper,
             bool init_n_tag = true) const;
-    status_t update_and_check_B_tag(memory_desc_t &B_md, int n_blk_size,
+    status_t update_and_check_B_tag(memory_desc_t &B_md, dim_t n_blk_size,
             const dnnl::impl::cpu::matmul::matmul_helper_t &helper) const;
     status_t set_or_check_tags(memory_desc_t &A_md, memory_desc_t &C_md,
             memory_desc_t &bias_md,
             const dnnl::impl::cpu::matmul::matmul_helper_t &helper) const;
     status_t set_B_flags(memory_desc_t &B_md) const;
-    format_tag_t pick_blocked_B_layout(int n_blk) const;
+    format_tag_t pick_blocked_B_layout(dim_t n_blk) const;
 
     format_tag_t get_gemv_A_tag(const memory_desc_t &A_md) const;
     format_tag_t get_gemv_B_tag(const memory_desc_t &B_md) const;
@@ -568,7 +568,7 @@ bool dims_adjacent(const memory_desc_wrapper &mdw, const int outer_dim,
  *
  * @return The total K dimension block size.
  */
-int get_wei_k_blk(data_type_t wei_dt);
+dim_t get_wei_k_blk(data_type_t wei_dt);
 
 } // namespace matmul
 } // namespace x64

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -655,7 +655,8 @@ private:
                     const dim_t off
                             = c * simd_w * types::data_type_size(wei_zp_dt_);
                     const int tail_bytes = has_tail
-                            ? rem * types::data_type_size(wei_zp_dt_)
+                            ? static_cast<int>(
+                                      rem * types::data_type_size(wei_zp_dt_))
                             : 0;
                     load_vec_zps_f32(vmm_zw(), wei_zp_dt_, ptr[reg_tmp + off],
                             has_tail, tail_bytes);

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -615,14 +615,14 @@ private:
             load_param(reg_a, GET_OFF(src_batch_ptr));
             load_param(reg_tmp, GET_OFF(m_base));
             add(reg_tmp, reg_m);
-            imul(reg_tmp, reg_tmp, src_m_stride_bytes_);
+            imul(reg_tmp, reg_tmp, static_cast<int>(src_m_stride_bytes_));
             add(reg_a, reg_tmp);
             emit_t_reduce_into_T_bc(subtract_Gzs);
         }
 
         // delta row base = delta + m * LDC * 4.
         push(reg_m);
-        imul(reg_m, reg_m, LDC_ * f32_sz);
+        imul(reg_m, reg_m, static_cast<int>(LDC_ * f32_sz));
         add(reg_m, reg_delta);
 
         for (int c = 0; c < chunks_; ++c) {

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_reduce.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_reduce.cpp
@@ -47,9 +47,9 @@ jit_brgemm_kernel_reduce_t<Vmm>::jit_brgemm_kernel_reduce_t(
     // MatMul `reduce` buffer.
     , out_dt_(bgmmc.reduce_dt)
     , acc_dt_(bgmmc.acc_dt)
-    , in_typesize_(types::data_type_size(in_dt_))
-    , out_typesize_(types::data_type_size(out_dt_))
-    , acc_typesize_(types::data_type_size(acc_dt_)) {
+    , in_typesize_(static_cast<int>(types::data_type_size(in_dt_)))
+    , out_typesize_(static_cast<int>(types::data_type_size(out_dt_)))
+    , acc_typesize_(static_cast<int>(types::data_type_size(acc_dt_))) {
     // This kernel must be called after the copy A routine because it assumes
     // that fp16 data has already been upconverted to f32.
     // Only reduction for `src` is supported.

--- a/src/cpu/x64/matmul/jit_uni_sparse_matmul.cpp
+++ b/src/cpu/x64/matmul/jit_uni_sparse_matmul.cpp
@@ -68,11 +68,11 @@ struct sparse_matmul_kernel_t : public jit_generator_t {
     int data_type_size() const { return sizeof(float); }
     int index_type_size() const { return sizeof(int32_t); }
 
-    int block_size() const { return vlen(); }
+    int block_size() const { return static_cast<int>(vlen()); }
 
     int unroll_factor() const { return 2; }
 
-    int N() const { return N_; }
+    int N() const { return static_cast<int>(N_); }
 
 protected:
     size_t N_;
@@ -173,17 +173,17 @@ struct jit_uni_sparse_matmul_kernel_t : public sparse_matmul_kernel_t {
 
     Vmm get_wei_reg(int index, bool is_tail_block) {
         // Vmm(0) is reserved for mask.
-        const int nloads = is_tail_block
-                ? utils::div_up(tail_block_size(), simd_w())
-                : block_size() / simd_w();
+        const int nloads = static_cast<int>(is_tail_block
+                        ? utils::div_up(tail_block_size(), simd_w())
+                        : block_size() / simd_w());
         return Vmm(nloads + index + 1);
     }
 
     void loop_within_block_row(
             Vmm vreg_src_val, Reg64 reg_src_col_idx, bool is_tail_block) {
-        const int nloads = is_tail_block
-                ? utils::div_up(tail_block_size(), simd_w())
-                : block_size() / simd_w();
+        const int nloads = static_cast<int>(is_tail_block
+                        ? utils::div_up(tail_block_size(), simd_w())
+                        : block_size() / simd_w());
         for (int i_load = 0; i_load < nloads; i_load++) {
             Vmm vreg_tmp_wei = get_wei_reg(i_load, is_tail_block);
             // Load a row of weights.
@@ -254,15 +254,15 @@ struct jit_uni_sparse_matmul_kernel_t : public sparse_matmul_kernel_t {
         Label loop_over_blocks_begin, loop_over_blocks_end;
         L(loop_over_blocks_begin);
         {
-            cmp(reg_blocks_count, nblocks);
+            cmp(reg_blocks_count, static_cast<dim_t>(nblocks));
             je(loop_over_blocks_end, T_NEAR);
 
             mov(reg_block_offset, reg_blocks_count);
             shl(reg_block_offset, math::ilog2q(block_size()));
 
-            const int nloads = is_tail_block
-                    ? utils::div_up(tail_block_size(), simd_w())
-                    : block_size() / simd_w();
+            const int nloads = static_cast<int>(is_tail_block
+                            ? utils::div_up(tail_block_size(), simd_w())
+                            : block_size() / simd_w());
             std::vector<Vmm> vregs_dst(nloads);
             for (int i_load = 0; i_load < nloads; i_load++) {
                 vregs_dst[i_load] = get_dst_reg(i_load);

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -44,9 +44,12 @@ public:
         if (res != status::success) return res;
 
         size_t code_size = post_ops_gen.getSize();
-        size_t estimated_vec_code_size = (size_t)nstl::max(
-                (int)code_size - (int)mean_none_vec_code_bytes, 0);
-        estimated_vec_insts = estimated_vec_code_size / mean_vec_inst_bytes;
+        const size_t estimated_vec_code_size
+                = code_size > mean_none_vec_code_bytes
+                ? code_size - mean_none_vec_code_bytes
+                : 0;
+        estimated_vec_insts = static_cast<int>(
+                estimated_vec_code_size / mean_vec_inst_bytes);
         return status::success;
     }
 
@@ -60,10 +63,10 @@ private:
         : jit_generator_t("dummy_generator") {
         auto dsc = memory_desc_wrapper(dst_md);
         const dnnl::impl::cpu::x64::binary_injector::rhs_arg_static_params_t
-                rhs_sp(static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
-                        this->r15, this->r13, false, false,
-                        static_cast<size_t>(0), static_cast<size_t>(0), dsc,
-                        static_cast<size_t>(0), Xbyak::Opmask(0), false);
+                rhs_sp(Xbyak::Zmm(1).getIdx(), this->r14, this->r15, this->r13,
+                        false, false, static_cast<size_t>(0),
+                        static_cast<size_t>(0), dsc, static_cast<size_t>(0),
+                        Xbyak::Opmask(0), false);
 
         const dnnl::impl::cpu::x64::binary_injector::static_params_t bsp(
                 this->param1,


### PR DESCRIPTION
Continuation of #5565
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
