### PR TITLE
cpu: aarch64: remove outdated conv heuristics

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -41,6 +41,20 @@ using namespace prop_kind;
 using namespace data_type;
 using namespace brgemm_utils;
 
+namespace {
+status_t validate_vpad_blocking(const brgemm_desc_t *brg) {
+    if (brg->is_dgmm) return status::success;
+
+    const int max_vpad = nstl::max(
+            brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
+
+    // virtual padding is restricted by bd_block size due to
+    // brgemm_kernel implementation. TODO: remove this restriction
+    const int min_bd_block = brg->bdb_tail > 0 ? brg->bdb_tail : brg->bd_block;
+    return max_vpad > min_bd_block ? status::unimplemented : status::success;
+}
+} // namespace
+
 void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch) {
     brgemm_kernel_params_t brgemm_p;
@@ -288,6 +302,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
                                     broadcasting_strategy_t::no_broadcast})))
         return status::unimplemented;
 
+    const bool had_sum_zp = brg->with_sum && brg->sum_zp != 0;
     const auto sum_idx = post_ops.find(primitive_kind::sum);
     const bool with_sum = sum_idx != -1;
     brg->with_sum = with_sum;
@@ -357,10 +372,16 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
 
     // src zero points require additional register in brgemm kernel
     const bool is_zp_src = brg->zp_type_a != brgemm_broadcast_t::none;
+    const bool sum_zp = brg->with_sum && brg->sum_zp != 0;
+
     if (brg->is_dgmm) {
         if (is_zp_src) CHECK(brdgmm_blocking(brg));
-    } else if (is_zp_src || brg->is_bf16_emu)
-        CHECK(brgemm_blocking(brg));
+    } else {
+        if (is_zp_src || brg->is_bf16_emu || had_sum_zp != sum_zp)
+            CHECK(brgemm_blocking(brg));
+
+        CHECK(validate_vpad_blocking(brg));
+    }
 
     return status::success;
 }
@@ -405,13 +426,7 @@ status_t brgemm_desc_set_attr(
             CHECK(brgemm_blocking(brg));
     }
 
-    if (!brg->is_dgmm) {
-        // virtual padding is restricted by bd_block size due to
-        // brgemm_kernel implementation. TODO: remove this restriction
-        const int min_bd_block
-                = brg->bdb_tail > 0 ? brg->bdb_tail : brg->bd_block;
-        if ((max_vpad > min_bd_block)) return status::unimplemented;
-    }
+    CHECK(validate_vpad_blocking(brg));
 
     brg->LDA2 = (brgattr.LDA2 != 0) ? brgattr.LDA2 : brg->LDA;
     brg->LDB2 = (brgattr.LDB2 != 0) ? brgattr.LDB2 : brg->LDB;

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -143,10 +143,11 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
                       || brg->brgattr.max_bottom_vpad > 0)
             && brg->zp_type_a != brgemm_broadcast_t::none;
     const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
+    const int sum_zp_regs = brg->with_sum && brg->sum_zp != 0 ? 1 : 0;
 
     const int max_isa_regs = isa_num_vregs(brg->isa_impl);
     auto max_reg_count = max_isa_regs - max_bcst_regs - beta_regs
-            - req_compensation - req_zp_a_comp_pads;
+            - req_compensation - req_zp_a_comp_pads - sum_zp_regs;
     if (req_zp_a_comp_pads)
         max_reg_count
                 = nstl::min(max_reg_count, max_isa_regs - max_bcst_regs - 5);

--- a/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_binary_injector.cpp
@@ -43,9 +43,9 @@ static bcast_set_t get_all_strategies_supported_by_injector() {
             broadcasting_strategy_t::no_broadcast};
 }
 
-bool is_data_supported(cpu_isa_t isa, data_type_t data_type) {
-    UNUSED(isa);
-    return !(data_type == data_type::bf16);
+bool is_data_supported(cpu_isa_t, data_type_t data_type) {
+    using namespace data_type;
+    return utils::one_of(data_type, f32, s32, u8, s8);
 }
 
 bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -16,10 +16,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "dnnl_types.h"
-
-#include "common/bfloat16.hpp"
 #include "common/c_types_map.hpp"
+#include "common/convolution_pd.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/math_utils.hpp"
 #include "common/memory_tracking.hpp"
@@ -31,7 +29,6 @@
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_brgemm_conv_utils.hpp"
-#include "cpu/aarch64/jit_generator.hpp"
 #include "cpu/platform.hpp"
 
 namespace dnnl {
@@ -46,15 +43,6 @@ using namespace dnnl::impl::utils;
 
 using namespace prop_kind;
 using namespace data_type;
-
-namespace {
-bool allow_perf_heuristics(const jit_brgemm_conv_conf_t &jcp) {
-    // Disable performance heuristics for plain weights as there are no other
-    // optimized implementations.
-    if (jcp.wei_plain) return false;
-    return true;
-}
-} // namespace
 
 namespace brgemm_convolution_utils {
 
@@ -1723,24 +1711,6 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     brg_blocking_t::last_ic_block_size = data_type_vnni_granularity(jcp.wei_dt);
 
-    // TODO: optimize depthwise convolutions (for now direct approach is faster)
-    const bool is_depthwise
-            = with_groups && jcp.ngroups > 1 && everyone_is(1, jcp.ic, jcp.oc);
-    if (is_depthwise)
-        if (allow_perf_heuristics(jcp)) return status::unimplemented;
-
-    // TODO: optimize grouped convolutions with small ic
-    const bool is_grouped_small_ic
-            = jcp.prop_kind != prop_kind::backward_weights && with_groups
-            && jcp.ngroups > 1
-            && jcp.ic <= jcp.acc_simd_w
-            // Enable the shapes not supported in direct convs
-            && IMPLICATION(with_groups, is_groups_ok(jcp));
-    if (is_grouped_small_ic)
-        if (allow_perf_heuristics(jcp)) return status::unimplemented;
-
-    // TODO: optimize the perf of 3d shape with small ic and large spatial
-
     const bool is_signed_input = jcp.src_dt == s8;
     jcp.s8s8_compensation_required = is_signed_input && !isa_has_s8s8(jcp.isa);
     jcp.has_int8_vnni = isa_has_s8s8(jcp.isa);
@@ -1821,8 +1791,6 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     CHECK(init_jcp(
             jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr, nthreads));
 
-    if (jcp.is_1x1)
-        if (allow_perf_heuristics(jcp)) return status::unimplemented;
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper weights_d(&weights_md);
     const memory_desc_wrapper dst_d(&dst_md);
@@ -2009,18 +1977,6 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             || !wei_scales.has_default_values()
             || jcp.scale_adjust_factor != 1.0f;
     jcp.is_oc_scale = wei_scales.get_mask() > 0;
-
-    // disables the shape with small ic but large spatial
-    // or specific large spatial shapes for int8 conv
-    const auto is_ok_large_spatial
-            = IMPLICATION(jcp.ic <= 128,
-                      jcp.od * jcp.oh < 100
-                              || jcp.ic * jcp.oc_block * jcp.ow_block > 8192)
-            && !(jcp.oc == 1024
-                    && utils::everyone_is(1, jcp.od, jcp.oh, jcp.kd, jcp.kh)
-                    && jcp.ow >= 595 && jcp.kw <= 5);
-    if (one_of(jcp.src_dt, u8, s8) && !is_ok_large_spatial)
-        if (allow_perf_heuristics(jcp)) return status::unimplemented;
 
     // For padding shapes, we calculate the comp along with the computation
     // inside brgemm kernel when output size is small to get optimal perf

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.hpp
@@ -1,6 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,14 +19,9 @@
 #define CPU_AARCH64_JIT_BRGEMM_CONV_UTILS_HPP
 
 #include "common/c_types_map.hpp"
-#include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 
-#include "cpu/aarch64/brgemm/brgemm.hpp"
 #include "cpu/aarch64/jit_primitive_conf.hpp"
-#include "cpu/cpu_convolution_pd.hpp"
-#include "cpu/cpu_engine.hpp"
-#include "cpu/platform.hpp"
 
 namespace dnnl {
 namespace impl {

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -349,6 +349,10 @@ mb1_ic2oc2_ih10oh12kh1sh1dh0ph1_iw7ow7kw1sw1dw0pw0_n"brgemm_post-op-jit_sum-with
 --attr-zero-points=dst:common:2+src:common:1
 mb1ic2ih10iw7oc2oh6ow4kh1kw1sh2sw2ph1pw0dh1dw1_n"brgemm_post-op-jit_sum-with-zp:2"
 
+# check vpad with sum+zero-point
+--reset
+--dt=s8:s8:s32 --attr-post-ops=sum:0:1 g64ic512ih240oc512oh120kh3sh2ph1n"brgemm_post_op-sum_zp-vpad-tail""
+
 # test primitive cache correctly dispatching proper CPU ISA
 --reset
 --dir=fwd_d --dt=f16 --stag=axb --dtag=axb --mb=1

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -67,6 +67,10 @@
 #AVX2
 mb1_g2ic4oc16_ih8oh6kh3sh1dh0ph0_iw8ow6kw3sw1dw0pw0
 
+# grouped int convolutions with small input-channel and source zero-points
+--reset --dir=FWD_I --dt=s8:s8:s32 --attr-zero-points=src:common:1
+g8mb1ic64ih52iw2oc640oh50ow3kh5kw1ph2pw1
+
 --reset --mb=2 --dir=BWD_W --dt=f32
 g1_ic16ih4iw8_oc16oh3ow8_kh1kw1sh2sw1ph0pw0
 g1_ic16ih4iw8_oc16oh3ow8_kh2kw1sh2sw1ph0pw0


### PR DESCRIPTION
# Description

The impl list was reordered in 03a3c098 (PR https://github.com/uxlfoundation/oneDNN/pull/5545), meaning that these skip heuristics were sending several implementations to ref. Remove these now, though they could possibly be added back later on a case-by-case, evidence-backed basis.

**Correctness issue:**
A lower ISA length could be selected leading to zero-points not being applied correctly.
```
# Before:
$ ./build-main/tests/benchdnn/benchdnn --conv --dir=FWD_I --dt=s8:s8:s32 --attr-zero-points=src:common:1 g8mb1ic64ih64iw2oc640oh64ow3kh5kw1ph2pw1
[   4][DST][0:0:1:1] exp_f32:         -28 exp:         -28 got:          -6 diff:      22 rdiff:0.785714
[   5][DST][0:0:1:2] exp_f32:         -68 exp:         -68 got:         -46 diff:      22 rdiff:0.323529
[   7][DST][0:0:2:1] exp_f32:         -14 exp:         -14 got:          12 diff:      26 rdiff: 1.85714
[   8][DST][0:0:2:2] exp_f32:         -44 exp:         -44 got:         -18 diff:      26 rdiff:0.590909
[  10][DST][0:0:3:1] exp_f32:         114 exp:         114 got:         140 diff:      26 rdiff: 0.22807
[  11][DST][0:0:3:2] exp_f32:          86 exp:          86 got:         112 diff:      26 rdiff:0.302326
[  13][DST][0:0:4:1] exp_f32:          40 exp:          40 got:          66 diff:      26 rdiff:    0.65
[  14][DST][0:0:4:2] exp_f32:         -42 exp:         -42 got:         -16 diff:      26 rdiff:0.619048
[  16][DST][0:0:5:1] exp_f32:           0 exp:           0 got:          26 diff:      26 rdiff:      26
[  17][DST][0:0:5:2] exp_f32:         -28 exp:         -28 got:          -2 diff:      26 rdiff:0.928571
[COMPARE_STATS][DST]: trh=0 err_max_diff:      62 err_max_rdiff:      62 all_max_diff:      62 all_max_rdiff:      62
0:FAILED (errors:77624 total:122880) (8 ms) __REPRO: --conv --dir=FWD_I --dt=s8:s8:s32 --attr-zero-points=src:common:1 g8mb1ic64ih64iw2oc640oh64ow3kh5kw1ph2pw1
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brgconv:sve_128 : 1 (100%)                               |
============================================================
===========================================================
= Failed cases summary (--summary=no-failures to disable) =
===========================================================
0:FAILED (errors:77624 total:122880) (8 ms) __REPRO: --conv --dir=FWD_I --dt=s8:s8:s32 --attr-zero-points=src:common:1 g8mb1ic64ih64iw2oc640oh64ow3kh5kw1ph2pw1
============================
tests:1 passed:0 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:1 listed:0
total: 0.01s; create_pd: 0.00s (4%); create_prim: 0.00s (5%); fill: 0.01s (62%); execute: 0.00s (2%); compute_ref: 0.00s (5%); compare: 0.00s (12%);

# After
$ ./build/tests/benchdnn/benchdnn --conv --dir=FWD_I --dt=s8:s8:s32 --attr-zero-points=src:common:1 g8mb1ic64ih64iw2oc640oh64ow3kh5kw1ph2pw1    
0:PASSED (7 ms) __REPRO: --conv --dir=FWD_I --dt=s8:s8:s32 --attr-zero-points=src:common:1 g8mb1ic64ih64iw2oc640oh64ow3kh5kw1ph2pw1
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| brgconv:sve_256 : 1 (100%)                               |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (3%); create_prim: 0.00s (8%); fill: 0.00s (61%); execute: 0.00s (1%); compute_ref: 0.00s (4%); compare: 0.00s (12%);
```

**Performance issue:**
Shapes get sent to ref even when support exists
```
# Before
$ ./build-main/tests/benchdnn/benchdnn --conv --mode=P --perf-template='%impl%,%-time%' --summary=no-impl --dir=FWD_I g2ic100id16oc200od16kd1pd0                         
Template entries: %impl%,%-time%
impl,min_time
gemm:ref,0.170898

# After
$ ./build/tests/benchdnn/benchdnn --conv --mode=P --perf-template='%impl%,%-time%' --summary=no-impl --dir=FWD_I g2ic100id16oc200od16kd1pd0                         
Template entries: %impl%,%-time%
impl,min_time
brgconv:sve_256,0.0639648
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?