### PR TITLE
x64: injectors: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -269,7 +269,7 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
         const std::vector<const void *> &orig_post_ops_binary_rhs_arg_vec,
         std::vector<const void *> &post_ops_binary_rhs_arg_vec,
         uint8_t *expanded_rhs, const std::vector<dim_t> &expanded_elems_len) {
-    size_t offset = 0;
+    dim_t offset = 0;
     const int po_len = post_ops.len();
     auto binary_post_op_idx = 0;
 
@@ -287,7 +287,7 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
             auto *dst = expanded_rhs + offset;
 
             for (dim_t j = 0; j < expanded_elems_len[i]; ++j) {
-                const size_t src_idx = j % rhs_len;
+                const dim_t src_idx = j % rhs_len;
                 memcpy(dst + j * dt_size, src + src_idx * dt_size, dt_size);
             }
 
@@ -322,56 +322,50 @@ static_params_t::static_params_t(const Xbyak::Reg64 &param1,
     : static_params_t(param1, get_all_strategies_supported_by_injector(),
               rhs_arg_static_params) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast,
               rhs_helper_reg, false /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               rhs_helper_reg, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        const Xbyak::Reg64 &reg_tail_size, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        const Xbyak::Opmask &tail_opmask, const Xbyak::Reg64 &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               reg_tail_size, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
-        bool is_opmask_set)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast,
+        const Xbyak::Reg64 &reg_tail_size, bool is_opmask_set)
     : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
     , rhs_addr_reg(rhs_addr_reg)
     , rhs_helper_reg(rhs_helper_reg)
@@ -412,14 +406,17 @@ static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         broadcasting_strategy_t rhs_broadcasting_strategy) {
 
+    const int vmm_idx1_int = jit_generator_t::xbyak_register_index(vmm_idx1);
+    const int vmm_idx2_int = jit_generator_t::xbyak_register_index(vmm_idx2);
+
     const auto &out_addr = rhs_arg_params.vmm_idx_to_out_addr;
     const auto &out_reg = rhs_arg_params.vmm_idx_to_out_reg;
     const auto &out_elem_off_val = rhs_arg_params.vmm_idx_to_out_elem_off_val;
 
     if (rhs_broadcasting_strategy != broadcasting_strategy_t::scalar) {
-        return params_differ(out_addr, vmm_idx1, vmm_idx2)
-                || params_differ(out_reg, vmm_idx1, vmm_idx2)
-                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2);
+        return params_differ(out_addr, vmm_idx1_int, vmm_idx2_int)
+                || params_differ(out_reg, vmm_idx1_int, vmm_idx2_int)
+                || params_differ(out_elem_off_val, vmm_idx1_int, vmm_idx2_int);
     }
     return false;
 }
@@ -496,20 +493,19 @@ std::pair<bool, int> jit_uni_binary_injector_t<isa, Vmm>::should_preserve_vmm(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(size_t start_idx,
-        size_t end_idx, std::size_t rhs_arg_idx,
-        const dnnl_post_ops::entry_t &post_op,
+void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(int start_idx,
+        int end_idx, dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     injector_utils::vmm_index_set_t vmm_idxs;
-    for (size_t i = start_idx; i < end_idx; i++)
+    for (int i = start_idx; i < end_idx; i++)
         vmm_idxs.emplace(i);
     compute_vector_range(vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
-        const injector_utils::vmm_index_set_t &vmm_idxs,
-        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const injector_utils::vmm_index_set_t &vmm_idxs, dim_t rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
 
     if (vmm_idxs.empty()) return;
@@ -547,7 +543,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
                     || !rhs_arg_params.vmm_idx_to_out_reg.empty());
@@ -641,7 +638,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     Xbyak::Address rhs2_arg_addr {};
 
     // Phase 3 Apply binary post-op over all vmms.
-    for (const auto vmm_idx : vmm_idxs) {
+    for (const auto set_vmm_idx : vmm_idxs) {
+        const int vmm_idx = set_vmm_idx;
         const bool is_start_idx = vmm_idx == start_idx;
         const bool with_tail = rhs_arg_static_params_.is_tail
                 && vmm_tail_idx.find(vmm_idx) != vmm_tail_idx.cend()
@@ -720,8 +718,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
 
 template <cpu_isa_t isa, typename Vmm>
 Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
-        std::size_t vmm_idx, std::size_t rhs_arg_idx,
-        const dnnl_post_ops::entry_t &post_op,
+        int vmm_idx, dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         const broadcasting_strategy_t rhs_broadcasting_strategy, bool is_first,
         bool is_ternary_input) const {
@@ -852,9 +849,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first, bool cache_addr) const {
+        dim_t elem_size_bytes, bool is_first, bool cache_addr) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -870,7 +867,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
         if (is_first || !cache_addr) {
             calculate_no_broadcast_base(out_addr, tmp_reg);
             if (elem_size_bytes > 1) {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->sal(tmp_reg, shift_val);
             }
             host_->add(addr_reg, tmp_reg);
@@ -898,14 +896,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
     host_->sub(out_reg,
             host_->ptr[param1_ + rhs_arg_static_params_.dst_orig_offset]);
     host_->shr(out_reg,
-            std::log2(types::data_type_size(
-                    rhs_arg_static_params_.dst_d.data_type())));
+            static_cast<int>(std::log2(types::data_type_size(
+                    rhs_arg_static_params_.dst_d.data_type()))));
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_partial(
-        const std::size_t offset, const Xbyak::Reg64 &out_reg,
-        std::size_t elem_size_bytes) const {
+        const dim_t offset, const Xbyak::Reg64 &out_reg,
+        dim_t elem_size_bytes) const {
     const auto offset_adj = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     host_->mov(out_reg,
@@ -917,9 +915,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -971,7 +969,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1026,8 +1025,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = (offset % strides[0]) / strides[1]
     const auto offset_adj
             = ((offset >> math::ilog2q(types::data_type_size(
@@ -1047,7 +1046,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
     const auto r8 = host_->r8;
@@ -1072,11 +1072,12 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     const auto offset_adj = ((offset_shr % strides[0]) / strides[1]) * blk_size
@@ -1104,8 +1105,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = offset % C
     const auto C = rhs_arg_static_params_.dst_d.dims()[1];
     const auto offset_adj = (offset >> math::ilog2q(types::data_type_size(
@@ -1132,8 +1133,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = offset / strides[1]
     const auto offset_adj = (offset >> math::ilog2q(types::data_type_size(
                                      rhs_arg_static_params_.dst_d.data_type())))
@@ -1147,9 +1148,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -1190,7 +1191,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1250,8 +1252,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // dst_offset % dstride[0] / dstride[2] = b*C + c
     const auto offset_adj
             = ((offset >> math::ilog2q(types::data_type_size(
@@ -1267,9 +1269,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first,
+        dim_t elem_size_bytes, bool is_first,
         const memory_desc_wrapper &rhs_d) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
@@ -1328,7 +1330,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
                 if (elem_size_bytes == 1) {
                     host_->add(addr_reg, rax);
                 } else {
-                    const int shift_val = std::log2(elem_size_bytes);
+                    const int shift_val
+                            = static_cast<int>(std::log2(elem_size_bytes));
                     host_->mov(tmp_reg, rax);
                     host_->sal(tmp_reg, shift_val);
                     host_->add(addr_reg, tmp_reg);
@@ -1374,7 +1377,7 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
         const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
         const dim_t *dst_strides, const Xbyak::Reg64 &addr_reg,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const {
     // offset = n*dst_stride_n + c*dst_stride_c + d*dst_stride_d + h*dst_stride_h + w*dst_stride_w
     // rhs_off = n*rhs_stride_n + d*rhs_stride_d + h*rhs_stride_h + w*rhs_stride_w
     // per_mb_spatial: channel c is broadcast, so rem = (offset % dst_stride_n) % dst_stride_c.
@@ -1448,7 +1451,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, r8);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = static_cast<int>(std::log2(elem_size_bytes));
         host_->mov(tmp_reg, r8);
         host_->sal(tmp_reg, shift_val);
         host_->add(addr_reg, tmp_reg);
@@ -1459,9 +1462,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa,
         Vmm>::calculate_mb_sp_ncsp_partial_rhs_strided(const memory_desc_wrapper
                                                                &dst_d,
-        const memory_desc_wrapper &rhs_d, std::size_t dst_offset_bytes,
+        const memory_desc_wrapper &rhs_d, dim_t dst_offset_bytes,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes) const {
+        dim_t elem_size_bytes) const {
     const dim_t rhs_offset
             = rhs_offset_per_mb_spatial(dst_d, rhs_d, dst_offset_bytes);
     if (rhs_offset == 0) return;
@@ -1469,7 +1472,7 @@ void jit_uni_binary_injector_t<isa,
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, rhs_offset);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = static_cast<int>(std::log2(elem_size_bytes));
         const uint64_t rhs_offset_bytes = static_cast<uint64_t>(rhs_offset)
                 << shift_val;
         host_->mov(tmp_reg, rhs_offset_bytes);
@@ -1523,8 +1526,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = (n * (stride_n/C)) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW)
@@ -1555,7 +1558,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
 
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1577,8 +1581,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
 
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1587,7 +1591,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
     const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
     const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
     const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
 
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
@@ -1619,8 +1624,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_sp_off = nDHW + dHW + hW + w
     // mb_sp_off = offset / C
@@ -1652,8 +1657,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_sp_off = dHWN + hWN + wN + n
     // mb_sp_off = offset % stride_c
@@ -1669,9 +1674,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -1724,7 +1729,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1821,8 +1827,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1852,8 +1858,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     calculate_mb_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
@@ -1912,8 +1918,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_w_off = nW + w
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1962,8 +1968,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_w_off = wN + n
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -1980,9 +1986,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2034,7 +2040,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2067,8 +2074,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
 }
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_hw_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nCHW + cHW + hW + w (for 4D)
     // per_spatial_off = offset % HW
 
@@ -2114,9 +2121,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2168,7 +2175,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2233,8 +2241,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // w_off = w * stride_w
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -2255,8 +2263,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     calculate_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
 
@@ -2289,8 +2297,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // w_off = w
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -2313,8 +2321,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // w_off = w
     calculate_w_nspc_partial(strides, offset, tmp_reg, elem_size_bytes);
@@ -2324,9 +2332,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2378,7 +2386,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2431,8 +2440,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_off = offset / stride_n
     // mb_off = n
@@ -2454,8 +2463,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_off = n;
     calculate_mb_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
@@ -2483,8 +2492,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_off = offset % N = offset % strides[ndims-1]
     // mb_off = n
@@ -2501,9 +2510,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2555,7 +2564,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2606,8 +2616,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // oc_spatial_off = offset % stride_n
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2628,8 +2638,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // oc_spatial_off = offset % stride_n
     calculate_oc_spatial_ncsp_partial(
@@ -2655,8 +2665,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // oc_spatial_off = offset / strides[ndims - 1]
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2672,9 +2682,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2726,7 +2736,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2777,8 +2788,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nCDHW + cDHW + dHW + hW + w
     // mb_oc_off = offset / DHW
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2820,8 +2831,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_oc_off = nC + c
     // mb_oc_off = (offset / DHWC) * C + offset % C
@@ -2869,8 +2880,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_oc_off = cN + n
     // mb_oc_off = (offset / DHWN) * N + offset % N
@@ -3277,14 +3288,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_with_opmask(
 
 static constexpr int xmm_size_elem = 4;
 
-static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
-        std::size_t tail_size, const std::function<void()> &init_op,
+static void load_tail_avx(jit_generator_t *host, int ymm_idx, dim_t tail_size,
+        const std::function<void()> &init_op,
         const std::function<void(int, bool)> &ymm_upper_half_op,
         const std::function<void(int)> &ymm_lower_half_op) {
 
     if (init_op) init_op();
 
-    const auto res = std::div(tail_size, xmm_size_elem);
+    const auto res = std::div(static_cast<int>(tail_size), xmm_size_elem);
     const auto &ymm_upper_half_op_data_size = res.rem;
     const bool should_load_lower_half = res.quot;
 
@@ -3306,8 +3317,7 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
     }
 }
 
-static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
-        std::size_t tail_size,
+static void load_tail_avx(jit_generator_t *host, int ymm_idx, dim_t tail_size,
         const std::function<void(int, bool)> &ymm_upper_half_op,
         const std::function<void(int)> &ymm_lower_half_op) {
     load_tail_avx(host, ymm_idx, tail_size, nullptr, ymm_upper_half_op,
@@ -3316,12 +3326,13 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
 
 static Xbyak::uint8 MM_SHUFFLE(
         Xbyak::uint8 z, Xbyak::uint8 y, Xbyak::uint8 x, Xbyak::uint8 w) {
-    return (((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
+    return static_cast<Xbyak::uint8>(
+            ((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
 }
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
         const Xbyak::Ymm &vmm, const Xbyak::Address &rhs_addr,
-        std::size_t tail_size) {
+        dim_t tail_size) {
 
     const auto vmm_idx = vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
@@ -3346,7 +3357,7 @@ static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
         const Xbyak::Xmm &vmm, const Xbyak::Address &rhs_addr,
-        std::size_t tail_size) {
+        dim_t tail_size) {
 
     const auto vmm_idx = vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
@@ -3365,7 +3376,7 @@ struct helper_bcast_tail_t {};
 template <typename Vmm>
 struct helper_bcast_tail_t<avx2, Vmm> {
     static void execute_broadcast_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const data_type_t &data_type,
+            const dim_t tail_size, const data_type_t &data_type,
             const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr) {
         host->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
@@ -3373,8 +3384,9 @@ struct helper_bcast_tail_t<avx2, Vmm> {
             execute_broadcast_f32_tail_avx(host, tmp_vmm, rhs_addr, tail_size);
         } else if (data_type == data_type::u8 || data_type == data_type::s8) {
             const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
-            for (std::size_t i = 0; i < tail_size; i++)
-                host->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
+            for (int i = 0; i < tail_size; i++)
+                host->vpinsrb(
+                        tmp_xmm, tmp_xmm, rhs_addr, static_cast<uint8_t>(i));
 
             if (data_type == data_type::s8)
                 host->vpmovsxbd(tmp_vmm, tmp_xmm);
@@ -3388,7 +3400,7 @@ struct helper_bcast_tail_t<avx2, Vmm> {
 template <typename Vmm>
 struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
     static void execute_broadcast_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const data_type_t &data_type,
+            const dim_t tail_size, const data_type_t &data_type,
             const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr,
             fp8_conversion_e5m2_t *f8_e5m2_cvt,
             fp8_conversion_e4m3_t *f8_e4m3_cvt) {
@@ -3397,7 +3409,8 @@ struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
             const auto tmp_lower_vmm =
                     typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
             host->load_bytes(tmp_lower_vmm, rhs_addr,
-                    tail_size * types::data_type_size(data_type));
+                    static_cast<int>(
+                            tail_size * types::data_type_size(data_type)));
             if (data_type == data_type::bf16) {
                 host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
                 host->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3416,7 +3429,7 @@ struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr, const std::size_t tail_size) const {
+        const Xbyak::Address &rhs_addr, const dim_t tail_size) const {
     assert(!"unsupported tail load mode");
 }
 
@@ -3425,7 +3438,7 @@ void jit_uni_binary_injector_t<avx2_vnni_2,
         Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2_vnni_2,
             Xbyak::Ymm>::execute_broadcast_tail_statically(host_, tail_size,
             data_type, tmp_vmm, rhs_addr, f8_e5m2_cvt_, f8_e4m3_cvt_);
@@ -3436,7 +3449,7 @@ void jit_uni_binary_injector_t<avx2_vnni_2,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2_vnni_2,
             Xbyak::Xmm>::execute_broadcast_tail_statically(host_, tail_size,
             data_type, tmp_vmm, rhs_addr, f8_e5m2_cvt_, f8_e4m3_cvt_);
@@ -3447,7 +3460,7 @@ void jit_uni_binary_injector_t<avx2,
         Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2, Xbyak::Ymm>::execute_broadcast_tail_statically(
             host_, tail_size, data_type, tmp_vmm, rhs_addr);
 }
@@ -3457,7 +3470,7 @@ void jit_uni_binary_injector_t<avx2,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2, Xbyak::Xmm>::execute_broadcast_tail_statically(
             host_, tail_size, data_type, tmp_vmm, rhs_addr);
 }
@@ -3467,7 +3480,7 @@ void jit_uni_binary_injector_t<avx,
         Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
@@ -3513,13 +3526,13 @@ void jit_uni_binary_injector_t<avx,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
     const auto load_tail_avx_xmm = [&]() {
-        for (size_t i = 0; i < tail_size; i++)
-            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, i);
+        for (int i = 0; i < tail_size; i++)
+            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, static_cast<uint8_t>(i));
     };
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
@@ -3539,7 +3552,7 @@ void jit_uni_binary_injector_t<sse41,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
     if (data_type == data_type::f32 || data_type == data_type::s32) {
@@ -3550,8 +3563,8 @@ void jit_uni_binary_injector_t<sse41,
         if (tail_size > 1) host_->shufps(tmp_vmm, tmp_vmm, imms[tail_size - 2]);
 
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (std::size_t i = 0; i < tail_size; i++)
-            host_->pinsrb(tmp_vmm, rhs_addr, i);
+        for (int i = 0; i < tail_size; i++)
+            host_->pinsrb(tmp_vmm, rhs_addr, static_cast<uint8_t>(i));
 
         if (data_type == data_type::s8)
             host_->pmovsxbd(tmp_vmm, tmp_vmm);
@@ -3729,7 +3742,7 @@ struct helper_load_tail_t {};
 template <typename Vmm>
 struct helper_load_tail_t<avx2, Vmm> {
     static void load_rhs_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
+            const dim_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
             const data_type_t &data_type, const Vmm &tmp_vmm,
             const Xbyak::Address &rhs_addr) {
 
@@ -3737,21 +3750,22 @@ struct helper_load_tail_t<avx2, Vmm> {
                     data_type::s8, data_type::u8))
             assert(!"unsupported data type");
 
-        host->load_data(data_type, tmp_vmm, rhs_addr_reg, 0, tail_size);
+        host->load_data(data_type, tmp_vmm, rhs_addr_reg, 0,
+                static_cast<int>(tail_size));
     }
 };
 
 template <typename Vmm>
 struct helper_load_tail_t<avx2_vnni_2, Vmm> {
     static void load_rhs_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
+            const dim_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
             const data_type_t &data_type, const Vmm &tmp_vmm,
             const Xbyak::Address &rhs_addr) {
         if (utils::one_of(data_type, data_type::bf16, data_type::f16)) {
             const auto tmp_lower_vmm =
                     typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
             host->load_bytes(tmp_lower_vmm, rhs_addr_reg, 0,
-                    tail_size * sizeof(bfloat16_t));
+                    static_cast<int>(tail_size * sizeof(bfloat16_t)));
             if (data_type == data_type::bf16) {
                 host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
                 host->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3814,7 +3828,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
     static constexpr int xmm_size_elem = 4;
-    const auto res = std::div(tail_size, xmm_size_elem);
+    const auto res = std::div(static_cast<int>(tail_size), xmm_size_elem);
     const auto vmm_idx = tmp_vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
 
@@ -3827,7 +3841,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
             for (int i = 0; i < res.rem; i++)
                 host_->vpinsrd(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + offset + i * sizeof(float)],
-                        i);
+                        static_cast<uint8_t>(i));
         };
 
         const auto lower_half_op = [&](int upper_half_data_size) {
@@ -3849,7 +3863,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
             for (int i = 0; i < upper_half_data_size; i++)
                 host_->vpinsrb(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + offset + i * sizeof(int8_t)],
-                        i);
+                        static_cast<uint8_t>(i));
             cvt_to_dword(tmp_xmm);
         };
 
@@ -3870,13 +3884,15 @@ void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::load_rhs_tail_statically(
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
-        for (size_t i = 0; i < tail_size; i++)
+        for (int i = 0; i < tail_size; i++)
             host_->vpinsrd(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(float)], i);
+                    host_->ptr[rhs_addr_reg + i * sizeof(float)],
+                    static_cast<uint8_t>(i));
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (size_t i = 0; i < tail_size; i++)
+        for (int i = 0; i < tail_size; i++)
             host_->vpinsrb(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)], i);
+                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)],
+                    static_cast<uint8_t>(i));
         if (data_type == data_type::s8)
             host_->vpmovsxbd(tmp_vmm, tmp_vmm);
         else
@@ -3895,7 +3911,7 @@ void jit_uni_binary_injector_t<sse41, Xbyak::Xmm>::load_rhs_tail_statically(
 
     const auto &tail_size = rhs_arg_static_params_.tail_size;
     host_->load_data(data_type, tmp_vmm, rhs_arg_static_params_.rhs_addr_reg, 0,
-            tail_size);
+            static_cast<int>(tail_size));
 }
 
 // Support compare with Address param only when isa is avx512.
@@ -3914,7 +3930,7 @@ jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
     const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
 
     push_opmask(host_, cmp_mask);
-    host_->vcmpps(cmp_mask, lhs, rhs, cmp_predicate);
+    host_->vcmpps(cmp_mask, lhs, rhs, static_cast<uint8_t>(cmp_predicate));
     host_->mov(reg_tmp, float2int(1));
     host_->uni_vmovq(xreg_one, reg_tmp);
     // broadcast 1.0f with mask
@@ -4083,8 +4099,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector(size_t idx,
-        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+void jit_uni_binary_injector_t<isa, Vmm>::compute_vector(int idx,
+        dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     compute_vector_range({idx}, rhs_arg_idx, post_op, rhs_arg_params);
 }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -406,8 +406,8 @@ static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         broadcasting_strategy_t rhs_broadcasting_strategy) {
 
-    const int vmm_idx1_int = jit_generator_t::xbyak_register_index(vmm_idx1);
-    const int vmm_idx2_int = jit_generator_t::xbyak_register_index(vmm_idx2);
+    const int vmm_idx1_int = static_cast<int>(vmm_idx1);
+    const int vmm_idx2_int = static_cast<int>(vmm_idx2);
 
     const auto &out_addr = rhs_arg_params.vmm_idx_to_out_addr;
     const auto &out_reg = rhs_arg_params.vmm_idx_to_out_reg;
@@ -543,8 +543,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = jit_generator_t::xbyak_register_index(
-            dst_d.blocking_desc().inner_blks[0]);
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
                     || !rhs_arg_params.vmm_idx_to_out_reg.empty());
@@ -1046,8 +1045,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = jit_generator_t::xbyak_register_index(
-            dst_d.blocking_desc().inner_blks[0]);
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
     const auto r8 = host_->r8;
@@ -1076,8 +1074,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
         dim_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int blk_size = jit_generator_t::xbyak_register_index(
-            dst_d.blocking_desc().inner_blks[0]);
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     const auto offset_adj = ((offset_shr % strides[0]) / strides[1]) * blk_size
@@ -1558,8 +1555,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = jit_generator_t::xbyak_register_index(
-            dst_d.blocking_desc().inner_blks[0]);
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
 
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1591,8 +1587,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
     const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
     const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
     const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
-    const int blk_size = jit_generator_t::xbyak_register_index(
-            dst_d.blocking_desc().inner_blks[0]);
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
 
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -643,8 +643,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     Xbyak::Address rhs2_arg_addr {};
 
     // Phase 3 Apply binary post-op over all vmms.
-    for (const auto set_vmm_idx : vmm_idxs) {
-        const int vmm_idx = set_vmm_idx;
+    for (const auto vmm_idx : vmm_idxs) {
         const bool is_start_idx = vmm_idx == start_idx;
         const bool with_tail = rhs_arg_static_params_.is_tail
                 && vmm_tail_idx.find(vmm_idx) != vmm_tail_idx.cend()

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -322,50 +322,56 @@ static_params_t::static_params_t(const Xbyak::Reg64 &param1,
     : static_params_t(param1, get_all_strategies_supported_by_injector(),
               rhs_arg_static_params) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
-        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
+        const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
-        const memory_desc_wrapper &dst_d, dim_t tail_size,
-        bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast,
               rhs_helper_reg, false /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
-        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
+        const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
-        const memory_desc_wrapper &dst_d, dim_t tail_size,
-        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               rhs_helper_reg, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
-        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
+        const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
-        const memory_desc_wrapper &dst_d, dim_t tail_size,
-        const Xbyak::Opmask &tail_opmask, const Xbyak::Reg64 &reg_tail_size,
-        bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+        const Xbyak::Reg64 &reg_tail_size, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               reg_tail_size, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
-        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
+        const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
-        const memory_desc_wrapper &dst_d, dim_t tail_size,
-        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast,
-        const Xbyak::Reg64 &reg_tail_size, bool is_opmask_set)
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+        bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
+        bool is_opmask_set)
     : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
     , rhs_addr_reg(rhs_addr_reg)
     , rhs_helper_reg(rhs_helper_reg)
@@ -3879,12 +3885,12 @@ void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::load_rhs_tail_statically(
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
-        for (int i = 0; i < tail_size; i++)
+        for (std::size_t i = 0; i < tail_size; i++)
             host_->vpinsrd(tmp_vmm, tmp_vmm,
                     host_->ptr[rhs_addr_reg + i * sizeof(float)],
                     static_cast<uint8_t>(i));
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (int i = 0; i < tail_size; i++)
+        for (std::size_t i = 0; i < tail_size; i++)
             host_->vpinsrb(tmp_vmm, tmp_vmm,
                     host_->ptr[rhs_addr_reg + i * sizeof(int8_t)],
                     static_cast<uint8_t>(i));

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -110,57 +110,56 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
  * for load with tail in runtime.
  */
 struct rhs_arg_static_params_t {
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size = 0u,
-            bool use_exact_tail_scalar_bcast = false);
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size = 0u, bool use_exact_tail_scalar_bcast = false);
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast);
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
             const Xbyak::Reg64 &reg_tail_size,
             bool use_exact_tail_scalar_bcast);
 
     bool is_opmask_set() const noexcept { return is_opmask_set_; }
 
-    mutable std::size_t rhs_dt_helper_vmm_idx;
+    mutable int rhs_dt_helper_vmm_idx;
     Xbyak::Reg64 rhs_addr_reg;
     Xbyak::Reg64 rhs_helper_reg;
     Xbyak::Reg64 rhs_addr_cache_reg;
     bool preserve_gpr_helpers;
     bool preserve_vmm_helper;
-    std::size_t abi_param_offset;
-    std::size_t dst_orig_offset;
+    dim_t abi_param_offset;
+    dim_t dst_orig_offset;
     memory_desc_wrapper dst_d;
-    std::size_t tail_size;
+    dim_t tail_size;
     Xbyak::Opmask tail_opmask;
     bool use_exact_tail_scalar_bcast;
     Xbyak::Reg64 reg_tail_size;
     bool is_tail;
 
 private:
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
             bool is_opmask_set);
 
@@ -237,7 +236,7 @@ enum class tail_lode_mode_t { STATIC, DYNAMIC, DEFAULT };
 struct rhs_arg_dynamic_params_t {
     std::map<int, Xbyak::Address> vmm_idx_to_out_addr;
     std::map<int, Xbyak::Reg64> vmm_idx_to_out_reg;
-    std::map<int, size_t> vmm_idx_to_out_elem_off_val;
+    std::map<int, dim_t> vmm_idx_to_out_elem_off_val;
 
     std::unordered_set<int> vmm_tail_idx_;
     tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT;
@@ -281,7 +280,7 @@ public:
      * described inside rhs_arg_params.
      */
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
     /*
@@ -291,8 +290,8 @@ public:
      * determined broadcast strategy and information about stored data in particular
      * vmm described inside rhs_arg_params.
      */
-    void compute_vector_range(size_t start_idx, size_t end_idx,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+    void compute_vector_range(int start_idx, int end_idx, dim_t rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
     /*
@@ -301,7 +300,7 @@ public:
      * for computations based on internally determined broadcast strategy and information
      * about stored data in particular vmm described inside rhs_arg_params.
      */
-    void compute_vector(size_t idx, std::size_t rhs_arg_idx,
+    void compute_vector(int idx, dim_t rhs_arg_idx,
             const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
@@ -319,8 +318,8 @@ private:
      * address of rhs tensor slice needed for binary operation and returns
      * ptr to it.
      */
-    Xbyak::Address prepare_rhs_arg_addr(std::size_t vmm_idx,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+    Xbyak::Address prepare_rhs_arg_addr(int vmm_idx, dim_t rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params,
             const broadcasting_strategy_t rhs_broadcasting_strategy,
             bool is_first, bool is_ternary_input) const;
@@ -343,229 +342,207 @@ private:
     void append_no_broadcast_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
-            bool is_first, bool cache_addr) const;
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes, bool is_first,
+            bool cache_addr) const;
     void calculate_no_broadcast_base(
             Xbyak::Address addr, const Xbyak::Reg64 &out_reg) const;
-    void calculate_no_broadcast_partial(const std::size_t offset,
-            const Xbyak::Reg64 &out_reg, std::size_t elem_size_bytes) const;
+    void calculate_no_broadcast_partial(const dim_t offset,
+            const Xbyak::Reg64 &out_reg, dim_t elem_size_bytes) const;
 
     void append_oc_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_blocked_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_oc_d_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_d_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_d_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_d_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_sp_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
-            bool is_first, const memory_desc_wrapper &rhs_d) const;
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes, bool is_first,
+            const memory_desc_wrapper &rhs_d) const;
     void calculate_mb_sp_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_ncsp_base_rhs_strided(const memory_desc_wrapper &dst_d,
             const memory_desc_wrapper &rhs_d, const dim_t *dst_strides,
             const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            dim_t elem_size_bytes) const;
     void calculate_mb_sp_ncsp_partial_rhs_strided(
             const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
-            std::size_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const;
+            dim_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_sp_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_mb_sp_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_w_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_w_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_w_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_mb_w_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_w_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_w_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_w_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_blocked_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_w_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_w_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_oc_spatial_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_spatial_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_oc_spatial_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_oc_spatial_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
 
     void append_hw_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_hw_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_hw_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_hw_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_oc_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_oc_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_oc_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_oc_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     template <typename T>
     typename std::enable_if<std::is_same<T, Xbyak::Zmm>::value
@@ -598,7 +575,7 @@ private:
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr) const;
     void execute_broadcast_tail_statically(const data_type_t &data_type,
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr,
-            const std::size_t tail_size) const;
+            const dim_t tail_size) const;
     void execute_broadcast_tail_with_gpr(const data_type_t &data_type,
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr) const;
     void load_rhs_tail_dynamically_with_opmask(const data_type_t &data_type,

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -110,56 +110,57 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
  * for load with tail in runtime.
  */
 struct rhs_arg_static_params_t {
-    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, dim_t abi_param_offset,
-            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            dim_t tail_size = 0u, bool use_exact_tail_scalar_bcast = false);
-    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+            bool preserve_vmm_helper, std::size_t abi_param_offset,
+            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size = 0u,
+            bool use_exact_tail_scalar_bcast = false);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, dim_t abi_param_offset,
-            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, std::size_t abi_param_offset,
+            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast);
-    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, dim_t abi_param_offset,
-            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, std::size_t abi_param_offset,
+            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
             const Xbyak::Reg64 &reg_tail_size,
             bool use_exact_tail_scalar_bcast);
 
     bool is_opmask_set() const noexcept { return is_opmask_set_; }
 
-    mutable int rhs_dt_helper_vmm_idx;
+    mutable std::size_t rhs_dt_helper_vmm_idx;
     Xbyak::Reg64 rhs_addr_reg;
     Xbyak::Reg64 rhs_helper_reg;
     Xbyak::Reg64 rhs_addr_cache_reg;
     bool preserve_gpr_helpers;
     bool preserve_vmm_helper;
-    dim_t abi_param_offset;
-    dim_t dst_orig_offset;
+    std::size_t abi_param_offset;
+    std::size_t dst_orig_offset;
     memory_desc_wrapper dst_d;
-    dim_t tail_size;
+    std::size_t tail_size;
     Xbyak::Opmask tail_opmask;
     bool use_exact_tail_scalar_bcast;
     Xbyak::Reg64 reg_tail_size;
     bool is_tail;
 
 private:
-    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, dim_t abi_param_offset,
-            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, std::size_t abi_param_offset,
+            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
             bool is_opmask_set);
 

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -64,7 +64,7 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg, data_type_t dt) {
 using namespace Xbyak;
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::get_stack_vmm_space() {
+dim_t jit_uni_eltwise_injector_t<isa, Wmm>::get_stack_vmm_space() {
     return (save_state_ * preserve_vmm_ * n_vregs_to_preserve_
                    + op_vecs_count(alg_, is_fwd_))
             * vlen_;
@@ -83,7 +83,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
     n_vregs_preserved_ = 0;
     assert(IMPLICATION(!vmm_aux_indices.empty(),
-            vmm_aux_indices.size() == n_vregs_to_preserve_));
+            static_cast<int>(vmm_aux_indices.size()) == n_vregs_to_preserve_));
 
     const auto start_idx = *(vmm_compute_idxs.begin());
     const auto end_idx = *(vmm_compute_idxs.rbegin()) + 1;
@@ -99,21 +99,21 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
     // `n_vregs_preserved_` is 0 for isa higher than `sse41`.
     // Note that by happy coincidence, idx=0 is skipped for `sse41`.
-    for (size_t idx = n_vregs_preserved_; idx < n_vregs_; idx++) {
+    for (int idx = n_vregs_preserved_; idx < n_vregs_; idx++) {
         // Once reserved enough vmm registers, break the loop.
         if (n_vregs_preserved_ >= n_vregs_to_preserve_) break;
 
         // Thanks to `std::set` LegacyBidirectionalIterator `iterator` member
         // that doesn't have operator+ defined.
-        size_t external_idx = 0;
+        int external_idx = 0;
         if (!vmm_aux_indices.empty()) {
             auto it = vmm_aux_indices.begin();
-            for (size_t i = 0; i < idx; i++)
+            for (int i = 0; i < idx; i++)
                 it++;
             external_idx = *it;
             assert(it != vmm_aux_indices.end());
         }
-        size_t preserve_idx = vmm_aux_indices.empty() ? idx : external_idx;
+        int preserve_idx = vmm_aux_indices.empty() ? idx : external_idx;
 
         // `start_idx` and `end_idx` is the range of indices passed to the
         // injector to apply `alg_` on top of them. Thus, they don't need to
@@ -145,8 +145,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     // injector will take first `n_vregs_not_preserved` from `vmm_compute_idxs`
     // to have legit generated code. This fact is saved through
     // `start_idx_tail_it` iterator and a second round of compute will happen.
-    size_t n_vregs_not_preserved = n_vregs_to_preserve_ - n_vregs_preserved_;
-    for (size_t i = 0; i < n_vregs_not_preserved; i++) {
+    int n_vregs_not_preserved = n_vregs_to_preserve_ - n_vregs_preserved_;
+    for (int i = 0; i < n_vregs_not_preserved; i++) {
         preserved_vmm_indices_[n_vregs_preserved_ - need_vmm_mask_register_]
                 = *start_idx_tail_it;
         n_vregs_preserved_++;
@@ -155,8 +155,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     assert(n_vregs_preserved_ == n_vregs_to_preserve_);
 
     // Preserve GPRs.
-    size_t preserved_gprs_count = 0;
-    size_t n_gprs_to_preserve = aux_gprs_count(alg_, is_fwd_, alpha_);
+    int preserved_gprs_count = 0;
+    int n_gprs_to_preserve = aux_gprs_count(alg_, is_fwd_, alpha_);
     if (n_gprs_to_preserve > 0) {
         // Allocate GPRs from the end not to mess with ABI compatibility.
         for (int gpr_idx = Operand::R15; gpr_idx >= 0; gpr_idx--) {
@@ -175,7 +175,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     if (save_state_) {
         if (preserve_p_table_) h->push(p_table_);
 
-        for (size_t i = 0; i < preserved_gprs_count; ++i)
+        for (int i = 0; i < preserved_gprs_count; ++i)
             h->push(Reg64(preserved_gpr_indices_[i]));
     }
 
@@ -202,13 +202,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
             assert(vmm_aux_indices.empty());
 
             if (need_vmm_mask_register_) {
-                size_t i = 0;
+                int i = 0;
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
                         Vmm(preserved_vmm_tail_indices_[i]));
             }
 
-            for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_;
-                    ++i)
+            for (int i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
                         Vmm(preserved_vmm_indices_[i
                                 - need_vmm_mask_register_]));
@@ -224,11 +223,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
-        size_t n_vregs_not_preserved) {
+        int n_vregs_not_preserved) {
     // There was enough vmm registers to compute everything in one round.
     if (n_vregs_not_preserved == 0) return;
 
-    const size_t idx_off = n_vregs_to_preserve_ - n_vregs_not_preserved;
+    const int idx_off = n_vregs_to_preserve_ - n_vregs_not_preserved;
     assert(idx_off < n_vregs_to_preserve_); // Overflow is undesired.
 
     if (save_state_) {
@@ -236,7 +235,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
         // an issue and `!preserve_vmm_` case never reaches this piece.
         assert(preserve_vmm_);
 
-        for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+        for (int i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(Vmm(preserved_vmm_indices_[idx_off + i
                                    - need_vmm_mask_register_]),
                     h->ptr[reg_vmm_stack_ptr_
@@ -246,12 +245,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
     // Update the rightmost indices. The injector uses vmms with indices coming
     // after compute vmm indices.
     // TODO: is it always a valid index?
-    for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+    for (int i = 0; i < n_vregs_not_preserved; ++i)
         preserved_vmm_indices_[idx_off + i - need_vmm_mask_register_]
                 += n_vregs_not_preserved;
 
     if (save_state_ && preserve_vmm_) {
-        for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+        for (int i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_
                                    + (i - n_vregs_not_preserved) * vlen_],
                     Vmm(preserved_vmm_indices_[idx_off + i
@@ -264,17 +263,17 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
     using namespace Xbyak::util;
-    const int stack_vmm_space = get_stack_vmm_space();
+    const dim_t stack_vmm_space = get_stack_vmm_space();
 
     if (save_state_ && preserve_vmm_) {
-        for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
+        for (int i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
             h->uni_vmovups(
                     Vmm(preserved_vmm_indices_[i - need_vmm_mask_register_]),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
 
         if (need_vmm_mask_register_) {
-            size_t i = 0;
+            int i = 0;
             h->uni_vmovups(Vmm(preserved_vmm_tail_indices_[i]),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
@@ -288,8 +287,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
     }
 
     if (!save_state_) return;
-    for (int i = static_cast<int>(aux_gprs_count(alg_, is_fwd_, alpha_)) - 1;
-            i >= 0; --i)
+    for (int i = aux_gprs_count(alg_, is_fwd_, alpha_) - 1; i >= 0; --i)
         h->pop(Reg64(preserved_gpr_indices_[i]));
 
     if (preserve_p_table_) h->pop(p_table_);
@@ -312,9 +310,10 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
                     eltwise_exp_use_dst_for_bwd);
 
     if (preserve_vec_for_avx) {
-        vmm_tmp_ = Vmm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
-        ymm_tmp_ = Ymm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
-        xmm_tmp_ = Xmm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
+        const int idx = preserved_vmm_indices_[n_vregs_to_preserve_ - 1];
+        vmm_tmp_ = Vmm(idx);
+        ymm_tmp_ = Ymm(idx);
+        xmm_tmp_ = Xmm(idx);
     }
 }
 
@@ -323,7 +322,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
 // initialized with stock values from the injector, or with external values
 // provided by the user.
 template <cpu_isa_t isa, typename Wmm>
-Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(size_t idx) {
+Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(int idx) {
     assert(idx < (n_vregs_preserved_ - need_vmm_mask_register_));
     return Vmm(preserved_vmm_indices_[idx]);
 }
@@ -344,11 +343,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::vec_shift(const Vmm &vmm_dst,
         if (vmm_dst.getIdx() != vmm_src.getIdx()) h->vmovups(ymm_dst, ymm_src);
         h->vextractf128(xmm_tmp_, ymm_dst, 1);
         if (shift_left) {
-            h->vpslld(xmm_dst, xmm_dst, imm);
-            h->vpslld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpslld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
+            h->vpslld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
         } else {
-            h->vpsrld(xmm_dst, xmm_dst, imm);
-            h->vpsrld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpsrld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
+            h->vpsrld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
         }
         h->vinsertf128(ymm_dst, ymm_dst, xmm_tmp_, 1);
     }
@@ -360,7 +359,8 @@ template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::compute_cmp_mask(const Vmm &vmm_src,
         const Xbyak::Operand &compare_operand, int cmp_predicate) {
     if (is_avx512_) {
-        h->vcmpps(k_mask_, vmm_src, compare_operand, cmp_predicate);
+        h->vcmpps(k_mask_, vmm_src, compare_operand,
+                static_cast<uint8_t>(cmp_predicate));
     } else {
         h->uni_vcmpps(vmm_mask_, vmm_src, compare_operand, cmp_predicate);
     }
@@ -551,12 +551,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
         switch (isa) {
             case sse41:
                 for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
+                    h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx,
+                            static_cast<uint8_t>(i));
                 break;
             case avx: {
                 Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
                 for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
+                    h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx,
+                            static_cast<uint8_t>(i));
             } break;
             case avx2_vnni_2:
             case avx2:
@@ -578,7 +580,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                     Xbyak::Address coeff_addr
                             = ptr[p_table_ + coeffs_off(coeff_idx)
                                     + gpr_idx[idx] * sizeof(float)];
-                    h->pinsrd(vmm_coeff, coeff_addr, idx);
+                    h->pinsrd(vmm_coeff, coeff_addr, static_cast<uint8_t>(idx));
                 }
                 break;
             case avx: {
@@ -587,7 +589,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                     Xbyak::Address coeff_addr
                             = ptr[p_table_ + coeffs_off(coeff_idx)
                                     + gpr_idx[idx] * sizeof(float)];
-                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
+                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr,
+                            static_cast<uint8_t>(idx));
                 }
             } break;
             case avx2_vnni_2:
@@ -1052,7 +1055,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
     const auto table_start_idx = (*it).second.off;
 
     auto gather_table_values
-            = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, size_t offt = 0) {
+            = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, dim_t offt = 0) {
         Xbyak::Address table_idx = h->ptr[p_table_ + table_start_idx + offt
                 + vmm_idxs * sizeof(float)];
         if (is_avx512_) {
@@ -1075,7 +1078,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
             // fetched values into vector register.
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + vlen_], vmm_idxs);
 
-            for (size_t i = 0; i < vlen_ / sizeof(float); ++i) {
+            for (dim_t i = 0; i < vlen_ / static_cast<dim_t>(sizeof(float));
+                    ++i) {
                 h->mov(reg_tmp.cvt32(),
                         h->ptr[reg_vmm_stack_ptr_ + vlen_ + i * sizeof(float)]);
                 h->shl(reg_tmp.cvt32(), 2); // multiply by simd_w
@@ -1191,21 +1195,21 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
     } else { // general path
         // caller obligation to save gprs as callee may use them
-        size_t gpr_size = 8;
+        int gpr_size = 8;
         Xbyak::Operand gprs_to_save[] = {h->r8, h->r9, h->r10, h->r11, h->r12,
                 h->rax, h->rcx, h->rdx, h->rdi, h->rsi, h->rbx};
-        size_t n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
+        int n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
 
         h->sub(h->rsp, n_gprs_to_save * gpr_size);
-        for (size_t i = 0; i < n_gprs_to_save; ++i)
+        for (int i = 0; i < n_gprs_to_save; ++i)
             h->mov(h->ptr[h->rsp + i * gpr_size], gprs_to_save[i]);
 
         // caller obligation to save k-regs as callee may use them
         static constexpr int k_mask_size = 8;
-        size_t n_k_regs_to_save = 8;
+        int n_k_regs_to_save = 8;
         if (is_avx512_) {
             h->sub(h->rsp, n_k_regs_to_save * k_mask_size);
-            for (size_t i = 0; i < n_k_regs_to_save; ++i) {
+            for (int i = 0; i < n_k_regs_to_save; ++i) {
                 if (mayiuse(avx512_core))
                     h->kmovq(h->ptr[h->rsp + i * k_mask_size], Opmask(i));
                 else
@@ -1220,7 +1224,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         // `isa` as the injector. Once the assumption is wrong, `n_vregs_` and
         // `vlen_` should be replaced with `host_isa::vlen_` and
         // `host_isa::n_vregs_`.
-        for (size_t i = 2; i < n_vregs_ + 2; ++i)
+        for (int i = 2; i < n_vregs_ + 2; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_], Vmm(i - 2));
         h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_], vmm_src); // src
         h->uni_vmovups(vmm_src, table_val(beta));
@@ -1246,7 +1250,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
 
         // Take src, apply powf on it and replace value on a stack with dst.
         Xmm xmm0 = Xmm(0), xmm1 = Xmm(1);
-        for (size_t i = 0; i < vlen_ / sizeof(float); ++i) {
+        for (int i = 0; i < vlen_ / static_cast<int>(sizeof(float)); ++i) {
             const Address &source
                     = h->ptr[reg_vmm_stack_ptr_ + i * sizeof(float)];
             h->uni_vmovss(xmm0, source);
@@ -1261,7 +1265,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         h->add(h->rsp, h->rbx);
 
         // restore vector registers
-        for (size_t i = n_vregs_ + 1; i >= 2; --i)
+        for (int i = n_vregs_ + 1; i >= 2; --i)
             h->uni_vmovups(Vmm(i - 2), h->ptr[reg_vmm_stack_ptr_ + i * vlen_]);
         h->uni_vmovups(vmm_src, h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_]);
 
@@ -1801,7 +1805,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::round_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
+int jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
         alg_kind_t alg, bool is_fwd, float alpha) {
     using namespace alg_kind;
     int ret = 0;
@@ -1821,7 +1825,7 @@ bool jit_uni_eltwise_injector_t<isa, Wmm>::need_vmm_stack_ptr(
 }
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
+int jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
         alg_kind_t alg, bool is_fwd) {
     using namespace alg_kind;
     int ret = 0;
@@ -1843,11 +1847,11 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
 }
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
+int jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
         alg_kind_t alg, bool is_fwd, float alpha) {
     // For avx we need a register to save the upper part of Ymm
     const bool extra_avx_vmm = isa == avx;
-    size_t n_vmms = 0;
+    int n_vmms = 0;
 
     using namespace alg_kind;
     if (is_fwd) {
@@ -2003,7 +2007,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
         const injector_utils::vmm_index_set_iterator_t &start_idx_it,
         const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
     using namespace alg_kind;
-    std::for_each(start_idx_it, end_idx_it, [&](size_t idx) {
+    std::for_each(start_idx_it, end_idx_it, [&](int idx) {
         if (is_fwd_) {
             switch (alg_) {
                 case eltwise_relu_use_dst_for_bwd:
@@ -2105,10 +2109,10 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
 
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
-        size_t start_compute_idx, size_t end_compute_idx,
+        int start_compute_idx, int end_compute_idx,
         const injector_utils::vmm_index_set_t &vmm_aux_indices) {
     injector_utils::vmm_index_set_t vmm_compute_idxs;
-    for (size_t i = start_compute_idx; i < end_compute_idx; i++)
+    for (int i = start_compute_idx; i < end_compute_idx; i++)
         vmm_compute_idxs.emplace(i);
     compute_vector_range(vmm_compute_idxs, vmm_aux_indices);
 }
@@ -2129,8 +2133,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
     injector_preamble(vmm_compute_idxs, start_idx_tail_it, vmm_aux_indices);
     compute_body(start_idx_tail_it, end_idx_it);
 
-    size_t n_vregs_not_preserved
-            = std::distance(start_idx_it, start_idx_tail_it);
+    // `std::distance` on a `std::set<int>` iterator returns a
+    // `ptrdiff_t`; this is the one genuine, documented boundary where we
+    // narrow it down to the bounded vmm-register count expected by
+    // `injector_preamble_tail`.
+    const int n_vregs_not_preserved
+            = static_cast<int>(std::distance(start_idx_it, start_idx_tail_it));
     injector_preamble_tail(n_vregs_not_preserved);
     compute_body(start_idx_it, start_idx_tail_it);
     injector_postamble();
@@ -2150,7 +2158,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
     // when we set the offsets. We verify that in asserts.
     // table_entry_val_t is assumed to be 32 bits
 #ifndef NDEBUG
-    size_t off = 0;
+    dim_t off = 0;
     key_t curr_key = undef_key;
     int key_occurences = 0;
 #endif
@@ -2158,8 +2166,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
     // Run through the map and insert values stored there
     for (auto it = entry_map_.begin(); it != entry_map_.end(); it++) {
         const auto &te = (*it).second; // get map entry for a given key
-        const auto len = te.bcast ? vlen_ : sizeof(table_entry_val_t);
-        for (size_t d = 0; d < len; d += sizeof(table_entry_val_t))
+        const dim_t len = te.bcast ? vlen_ : sizeof(table_entry_val_t);
+        for (dim_t d = 0; d < len; d += sizeof(table_entry_val_t))
             h->dd(te.val);
 
 #ifndef NDEBUG
@@ -2170,7 +2178,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
             key_occurences = 0;
         }
         key_occurences++;
-        auto expected_off = table_off(key, key_occurences - 1);
+        const dim_t expected_off = table_off(key, key_occurences - 1);
         assert(off == expected_off);
         MAYBE_UNUSED(expected_off);
         off += len;
@@ -2917,7 +2925,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::register_table_entries() {
     // entries should be registered after this point.  This allows to
     // expect the same order when injecting the table entries in
     // prepare_table.
-    size_t off = 0;
+    dim_t off = 0;
     for (auto it = entry_map_.begin(); it != entry_map_.end(); it++) {
         auto &te = (*it).second;
         te.off = off;

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -128,12 +128,12 @@ struct jit_uni_eltwise_injector_t {
                   eltwise.beta, eltwise.scale, dt, save_state, p_table, k_mask,
                   is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
-    void compute_vector_range(size_t start_compute_idx, size_t end_compute_idx,
+    void compute_vector_range(int start_compute_idx, int end_compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});
     void compute_vector_range(
             const injector_utils::vmm_index_set_t &vmm_compute_idxs,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});
-    void compute_vector(size_t compute_idx,
+    void compute_vector(int compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {}) {
         compute_vector_range({compute_idx}, vmm_aux_indices);
     }
@@ -143,7 +143,7 @@ struct jit_uni_eltwise_injector_t {
     // This call is `static` and `public` to make a decision on the injector's
     // saving state if the caller can supply the necessary number of vmms. The
     // decision must be made BEFORE constructing the injector, thus, `static`.
-    static size_t aux_vecs_count(alg_kind_t alg, bool is_fwd, float alpha);
+    static int aux_vecs_count(alg_kind_t alg, bool is_fwd, float alpha);
 
 private:
     const alg_kind_t alg_;
@@ -179,21 +179,21 @@ private:
 
     const bool is_avx512_ = is_superset(isa, avx512_core);
 
-    static constexpr size_t vlen_ = vreg_traits_t<Vmm>::vlen;
-    static constexpr size_t preserved_vecs_max_ = 6;
-    static constexpr size_t preserved_gprs_max_ = 5;
-    static constexpr size_t n_vregs_ = cpu_isa_traits_t<isa>::n_vregs;
+    static constexpr dim_t vlen_ = vreg_traits_t<Vmm>::vlen;
+    static constexpr dim_t preserved_vecs_max_ = 6;
+    static constexpr dim_t preserved_gprs_max_ = 5;
+    static constexpr int n_vregs_ = cpu_isa_traits_t<isa>::n_vregs;
     static constexpr int n_mantissa_bits_ = 23;
 
-    const size_t n_vregs_to_preserve_;
-    size_t n_vregs_preserved_ = 0;
+    const int n_vregs_to_preserve_;
+    int n_vregs_preserved_ = 0;
     bool need_vmm_mask_register_ = false;
     // Default initialization will put zeros. Putting any value to trigger a
     // potential error to Xbyak is not working as Xbyak cycles vmm indices
     // over 32 value.
-    size_t preserved_vmm_indices_[preserved_vecs_max_] = {};
-    size_t preserved_vmm_tail_indices_[preserved_vecs_max_] = {};
-    size_t preserved_gpr_indices_[preserved_gprs_max_] = {};
+    int preserved_vmm_indices_[preserved_vecs_max_] = {};
+    int preserved_vmm_tail_indices_[preserved_vecs_max_] = {};
+    int preserved_gpr_indices_[preserved_gprs_max_] = {};
 
     Vmm vmm_mask_;
     Vmm vmm_tmp_;
@@ -201,10 +201,10 @@ private:
     Xbyak::Xmm xmm_tmp_;
 
     static bool need_mask_register(alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t aux_gprs_count(alg_kind_t alg, bool is_fwd, float alpha);
+    static int aux_gprs_count(alg_kind_t alg, bool is_fwd, float alpha);
     static bool need_vmm_stack_ptr(alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t op_vecs_count(alg_kind_t alg, bool is_fwd);
-    size_t get_stack_vmm_space();
+    static int op_vecs_count(alg_kind_t alg, bool is_fwd);
+    dim_t get_stack_vmm_space();
 
     void compute_body(
             const injector_utils::vmm_index_set_iterator_t &start_idx_it,
@@ -212,10 +212,10 @@ private:
     void injector_preamble(const injector_utils::vmm_index_set_t &vmm_idxs,
             injector_utils::vmm_index_set_iterator_t &start_idx_tail_it,
             const injector_utils::vmm_index_set_t &vmm_aux_indices);
-    void injector_preamble_tail(size_t n_vregs_not_preserved);
+    void injector_preamble_tail(int n_vregs_not_preserved);
     void injector_postamble();
     void assign_regs();
-    Wmm vmm_aux(size_t idx);
+    Wmm vmm_aux(int idx);
     void vec_shift(const Vmm &vmm_dst, const Vmm &vmm_src, bool shift_left,
             const int imm);
     void compute_cmp_mask(const Vmm &vmm_src,

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -26,8 +26,8 @@ namespace injector {
 #define VCHECK_PO_INJ_BOOL(cond, msg) \
     VCONDCHECK(primitive, create, check, postops_injector, cond, false, msg);
 
-size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
-    size_t res = 0;
+int aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
+    int res = 0;
 #define CASE_ELTWISE_SUPERSET(_isa) \
     if (is_superset(isa, _isa)) { \
         res = nstl::max(res, \
@@ -252,19 +252,19 @@ jit_uni_postops_injector_base_t<Vmm>::create(jit_generator_t *host,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
-        size_t start_idx, size_t end_idx,
+void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(int start_idx,
+        int end_idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
     injector_utils::vmm_index_set_t vmm_idxs;
-    for (size_t i = start_idx; i < end_idx; i++)
+    for (int i = start_idx; i < end_idx; i++)
         vmm_idxs.emplace(i);
     compute_vector_range(vmm_idxs, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
-        size_t start_idx, size_t end_idx) {
+        int start_idx, int end_idx) {
     compute_vector_range(
             start_idx, end_idx, binary_injector::rhs_arg_dynamic_params_t());
 }
@@ -274,7 +274,7 @@ void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
-    std::size_t rhs_arg_idx = 0;
+    dim_t rhs_arg_idx = 0;
     for (int i = 0; i < post_ops_.len(); i++) {
         const auto &post_op = post_ops_.entry_[i];
         if (post_op.is_eltwise()) {
@@ -305,13 +305,13 @@ void jit_uni_postops_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(size_t idx,
+void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(int idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
     compute_vector_range({idx}, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(size_t idx) {
+void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(int idx) {
     compute_vector_range({idx});
 }
 

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -46,7 +46,7 @@ namespace injector {
 using lambda_jit_injectors_t
         = std::map<dnnl_primitive_kind_t, std::function<void()>>;
 
-size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
+int aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
 
 // A base isa-agnostic post-ops injector abstract class.
 //
@@ -90,18 +90,18 @@ public:
     // Generates code of post_ops chain injected to host primitive. Applied to
     // range <start_idx, end_idx) of vector registers' indexes.
     // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector_range(size_t start_idx, size_t end_idx,
+    virtual void compute_vector_range(int start_idx, int end_idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             = 0;
-    virtual void compute_vector_range(size_t start_idx, size_t end_idx) = 0;
+    virtual void compute_vector_range(int start_idx, int end_idx) = 0;
 
     // Generates code of post_ops chain injected to host primitive. Applied to
     // a single vector register index.
     // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector(size_t idx,
+    virtual void compute_vector(int idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             = 0;
-    virtual void compute_vector(size_t idx) = 0;
+    virtual void compute_vector(int idx) = 0;
 
     // Thin wrapper for eltwise injector specific function
     virtual void prepare_table(bool gen_table) = 0;
@@ -154,17 +154,17 @@ public:
             const injector_utils::vmm_index_set_t &vmm_idxs) override;
 
     // See `jit_uni_postops_injector_base_t::compute_vector_range(...)`
-    void compute_vector_range(size_t start_idx, size_t end_idx,
+    void compute_vector_range(int start_idx, int end_idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             override;
 
-    void compute_vector_range(size_t start_idx, size_t end_idx) override;
+    void compute_vector_range(int start_idx, int end_idx) override;
 
     // See `jit_uni_postops_injector_base_t::compute_vector(...)`
-    void compute_vector(size_t idx,
+    void compute_vector(int idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             override;
-    void compute_vector(size_t idx) override;
+    void compute_vector(int idx) override;
 
     /*
      * Thin wrapper for eltwise injector specific function

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -64,7 +64,9 @@ protected:
         return utils::one_of(
                 data_type(), data_type::f8_e5m2, data_type::f8_e4m3);
     }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    int dtype_size() const {
+        return static_cast<int>(types::data_type_size(data_type()));
+    }
     cpu_isa_t get_io_isa(cpu_isa_t isa) const {
         // reusing avx512_core instantiation for bf16
         return is_bf16() && is_superset(isa, avx512_core)

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -36,7 +36,7 @@ struct jit_args_int8_t {
     const void *from;
     const void *for_comparison;
     const void *to;
-    size_t work_amount;
+    dim_t work_amount;
 };
 
 struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
@@ -50,7 +50,7 @@ struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
 
 protected:
     data_type_t data_type() const { return pd_->src_md()->data_type; }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    dim_t dtype_size() const { return types::data_type_size(data_type()); }
 
     const eltwise_desc_t &desc() const { return *pd_->desc(); }
 
@@ -80,11 +80,11 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
     void generate() override {
         Reg64 param = abi_param1;
 
-        const size_t vlen = cpu_isa_traits_t<isa>::vlen;
-        const size_t simd_w = vlen / sizeof(float);
-        const size_t loop_dec[] = {simd_w, 1};
-        const size_t uf[] = {1, 1};
-        const size_t shift[] = {dtype_size() * simd_w, (size_t)dtype_size()};
+        const dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+        const dim_t simd_w = vlen / sizeof(float);
+        const dim_t loop_dec[] = {simd_w, 1};
+        const dim_t uf[] = {1, 1};
+        const dim_t shift[] = {dtype_size() * simd_w, dtype_size()};
         const bool loop_vectorize[] = {true, false};
 
         preamble();
@@ -114,7 +114,8 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
 
         for (int id = 0; id < 2; id++) {
             L(loop_label[id]);
-            cmp(reg_work_amount, uf[id] * loop_dec[id] - 1);
+            cmp(reg_work_amount,
+                    static_cast<uint32_t>(uf[id] * loop_dec[id] - 1));
             jle(loop_label[id + 1], T_NEAR);
 
             compute_step(
@@ -123,7 +124,7 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
             add(reg_from, uf[id] * shift[id]);
             add(reg_to, uf[id] * shift[id]);
 
-            sub(reg_work_amount, uf[id] * loop_dec[id]);
+            sub(reg_work_amount, static_cast<uint32_t>(uf[id] * loop_dec[id]));
             jmp(loop_label[id]);
         }
 
@@ -232,35 +233,39 @@ private:
             store_8bit(vectorize, mem_to, vr_to, data_type() == data_type::s8);
     }
 
-    void compute_step(bool vectorize, const size_t uf, const size_t shift,
+    void compute_step(bool vectorize, const dim_t uf, const dim_t shift,
             const alg_kind_t alg) {
 
-        auto vreg_from = [&](const size_t i) -> Vmm { return Vmm(i + 1); };
-        auto vreg_to = [&](const size_t i) -> Vmm { return Vmm(uf + i + 1); };
+        auto vreg_from = [&](const dim_t i) -> Vmm {
+            return Vmm(static_cast<int>(i + 1));
+        };
+        auto vreg_to = [&](const dim_t i) -> Vmm {
+            return Vmm(static_cast<int>(uf + i + 1));
+        };
 
         // 1. Load (vregs <- mem)
-        for (size_t i = 0; i < uf; i++)
+        for (dim_t i = 0; i < uf; i++)
             load(vectorize, vreg_from(i), ptr[reg_from + i * shift]);
 
         // 2. Process (vregs <- vergs)
         switch (alg) {
             case alg_kind::eltwise_linear:
-                for (size_t i = 0; i < uf; i++)
+                for (dim_t i = 0; i < uf; i++)
                     process_linear(vreg_to(i), vreg_from(i));
                 break;
             case alg_kind::eltwise_relu:
-                for (size_t i = 0; i < uf; i++)
+                for (dim_t i = 0; i < uf; i++)
                     process_relu(vreg_to(i), vreg_from(i));
                 break;
             case alg_kind::eltwise_clip:
-                for (size_t i = 0; i < uf; i++)
+                for (dim_t i = 0; i < uf; i++)
                     process_clip(vreg_to(i), vreg_from(i));
                 break;
             default: assert(!"unsupported alg");
         }
 
         // 3. Store (mem <- vregs)
-        for (size_t i = 0; i < uf; i++)
+        for (dim_t i = 0; i < uf; i++)
             store(vectorize, ptr[reg_to + i * shift], vreg_to(i));
     }
 };
@@ -493,14 +498,15 @@ status_t jit_uni_eltwise_int_fwd_t<isa>::execute_forward(
 
     const memory_desc_wrapper src_d(pd()->src_md());
 
-    const size_t nelems = src_d.nelems(true);
+    const dim_t nelems = src_d.nelems(true);
 
-    src += src_d.data_type_size() * src_d.offset0();
-    dst += src_d.data_type_size() * src_d.offset0();
+    const dim_t data_type_size = src_d.data_type_size();
+    src += data_type_size * src_d.offset0();
+    dst += data_type_size * src_d.offset0();
 
-    const int cache_line = 64 / src_d.data_type_size();
+    const dim_t cache_line = 64 / data_type_size;
     parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
 
         balance211(utils::div_up(nelems, cache_line), nthr, ithr, start, end);
         start = nstl::min(nelems, start * cache_line);
@@ -508,9 +514,9 @@ status_t jit_uni_eltwise_int_fwd_t<isa>::execute_forward(
         if (start == end) return;
 
         jit_args_int8_t arg;
-        arg.from = src + src_d.data_type_size() * start;
-        arg.for_comparison = src + src_d.data_type_size() * start;
-        arg.to = dst + src_d.data_type_size() * start;
+        arg.from = src + data_type_size * start;
+        arg.for_comparison = src + data_type_size * start;
+        arg.to = dst + data_type_size * start;
         arg.work_amount = end - start;
         (*kernel_)(&arg);
     });

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -310,30 +310,35 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
     // For f16 we do not need such interleaving.
     const int xmm_size_elem = (data_type_ == data_type::f16) ? 8 : 4;
     const int number_of_xmms = tail
-            ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
-            : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
+            ? static_cast<int>(
+                      utils::div_up(tail_conf_->tail_size_, xmm_size_elem))
+            : static_cast<int>(
+                      utils::div_up(gather_conf_->simd_w_, xmm_size_elem));
     const int num_indices_in_xmm = 16 / sizeof(int);
     for (int i = 0, idx = 0; i < number_of_xmms; i++) {
 
         const int number_of_values_to_load = i == number_of_xmms - 1 && tail
                         && tail_conf_->tail_size_ % xmm_size_elem != 0
-                ? tail_conf_->tail_size_ % xmm_size_elem
+                ? static_cast<int>(tail_conf_->tail_size_ % xmm_size_elem)
                 : xmm_size_elem;
         for (int j = 0; j < number_of_values_to_load; j++) {
 
             if (j % num_indices_in_xmm == 0)
-                host_->vextractf32x4(xmm_tmp, indices_vmm, idx++);
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+                host_->vextractf32x4(
+                        xmm_tmp, indices_vmm, static_cast<uint8_t>(idx++));
+            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp,
+                    static_cast<uint8_t>(j));
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j));
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
-                            xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j * 2));
                     break;
                 case data_type::s8:
                 case data_type::u8:
@@ -345,7 +350,7 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                    fp8_supported_)
                             && "Unsupported data type.");
                     host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            static_cast<uint8_t>(i * xmm_size_elem + j));
                     break;
                 }
                 default: assert(!"Unsupported data type.");
@@ -353,10 +358,12 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
             host_->mov(src_reg, gather_conf_->reg_tmp1_);
         }
         if (data_type_ == data_type::bf16) {
-            host_->vinsertf32x4(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf32x4(
+                    dst_vmm, dst_vmm, xmm_dst, static_cast<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         } else if (data_type_ == data_type::f16) {
-            host_->vinsertf32x4(dst_ymm, dst_ymm, xmm_dst, i);
+            host_->vinsertf32x4(
+                    dst_ymm, dst_ymm, xmm_dst, static_cast<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         }
     }
@@ -392,33 +399,37 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
     // For f16 we do not need such interleaving.
     const int xmm_size_elem = 4;
     const int number_of_xmms = tail
-            ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
-            : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
+            ? static_cast<int>(
+                      utils::div_up(tail_conf_->tail_size_, xmm_size_elem))
+            : static_cast<int>(
+                      utils::div_up(gather_conf_->simd_w_, xmm_size_elem));
     for (int i = 0; i < number_of_xmms; i++) {
-        host_->vextractf128(xmm_tmp, indices_vmm, i);
+        host_->vextractf128(xmm_tmp, indices_vmm, static_cast<uint8_t>(i));
 
         const int number_of_values_to_load = i == number_of_xmms - 1 && tail
                         && tail_conf_->tail_size_ % xmm_size_elem != 0
-                ? tail_conf_->tail_size_ % xmm_size_elem
+                ? static_cast<int>(tail_conf_->tail_size_ % xmm_size_elem)
                 : xmm_size_elem;
         for (int j = 0; j < number_of_values_to_load; j++) {
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp,
+                    static_cast<uint8_t>(j));
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f32:
                 case data_type::s32: {
-                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j));
                     break;
                 }
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
                     host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            static_cast<uint8_t>(i * xmm_size_elem + j));
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
-                            xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j * 2));
                     break;
                 case data_type::s8:
                 case data_type::u8:
@@ -430,7 +441,7 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                    fp8_supported_)
                             && "Unsupported data type.");
                     host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            static_cast<uint8_t>(i * xmm_size_elem + j));
                     break;
                 }
                 default: assert(!"Unsupported data type.");
@@ -440,7 +451,8 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
 
         if (utils::one_of(data_type_, data_type::f32, data_type::s32,
                     data_type::bf16))
-            host_->vinsertf128(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf128(
+                    dst_vmm, dst_vmm, xmm_dst, static_cast<uint8_t>(i));
     }
 
     if (data_type_ == data_type::s32 || data_type_ == data_type::bf16)
@@ -462,24 +474,28 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
     host_->mov(gather_conf_->reg_tmp1_, src_reg);
 
     const unsigned xmm_size_elem = 4;
-    const unsigned number_of_values_to_load
-            = tail ? tail_conf_->tail_size_ : xmm_size_elem;
-    for (unsigned j = 0; j < number_of_values_to_load; j++) {
-        host_->pextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm, j);
+    const int number_of_values_to_load
+            = tail ? static_cast<int>(tail_conf_->tail_size_) : xmm_size_elem;
+    for (int j = 0; j < number_of_values_to_load; j++) {
+        host_->pextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm,
+                static_cast<uint8_t>(j));
         host_->add(src_reg, gather_conf_->reg_tmp_);
         switch (data_type_) {
             case data_type::f32:
             case data_type::s32: {
-                host_->pinsrd(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrd(
+                        dst_vmm, host_->ptr[src_reg], static_cast<uint8_t>(j));
                 break;
             }
             case data_type::f16:
                 assert(f16_supported_ && "Unsupported data type.");
-                host_->pinsrw(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrw(
+                        dst_vmm, host_->ptr[src_reg], static_cast<uint8_t>(j));
                 break;
             case data_type::bf16:
                 assert(bf16_supported_ && "Unsupported data type.");
-                host_->pinsrw(dst_vmm, host_->ptr[src_reg], j * 2);
+                host_->pinsrw(dst_vmm, host_->ptr[src_reg],
+                        static_cast<uint8_t>(j * 2));
                 break;
             case data_type::s8:
             case data_type::u8:
@@ -489,7 +505,8 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                            data_type::f8_e5m2),
                                fp8_supported_)
                         && "Unsupported data type.");
-                host_->pinsrb(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrb(
+                        dst_vmm, host_->ptr[src_reg], static_cast<uint8_t>(j));
                 break;
             }
             default: assert(!"Unsupported data type.");
@@ -626,7 +643,8 @@ void jit_io_helper_t<Vmm>::load(const Xbyak::Address &src_addr,
                     || (!is_tail_load_supported && (is_i8 || is_xf16)));
 
     if (can_load_byte_by_byte) {
-        load_byte_by_byte(src_addr, dst_vmm, tail_conf_->tail_size_);
+        load_byte_by_byte(
+                src_addr, dst_vmm, static_cast<int>(tail_conf_->tail_size_));
     } else {
         switch (data_type_) {
             case data_type::f32: load_f32(src_addr, dst_vmm, tail); break;
@@ -785,7 +803,7 @@ void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
                 = vreg_traits_t<Xbyak::Xmm>::vlen / sizeof(int32_t);
         const size_t store_size = (tail ? tail_conf_->tail_size_ : xmm_length)
                 * types::data_type_size(data_type_);
-        store_byte_by_byte(src_vmm, dst_addr, store_size);
+        store_byte_by_byte(src_vmm, dst_addr, static_cast<int>(store_size));
     } else {
         switch (data_type_) {
             case data_type::f32:


### PR DESCRIPTION
Continuation of https://github.com/uxlfoundation/oneDNN/pull/5565
Partially fixes [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
