### PR TITLE
x64: brgemm: other: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -798,7 +798,7 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
         }
     }
 
-    buff->palette_id = amx::get_target_palette();
+    buff->palette_id = static_cast<uint8_t>(amx::get_target_palette());
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -563,8 +563,9 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     if (brg->can_dispatch_uker()) {
         // Blocking heuristics for some shapes
         // TODO: Review these criteria
-        const size_t eff_K
-                = brg->reduce_dim * brg->typesize_A * brg->brgattr.K_koef;
+        const size_t eff_K = static_cast<size_t>(
+                static_cast<float>(brg->reduce_dim * brg->typesize_A)
+                * brg->brgattr.K_koef);
         const auto low_K = (L1 - 4 * 1024) / (6 * 16);
 
         // TODO: if rdb_tail != 0 then we should limit
@@ -926,14 +927,17 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
         const auto bd_block_disb = (brg->bcast_dim <= 0 || bd_block == 0)
                 ? 0.f
                 : static_cast<float>(brg->bcast_dim)
-                        / rnd_up(brg->bcast_dim, bd_block);
+                        / static_cast<float>(rnd_up(brg->bcast_dim, bd_block));
         const auto brgemm_microkernel_eff
-                = (static_cast<float>(adj_ld_block2) * bd_block)
-                / (((adj_ld_block2) + bd_block) * max_bcast_block);
+                = (static_cast<float>(adj_ld_block2)
+                          * static_cast<float>(bd_block))
+                / static_cast<float>(
+                        ((adj_ld_block2) + bd_block) * max_bcast_block);
         const auto bd_block_eff = bd_block_disb * brgemm_microkernel_eff;
 
-        float block_foot_print = static_cast<float>(brg->typesize_A) * bd_block
-                * brg->reduce_dim;
+        float block_foot_print = static_cast<float>(brg->typesize_A)
+                * static_cast<float>(bd_block)
+                * static_cast<float>(brg->reduce_dim);
         if (block_foot_print <= static_cast<float>(L1)
                 && (bd_block_eff > best_bd_block_eff)) {
             brg->bd_block = bd_block;

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -253,10 +253,10 @@ private:
     // iteration_map_t) describe the structure of cycles and are used for
     // JIT code generation
     struct iteration_block_t {
-        dim_t block = 0;
+        int block = 0;
         dim_t pos = 0;
         bool is_tail = false;
-        iteration_block_t(dim_t pos_, dim_t block_, bool is_tail_ = false)
+        iteration_block_t(dim_t pos_, int block_, bool is_tail_ = false)
             : block(block_), pos(pos_), is_tail(is_tail_) {}
         bool operator==(const iteration_block_t &rhs) const {
             return block == rhs.block && is_tail == rhs.is_tail;
@@ -283,7 +283,7 @@ private:
             return (blocks[b].pos - blocks[0].pos);
         }
 
-        dim_t block(size_t b) const {
+        int block(size_t b) const {
             assert(b < blocks.size());
             return blocks[b].block;
         }
@@ -293,9 +293,9 @@ private:
             return blocks[b].is_tail;
         }
 
-        dim_t block2() const { return static_cast<dim_t>(blocks.size()); }
+        int block2() const { return static_cast<int>(blocks.size()); }
 
-        dim_t length() const {
+        int length() const {
             if (blocks.empty()) return 0;
             const int n = static_cast<int>(blocks.size());
             // only last block may be different
@@ -374,9 +374,9 @@ private:
 
     struct prf_t {
         brgemm_kernel_prefetching_t pft = brgemm_prf_default;
-        dim_t dist = -1;
-        dim_t vec = 0;
-        void set(brgemm_kernel_prefetching_t pft_, dim_t dist_) {
+        int dist = -1;
+        int vec = 0;
+        void set(brgemm_kernel_prefetching_t pft_, int dist_) {
             pft = pft_;
             dist = dist_;
             vec = 0;
@@ -405,8 +405,8 @@ private:
     // saved parameters for storing
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
-    dim_t ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    dim_t ils_bd_step_ = 3; // heuristic value
+    int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
+    int ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -441,18 +441,18 @@ private:
     const Xbyak::Zmm zmm_ubound = zmm9;
 
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
-    Xbyak::Zmm accm(dim_t bd) const {
+    Xbyak::Zmm accm(int bd) const {
         assert(bd < 16);
         return Xbyak::Zmm(static_cast<int>(31 - (bd % ils_bd_step_)));
     }
 
-    Xbyak::Zmm zmm_bias(dim_t ldb) const {
+    Xbyak::Zmm zmm_bias(int ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
         return Xbyak::Zmm(static_cast<int>(10 + ldb));
     }
 
-    Xbyak::Zmm zmm_scales(dim_t ldb) const {
+    Xbyak::Zmm zmm_scales(int ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
@@ -473,19 +473,19 @@ private:
     void maybe_saturation(Xbyak::Zmm &zmm);
     void apply_alpha_beta_to_vector(
             int idx, const Address &addr, bool is_ld_tail);
-    void apply_post_ops_to_range(brgemm_iteration_t &bi, dim_t bd_start,
-            dim_t bd_finish, dim_t bdb, dim_t ldb);
+    void apply_post_ops_to_range(brgemm_iteration_t &bi, int bd_start,
+            int bd_finish, int bdb, int ldb);
     void store_vector_with_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, dim_t ldb);
+    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, int ldb);
     void prepare_post_ops_registers(brgemm_iteration_t &bi);
 
     bool bi_shift_output(
-            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
     bool bi_shift_A(
-            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
     bool bi_shift_B(
-            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
 
     void uni_prefetch(const Address &addr, brgemm_kernel_prefetching_t pft,
             bool for_write);
@@ -502,13 +502,13 @@ private:
             prf_t &prf, bool prefetch_all);
     void prefetching(brgemm_iteration_t &bi, bool prefetch_all);
 
-    void process_output_range(brgemm_iteration_t &bi, dim_t bd_start,
-            dim_t bd_finish, dim_t bdb, dim_t ldb);
+    void process_output_range(brgemm_iteration_t &bi, int bd_start,
+            int bd_finish, int bdb, int ldb);
     void store_vector_without_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void store_vector(brgemm_iteration_t &bi, dim_t bdb, dim_t bd, dim_t ldb);
-    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, dim_t bdb,
-            dim_t inp_bd, dim_t ldb, const int idx);
+    void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
+    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
+            int ldb, const int idx);
 
     void interleave_store(brgemm_iteration_t &bi, bool store_all);
 
@@ -536,24 +536,24 @@ private:
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, dim_t bdb,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
 
     bool process_k_tail_only_last_tile();
 
-    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, dim_t bdb,
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
             bool mem_advice_A);
 
     void maybe_tileloadd_nt(
-            brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset);
+            brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset);
 
-    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, dim_t bdb);
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
 
     void maybe_sprinkle_prefetches();
 
-    void tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
+    void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
@@ -588,20 +588,20 @@ private:
                 && !skip_accumulation);
     }
 
-    dim_t A_offset(const brgemm_iteration_t &bi, dim_t bdb,
-            dim_t rdb = 0) const noexcept;
+    dim_t A_offset(
+            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
 
-    dim_t A_offset_wsp(const brgemm_iteration_t &bi, dim_t bdb,
-            dim_t rdb = 0) const noexcept;
+    dim_t A_offset_wsp(
+            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
 
-    dim_t A_offset_line(const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb = 0,
-            dim_t bd_elem_idx = 0) const noexcept;
+    dim_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
+            int bd_elem_idx = 0) const noexcept;
 
-    dim_t B_offset(const brgemm_iteration_t &bi, dim_t ldb,
-            dim_t rdb = 0) const noexcept;
+    dim_t B_offset(
+            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
 
-    dim_t B_offset_line(const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb = 0,
-            dim_t rd_elem_idx = 0) const noexcept;
+    dim_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
+            int rd_elem_idx = 0) const noexcept;
 
     dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             dim_t ldb) const noexcept;
@@ -625,9 +625,9 @@ private:
     bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
     dim_t get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
 
-    void maybe_tilestore(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
+    void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
-    dim_t get_C_tensor(brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept;
+    int get_C_tensor(brgemm_iteration_t &bi, int m, int n) const noexcept;
     void top_loop(brgemm_iteration_t &bi);
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
@@ -639,7 +639,7 @@ private:
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
-        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     if (shift == 0) return true;
 
@@ -669,7 +669,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_output(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_A(
-        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nbdis = tloop.bdis.size();
@@ -689,7 +689,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_A(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_B(
-        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nldis = tloop.ldis.size();
@@ -708,8 +708,8 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_B(
     return true;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::get_C_tensor(
-        brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept {
+int jit_brgemm_amx_uker_base_t::get_C_tensor(
+        brgemm_iteration_t &bi, int m, int n) const noexcept {
     return brg.get_C_tensor(m, n, bi.bdi->is_tail(m), bi.ldi->is_tail(n));
 }
 
@@ -744,7 +744,7 @@ dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
-        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
+        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
     // Full WSP buffer layout:
     //   1. partial C results.
     //   2. data type conversion.
@@ -764,7 +764,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
+        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
@@ -775,12 +775,12 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
-        dim_t bdb, dim_t rdb, dim_t bd_elem_idx) const noexcept {
+        int bdb, int rdb, int bd_elem_idx) const noexcept {
     return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb) const noexcept {
+        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
@@ -796,7 +796,7 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
-        dim_t ldb, dim_t rdb, dim_t rd_elem_idx) const noexcept {
+        int ldb, int rdb, int rd_elem_idx) const noexcept {
     return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
@@ -978,8 +978,8 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
         ils_shift = need_ils_shift ? bi.bdi->C_shift : 0;
     }
 
-    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
             tileloadd(Tmm(static_cast<int>(get_C_tensor(bi, bdb, ldb))),
@@ -1035,8 +1035,8 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     }
 }
 
-void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(brgemm_iteration_t &bi,
-        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
+void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
+        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1127,7 +1127,7 @@ void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
 }
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
-        brgemm_iteration_t &bi, dim_t ldb) {
+        brgemm_iteration_t &bi, int ldb) {
     if (!bi.apply_postops) return;
     auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
 
@@ -1168,7 +1168,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1212,7 +1212,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 case data_type::f32:
                 default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
             }
-            for (dim_t ldb = 0; ldb < ldi->block2(); ldb++)
+            for (int ldb = 0; ldb < ldi->block2(); ldb++)
                 vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
         }
     }
@@ -1222,7 +1222,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
                     = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1233,7 +1233,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
@@ -1261,7 +1261,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1348,7 +1348,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
         brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish, int bdb,
         int ldb) {
     const auto ldb_pos = bi.ldi->pos(ldb);
-    for (dim_t bd = bd_start; bd < bd_finish; bd++) {
+    for (int bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
@@ -1394,7 +1394,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
             = (are_post_ops_applicable_ && !prev_bi_.apply_postops)
             ? brg.typesize_C
             : brg.typesize_D;
-    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / bdb_row;
         const auto vec_in_bdb_row = prf.vec - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / pfo_bi.bdi->block(bdb);
@@ -1418,7 +1418,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_A(brgemm_iteration_t &bi,
             ? tot_vecs
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
-    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / pfo_bi.bdi->block(0);
         const auto bd = prf.vec % pfo_bi.bdi->block(0);
 
@@ -1442,7 +1442,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_B(brgemm_iteration_t &bi,
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
     // TODO: check these addressing for correctness
-    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
 
         const auto ldb = prf.vec / pfo_bi.rdi->block(0);
         const auto rb = prf.vec % pfo_bi.rdi->block(0);
@@ -1505,8 +1505,7 @@ void jit_brgemm_amx_uker_base_t::prefetching(
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
-        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb,
-        const int idx) {
+        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb, const int idx) {
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     auto zmm = Zmm(idx);
@@ -1527,8 +1526,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vaddps(zmm_masked, zmm, zmm_zp_comp_a);
 }
 
-void jit_brgemm_amx_uker_base_t::process_output_range(brgemm_iteration_t &bi,
-        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
+void jit_brgemm_amx_uker_base_t::process_output_range(
+        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
 
     const auto k_mask = bi.ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
@@ -1779,7 +1778,7 @@ void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector(
-        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb) {
+        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb) {
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
@@ -1839,7 +1838,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
     const auto bdb_row = prev_bi_.bdi->block(0) * prev_bi_.ldi->block2();
     const auto total_vectors = prev_bi_.bdi->length() * prev_bi_.ldi->block2();
     const auto nvecs = store_all ? total_vectors : ils_vecs_per_store;
-    for (dim_t vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
+    for (int vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
         const auto bdb = ils_vec_ / bdb_row;
         const auto vec_in_bdb_row = ils_vec_ - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / prev_bi_.bdi->block(bdb);
@@ -1888,8 +1887,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     if (store_by_vectors && !real_ils && !prepare_post_ops_registers_once_)
         prepare_post_ops_registers(bi);
 
-    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (store_by_vectors) {
             if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
                 const auto wsp_offset = use_ils_
@@ -1903,7 +1902,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
 
             prepare_post_ops_registers_ldb(bi, ldb);
 
-            for (dim_t bd_step = 0; bd_step < bi.bdi->block(bdb);
+            for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
                     bd_step += ils_bd_step_) {
                 auto bd_finish
                         = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
@@ -2001,11 +2000,13 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
         // Calculate the number of cache lines to jit
         float total_cache_lines_to_prefetch
                 = (float)prf_sprinkled.prefetch_offsets.size();
-        float cache_lines_per_amx_op
-                = total_cache_lines_to_prefetch / num_amx_ops;
+        float cache_lines_per_amx_op = total_cache_lines_to_prefetch
+                / static_cast<float>(num_amx_ops);
         int num_prefetches_to_jit
-                = (int)((current_num_amx_ops + 1) * cache_lines_per_amx_op)
-                - (int)(current_num_amx_ops * cache_lines_per_amx_op);
+                = (int)(static_cast<float>(current_num_amx_ops + 1)
+                          * cache_lines_per_amx_op)
+                - (int)(static_cast<float>(current_num_amx_ops)
+                        * cache_lines_per_amx_op);
 
         // Jit the prefetches
         for (size_t i = prf_sprinkled.current_prefetch_idx;
@@ -2026,7 +2027,7 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
     current_num_amx_ops++;
 }
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
-        brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset) {
+        brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset) {
 
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
@@ -2068,7 +2069,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 }
 
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
-        brgemm_iteration_t &bi, dim_t bdb) {
+        brgemm_iteration_t &bi, int bdb) {
     auto t1 = Tmm(
             static_cast<int>(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
@@ -2109,7 +2110,7 @@ void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
     };
 }
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
-        dim_t bdb_idx, dim_t ldb_idx, bool do_pre_tilestore,
+        int bdb_idx, int ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
     if (bi.skip_accumulation) return;
     auto current_tensor_idx = get_C_tensor(bi, bdb_idx, ldb_idx);
@@ -2154,8 +2155,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     tilezero(acc);
 }
 
-void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
-        dim_t ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
+void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
+        int ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
@@ -2467,7 +2468,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 }
 
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
-        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
     if (offset_dst) add(reg_buf, offset_dst);
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
@@ -2484,7 +2485,7 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
 }
 
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
         bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
@@ -2590,7 +2591,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     else
         mov(reg_stride_ld_block, LDC_size_);
 
-    for (dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+    for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
         if (brg.fused_copy_a) {
             maybe_fused_copy_A_nt_load(bi, bdb);
         } else {
@@ -2598,7 +2599,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
                     bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
         }
 
-        for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
                         bi, matrix_kind_t::matrix_B, ldb, B_offset(bi, ldb));
@@ -2845,8 +2846,8 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (brg.interleave_tilestores_) {
         prev_bi_ = bi;
         was_prev_bi_ = true;
-        for_(dim_t bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
-        for (dim_t ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
+        for_(int bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
+        for (int ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
             maybe_tilestore(prev_bi_, bdb, ldb, true, false);
         }
     }
@@ -3200,7 +3201,7 @@ void jit_brgemm_amx_uker_base_t::generate() {
 
     // if beta == 1 and C datatype is f32 it is better to perform addition by
     // reading tiles directly from C instead of by reading/writing by vectors
-    may_load_accumulators_ = one_of(brg.alpha, 0, 1) && brg.beta == 1.f
+    may_load_accumulators_ = one_of(brg.alpha, 0.f, 1.f) && brg.beta == 1.f
             && brg.dt_c == brg.dt_d
             && IMPLICATION(brg.is_input_convert(), brg.is_fp8_via_convert())
             && IMPLICATION(

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -85,10 +85,10 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    Xbyak::Zmm(1).getIdx(), this->r14, this->r15, this->r13,
-                    preserve_gpr, preserve_vmm,
+                    static_cast<std::size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
+                    this->r15, this->r13, preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<dim_t>(brg.ldb_tail),
+                    dst_md_wrapper, static_cast<std::size_t>(brg.ldb_tail),
                     ld_tail_mask, use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp(this->param1,

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -85,10 +85,10 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
-                    this->r15, this->r13, preserve_gpr, preserve_vmm,
+                    Xbyak::Zmm(1).getIdx(), this->r14, this->r15, this->r13,
+                    preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(brg.ldb_tail),
+                    dst_md_wrapper, static_cast<dim_t>(brg.ldb_tail),
                     ld_tail_mask, use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp(this->param1,

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.cpp
@@ -45,10 +45,11 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
 
     preamble();
 
-    const int vnni_width = data_type_vnni_granularity(wjcp.wei_dt);
-    const auto wei_dsz = types::data_type_size(wjcp.wei_dt);
-    const auto inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
-    const auto out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
+    const int vnni_width
+            = static_cast<int>(data_type_vnni_granularity(wjcp.wei_dt));
+    const dim_t wei_dsz = types::data_type_size(wjcp.wei_dt);
+    const dim_t inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
+    const dim_t out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
     const auto oc_chunks = wjcp.out_oc_block / wjcp.inp_oc_block;
     const auto has_ocb_tail = (oc_chunks != wjcp.last_occ_to_copy);
     auto nb_rd = div_up(wjcp.rd, vnni_width);
@@ -89,7 +90,7 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
                 else
                     copy_zmm(false);
 
-                add(aux_reg_src, wjcp.inp_ocb_offs);
+                add(aux_reg_src, static_cast<dim_t>(wjcp.inp_ocb_offs));
                 add(aux_reg_dst, inp_ocb_size);
             }
             add(reg_src, inp_ocb_size);

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
@@ -30,10 +30,10 @@ struct jit_brgemm_relo_copy_to_wbuffer_t : public jit_generator_t {
         data_type_t wei_dt {data_type_t::dnnl_data_type_undef};
         int out_oc_block {0};
         int inp_oc_block {0};
-        int rd {0};
+        dim_t rd {0};
         bool is_rd_padded_to_block {false};
-        int inp_ocb_offs {0};
-        int last_occ_to_copy {0};
+        dim_t inp_ocb_offs {0};
+        dim_t last_occ_to_copy {0};
     };
 
     struct ctx_t {

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -82,11 +82,10 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_tmp(4).getIdx()), this->r14, this->r15,
-                this->r13, preserve_gpr, preserve_vmm,
-                GET_OFF(ptr_binary_post_ops_rhs), GET_OFF(dst_orig),
-                memory_desc_wrapper(brg_.dst_md()),
-                static_cast<size_t>(brg_.load_dim % brg_.ld_block), k_tail_mask,
+                vmm_tmp(4).getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm, GET_OFF(ptr_binary_post_ops_rhs),
+                GET_OFF(dst_orig), memory_desc_wrapper(brg_.dst_md()),
+                static_cast<dim_t>(brg_.load_dim % brg_.ld_block), k_tail_mask,
                 use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp(this->param1,
                 binary_injector::get_all_strategies_supported_by_injector(),
@@ -578,8 +577,8 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
 
 template <typename Vmm>
 void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
-        int m_block, int nb2, int nb2_tail, int nb_tail) {
-    if (brg_.alpha) { mov(aux_reg_in, reg_in); }
+        int m_block, dim_t nb2, int nb2_tail, dim_t nb_tail) {
+    if (brg_.alpha != 0) { mov(aux_reg_in, reg_in); }
     if (brg_.beta != 0) {
         if (brg_.with_bias) mov(aux_reg_bias, reg_bias);
         if (brg_.zp_type_c != brgemm_broadcast_t::none) {
@@ -598,7 +597,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
     }
     mov(aux_reg_out, reg_out);
 
-    for (int n_loop_ = 0; n_loop_ < nb2; n_loop_++) {
+    for (dim_t n_loop_ = 0; n_loop_ < nb2; n_loop_++) {
         apply_post_ops(m_block, n_block2_);
 
         const auto oc_l_offset = n_block2_ * brg_.ld_block;
@@ -614,17 +613,21 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.zp_type_a != brgemm_broadcast_t::none) {
                 mov(aux_reg_zp_a_comp, ptr[rsp + aux_reg_zp_a_comp_offs_]);
-                add(aux_reg_zp_a_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_zp_a_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_zp_a_comp_offs_], aux_reg_zp_a_comp);
             }
             if (brg_.req_s8s8_compensation) {
                 mov(aux_reg_s8s8_comp, ptr[rsp + aux_reg_s8s8_comp_offs_]);
-                add(aux_reg_s8s8_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_s8s8_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_s8s8_comp_offs_], aux_reg_s8s8_comp);
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
+                        static_cast<dim_t>(
+                                brg_.is_per_n_wei_scales * sizeof(float))
+                                * oc_l_offset);
         }
     }
     if (nb2_tail > 0) {
@@ -642,21 +645,25 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.zp_type_a != brgemm_broadcast_t::none) {
                 mov(aux_reg_zp_a_comp, ptr[rsp + aux_reg_zp_a_comp_offs_]);
-                add(aux_reg_zp_a_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_zp_a_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_zp_a_comp_offs_], aux_reg_zp_a_comp);
             }
             if (brg_.req_s8s8_compensation) {
                 mov(aux_reg_s8s8_comp, ptr[rsp + aux_reg_s8s8_comp_offs_]);
-                add(aux_reg_s8s8_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_s8s8_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_s8s8_comp_offs_], aux_reg_s8s8_comp);
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
+                        static_cast<dim_t>(
+                                brg_.is_per_n_wei_scales * sizeof(float))
+                                * oc_l_offset);
         }
     }
     if (nb_tail > 0) {
-        apply_post_ops(m_block, 1, nb_tail);
+        apply_post_ops(m_block, 1, static_cast<int>(nb_tail));
 
         if (brg_.alpha != 0) { add(aux_reg_in, inp_typesize_ * (nb_tail)); }
         if (brg_.beta != 0) {
@@ -668,12 +675,14 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.zp_type_a != brgemm_broadcast_t::none) {
                 mov(aux_reg_zp_a_comp, ptr[rsp + aux_reg_zp_a_comp_offs_]);
-                add(aux_reg_zp_a_comp, sizeof(int32_t) * nb_tail);
+                add(aux_reg_zp_a_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * nb_tail);
                 mov(ptr[rsp + aux_reg_zp_a_comp_offs_], aux_reg_zp_a_comp);
             }
             if (brg_.req_s8s8_compensation) {
                 mov(aux_reg_s8s8_comp, ptr[rsp + aux_reg_s8s8_comp_offs_]);
-                add(aux_reg_s8s8_comp, sizeof(int32_t) * nb_tail);
+                add(aux_reg_s8s8_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * nb_tail);
                 mov(ptr[rsp + aux_reg_s8s8_comp_offs_], aux_reg_s8s8_comp);
             }
             if (brg_.with_wei_scales)
@@ -690,11 +699,11 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
 
     sub(rsp, stack_space_needed_);
 
-    int nb = static_cast<int>(brg_.load_dim / brg_.ld_block);
-    int nb_tail = static_cast<int>(brg_.load_dim % brg_.ld_block);
+    const dim_t nb = brg_.load_dim / brg_.ld_block;
+    const dim_t nb_tail = brg_.load_dim % brg_.ld_block;
 
-    int nb2 = nb / n_block2_;
-    int nb2_tail = nb % n_block2_;
+    dim_t nb2 = nb / n_block2_;
+    int nb2_tail = static_cast<int>(nb % n_block2_);
     int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : n_block2_;
 
     int m_max_regs = (brg_.is_bf16_emu
@@ -704,8 +713,8 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
     int m_block
             = static_cast<int>(nstl::min<dim_t>(brg_.bcast_dim, m_max_regs));
 
-    int mb = static_cast<int>(brg_.bcast_dim / m_block);
-    int mb_tail = static_cast<int>(brg_.bcast_dim % m_block);
+    const dim_t mb = brg_.bcast_dim / m_block;
+    const dim_t mb_tail = brg_.bcast_dim % m_block;
 
     if (isa_has_masks(brg_.isa_impl)) {
         const auto full_mask = size_t {0xffffffffffffffff};
@@ -753,7 +762,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
     }
     mov(reg_out, ptr[param1 + GET_OFF(ptr_out)]);
 
-    for (int mb_ = 0; mb_ < mb; mb_++) {
+    for (dim_t mb_ = 0; mb_ < mb; mb_++) {
         loop_by_N(m_block, nb2, nb2_tail, nb_tail);
 
         if (brg_.alpha != 0) add(reg_in, inp_typesize_ * (m_block * brg_.LDC));
@@ -771,7 +780,8 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
         }
         add(reg_out, out_typesize_ * (m_block * brg_.LDD));
     }
-    if (mb_tail > 0) loop_by_N(mb_tail, nb2, nb2_tail, nb_tail);
+    if (mb_tail > 0)
+        loop_by_N(static_cast<int>(mb_tail), nb2, nb2_tail, nb_tail);
 
     add(rsp, stack_space_needed_);
 

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -82,11 +82,12 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                vmm_tmp(4).getIdx(), this->r14, this->r15, this->r13,
-                preserve_gpr, preserve_vmm, GET_OFF(ptr_binary_post_ops_rhs),
-                GET_OFF(dst_orig), memory_desc_wrapper(brg_.dst_md()),
-                static_cast<dim_t>(brg_.load_dim % brg_.ld_block), k_tail_mask,
-                use_exact_tail_scalar_bcast};
+                static_cast<size_t>(vmm_tmp(4).getIdx()), this->r14, this->r15,
+                this->r13, preserve_gpr, preserve_vmm,
+                GET_OFF(ptr_binary_post_ops_rhs), GET_OFF(dst_orig),
+                memory_desc_wrapper(brg_.dst_md()),
+                static_cast<std::size_t>(brg_.load_dim % brg_.ld_block),
+                k_tail_mask, use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp(this->param1,
                 binary_injector::get_all_strategies_supported_by_injector(),
                 rhs_sp, f8_e5m2_cvt_.get(), f8_e4m3_cvt_.get());

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -123,9 +123,9 @@ private:
     int max_vregs_;
     const bool with_binary_non_scalar_bcast_;
 
-    int inp_typesize_;
-    int out_typesize_;
-    int bia_typesize_;
+    dim_t inp_typesize_;
+    dim_t out_typesize_;
+    dim_t bia_typesize_;
 
     using reg64_t = const Xbyak::Reg64;
 
@@ -218,7 +218,7 @@ private:
     void apply_comp(int m_block, int n_block, int tail = 0);
     void maybe_apply_comp(int m_block, int n_block, int tail = 0);
     void apply_post_ops(int m_block, int n_block, int tail = 0);
-    void loop_by_N(int m_block, int nb2, int nb2_tail, int nb_tail);
+    void loop_by_N(int m_block, dim_t nb2, int nb2_tail, dim_t nb_tail);
     void generate() override;
 };
 

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -54,10 +54,10 @@ struct jit_trans_iw_ic_t : public jit_trans_src_t, public jit_generator_t {
     }
 
 private:
-    int typesize = 0;
+    dim_t typesize = 0;
     bool is_layout_nxc = false;
     static constexpr int transpose_size = 16;
-    size_t src_stride = 0, tr_src_stride = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
 
     Opmask kLoadMask1 = k1;
     Opmask kLoadMask2 = k2;
@@ -111,14 +111,17 @@ private:
         jit_generator_t::vmovdqa32(z, ptr[imm_addr64]);
     }
 
-    void transpose(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
-    void transpose_2b(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
-    void transpose_1b(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
+    void transpose(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
+    void transpose_2b(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
+    void transpose_1b(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
     void generate() override;
 };
 
 void jit_trans_iw_ic_t::transpose(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 16, "Unsupported transpose size");
     if (!nrows) return;
@@ -132,7 +135,7 @@ void jit_trans_iw_ic_t::transpose(
 }
 
 void jit_trans_iw_ic_t::transpose_2b(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
     auto load_ymm = [this](int i) {
         vmovups(src_ymm(i), EVEX_compress_addr(reg_src, i * src_stride));
     };
@@ -141,28 +144,28 @@ void jit_trans_iw_ic_t::transpose_2b(
         mov(regw_tmp, w);
         jit_generator_t::kmovd(k, regw_tmp);
     };
-    int l_pad_tail {0}, l_pad_rows {0};
-    int r_pad_tail {0}, r_pad_rows {0};
+    dim_t l_pad_tail {0}, l_pad_rows {0};
+    dim_t r_pad_tail {0}, r_pad_rows {0};
 
     if (l_pad > 0) {
-        int store_pad = 2 * transpose_size;
+        dim_t store_pad = 2 * transpose_size;
         l_pad_rows = l_pad / store_pad;
         l_pad_tail = div_up(l_pad % store_pad, 2);
         kmovw(kLPad, (1 << l_pad_tail) - 1);
     }
     if (r_pad > 0) {
-        int store_pad = div_up(r_pad, 2);
+        dim_t store_pad = div_up(r_pad, 2);
         r_pad_rows = store_pad / transpose_size;
         r_pad_tail = store_pad % transpose_size;
         kmovw(kRPad, (1 << r_pad_tail) - 1);
     }
 
-    auto padding = [this](Reg64 base, int addr_shift, int pad_rows,
-                           int pad_tail, const Opmask &mask, int i) {
+    auto padding = [this](Reg64 base, dim_t addr_shift, dim_t pad_rows,
+                           dim_t pad_tail, const Opmask &mask, dim_t i) {
         // note: pad can be bigger than 16 because of dilation
-        const size_t row_offset = 2 * transpose_size * typesize;
+        const dim_t row_offset = 2 * transpose_size * typesize;
         const auto pshift = addr_shift * typesize + i * tr_src_stride;
-        for (int i_row = 0; i_row < pad_rows; i_row++) {
+        for (dim_t i_row = 0; i_row < pad_rows; i_row++) {
             auto addr = EVEX_compress_addr(base, pshift + i_row * row_offset);
             vmovups(addr, zmm_zero);
         }
@@ -174,14 +177,14 @@ void jit_trans_iw_ic_t::transpose_2b(
         }
     };
 
-    auto store = [&](Zmm r, int i) {
+    auto store = [&](Zmm r, dim_t i) {
         mov(reg_tr_src_tmp, reg_tr_src);
         if (l_pad > 0) {
             padding(reg_tr_src_tmp, 0, l_pad_rows, l_pad_tail, kLPad, i);
             add(reg_tr_src_tmp, l_pad * typesize);
         }
         if (r_pad > 0) {
-            int addr_shift = nrows - r_pad % 2;
+            dim_t addr_shift = nrows - r_pad % 2;
             padding(reg_tr_src_tmp, addr_shift, r_pad_rows, r_pad_tail, kRPad,
                     i);
         }
@@ -194,12 +197,12 @@ void jit_trans_iw_ic_t::transpose_2b(
     };
 
     if (l_pad > 0 || r_pad > 0) vpxord(zmm_zero, zmm_zero, zmm_zero);
-    int store_tail = rnd_up(nrows, 2);
+    dim_t store_tail = rnd_up(nrows, 2);
     kmovw(kTail, (1 << store_tail / 2) - 1);
 
-    const int ic_block = conf_->ic_block;
+    const dim_t ic_block = conf_->ic_block;
     const bool is_short_block = ic_block != 16;
-    const int ic_tail = conf_->ic_tail;
+    const dim_t ic_tail = conf_->ic_tail;
     // Assertion below as we need vmovdqu16 for ic_tails.
     // If needed, can be extended by using load_bytes() helper.
     assert(IMPLICATION(ic_tail, mayiuse(avx512_core)));
@@ -245,14 +248,14 @@ void jit_trans_iw_ic_t::transpose_2b(
 
         // for odd numbers we need to mix row with zeroes
         if (nrows % 2) {
-            int i = nrows - 1;
+            int i = static_cast<int>(nrows - 1);
             auto zmm_src0 = src_zmm(i);
             vmovdqu16(zmm_src0 | kLoadMask1 | T_z,
                     EVEX_compress_addr(reg_src, i * src_stride));
             vpermw(zmm_src0, vidx5, zmm_src0);
         }
 
-        for (int i = rnd_up(nrows, 2); i < 16; i += 2) {
+        for (int i = static_cast<int>(rnd_up(nrows, 2)); i < 16; i += 2) {
             vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
         }
     } else {
@@ -277,7 +280,7 @@ void jit_trans_iw_ic_t::transpose_2b(
 
         // for odd numbers we need to mix row with zeroes
         if (nrows % 2) {
-            int i = nrows - 1;
+            int i = static_cast<int>(nrows - 1);
             auto src0 = src_ymm(i);
             auto src1 = src_ymm(i + 1); // zero
 
@@ -396,7 +399,7 @@ void jit_trans_iw_ic_t::transpose_2b(
 }
 
 void jit_trans_iw_ic_t::transpose_1b(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
 
     auto load = [this, nrows](int i) {
         auto zmm_src = src_zmm(i);
@@ -407,7 +410,7 @@ void jit_trans_iw_ic_t::transpose_1b(
             vpxord(zmm_src, zmm_src, zmm_src);
     };
 
-    int l_pad_tail {0}, r_pad_tail {0}, l_pad_rows {0}, r_pad_rows {0};
+    dim_t l_pad_tail {0}, r_pad_tail {0}, l_pad_rows {0}, r_pad_rows {0};
 
     if (l_pad > 0) {
         l_pad_rows = l_pad / transpose_size;
@@ -420,13 +423,13 @@ void jit_trans_iw_ic_t::transpose_1b(
         kmovw(kRPad, (1 << r_pad_tail) - 1);
     }
 
-    auto padding = [this](Reg64 base, int addr_shift, int pad_rows,
-                           int pad_tail, const Opmask &mask, int i) {
+    auto padding = [this](Reg64 base, dim_t addr_shift, dim_t pad_rows,
+                           dim_t pad_tail, const Opmask &mask, dim_t i) {
         // note: pad can be bigger than 16 because of dilation
-        const size_t row_off = transpose_size;
+        const dim_t row_off = transpose_size;
         auto xmm_zero = Xmm(zmm_zero.getIdx());
         const auto pshift = addr_shift * typesize + i * tr_src_stride;
-        for (int i_row = 0; i_row < pad_rows; i_row++) {
+        for (dim_t i_row = 0; i_row < pad_rows; i_row++) {
             auto addr = EVEX_compress_addr(base, pshift + i_row * row_off);
             vmovups(addr, xmm_zero);
         }
@@ -437,7 +440,7 @@ void jit_trans_iw_ic_t::transpose_1b(
         }
     };
 
-    auto store = [&](Zmm r, int i) {
+    auto store = [&](Zmm r, dim_t i) {
         mov(reg_tr_src_tmp, reg_tr_src);
         if (l_pad > 0) {
             padding(reg_tr_src_tmp, 0, l_pad_rows, l_pad_tail, kLPad, i);
@@ -455,7 +458,7 @@ void jit_trans_iw_ic_t::transpose_1b(
     };
 
     if (l_pad > 0 || r_pad > 0) vpxord(zmm_zero, zmm_zero, zmm_zero);
-    int store_tail = rnd_up(nrows, 4);
+    dim_t store_tail = rnd_up(nrows, 4);
     kmovw(kTail, (1 << store_tail) - 1);
 
     // load rows and swap bytes
@@ -479,7 +482,8 @@ void jit_trans_iw_ic_t::transpose_1b(
         vpermb(zmm_src0, vidx1, zmm_src0);
     }
     // zero rest zmm_src
-    for (int i = rnd_up(nrows, 4); i < transpose_size; i += 4) {
+    for (int i = static_cast<int>(rnd_up(nrows, 4)); i < transpose_size;
+            i += 4) {
         auto zmm_src0 = src_zmm(i);
         vpxord(zmm_src0, zmm_src0, zmm_src0);
     }
@@ -537,7 +541,7 @@ void jit_trans_iw_ic_t::transpose_1b(
         return mod * 4 + div;
     };
 
-    const int ic_block = conf_->ic_block;
+    const dim_t ic_block = conf_->ic_block;
     for (int col_idx = 0; col_idx < ic_block; col_idx++) {
         store(src_zmm(get_vec_idx(col_idx)), col_idx);
     }
@@ -547,7 +551,7 @@ void jit_trans_iw_ic_t::generate() {
     preamble();
 
     if (mayiuse(avx512_core)) {
-        const int ic_block = conf_->ic_block;
+        const dim_t ic_block = conf_->ic_block;
         const int ic_tail = conf_->ic_tail;
         if (conf_->stride_w > 1 || is_layout_nxc) {
             kmovd(kLoadMask1, (1 << ic_block) - 1);
@@ -607,39 +611,41 @@ void jit_trans_iw_ic_t::generate() {
     } else
         assert(!"unsupported data type");
 
-    const int ic_block = conf_->ic_block;
-    const size_t src_mult
+    const dim_t ic_block = conf_->ic_block;
+    const dim_t src_mult
             = is_layout_nxc ? conf_->ngroups * conf_->ic : ic_block;
-    const int iw = conf_->iw;
-    const int tr_iw = conf_->tr_iw;
-    const int str_w = conf_->stride_w;
+    const dim_t iw = conf_->iw;
+    const dim_t tr_iw = conf_->tr_iw;
+    const dim_t str_w = conf_->stride_w;
     assert(tr_iw % str_w == 0);
-    const int tr_iw_s = tr_iw / str_w;
+    const dim_t tr_iw_s = tr_iw / str_w;
     assert(transpose_size >= ic_block);
 
     // Data for every strided case is placed consecutively
     // For 1x1 convolutions with strides we transpose only needed elements
     const auto str_w_end = (conf_->kw == 1) ? 1 : str_w;
-    for (int s = 0; s < str_w_end; s++) {
-        const int left_pad = div_up(nstl::max(0, conf_->l_pad - s), str_w);
-        const int iw1 = iw + conf_->l_pad;
-        const int iw_s = (s < (iw1 % str_w) ? div_up(nstl::max(0, iw1), str_w)
-                                            : iw1 / str_w)
+    for (dim_t s = 0; s < str_w_end; s++) {
+        const dim_t left_pad
+                = div_up(nstl::max<dim_t>(0, conf_->l_pad - s), str_w);
+        const dim_t iw1 = iw + conf_->l_pad;
+        const dim_t iw_s
+                = (s < (iw1 % str_w) ? div_up(nstl::max<dim_t>(0, iw1), str_w)
+                                     : iw1 / str_w)
                 - left_pad;
-        const int right_pad = tr_iw_s - iw_s - left_pad;
+        const dim_t right_pad = tr_iw_s - iw_s - left_pad;
 
-        const int transposes
-                = utils::div_up(nstl::max(0, iw_s), transpose_size);
-        int loop_iters = nstl::max(0, transposes - 1);
-        int tail = iw_s - loop_iters * transpose_size;
+        const dim_t transposes
+                = utils::div_up(nstl::max<dim_t>(0, iw_s), transpose_size);
+        dim_t loop_iters = nstl::max<dim_t>(0, transposes - 1);
+        dim_t tail = iw_s - loop_iters * transpose_size;
 
         src_stride = src_mult * typesize * str_w;
         tr_src_stride = tr_iw * typesize;
 
         bool nontemporal_stores = false;
 
-        const size_t src_step = src_mult * transpose_size * str_w * typesize;
-        const size_t tr_src_step = transpose_size * typesize;
+        const dim_t src_step = src_mult * transpose_size * str_w * typesize;
+        const dim_t tr_src_step = transpose_size * typesize;
 
         mov(reg_src, ptr[param1 + GET_OFF(src)]);
         mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -647,8 +653,8 @@ void jit_trans_iw_ic_t::generate() {
         mov(reg_tr_src_prf, ptr[param1 + GET_OFF(tr_src_prf)]);
 
         if (str_w > 1) {
-            int tr_src_shift = s;
-            int src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
+            dim_t tr_src_shift = s;
+            dim_t src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
             add(reg_src, src_shift * src_mult * typesize);
             add(reg_tr_src, tr_src_shift * tr_iw_s * typesize);
             add(reg_src_prf, src_shift * src_mult * typesize);
@@ -709,12 +715,12 @@ struct jit_trans_ow_oc_t : public jit_trans_dst_t, public jit_generator_t {
     }
 
 private:
-    int typesize = 0;
+    dim_t typesize = 0;
     bool is_layout_nxc = false;
-    int vnni_block = 0;
+    dim_t vnni_block = 0;
     static constexpr int transpose_size = 16;
-    size_t src_stride = 0, tr_src_stride = 0;
-    int tail = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
+    dim_t tail = 0;
 
     Opmask kFF = k1;
     Opmask mask_lo = k2;
@@ -755,18 +761,19 @@ private:
         return Xmm(i);
     }
 
-    void transpose(int nrows, bool nontemporal_stores, bool do_convert = true);
+    void transpose(
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void transpose_2b(
-            int nrows, bool nontemporal_stores, bool do_convert = true);
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void transpose_1b(
-            int nrows, bool nontemporal_stores, bool do_convert = true);
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void generate() override;
 };
 
 // do_convert (default is 'true') is a flag that determines when to do the
 // transformation of the input data and when to simply zero out the output data
 void jit_trans_ow_oc_t::transpose(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 16, "Unsupported transpose size");
     if (!nrows) return;
@@ -779,7 +786,7 @@ void jit_trans_ow_oc_t::transpose(
 }
 
 void jit_trans_ow_oc_t::transpose_2b(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
 
     auto load_ymm = [this](int i) {
         auto ymm_reg = src_ymm(i);
@@ -827,7 +834,7 @@ void jit_trans_ow_oc_t::transpose_2b(
             } else {
                 vpxord(zmm_src0, zmm_src0, zmm_src0);
             }
-            store(zmm_src0, nrows - 1);
+            store(zmm_src0, static_cast<int>(nrows - 1));
         }
     } else {
         for (int i = 0; i < rnd_dn(nrows, 2); i += 2) {
@@ -856,11 +863,11 @@ void jit_trans_ow_oc_t::transpose_2b(
             store(zmm_src0, i);
         }
         if (row_pad > 0) {
-            auto src0 = src_ymm(nrows - 1);
-            auto src1 = src_ymm(nrows);
+            auto src0 = src_ymm(static_cast<int>(nrows - 1));
+            auto src1 = src_ymm(static_cast<int>(nrows));
             auto zmm_src0 = src_zmm(30);
             if (do_convert) {
-                load_ymm(nrows - 1);
+                load_ymm(static_cast<int>(nrows - 1));
 
                 vpxor(src1, src1, src1);
                 vpunpckhwd(src1, src0, src1);
@@ -872,13 +879,13 @@ void jit_trans_ow_oc_t::transpose_2b(
             } else {
                 vpxord(zmm_src0, zmm_src0, zmm_src0);
             }
-            store(zmm_src0, nrows - 1);
+            store(zmm_src0, static_cast<int>(nrows - 1));
         }
     }
 }
 
 void jit_trans_ow_oc_t::transpose_1b(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
     auto load_xmm = [this](int i) {
         auto xmm_reg = src_xmm(i);
         auto addr = EVEX_compress_addr(reg_src, i * src_stride);
@@ -903,7 +910,8 @@ void jit_trans_ow_oc_t::transpose_1b(
     assert(is_layout_nxc);
     assert(vnni_block == 4);
 
-    for (int i = 0; i < rnd_up(nrows, vnni_block); i += vnni_block) {
+    for (int i = 0; i < static_cast<int>(rnd_up(nrows, vnni_block));
+            i += static_cast<int>(vnni_block)) {
         const auto idx0 = i;
         const auto idx1 = i + 1;
         const auto idx2 = i + 2;
@@ -997,12 +1005,12 @@ void jit_trans_ow_oc_t::generate() {
         vmovdqa64(vidx4 /*vreg_idx_hi_128*/, (const int64_t *)idx_hi_8);
     }
 
-    const int oc_block = conf_->oc_block;
-    const size_t src_mult
+    const dim_t oc_block = conf_->oc_block;
+    const dim_t src_mult
             = is_layout_nxc ? conf_->ngroups * conf_->oc : oc_block;
-    const int ow = conf_->ow;
-    const int transposes = utils::div_up(ow, transpose_size);
-    int loop_iters = nstl::max(0, transposes - 1);
+    const dim_t ow = conf_->ow;
+    const dim_t transposes = utils::div_up(ow, transpose_size);
+    dim_t loop_iters = nstl::max<dim_t>(0, transposes - 1);
     tail = ow - loop_iters * transpose_size;
 
     src_stride = src_mult * typesize;
@@ -1010,10 +1018,11 @@ void jit_trans_ow_oc_t::generate() {
 
     bool nontemporal_stores = conf_->use_nt_stores_ddst;
 
-    const size_t src_step = src_mult * transpose_size * typesize;
-    const size_t tr_src_step = (size_t)oc_block * transpose_size * typesize;
+    const dim_t src_step = src_mult * transpose_size * typesize;
+    const dim_t tr_src_step = oc_block * transpose_size * typesize;
 
-    const auto zero_tr_ow = nstl::max(0, conf_->tr_ow - rnd_up(ow, vnni_block));
+    const dim_t zero_tr_ow
+            = nstl::max<dim_t>(0, conf_->tr_ow - rnd_up(ow, vnni_block));
 
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -1047,11 +1056,11 @@ void jit_trans_ow_oc_t::generate() {
     transpose(tail, nontemporal_stores);
     if (zero_tr_ow) {
         const auto zero_transposes = utils::div_up(zero_tr_ow, transpose_size);
-        const auto zero_loop_iters = nstl::max(0, zero_transposes - 1);
+        const auto zero_loop_iters = nstl::max<dim_t>(0, zero_transposes - 1);
         const auto zero_tail = zero_tr_ow - zero_loop_iters * transpose_size;
 
         // shift over tail
-        add(reg_tr_src, (size_t)oc_block * rnd_up(tail, vnni_block) * typesize);
+        add(reg_tr_src, oc_block * rnd_up(tail, vnni_block) * typesize);
 
         // zero the tr_ow - ow
         if (zero_loop_iters) {
@@ -1077,7 +1086,7 @@ void jit_trans_ow_oc_t::generate() {
 // -------------------------------------------------
 */
 
-void jit_transpose4x16_src_t::transpose(int nrows) {
+void jit_transpose4x16_src_t::transpose(dim_t nrows) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 4, "Unsupported transpose size");
     if (!nrows) return;
@@ -1135,8 +1144,9 @@ void jit_transpose4x16_src_t::transpose(int nrows) {
         load(i);
     }
 
-    for (size_t i = nrows; i < 4; i++) {
-        vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
+    for (dim_t i = nrows; i < 4; i++) {
+        const int reg_idx = static_cast<int>(i);
+        vpxord(src_zmm(reg_idx), src_zmm(reg_idx), src_zmm(reg_idx));
     }
 
     vmovupd(tmp0, src0);
@@ -1200,16 +1210,16 @@ alignas(64) static constexpr const int32_t idxP[16]
 void jit_transpose4x16_src_t::generate() {
     preamble();
 
-    const int ic_block = params->ic_block;
-    const int is = params->is;
-    int tail = is % transpose_size;
+    const dim_t ic_block = params->ic_block;
+    const dim_t is = params->is;
+    dim_t tail = is % transpose_size;
 
     src_stride = ic_block * typesize;
     assert(src_stride == 64);
     tr_src_stride = ic_block * typesize;
 
-    const int src_step = ic_block * transpose_size * typesize;
-    const int tr_src_step = ic_block * transpose_size * typesize;
+    const dim_t src_step = ic_block * transpose_size * typesize;
+    const dim_t tr_src_step = ic_block * transpose_size * typesize;
 
 #define GET_TR_OFF(x) offsetof(jit_transpose_src_args_t, x)
     mov(reg_loop, ptr[param1 + GET_TR_OFF(size)]);
@@ -1275,9 +1285,9 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     /* Reorder part of F32 weights tensor
        from [VNNI_GRANULARITY][I][kd][kh][kw][16i][16o] to VNNI format [kd][kh][kw][16i][16o][VNNI_GRANULARITY][i]
        and down-convert it to required float. */
-    const int ts_out = types::data_type_size(out_dt_);
-    const int ts_inp = 4;
-    const int simd_w = 16;
+    const dim_t ts_out = types::data_type_size(out_dt_);
+    const dim_t ts_inp = 4;
+    const dim_t simd_w = 16;
 
     const Reg64 &reg_output = r15;
     const Reg64 &reg_output_kd = r14;
@@ -1316,7 +1326,7 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     auto get_zmm_src = [&](int idx, int ic) { return Zmm(4 * idx + ic); };
     auto get_zmm_bf16 = [&](int ic) { return Zmm(16 + ic); };
 
-    const int vnni_granularity = data_type_vnni_granularity(out_dt_);
+    const dim_t vnni_granularity = data_type_vnni_granularity(out_dt_);
 
     Xbyak::Label prm_table, zero_buffer;
     Xbyak::Label kd_loop_label, kh_loop_label;
@@ -1477,10 +1487,10 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
         L(prm_table);
         uint8_t prm_array[64];
         for (size_t i = 0; i < 16; i++) {
-            prm_array[4 * i] = i;
-            prm_array[4 * i + 1] = i + 16;
-            prm_array[4 * i + 2] = i + 32;
-            prm_array[4 * i + 3] = i + 48;
+            prm_array[4 * i] = static_cast<uint8_t>(i);
+            prm_array[4 * i + 1] = static_cast<uint8_t>(i + 16);
+            prm_array[4 * i + 2] = static_cast<uint8_t>(i + 32);
+            prm_array[4 * i + 3] = static_cast<uint8_t>(i + 48);
         }
 
         for (size_t i = 0; i < 64; ++i)

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -90,7 +90,7 @@ struct jit_transpose4x16_src_t : public jit_generator_t {
 private:
     static const int typesize = sizeof(float);
 
-    int src_stride = 0, tr_src_stride = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
 
     Xbyak::Reg64 imm_addr64 = rbx;
 
@@ -112,8 +112,8 @@ private:
     Xbyak::Reg64 reg_tr_src_tmp = r13;
     Xbyak::Reg32 regw_tmp = r14d;
 
-    void transpose_block(int ur, int nrows);
-    void transpose(int nrows);
+    void transpose_block(dim_t ur, dim_t nrows);
+    void transpose(dim_t nrows);
     void generate() override;
 };
 

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
@@ -379,7 +379,7 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
     // rows -> sp, cols -> ic
     // M -> ic, K -> sp
     assert(conf_->ic_block % transpose_size == 0);
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = conf_->K_tail % os_block;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize;
@@ -708,10 +708,11 @@ void jit_brgemm_trans_m_k_bf16_t::generate() {
     constexpr int amx_xf16_granularity = 2;
     const bool last_row_padded = is_superset(conf_->isa, avx512_core_amx)
             && conf_->os % amx_xf16_granularity != 0;
-    const int eff_K_tail = conf_->K_tail - (last_row_padded ? 1 : 0);
+    const dim_t eff_K_tail = conf_->K_tail - (last_row_padded ? 1 : 0);
 
-    const int os_block = conf_->os_block;
-    const int last_os_block_tail = eff_K_tail % transpose_size;
+    const int os_block = static_cast<int>(conf_->os_block);
+    const int last_os_block_tail
+            = static_cast<int>(eff_K_tail % transpose_size);
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize;
     tr_src_stride = conf_->LDA * typesize;
@@ -1036,7 +1037,7 @@ void jit_brgemm_trans_m_k_f16_t::transpose_16x16(int nrows, int ncolumns) {
 void jit_brgemm_trans_m_k_f16_t::generate() {
     preamble();
     assert(conf_->ic_block % transpose_size == 0);
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = conf_->K_tail % transpose_size;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize_in;


### PR DESCRIPTION
Continuation of https://github.com/uxlfoundation/oneDNN/pull/5565
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
