### PR TITLE
cpu: conv: AVX512 common: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -56,7 +56,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
@@ -73,7 +73,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
     }
 }
 
-void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
+void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(dim_t load_loop_blk) {
     mov(aux1_reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
     mov(aux_reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
 
@@ -90,9 +90,9 @@ void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             if (i + 1 == num_substeps) L(large_tail);
             reduce_loop(load_loop_blk, jcp.ur, i, false);
             if (i < num_substeps - 1) {
@@ -131,44 +131,45 @@ void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
 }
 
 Address jit_avx512_common_1x1_conv_kernel_t::output_ptr(
-        const bool is_out_layout_nxc, const int i_load, const int i_ur) {
+        const bool is_out_layout_nxc, const dim_t i_load, const dim_t i_ur) {
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         auto i_load_shift = is_out_layout_nxc
                 ? jcp.load_block
                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
-        int i_ur_shift = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t i_ur_shift = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
         auto offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
         return EVEX_compress_addr(aux_reg_output_data, offset);
     } else
         return ptr[aux_reg_output_data
-                + (i_load ? reg_output_stride * i_load
+                + (i_load ? reg_output_stride * static_cast<int>(i_load)
                           : 0) // TODO: Xbyak should allow 0 scale
                 + jcp.typesize_out * jcp.load_block * i_ur];
 }
 
 static int vreg_accum_idx(
-        const int load_loop_blk, const int i_load, const int i_ur) {
-    return (i_ur * load_loop_blk + i_load);
+        const dim_t load_loop_blk, const dim_t i_load, const dim_t i_ur) {
+    return static_cast<int>(i_ur * load_loop_blk + i_load);
 }
 
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const bool mask_tail,
-        const F &fun) {
-    for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
+        const bool mask_tail, const F &fun) {
+    for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
         const bool mask_flag = mask_tail && i_load + 1 == load_loop_blk;
-        for (int i_ur = 0; i_ur < ur; ++i_ur)
+        for (dim_t i_ur = 0; i_ur < ur; ++i_ur)
             fun(mask_flag, i_load, i_ur);
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const F &fun) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur, const F &fun) {
     iterate(load_loop_blk, ur, false, fun);
 }
 
 void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
-        const bool is_out_layout_nxc, const int load_loop_blk, const int ur) {
+        const bool is_out_layout_nxc, const dim_t load_loop_blk,
+        const dim_t ur) {
     injector_utils::vmm_index_set_t vmm_idxs;
     if (jcp.with_binary) {
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
@@ -178,7 +179,8 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
                     EVEX_compress_addr(rsp, reg_dw_binary_output_off));
         }
         iterate(load_loop_blk, ur, mask_tail,
-                [&](const bool mask_flag, const int i_load, const int i_ur) {
+                [&](const bool mask_flag, const dim_t i_load,
+                        const dim_t i_ur) {
             const auto vmm_idx = vreg_accum_idx(load_loop_blk, i_load, i_ur);
             vmm_idxs.emplace(vmm_idx);
             const dim_t oft
@@ -198,7 +200,7 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
         }
     } else {
         iterate(load_loop_blk, ur,
-                [&](const bool, const int i_load, const int i_ur) {
+                [&](const bool, const dim_t i_load, const dim_t i_ur) {
             vmm_idxs.emplace(vreg_accum_idx(load_loop_blk, i_load, i_ur));
         });
         postops_injector_->compute_vector_range(vmm_idxs);
@@ -206,55 +208,55 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
 }
 
 void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
-        int load_loop_blk, int ur, int substep, bool wraparound) {
+        dim_t load_loop_blk, dim_t ur, dim_t substep, bool wraparound) {
     const bool out_layout_nxc = is_out_layout_nxc(jcp);
     const bool load_layout_nxc = is_load_layout_nxc(jcp);
     const bool bcast_layout_nxc = is_bcast_layout_nxc(jcp);
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const dim_t reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+    const dim_t load_dim_tail = jcp.load_dim % jcp.load_block;
 
-    auto vreg_load = [ur, load_loop_blk](int i_load) {
-        return Zmm(ur * load_loop_blk + i_load);
+    auto vreg_load = [ur, load_loop_blk](dim_t i_load) {
+        return Zmm(static_cast<int>(ur * load_loop_blk + i_load));
     };
 
-    auto vreg_accum = [load_loop_blk](int i_load, int i_ur) {
+    auto vreg_accum = [load_loop_blk](dim_t i_load, dim_t i_ur) {
         return Zmm(vreg_accum_idx(load_loop_blk, i_load, i_ur));
     };
 
-    auto bias_ptr = [this](int i_load) {
+    auto bias_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_bias_data, jcp.typesize_out * jcp.oc_block * i_load);
     };
 
-    auto bcast_ptr = [&](int i_reduce, int i_ur, bool bcast) {
+    auto bcast_ptr = [&](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
         dim_t offt;
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const dim_t reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                      : jcp.reduce_loop_unroll;
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
         } else {
-            int rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
+            const dim_t rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
             offt = static_cast<dim_t>(i_reduce) * rmul + i_ur;
         }
         return EVEX_compress_addr(
                 aux_reg_bcast_data, jcp.typesize_in * offt, bcast);
     };
 
-    auto load_ptr = [&](int i_reduce, int i_load) {
-        int offt;
-        int u0 = i_reduce % jcp.reduce_loop_unroll;
-        int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+    auto load_ptr = [&](dim_t i_reduce, dim_t i_load) {
+        dim_t offt;
+        const dim_t u0 = i_reduce % jcp.reduce_loop_unroll;
+        const dim_t u1 = i_reduce / jcp.reduce_loop_unroll;
+        const dim_t lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
                                              jcp.reduce_dim, jcp.reduce_block));
-        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        const dim_t rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
@@ -345,12 +347,12 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block = [&](bool last_block) {
-        const int i_reduce_end = reduce_dim_tail && last_block
+        const dim_t i_reduce_end = reduce_dim_tail && last_block
                 ? reduce_dim_tail
                 : jcp.reduce_loop_unroll;
 
-        for (int i_reduce = 0; i_reduce < i_reduce_end; i_reduce++) {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+        for (dim_t i_reduce = 0; i_reduce < i_reduce_end; i_reduce++) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 auto vreg = vreg_load(i_load);
                 if (i_load + 1 == load_loop_blk && load_dim_tail)
                     vreg = vreg | k_load_dim_mask | T_z;
@@ -358,10 +360,10 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
                 vmovups(vreg, load_ptr(i_reduce, i_load));
             }
 
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 if (jcp.expl_bcast && load_loop_blk > 1)
                     vbroadcastss(vreg_bcast, bcast_ptr(i_reduce, i_ur, false));
-                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                     auto vreg_acc = vreg_accum(i_load, i_ur);
                     if (i_load + 1 == load_loop_blk && load_dim_tail)
                         vreg_acc = vreg_acc | k_load_dim_mask | T_z;
@@ -430,7 +432,7 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
     if (jcp.prop_kind == backward_weights)
         mov(reg_output_stride, ptr[param1 + GET_OFF(output_stride)]);
 
-    const int load_dim_tail
+    const dim_t load_dim_tail
             = (one_of(jcp.prop_kind, forward_training, forward_inference)
                               ? jcp.oc_without_padding
                               : jcp.load_dim)
@@ -441,7 +443,7 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
         kmovw(k_load_dim_tail_mask, reg_tail_32);
     }
 
-    auto load_loop_body = [&](int load_loop_blk) {
+    auto load_loop_body = [&](dim_t load_loop_blk) {
         if (load_dim_tail)
             kxnorw(k_load_dim_mask, k_load_dim_mask, k_load_dim_mask);
         sub(reg_load_loop_work, load_loop_blk * jcp.load_loop_iter_step);
@@ -453,12 +455,12 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
         }
         bcast_loop(load_loop_blk);
         add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
-        const size_t offst_with_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_with_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc(jcp)
                                 ? 1
                                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim));
-        const size_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc(jcp) ? 1 : jcp.bcast_dim);
         switch (jcp.prop_kind) {
@@ -718,12 +720,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     const int BIG_REDUCE_DIM = 1024;
     const int BIG_LOAD_DIM = 256;
 
-    int load_blocking {0};
-    int load_blocking_max {0};
-    int bcast_blocking {0};
-    int bcast_blocking_max {0};
-    int reduce_blocking {0};
-    int reduce_blocking_max {0};
+    dim_t load_blocking {0};
+    dim_t load_blocking_max {0};
+    dim_t bcast_blocking {0};
+    dim_t bcast_blocking_max {0};
+    dim_t reduce_blocking {0};
+    dim_t reduce_blocking_max {0};
 
     jcp.load_grp_count = 1;
 
@@ -735,7 +737,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            if (jcp.with_dw_conv)
+                jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
             jcp.reduce_dim = jcp.ic;
             jcp.reduce_block = jcp.ic_block;
 
@@ -759,12 +762,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
         jcp.load_loop_load_step
-                = (utils::rnd_up(jcp.reduce_dim, jcp.reduce_block))
+                = utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
                 * jcp.load_block * jcp.typesize_in;
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold;
-        const int spatial
+        const dim_t spatial
                 = (one_of(jcp.prop_kind, forward_training, forward_inference))
                 ? jcp.od * jcp.oh
                 : jcp.id * jcp.ih;
@@ -797,10 +800,10 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            dim_t os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
-                int i_tail = jcp.os % i;
+                const dim_t i_tail = jcp.os % i;
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -824,9 +827,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
-        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+        const dim_t nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+        const dim_t nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+        const dim_t nb_load = div_up(jcp.load_dim, jcp.load_block);
         if (is_data_layout_nxc) {
             reduce_blocking = jcp.reduce_dim;
         } else if (jcp.expl_bcast) {
@@ -844,7 +847,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             else if (spatial > SMALL_SPATIAL
                     && jcp.reduce_dim >= BIG_REDUCE_DIM)
                 reduce_blocking = 8;
-            reduce_blocking = best_divider(nb_reduce, 1, reduce_blocking, true);
+            reduce_blocking = best_divider(
+                    nb_reduce, 1, static_cast<int>(reduce_blocking), true);
             reduce_blocking *= jcp.reduce_block;
         }
 
@@ -853,22 +857,22 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         // 64 * 1024 is chosen due to 1MB L2 16-way cache.
         // 7 is empirical value. It is about half of 16.
         // So we leave about half of the set for other data - weights, dst
-        int way_size = (64 * 1024) / jcp.typesize_in;
+        const dim_t way_size = (64 * 1024) / jcp.typesize_in;
         int max_hits = 7;
         if (!is_data_layout_nxc
                 && jcp.bcast_dim * reduce_blocking
                         > static_cast<dim_t>(way_size) * max_hits) {
-            int nrb = reduce_blocking / simd_w;
+            const dim_t nrb = reduce_blocking / simd_w;
             auto sp = jcp.bcast_dim;
-            int wl = way_size / simd_w;
-            for (int start_off = 0; start_off < jcp.ur; start_off++) {
+            const dim_t wl = way_size / simd_w;
+            for (dim_t start_off = 0; start_off < jcp.ur; start_off++) {
                 for (dim_t off = start_off, hits = 0; off < sp * nrb;
                         off += wl) {
                     if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                    int max_r_blocking
+                    const dim_t max_r_blocking
                             = simd_w * nstl::max<dim_t>(1, (off + wl) / sp);
                     reduce_blocking
-                            = nstl::min(reduce_blocking, max_r_blocking);
+                            = nstl::min<dim_t>(reduce_blocking, max_r_blocking);
                     break;
                 }
             }
@@ -882,7 +886,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         }
         load_blocking = jcp.load_dim;
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
+        const dim_t load_size = jcp.load_dim * jcp.reduce_dim;
         auto bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
@@ -893,20 +897,20 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int n_lgc = jcp.nthr;
             float ratio = (float)load_size / (float)bcast_size;
             int best_lgc = ratio > 1 ? n_lgc : 1;
-            auto calc_job_cost = [&](int lb, int tg, float mem_k) {
-                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+            auto calc_job_cost = [&](dim_t lb, dim_t tg, float mem_k) {
+                const dim_t bb_size = jcp.mb * div_up(nb_bcast, tg);
                 float calc_size = (float)(bb_size * jcp.ur)
-                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                        * (float)(lb * jcp.load_block) * (float)jcp.reduce_dim;
                 float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
-                        * jcp.reduce_dim;
+                        * (float)jcp.reduce_dim;
                 return calc_koef * calc_size + mem_k * mem_size;
             };
             for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
                 lgc = ratio > 1 ? n_lgc - ilgc : ilgc + 1;
-                int min_lb = nb_load / lgc;
-                int max_lb = div_up(nb_load, lgc);
-                int min_tg = jcp.nthr / lgc;
-                int max_tg = div_up(jcp.nthr, lgc);
+                const dim_t min_lb = nb_load / lgc;
+                const dim_t max_lb = div_up(nb_load, lgc);
+                const dim_t min_tg = jcp.nthr / lgc;
+                const dim_t max_tg = div_up(jcp.nthr, lgc);
                 // Some heuristic here
                 float mem_koef = (max_tg == 1) ? 1.f : 1.3f;
                 float job_cost = 0.;
@@ -919,7 +923,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 }
 
                 if (job_cost < best_cost) {
-                    best_lgc = lgc;
+                    best_lgc = static_cast<int>(lgc);
                     best_cost = job_cost;
                 }
             }
@@ -941,21 +945,21 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             load_blocking = jcp.load_block;
         }
 
-        auto get_thr_eff = [&](int load_chunk, int nthr) {
-            int lgc = div_up(nb_load, load_chunk);
-            int thr_per_grp = div_up(nthr, lgc);
-            int bcast_per_thr
+        auto get_thr_eff = [&](dim_t load_chunk, int nthr) {
+            const dim_t lgc = div_up(nb_load, load_chunk);
+            const dim_t thr_per_grp = div_up(nthr, lgc);
+            const dim_t bcast_per_thr
                     = div_up(jcp.mb * nb_bcast, thr_per_grp) * jcp.bcast_block;
-            int load_per_thr = load_chunk * simd_w;
-            float data_norm = (bcast_per_thr + load_per_thr) / 2.f;
-            float data_eff
-                    = (bcast_per_thr * load_per_thr) / (data_norm * data_norm);
-            float thr_eff_over_grp
-                    = (float)nstl::max(1, nthr / lgc) / div_up(nthr, lgc);
-            float thr_eff_in_grp = ((float)jcp.mb * nb_bcast)
-                    / rnd_up(jcp.mb * nb_bcast, thr_per_grp);
+            const dim_t load_per_thr = load_chunk * simd_w;
+            float data_norm = (float)(bcast_per_thr + load_per_thr) / 2.f;
+            float data_eff = (float)(bcast_per_thr * load_per_thr)
+                    / (data_norm * data_norm);
+            float thr_eff_over_grp = (float)nstl::max<dim_t>(1, nthr / lgc)
+                    / (float)div_up(nthr, lgc);
+            float thr_eff_in_grp = ((float)jcp.mb * (float)nb_bcast)
+                    / (float)rnd_up(jcp.mb * nb_bcast, thr_per_grp);
             float thr_eff = thr_eff_over_grp * thr_eff_in_grp;
-            float load_eff = (float)nb_load / rnd_up(nb_load, lgc);
+            float load_eff = (float)nb_load / (float)rnd_up(nb_load, lgc);
             float overall_eff = data_eff + thr_eff + load_eff;
             return overall_eff;
         };
@@ -965,13 +969,13 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int best_lgc = 1;
             float eff;
 
-            for (int load_chunk = 1; load_chunk <= nb_load; load_chunk++) {
-                int lgc = div_up(nb_load, load_chunk);
+            for (dim_t load_chunk = 1; load_chunk <= nb_load; load_chunk++) {
+                const dim_t lgc = div_up(nb_load, load_chunk);
                 if (lgc > nthr) continue;
                 eff = get_thr_eff(load_chunk, nthr);
                 if (eff > best_eff) {
                     best_eff = eff;
-                    best_lgc = lgc;
+                    best_lgc = static_cast<int>(lgc);
                 }
             }
             return best_lgc;
@@ -988,7 +992,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int overall_lgc = jcp.load_grp_count;
             int lgc = 1;
             int best_nthr = jcp.nthr;
-            int end_nthr = with_groups ? jcp.ngroups : 1;
+            const int end_nthr
+                    = with_groups ? static_cast<int>(jcp.ngroups) : 1;
             for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
                 lgc = get_load_chunk(nthr);
                 thr_eff = get_thr_eff(lgc, nthr);
@@ -1010,15 +1015,15 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
         bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-        int space_for_bcast = (L2_capacity - /* kernel_size - */
+        dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
                 2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
                 - 3 * 1024);
         if (jcp.reduce_dim * jcp.bcast_dim > static_cast<dim_t>(L2_capacity))
             space_for_bcast /= 2;
 
-        int bcast_in_cache
-                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-        bcast_blocking = nstl::min(
+        const dim_t bcast_in_cache = nstl::max<dim_t>(
+                jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = nstl::min<dim_t>(
                 bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
         // NHWC perf
         if (is_data_layout_nxc) bcast_blocking = jcp.bcast_block;
@@ -1048,14 +1053,14 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 !(is_data_layout_nxc && jcp.load_dim <= jcp.load_block)) {
             // if reduce_block is big then generated JIT code may be big
             // for small values of ur because reduce_loop_unroll = reduce_block
-            jcp.ur = jcp.bcast_block / 2;
+            jcp.ur = static_cast<int>(jcp.bcast_block / 2);
             jcp.expl_bcast = true;
         } else {
-            jcp.ur = jcp.bcast_block;
+            jcp.ur = static_cast<int>(jcp.bcast_block);
             jcp.expl_bcast = false;
         }
 
-        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.ur_tail = static_cast<int>(jcp.bcast_dim % jcp.bcast_block);
         jcp.reduce_loop_unroll = jcp.reduce_block;
         jcp.reduce_loop_bcast_step = static_cast<dim_t>(jcp.typesize_in)
                 * jcp.reduce_loop_unroll
@@ -1089,12 +1094,13 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         assert(IMPLICATION(
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int min_bcast_blocking = 5;
+        const dim_t max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        const dim_t min_bcast_blocking = 5;
 
         bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        bcast_blocking = best_divider(
-                bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
+        bcast_blocking = best_divider(bcast_blocking,
+                static_cast<int>(min_bcast_blocking),
+                static_cast<int>(max_bcast_blocking), false);
         bcast_blocking *= jcp.bcast_block;
         bcast_blocking_max = bcast_blocking;
         assert(IMPLICATION(
@@ -1103,17 +1109,19 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         // for reduction balance
         if (is_data_layout_nxc && jcp.reduce_dim >= BIG_SPATIAL * BIG_SPATIAL
                 && jcp.load_dim >= BIG_LOAD_DIM / 2) {
-            reduce_blocking = rnd_up(nstl::min(jcp.ow, 256), jcp.reduce_block);
-        } else {
-            int max_reduce_blocking
-                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
-            int min_reduce_blocking = nstl::min(
-                    L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
-            reduce_blocking = best_divider(jcp.reduce_dim, min_reduce_blocking,
-                    max_reduce_blocking, true);
             reduce_blocking
-                    = nstl::max(rnd_dn(reduce_blocking, jcp.reduce_block),
-                            jcp.reduce_block);
+                    = rnd_up(nstl::min<dim_t>(jcp.ow, 256), jcp.reduce_block);
+        } else {
+            const dim_t max_reduce_blocking
+                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
+            const dim_t min_reduce_blocking = nstl::min<dim_t>(
+                    L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+            reduce_blocking = best_divider(jcp.reduce_dim,
+                    static_cast<int>(min_reduce_blocking),
+                    static_cast<int>(max_reduce_blocking), true);
+            reduce_blocking = nstl::max<dim_t>(
+                    rnd_dn(reduce_blocking, jcp.reduce_block),
+                    jcp.reduce_block);
         }
 
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
@@ -1164,16 +1172,17 @@ void jit_avx512_common_1x1_conv_kernel_t::init_scratchpad(
                     || (jcp.prop_kind == backward_weights // nxc layout
                             && jcp.oc % jcp.oc_block != 0))) {
 
-        const size_t nelems_padded_bias
+        const dim_t nelems_padded_bias
                 = jcp.ngroups * utils::rnd_up(jcp.oc, jcp.oc_block);
-        scratchpad.book(
-                key_conv_padded_bias, nelems_padded_bias, jcp.typesize_out);
+        scratchpad.book(key_conv_padded_bias,
+                static_cast<size_t>(nelems_padded_bias), jcp.typesize_out);
     }
 
     if (jcp.prop_kind == backward_weights) {
-        const size_t wei_size = (size_t)jcp.ngroups
-                * rnd_up(jcp.oc, jcp.oc_block) * rnd_up(jcp.ic, jcp.ic_block);
-        scratchpad.book(key_conv_wei_reduction, wei_size * (jcp.nthr_mb - 1),
+        const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+                * rnd_up(jcp.ic, jcp.ic_block);
+        scratchpad.book(key_conv_wei_reduction,
+                static_cast<size_t>(wei_size * (jcp.nthr_mb - 1)),
                 jcp.typesize_out);
         if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
             scratchpad.book<simple_barrier::ctx_t>(
@@ -1190,11 +1199,11 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const dim_t nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    const dim_t nb_load = div_up(jcp.load_dim, jcp.load_block);
+    const dim_t nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
-    jcp.nthr_g = jcp.ngroups;
+    jcp.nthr_g = static_cast<int>(jcp.ngroups);
     const int nthr = nthreads / jcp.nthr_g;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -1226,12 +1235,15 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
     auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, jcp.mb * nb_reduce));
     for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, nb_load));
         for (nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, nb_bcast);
+            nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, nb_bcast));
             auto mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
                 best_mem_cost = mem_cost;
@@ -1242,7 +1254,7 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         }
     }
     if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
-        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(jcp.mb, nthreads));
 
     jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
     assert(jcp.nthr <= nthreads);

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -1145,13 +1145,17 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
 
     assert(jcp.bcast_block % jcp.ur == 0);
 
-    jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
-    jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;
-    jcp.nb_load_blocking = utils::div_up(load_blocking, jcp.load_block);
-    jcp.nb_load_blocking_max = utils::div_up(load_blocking_max, jcp.load_block);
-    jcp.nb_reduce_blocking = utils::div_up(reduce_blocking, jcp.reduce_block);
-    jcp.nb_reduce_blocking_max
-            = utils::div_up(reduce_blocking_max, jcp.reduce_block);
+    jcp.nb_bcast_blocking = static_cast<int>(bcast_blocking / jcp.bcast_block);
+    jcp.nb_bcast_blocking_max
+            = static_cast<int>(bcast_blocking_max / jcp.bcast_block);
+    jcp.nb_load_blocking
+            = static_cast<int>(utils::div_up(load_blocking, jcp.load_block));
+    jcp.nb_load_blocking_max = static_cast<int>(
+            utils::div_up(load_blocking_max, jcp.load_block));
+    jcp.nb_reduce_blocking = static_cast<int>(
+            utils::div_up(reduce_blocking, jcp.reduce_block));
+    jcp.nb_reduce_blocking_max = static_cast<int>(
+            utils::div_up(reduce_blocking_max, jcp.reduce_block));
 
     jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -578,32 +578,35 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc = jcp.oc_without_padding;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic = jcp.ic_without_padding;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
@@ -761,9 +764,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
 
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
-        jcp.load_loop_load_step
-                = utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
-                * jcp.load_block * jcp.typesize_in;
+        jcp.load_loop_load_step = static_cast<int>(
+                utils::rnd_up(jcp.reduce_dim, jcp.reduce_block) * jcp.load_block
+                * jcp.typesize_in);
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold;
@@ -816,8 +819,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         jcp.bcast_loop_output_step = jcp.ur * jcp.typesize_out
                 * (is_data_layout_nxc ? jcp.load_dim : jcp.load_block);
         jcp.bcast_loop_output_substep = -1; // unused
-        jcp.bcast_loop_bcast_step = jcp.ur * jcp.typesize_in
-                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block);
+        jcp.bcast_loop_bcast_step = static_cast<int>(jcp.ur * jcp.typesize_in
+                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block));
         jcp.bcast_loop_bcast_substep = -1; // unused
 
         jcp.load_loop_iter_step = jcp.load_block;
@@ -1072,15 +1075,15 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 = jcp.oc_block * jcp.ic_block * jcp.typesize_out;
         jcp.bcast_loop_output_substep
                 = jcp.oc_block * jcp.ur * jcp.typesize_out;
-        jcp.bcast_loop_bcast_step = jcp.ic_block
+        jcp.bcast_loop_bcast_step = static_cast<int>(jcp.ic_block
                 * (is_data_layout_nxc ? 1
                                       : utils::rnd_up(jcp.reduce_dim,
                                                 jcp.reduce_block))
-                * jcp.typesize_in;
+                * jcp.typesize_in);
         jcp.bcast_loop_bcast_substep = jcp.ur * jcp.typesize_in;
 
-        jcp.load_loop_load_step = jcp.typesize_in * jcp.oc_block
-                * (is_data_layout_nxc ? 1 : jcp.os);
+        jcp.load_loop_load_step = static_cast<int>(jcp.typesize_in
+                * jcp.oc_block * (is_data_layout_nxc ? 1 : jcp.os));
         jcp.load_loop_iter_step = jcp.oc_block;
 
         /* --- */
@@ -1157,9 +1160,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     jcp.nb_reduce_blocking_max = static_cast<int>(
             utils::div_up(reduce_blocking_max, jcp.reduce_block));
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     return status::success;
 }

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -56,7 +56,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const std::size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
@@ -87,24 +87,25 @@ private:
     constexpr static int reg_dw_binary_output_off = 3 * reg64_size_;
     constexpr static int stack_space_needed = 4 * reg64_size_;
 
-    void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
+    void bcast_loop(dim_t load_loop_blk);
+    void reduce_loop(
+            dim_t load_loop_blk, dim_t ur, dim_t substep, bool wraparound);
 
     inline size_t get_output_offset(const bool is_out_layout_nxc,
-            const int i_load, const int i_ur, bool ignore_dw_conv = false) {
-        const size_t i_load_shift = is_out_layout_nxc
+            const dim_t i_load, const dim_t i_ur, bool ignore_dw_conv = false) {
+        const dim_t i_load_shift = is_out_layout_nxc
                 ? jcp.load_block
                 : (!ignore_dw_conv && jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
                         * jcp.load_block;
-        const size_t i_ur_shift
+        const dim_t i_ur_shift
                 = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
         return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
     }
 
     Xbyak::Address output_ptr(
-            const bool out_layout_nxc, const int i_load, const int i_ur);
-    void apply_postops(const bool is_out_layout_nxc, const int load_loop_blk,
-            const int ur);
+            const bool out_layout_nxc, const dim_t i_load, const dim_t i_ur);
+    void apply_postops(const bool is_out_layout_nxc, const dim_t load_loop_blk,
+            const dim_t ur);
     void generate() override;
     static void balance(jit_1x1_conv_conf_t &jcp);
 };

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -116,7 +116,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_ic = jcp.nb_reduce;
     const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -397,10 +397,9 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         row_offset = dw_conv_buffer_size / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end,
-                static_cast<dim_t>(jcp.load_grp_count));
+                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
 
         while (ocb_start < ocb_end) {
             dim_t load_step;
@@ -443,10 +442,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         conv_dw();
     } else {
 
-        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                ocb_start, ocb_end, static_cast<dim_t>(jcp.load_grp_count));
+                ocb_start, ocb_end, jcp.load_grp_count);
 
         conv_1x1(bcast_start, bcast_end, ocb_start, ocb_end);
     }
@@ -483,11 +482,11 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
     const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     const dim_t nb_ic = jcp.nb_load;
-    const dim_t nb_oc = jcp.nb_reduce;
-    const dim_t os_block = jcp.bcast_block;
-    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
+    const int nb_oc = jcp.nb_reduce;
+    const int os_block = jcp.bcast_block;
+    const int nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
@@ -498,9 +497,9 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-        dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+        int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                icb_start, icb_end, static_cast<dim_t>(jcp.load_grp_count));
+                icb_start, icb_end, jcp.load_grp_count);
 
         bool reduce_outer
                 = (jcp.loop_order == loop_rbl || jcp.loop_order == loop_rlb);
@@ -678,11 +677,11 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     const dim_t nb_ic = jcp.nb_bcast;
     const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const dim_t sp_nb = jcp.nb_reduce;
-    const dim_t mb_sp_work = jcp.mb * sp_nb;
+    const int sp_nb = jcp.nb_reduce;
+    const int mb_sp_work = jcp.mb * sp_nb;
 
     const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
     const dim_t stride_w = pd()->desc()->strides[ndims - 3];
@@ -729,13 +728,13 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
+        int mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
-        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
+        int g_start {0}, oc_b_start {0}, ic_b_start {0};
+        int g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -55,7 +55,8 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_
             ? binary_injector::prepare_binary_args(
                       pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -102,11 +103,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
             : nullptr;
 
     const int ndims = src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -115,18 +116,19 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
     const bool is_dst_layout_nxc = utils::one_of(
@@ -138,23 +140,23 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
     memory_tracking::grantor_t dw_scratchpad(
             scratchpad, memory_tracking::names::prefix_fusion);
     dst_data_t *pbuf;
-    size_t row_offset;
-    const int nb_buffer = jcp.nb_load_blocking;
+    dim_t row_offset;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<dst_data_t *> addrs;
     // End
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
-        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+        bcast_step = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -167,16 +169,16 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
-        const auto max_oc
-                = nstl::min(ocb_end * jcp.oc_block, jcp.oc_without_padding);
+        const auto max_oc = nstl::min<dim_t>(
+                ocb_end * jcp.oc_block, jcp.oc_without_padding);
         p.load_dim = this_block_size(
                 ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
     };
 
-    auto init_reduce = [&](int icb) {
-        const int nb_ic_blocking_step
+    auto init_reduce = [&](dim_t icb) {
+        const dim_t nb_ic_blocking_step
                 = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
         p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
@@ -186,12 +188,13 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t icb, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
 
         p.output_data = jcp.with_dw_conv
                 ? pbuf + (oh % pd()->dw_conv_pd_->jcp_.kh) * row_offset
@@ -203,7 +206,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         p.load_data
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
         if (pd()->rtus_.reduce_src_) {
@@ -224,21 +227,22 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
 
         if (jcp.loop_order == loop_rlb) {
-            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+            for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                 init_reduce(icb);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    int iwork = bcast_start;
+                    dim_t iwork = bcast_start;
                     while (iwork < bcast_end) {
-                        int n {0}, g {0}, bcast_step {0}, od {0}, oh {0},
-                                ow {0}, id {0}, ih {0}, iw {0};
+                        dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0},
+                                ih {0}, iw {0};
+                        dim_t bcast_step {0};
                         init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh,
                                 ow, id, ih, iw);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
@@ -249,17 +253,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 }
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -269,17 +274,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_rbl) {
-            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+            for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                 init_reduce(icb);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    int ocb = ocb_start;
+                    dim_t ocb = ocb_start;
                     while (ocb < ocb_end) {
-                        int load_step;
+                        dim_t load_step;
                         init_load(ocb, ocb_end, load_step);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -289,17 +295,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 }
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                        id {0}, ih {0}, iw {0};
+                dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                        iw {0};
+                dim_t bcast_step {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -313,9 +320,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
 
         for (int i = 0; i < jcp_dw.kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw.kh) * row_offset;
@@ -323,31 +331,31 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         const auto ocb_end = ocb_start + load_step;
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw.iw)
                 * jcp_dw.nb_ch_blocking * jcp_dw.ch_block;
-        const int dil_h = jcp_dw.dilate_h + 1;
-        const int str_h = jcp_dw.stride_h;
-        const int ch_num = jcp_dw.nb_ch_blocking;
-        const int ow = 0;
-        const int kw = 0;
+        const dim_t dil_h = jcp_dw.dilate_h + 1;
+        const dim_t str_h = jcp_dw.stride_h;
+        const dim_t ch_num = jcp_dw.nb_ch_blocking;
+        const dim_t ow = 0;
+        const dim_t kw = 0;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw.t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw.ih,
-                              (int)(dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
-                                      - jcp_dw.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw.t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw.ih,
+                              dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
+                                      - jcp_dw.t_pad + 1)
                     - jcp_dw.ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw.ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -359,9 +367,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw.ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw.nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw.nb_ch) - ch)
                     * jcp_dw.ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -381,43 +391,47 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 = dw_scratchpad.get<dst_data_t>(key_fusion_inout_buffer);
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
 
-        const auto dw_conv_buffer_size_
-                = (size_t)jcp_dw.kh * jcp.ow * nb_buffer * jcp.oc_block;
-        pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size_;
-        row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
+        const dim_t dw_conv_buffer_size
+                = jcp_dw.kh * jcp.ow * nb_buffer * jcp.oc_block;
+        pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size;
+        row_offset = dw_conv_buffer_size / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+                bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw.oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw.kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_range
+                        = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw.kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
                 oh_1x1 = oh_1x1_end;
-                ker_dw(n, g * nb_oc + ocb_start, load_step, oh_dw);
+                ker_dw(n, static_cast<int>(g * nb_oc + ocb_start), load_step,
+                        oh_dw);
 
                 bcast_iter += nb_bcast_blocking;
             }
@@ -429,10 +443,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         conv_dw();
     } else {
 
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                ocb_start, ocb_end, jcp.load_grp_count);
+                ocb_start, ocb_end, static_cast<dim_t>(jcp.load_grp_count));
 
         conv_1x1(bcast_start, bcast_end, ocb_start, ocb_end);
     }
@@ -464,18 +478,18 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
 
     assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -484,27 +498,27 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-        int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                icb_start, icb_end, jcp.load_grp_count);
+                icb_start, icb_end, static_cast<dim_t>(jcp.load_grp_count));
 
         bool reduce_outer
                 = (jcp.loop_order == loop_rbl || jcp.loop_order == loop_rlb);
-        int nboc_outer = reduce_outer ? nb_oc : 1;
-        int ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
+        const dim_t nboc_outer = reduce_outer ? nb_oc : 1;
+        const dim_t ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
 
-        int nboc_inner = reduce_outer ? 1 : nb_oc;
-        int ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
-        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+        const dim_t nboc_inner = reduce_outer ? 1 : nb_oc;
+        const dim_t ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
+        const dim_t max_ic = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
 
-        for (int ocb_outer = 0; ocb_outer < nboc_outer;
+        for (dim_t ocb_outer = 0; ocb_outer < nboc_outer;
                 ocb_outer += ocb_outer_step) {
-            size_t cur_ocb_outer
+            dim_t cur_ocb_outer
                     = nstl::min(ocb_outer + ocb_outer_step, nboc_outer)
                     - ocb_outer;
 
-            int load_step = 0;
-            for (int icb = icb_start; icb < icb_end; icb += load_step) {
+            dim_t load_step = 0;
+            for (dim_t icb = icb_start; icb < icb_end; icb += load_step) {
                 load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
                         jcp.nb_load_blocking_max);
 
@@ -512,34 +526,35 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
                         icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
                 rp.icb = p.load_dim;
 
-                int bcast_step;
-                for (int iwork = bcast_start; iwork < bcast_end;
+                dim_t bcast_step;
+                for (dim_t iwork = bcast_start; iwork < bcast_end;
                         iwork += bcast_step) {
-                    int n {0}, g {0}, osb {0};
+                    dim_t n {0}, g {0}, osb {0};
                     nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb,
                             jcp.nb_bcast);
 
                     bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
                             jcp.nb_bcast_blocking_max);
-                    bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+                    bcast_step
+                            = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-                    const int os = osb * os_block;
+                    const dim_t os = osb * os_block;
                     p.bcast_dim = this_block_size(
                             os, jcp.os, bcast_step * os_block);
                     rp.os = p.bcast_dim;
 
-                    const int od = os / (jcp.oh * jcp.ow);
-                    const int os_2d = os % (jcp.oh * jcp.ow);
-                    const int oh = os_2d / jcp.ow;
-                    const int ow = os_2d % jcp.ow;
-                    const int id = od * stride_d;
-                    const int ih = oh * stride_h;
-                    const int iw = ow * stride_w;
+                    const dim_t od = os / (jcp.oh * jcp.ow);
+                    const dim_t os_2d = os % (jcp.oh * jcp.ow);
+                    const dim_t oh = os_2d / jcp.ow;
+                    const dim_t ow = os_2d % jcp.ow;
+                    const dim_t id = od * stride_d;
+                    const dim_t ih = oh * stride_h;
+                    const dim_t iw = ow * stride_w;
                     rp.iw_start = iw;
                     const bool is_dsrc_layout_nxc
                             = utils::one_of(jcp.src_tag, format_tag::nwc,
                                     format_tag::nhwc, format_tag::ndhwc);
-                    const int ic_off_idx = is_dsrc_layout_nxc
+                    const dim_t ic_off_idx = is_dsrc_layout_nxc
                             ? g * jcp.ic + icb * jcp.ic_block
                             : g * nb_ic + icb;
                     rp.src = diff_src
@@ -552,23 +567,23 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
                     } else
                         p.output_data = rp.src;
 
-                    for (int ocb_inner = 0; ocb_inner < nboc_inner;
+                    for (dim_t ocb_inner = 0; ocb_inner < nboc_inner;
                             ocb_inner += ocb_inner_step) {
-                        int cur_ocb_inner
+                        const dim_t cur_ocb_inner
                                 = nstl::min(ocb_inner + ocb_inner_step,
                                           nboc_inner)
                                 - ocb_inner;
 
-                        int ocb = reduce_outer ? ocb_outer : ocb_inner;
-                        int nb_oc_blocking_step
+                        const dim_t ocb = reduce_outer ? ocb_outer : ocb_inner;
+                        const dim_t nb_oc_blocking_step
                                 = reduce_outer ? cur_ocb_outer : cur_ocb_inner;
                         const bool is_ddst_layout_nxc
                                 = utils::one_of(jcp.dst_tag, format_tag::nwc,
                                         format_tag::nhwc, format_tag::ndhwc);
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + ocb * jcp.oc_block
                                 : g * nb_oc + ocb;
-                        size_t diff_dst_off = data_blk_off(
+                        dim_t diff_dst_off = data_blk_off(
                                 diff_dst_d, n, oc_off_idx, od, oh, ow);
                         p.bcast_data = &diff_dst[diff_dst_off];
 
@@ -643,7 +658,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     auto wei_reduction = scratchpad.get<data_t>(key_conv_wei_reduction);
 
     const int ndims = src_d.ndims();
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block);
 
     simple_barrier::ctx_t *reduction_barrier
@@ -660,19 +675,19 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic = jcp.nb_bcast;
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t nb_ic = jcp.nb_bcast;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const int sp_nb = jcp.nb_reduce;
-    const int mb_sp_work = jcp.mb * sp_nb;
+    const dim_t sp_nb = jcp.nb_reduce;
+    const dim_t mb_sp_work = jcp.mb * sp_nb;
 
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -683,22 +698,22 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (is_ddst_layout_nxc && ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = nb_ic - 1;
-                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const dim_t z_icb = nb_ic - 1;
+                const dim_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
                         + ic_tail * jcp.oc_block;
                 data_t *z_wei = diff_weights + off;
-                const int zero_work
+                const dim_t zero_work
                         = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -714,30 +729,30 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
         balance211(
                 jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
 
-        const int g_work = g_end - g_start;
-        const int oc_b_work = oc_b_end - oc_b_start;
-        const int ic_b_work = ic_b_end - ic_b_start;
+        const dim_t g_work = g_end - g_start;
+        const dim_t oc_b_work = oc_b_end - oc_b_start;
+        const dim_t ic_b_work = ic_b_end - ic_b_start;
         const bool cache_aliasing
                 = (jcp.ic * jcp.ngroups * sizeof(float)) % 1024 == 0;
-        int reduce_step = jcp.nb_reduce_blocking;
-        int reduce_step_max = jcp.nb_reduce_blocking_max;
+        dim_t reduce_step = jcp.nb_reduce_blocking;
+        dim_t reduce_step_max = jcp.nb_reduce_blocking_max;
         if (is_src_layout_nxc && cache_aliasing) {
             // Experiments show 4 is a magic number with the tested shapes.
             // TODO: maybe tune for shapes with sp_dim%4 != 0
-            reduce_step = nstl::min(4, reduce_step);
+            reduce_step = nstl::min<dim_t>(4, reduce_step);
             reduce_step_max = reduce_step;
         }
 
@@ -745,19 +760,19 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 ? diff_weights
                 : wei_reduction + (ithr_mb - 1) * wei_size;
 
-        int sp_b_step = 0;
-        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+        dim_t sp_b_step = 0;
+        for (dim_t mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
                 mb_sp_b += sp_b_step) {
-            int img {0}, sp_b {0};
+            dim_t img {0}, sp_b {0};
             nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
             sp_b_step = step(reduce_step,
                     nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
                     reduce_step_max);
 
-            for (int g = g_start; g < g_end; ++g) {
-                int load_step = 0;
-                int bcast_step = 0;
-                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+            for (dim_t g = g_start; g < g_end; ++g) {
+                dim_t load_step = 0;
+                dim_t bcast_step = 0;
+                for (dim_t ic_b = ic_b_start; ic_b < ic_b_end;
                         ic_b += bcast_step) {
                     if (is_src_layout_nxc && cache_aliasing) {
                         bcast_step = ic_b_work;
@@ -766,28 +781,28 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                 jcp.nb_bcast_blocking_max);
                     }
 
-                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                    for (dim_t oc_b = oc_b_start; oc_b < oc_b_end;
                             oc_b += load_step) {
                         load_step = step(nb_oc_blocking, oc_b_end - oc_b,
                                 jcp.nb_load_blocking_max);
-                        const int _ic_b = g * nb_ic + ic_b;
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t _ic_b = g * nb_ic + ic_b;
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + oc_b * jcp.oc_block
                                 : g * nb_oc + oc_b;
 
                         data_t *store_to;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         store_to = diff_wei + off;
 
-                        const int ic_off_idx
+                        const dim_t ic_off_idx
                                 = (is_src_layout_nxc ? jcp.ic_block : 1)
                                 * _ic_b;
                         const data_t *diff_src
                                 = &src[src_d.blk_off(img, ic_off_idx)];
 
-                        int sp_b_end = sp_b + sp_b_step;
+                        const dim_t sp_b_end = sp_b + sp_b_step;
                         const data_t *pdiff_dst = &diff_dst[diff_dst_d.blk_off(
                                 img, oc_off_idx)];
                         const data_t *local_src = diff_src;
@@ -814,17 +829,17 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                                             : 0)
                                 | (sp_b_end == sp_nb ? FLAG_SP_LAST : 0);
 
-                        int sp = sp_b * jcp.reduce_block;
-                        int oc_mult
+                        dim_t sp = sp_b * jcp.reduce_block;
+                        dim_t oc_mult
                                 = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
                         p.load_data = pdiff_dst + sp * oc_mult;
 
                         if (pd()->rtus_.reduce_src_) {
-                            const int oh = sp / jcp.ow;
-                            const int ow = sp % jcp.ow;
+                            const dim_t oh = sp / jcp.ow;
+                            const dim_t ow = sp % jcp.ow;
 
-                            const int ih = oh * stride_h;
-                            const int iw = ow * stride_w;
+                            const dim_t ih = oh * stride_h;
+                            const dim_t iw = ow * stride_w;
                             rp.iw_start = iw;
 
                             rp.ws = rtus_space
@@ -842,7 +857,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
                             p.bcast_data = rp.ws;
                         } else {
-                            int ic_mult
+                            dim_t ic_mult
                                     = is_src_layout_nxc ? jcp.ic : jcp.ic_block;
                             p.bcast_data = local_src + sp * ic_mult;
                         }
@@ -860,29 +875,30 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* diff_weights[:] += sum(wei_reduction[thr_mb][:]) */
         if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
             simple_barrier::barrier(reduction_barrier, jcp.nthr);
-            const int work = g_work * oc_b_work * ic_b_work;
-            int start {0}, end {0};
+            const dim_t work = g_work * oc_b_work * ic_b_work;
+            dim_t start {0}, end {0};
             balance211(work, jcp.nthr_mb, ithr_mb, start, end);
             if (start == end) return;
 
             for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                int w = start;
-                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                dim_t w = start;
+                dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
                 nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                         oc_b_work, sub_ic_b_start, ic_b_work);
                 while (w < end) {
-                    const int g = g_start + sub_g_start;
-                    const int oc_b = oc_b_start + sub_oc_b_start;
-                    const int ic_b = ic_b_start + sub_ic_b_start;
-                    const int ic_to_accumulate
-                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
-                            * jcp.ic_block;
-                    const int acc_size
-                            = this_block_size(ic_b * jcp.ic_block,
-                                      jcp.ic_without_padding, ic_to_accumulate)
-                            * jcp.oc_block;
+                    const dim_t g = g_start + sub_g_start;
+                    const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                    const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                    const int ic_to_accumulate = static_cast<int>(
+                            nstl::min<dim_t>(
+                                    end - w, ic_b_work - sub_ic_b_start)
+                            * jcp.ic_block);
+                    const int acc_size = static_cast<int>(
+                            this_block_size(ic_b * jcp.ic_block,
+                                    jcp.ic_without_padding, ic_to_accumulate)
+                            * jcp.oc_block);
 
-                    const size_t off
+                    const dim_t off
                             = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                     data_t *d = diff_weights + off;
                     data_t *s = wei_reduction + (thr_mb - 1) * wei_size + off;
@@ -908,7 +924,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* reduction dimension */
         int img_start {0}, img_end {0};
 
-        balance211(jcp.mb, rb->balancer().nthr_per_group_,
+        balance211(static_cast<int>(jcp.mb), rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
@@ -916,10 +932,10 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         nd_iterator_init(
                 b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_load);
 
-        for (int img = img_start; img < img_end; ++img) {
+        for (dim_t img = img_start; img < img_end; ++img) {
             int g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g * jcp.nb_load + ocb;
                 const data_t *d_dst
@@ -928,8 +944,8 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
                                          reducer_bia_scratchpad)
                         + b_job_loc * rb->balancer().job_size_;
-                const int sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
-                                                        : jcp.oc_block;
+                const dim_t sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
+                                                          : jcp.oc_block;
                 const auto max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
                 if (img == img_start)
@@ -938,7 +954,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
                 for (dim_t os = 0; os < jcp.os; ++os) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += sp_shift;
                 }
@@ -974,11 +990,12 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 int g_start {0}, oc_b_start {0}, ic_b_start {0};
                 int g_end {0}, oc_b_end {0}, ic_b_end {0};
 
-                balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
-                balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
-                        oc_b_end);
-                balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
-                        ic_b_end);
+                balance211(static_cast<int>(jcp.ngroups), jcp.nthr_g, ithr_g,
+                        g_start, g_end);
+                balance211(static_cast<int>(jcp.nb_load), jcp.nthr_oc_b,
+                        ithr_oc_b, oc_b_start, oc_b_end);
+                balance211(static_cast<int>(jcp.nb_bcast), jcp.nthr_ic_b,
+                        ithr_ic_b, ic_b_start, ic_b_end);
 
                 const int g_work = g_end - g_start;
                 const int oc_b_work = oc_b_end - oc_b_start;
@@ -998,16 +1015,17 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         const int g = g_start + sub_g_start;
                         const int oc_b = oc_b_start + sub_oc_b_start;
                         const int ic_b = ic_b_start + sub_ic_b_start;
-                        const int ic_to_accumulate
-                                = nstl::min(end - w, ic_b_work - sub_ic_b_start)
-                                * jcp.ic_block;
-                        const int acc_size
-                                = this_block_size(ic_b * jcp.ic_block,
-                                          jcp.ic_without_padding,
-                                          ic_to_accumulate)
-                                * jcp.oc_block;
+                        const int ic_to_accumulate = static_cast<int>(
+                                nstl::min<dim_t>(
+                                        end - w, ic_b_work - sub_ic_b_start)
+                                * jcp.ic_block);
+                        const int acc_size = static_cast<int>(
+                                this_block_size(ic_b * jcp.ic_block,
+                                        jcp.ic_without_padding,
+                                        ic_to_accumulate)
+                                * jcp.oc_block);
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         data_t *d = diff_weights + off;
                         data_t *s
@@ -1037,9 +1055,9 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* TODO: put this in ker_bias */
         if (is_bias_padded) {
             assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -293,11 +293,11 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);
 
-            size_t dw_conv_buffer_size_ = (size_t)nthr * jcp_dw.kh * jcp_dw.iw
-                    * jcp_dw.dw_conv_buffer_oc;
-            assert(dw_conv_buffer_size_);
+            const dim_t dw_conv_buffer_size = static_cast<dim_t>(nthr)
+                    * jcp_dw.kh * jcp_dw.iw * jcp_dw.dw_conv_buffer_oc;
+            assert(dw_conv_buffer_size);
             dw_scratchpad.book(memory_tracking::names::key_fusion_inout_buffer,
-                    dw_conv_buffer_size_,
+                    static_cast<size_t>(dw_conv_buffer_size),
                     types::data_type_size(dw_conv_pd_->src_md()->data_type));
 
             jit_uni_dw_conv_fwd_kernel_t<avx512_core,
@@ -554,11 +554,14 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
 
     private:
         void init_balancers() {
-            const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
+            const dim_t max_buffer_size
+                    = static_cast<dim_t>(jcp_.nthr) * 3 * 5 * 5 * 16 * 16;
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_load, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_load),
+                        static_cast<int>(jcp_.mb),
+                        static_cast<size_t>(max_buffer_size), true));
             }
         }
     };

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -102,7 +102,7 @@ jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_args_static_params {
@@ -208,7 +208,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::store_output(int ur_w) {
     L(no_update_label);
     if (jcp.with_bias) {
         for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-            int bias_offset = jcp.typesize_out * k * jcp.oc_block;
+            const dim_t bias_offset = jcp.typesize_out * k * jcp.oc_block;
             for (int j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 // mask only needed for last oc_block
@@ -251,16 +251,16 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::store_output(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     const bool is_source_layout_nxc = is_src_layout_nxc();
     const bool icb_loop_in_compute_function = is_source_layout_nxc;
     const int ic_tail = jcp.ic_tail;
     const int oc_tail = jcp.oc == jcp.oc_without_padding ? jcp.oc_tail : 0;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_oc_block = jcp.nb_oc_blocking;
+    dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
     Label kh_label, kd_label;
     std::vector<Label> ic_tail_jmp(kw);
 
@@ -268,14 +268,15 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
     // assert if it is extended in future to catch unpadded_oc_tail.
     assert(IMPLICATION(oc_tail, nb_oc_block == 1));
 
-    int num_ker_loads = ic_block * nb_oc_block * kw;
-    int ker_pipeline_depth
-            = oc_tail || ic_tail ? 1 : nstl::min(4, num_ker_loads);
+    const dim_t num_ker_loads = ic_block * nb_oc_block * kw;
+    int ker_pipeline_depth = oc_tail || ic_tail
+            ? 1
+            : static_cast<int>(nstl::min<dim_t>(4, num_ker_loads));
     assert(ker_reg_base_idx + ker_pipeline_depth <= 32);
     assert(oc_block >= ker_pipeline_depth);
 
-    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
-                                       : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                         : (!jcp.is_1stconv ? ic_block : 1);
 
     if (one_of(jcp.ndims, 3, 4)) {
         mov(aux_reg_inp, reg_inp);
@@ -322,7 +323,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                         je(ic_tail_jmp[ki], T_NEAR);
                     }
                 }
-                int aux_kernel_offset = 0;
+                dim_t aux_kernel_offset = 0;
                 if (step == 0) {
                     for (int i = 0; i < ker_pipeline_depth; i++) {
                         aux_kernel_offset = get_kernel_offset(ki, ic, 0, i);
@@ -331,7 +332,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                                         aux_reg_ker, aux_kernel_offset));
                     }
                 } else if (step < num_ker_loads - ker_pipeline_depth + 1) {
-                    int load_offset = ker_pipeline_depth - 1;
+                    const dim_t load_offset = ker_pipeline_depth - 1;
                     int ker_load_reg_idx
                             = (step + load_offset) % ker_pipeline_depth;
                     aux_kernel_offset
@@ -341,10 +342,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                 }
 
                 Vmm vmm_kernel = vmm_ker(step % ker_pipeline_depth);
-                int j_start = get_ow_start(ki, pad_l);
-                int j_end = get_ow_end(ur_w, ki, pad_r);
-                for (int j = j_start; j < j_end; j++) {
-                    size_t aux_input_offset
+                const dim_t j_start = get_ow_start(ki, pad_l);
+                const dim_t j_end = get_ow_end(ur_w, ki, pad_r);
+                for (dim_t j = j_start; j < j_end; j++) {
+                    const dim_t aux_input_offset
                             = get_input_offset(ki, ic, j, pad_l);
                     auto addr = EVEX_compress_addr_safe(
                             aux_reg_inp, aux_input_offset, reg_long_offt, true);
@@ -354,9 +355,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
             }
             L(ic_tail_jmp[ki]);
         }
-        int ker_shift = jcp.typesize_in * kw * oc_block * ic_block;
+        const dim_t ker_shift = jcp.typesize_in * kw * oc_block * ic_block;
         add(aux_reg_ker, ker_shift);
-        int inp_shift = jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul;
+        const dim_t inp_shift
+                = jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul;
         add(aux_reg_inp, inp_shift);
         dec(reg_kj);
         cmp(reg_kj, 0);
@@ -364,10 +366,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
     }
 
     if (jcp.ndims == 5) {
-        int inp_shift
+        const dim_t inp_shift
                 = typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul;
         add(aux_reg_inp_d, inp_shift);
-        int ker_shift
+        const dim_t ker_shift
                 = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
         add(aux_reg_ker_d, ker_shift);
 
@@ -382,23 +384,23 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
-        int ur_w, int pad_l, int pad_r) {
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_oc_block = jcp.nb_oc_blocking;
+        int ur_w, dim_t pad_l, dim_t pad_r) {
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
     const bool is_source_layout_nxc = is_src_layout_nxc();
     const bool icb_loop_in_compute_function = is_source_layout_nxc;
     const int ic_tail = jcp.ic_tail;
 
     Label kh_label, kd_label;
     std::vector<Label> ic_tail_jmp(kw);
-    int shift_kernel_ptr
+    dim_t shift_kernel_ptr
             = jcp.typesize_in * jcp.kw * jcp.oc_block * jcp.ic_block;
-    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
-                                       : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                         : (!jcp.is_1stconv ? ic_block : 1);
 
-    int shift_input_ptr
+    dim_t shift_input_ptr
             = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mul;
 
     if (one_of(jcp.ndims, 3, 4)) {
@@ -435,8 +437,8 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_ow_start(ki, pad_l);
-            int jj_end = get_ow_end(ur_w, ki, pad_r);
+            const dim_t jj_start = get_ow_start(ki, pad_l);
+            const dim_t jj_end = get_ow_end(ur_w, ki, pad_r);
             for (int ic = 0; ic < ic_block; ic++) {
                 if (ic_tail && ic >= ic_tail) {
                     // if src has only tails to compute, skip early
@@ -448,8 +450,8 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                     }
                 }
                 if (jcp.kernel_kind == expl_bcast) {
-                    for (int jj = jj_start; jj < jj_end; jj++) {
-                        size_t aux_input_offset
+                    for (dim_t jj = jj_start; jj < jj_end; jj++) {
+                        dim_t aux_input_offset
                                 = get_input_offset(ki, ic, jj, pad_l);
                         vbroadcastss(vmm_inp(jj, nb_oc_block),
                                 EVEX_compress_addr_safe(aux_reg_inp,
@@ -457,7 +459,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                     }
                 }
                 for (int ii = 0; ii < nb_oc_block; ii++) {
-                    int aux_kernel_offset = jcp.typesize_in
+                    dim_t aux_kernel_offset = jcp.typesize_in
                             * (ii * jcp.nb_ic * jcp.kh * jcp.kw * jcp.kd
                                             * ic_block * oc_block
                                     + ki * ic_block * oc_block + ic * oc_block);
@@ -465,12 +467,12 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(
                                         aux_reg_ker, aux_kernel_offset));
-                    for (int jj = jj_start; jj < jj_end; jj++)
+                    for (dim_t jj = jj_start; jj < jj_end; jj++)
                         if (jcp.kernel_kind == expl_bcast)
                             vfmadd231ps(vmm_out(jj, ii),
                                     vmm_inp(jj, nb_oc_block), vmm_wei);
                         else {
-                            size_t aux_input_offset
+                            dim_t aux_input_offset
                                     = get_input_offset(ki, ic, jj, pad_l);
                             vfmadd231ps(vmm_out(jj, ii), vmm_wei,
                                     EVEX_compress_addr_safe(aux_reg_inp,
@@ -491,7 +493,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
     if (jcp.ndims == 5) {
         add(aux_reg_inp_d,
                 typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul);
-        const int ker_shift
+        const dim_t ker_shift
                 = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
         add(aux_reg_ker_d, ker_shift);
 
@@ -506,7 +508,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     if (jcp.ndims == 5) push(reg_oi);
 
     prepare_output(ur_w);
@@ -548,7 +550,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
     if (generate_icb_loop) {
         assert(is_src_layout_nxc());
-        const int inp_shift = jcp.ic_block * jcp.typesize_in;
+        const dim_t inp_shift = jcp.ic_block * jcp.typesize_in;
         add(reg_inp, inp_shift);
         const size_t ker_shift = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.ic_block
                 * jcp.oc_block * jcp.typesize_in;
@@ -567,22 +569,23 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int ow_block = jcp.ow_block;
-    int nb_ow = jcp.nb_ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    dim_t ow_block = jcp.ow_block;
+    dim_t nb_ow = jcp.nb_ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
-    int inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
-                                       : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    int inp_shift_pad = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
-    int inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
-    int inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
-    int out_shift = jcp.typesize_out * ur_w
+    dim_t inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
+                                         : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    dim_t inp_shift_pad
+            = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
+    dim_t inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
+    dim_t inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
+    dim_t out_shift = jcp.typesize_out * ur_w
             * (is_dst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block);
 
     preamble();
@@ -612,9 +615,9 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
             kmovw(postops_mask, reg_tail_32);
         }
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    const dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
+    dim_t n_oi = ow / ur_w;
+    const dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -666,14 +669,15 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
         Label oi_loop_label, oi_loop_start_label, oi_loop_end_label;
 
         assert(ow_block % ur_w == 0);
-        int n_oi_not_last_ow_block = ow_block / ur_w;
+        int n_oi_not_last_ow_block = static_cast<int>(ow_block / ur_w);
         // to simplify code (and general regs usage),
         // size of ow block must be >= 2 * ur_w
         assert(n_oi_not_last_ow_block > 1);
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+        int n_oi_last_ow_block
+                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -828,9 +832,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -987,11 +991,11 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.typesize_out = typesize;
 
     if (jcp.is_1stconv) {
-        jcp.ur_w = nstl::min(jcp.ow, regs);
+        jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
     } else {
         // avx512_core guard - just to avoid possible regression for other archs
         if (mayiuse(avx512_core)) {
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
         } else {
             for (int ur_w = regs; ur_w > 0; --ur_w) {
                 if (jcp.ow % ur_w == 0) {
@@ -1001,15 +1005,15 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             }
         }
         if ((ndims == 5 && jcp.ur_w <= 8) || (jcp.ur_w <= 1)) {
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
         }
     }
     // TODO (Tanya): currently applied to Segnet convolutions only.
     // Need to try for other topologies
     if (jcp.ow > 150 && jcp.ur_w < regs / 2) jcp.ur_w = regs;
 
-    int n_oi = (jcp.ow / jcp.ur_w);
-    int r_pad = calculate_end_padding(
+    dim_t n_oi = jcp.ow / jcp.ur_w;
+    dim_t r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ur_w * n_oi, jcp.iw, jcp.stride_w, ext_kw);
     if (jcp.l_pad > 0 && r_pad > 0) n_oi--;
 
@@ -1018,12 +1022,12 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && ((jcp.l_pad <= 0 && n_oi > 0) || (jcp.l_pad > 0 && n_oi > 1));
     if (large_code_size) {
         const int max_code_size = 24 * 1024;
-        const int num_ops_per_reg = 6 + jcp.ic_block * jcp.kw;
+        const dim_t num_ops_per_reg = 6 + jcp.ic_block * jcp.kw;
         int mult = 1;
         if (jcp.l_pad > 0) mult += 1;
         if (r_pad > 0) mult += 1;
         for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
-            if (ur_w * mult * num_ops_per_reg * 9.0 < max_code_size) {
+            if ((double)(ur_w * mult * num_ops_per_reg) * 9.0 < max_code_size) {
                 jcp.ur_w = ur_w;
                 break;
             }
@@ -1032,10 +1036,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     /* Grouped channel offset to support 'non-blocked data' format for
      * convolution sizes with '(input_channel / ngroups) < simd' */
-    jcp.nonblk_group_off
-            = (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw))
-            ? jcp.ic
-            : 1;
+    jcp.nonblk_group_off = static_cast<int>(
+            (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw)) ? jcp.ic
+                                                                       : 1);
 
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
@@ -1046,39 +1049,39 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ow_block = jcp.ow;
 
-    auto get_thr_eff = [&](int nb_oc_blocking, int ow_block, int nthr) {
-        int nb_ow = div_up(jcp.ow, ow_block);
-        int nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
-        int work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
-        float disbalance = (float)jcp.ow / rnd_up(jcp.ow, ow_block);
-        float thr_eff
-                = disbalance * (float)work_amount / rnd_up(work_amount, nthr);
+    auto get_thr_eff = [&](int nb_oc_blocking, dim_t ow_block, int nthr) {
+        const dim_t nb_ow = div_up(jcp.ow, ow_block);
+        const dim_t nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
+        const dim_t work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
+        float disbalance = (float)jcp.ow / (float)rnd_up(jcp.ow, ow_block);
+        float thr_eff = disbalance * (float)work_amount
+                / (float)rnd_up(work_amount, nthr);
         return thr_eff;
     };
 
     auto get_ow_block = [&](int nb_oc_blocking, int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+        dim_t res_ow_block = jcp.ow;
         float eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         if (!is_ow_threading_applicable()) return res_ow_block;
 
         int L2_part = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
-        int size_src_chunk = jcp.ic_block * ur_w * jcp.kh;
-        int size_dst_chunk = jcp.oc_block * nb_oc_blocking * ur_w;
-        int size_wei_chunk = jcp.oc_block * nb_oc_blocking * jcp.ic_block
-                * jcp.kw * jcp.kh;
-        int nurw_cache = (L2_part - 2 * size_wei_chunk)
+        const dim_t size_src_chunk = jcp.ic_block * ur_w * jcp.kh;
+        const dim_t size_dst_chunk = jcp.oc_block * nb_oc_blocking * ur_w;
+        const dim_t size_wei_chunk = jcp.oc_block * nb_oc_blocking
+                * jcp.ic_block * jcp.kw * jcp.kh;
+        const dim_t nurw_cache = (L2_part - 2 * size_wei_chunk)
                 / (2 * size_dst_chunk + 2 * size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        int ow_block_cache = ur_w * nstl::max(2, nurw_cache);
+        const dim_t ow_block_cache = ur_w * nstl::max<dim_t>(2, nurw_cache);
 
-        int ow_block_thr = ow_block_cache;
+        dim_t ow_block_thr = ow_block_cache;
         eff = get_thr_eff(nb_oc_blocking, ow_block_thr, nthr);
 
-        int max_nb_ow = div_up(jcp.ow, 2 * ur_w);
-        int start_nb_ow = div_up(jcp.ow, ow_block_thr);
-        for (int nb_ow = start_nb_ow; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, 2 * ur_w);
+        const dim_t start_nb_ow = div_up(jcp.ow, ow_block_thr);
+        for (dim_t nb_ow = start_nb_ow; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             float eff_threshold = 0.9f;
             if (ow_block < nb_oc_blocking * jcp.oc_block && eff > eff_threshold)
                 break;
@@ -1092,7 +1095,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             eff_threshold = 0.98f;
             if (eff > eff_threshold) break;
         }
-        res_ow_block = nstl::min(jcp.ow, nstl::max(2 * ur_w, ow_block_thr));
+        res_ow_block = static_cast<int>(nstl::min<dim_t>(
+                jcp.ow, nstl::max<dim_t>(2 * ur_w, ow_block_thr)));
         eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         return res_ow_block;
     };
@@ -1100,9 +1104,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const size_t L1_cache_size = platform::get_per_core_cache_size(1);
     if (mayiuse(avx512_core)) {
         int try_nb_oc_blocking = 2;
-        unsigned int ker_inp_size = typesize * div_up(jcp.iw, jcp.stride_w)
+        const size_t ker_inp_size = typesize * div_up(jcp.iw, jcp.stride_w)
                 * jcp.ic_block * jcp.kh * jcp.kd;
-        unsigned int ker_out_size
+        const size_t ker_out_size
                 = typesize * jcp.ow * jcp.oc_block * try_nb_oc_blocking;
         size_t ker_wei_size = static_cast<size_t>(typesize) * jcp.kh * jcp.kw
                 * jcp.ic_block * jcp.oc_block * try_nb_oc_blocking * jcp.kd;
@@ -1137,19 +1141,21 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                         || (jcp.ow <= 147 && jcp.oc <= 96))));
 
         if (jcp.mb == 1) {
-            unsigned int inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
+            const size_t inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
                     * div_up(jcp.iw, jcp.stride_w) * jcp.ic;
-            unsigned int wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
+            const size_t wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
 
             // Estimate whether we need to limit the number of threads
             // and calculate this number. Includes some heuristic.
-            int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-            int work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
-            int job_size_min = work_amount / nthreads;
-            int job_size_max = div_up(work_amount, nthreads);
-            int ch_max = rnd_up(jcp.oh, job_size_max);
-            int ch_min = (job_size_min == 0) ? jcp.oh
-                                             : rnd_up(jcp.oh, job_size_min);
+            const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            const dim_t work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
+            const int job_size_min = static_cast<int>(work_amount / nthreads);
+            const int job_size_max
+                    = static_cast<int>(div_up(work_amount, nthreads));
+            const dim_t ch_max = rnd_up(jcp.oh, job_size_max);
+            const dim_t ch_min = (job_size_min == 0)
+                    ? jcp.oh
+                    : rnd_up(jcp.oh, job_size_min);
             bool not_aligned_max = ch_max % jcp.oh != 0 && ch_max / jcp.oh < 2
                     && (jcp.oh != 8 || ch_max / jcp.oh > 1);
             bool not_aligned_min = ch_min % jcp.oh != 0 && ch_min / jcp.oh < 2
@@ -1176,7 +1182,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const int max_nb_oc = 5;
         if (embd_bcast_condition) {
             jcp.kernel_kind = embd_bcast;
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
             jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
             const unsigned int L1_cache_size
                     = platform::get_per_core_cache_size(1);
@@ -1185,7 +1191,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     && IMPLICATION(jcp.is_1stconv, jcp.mb == 1)
                     && IMPLICATION(jcp.mb == 1, jcp.ur_w < jcp.ow)) {
                 jcp.nb_oc_blocking = try_nb_oc_blocking;
-                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                jcp.ur_w = static_cast<int>(nstl::min<dim_t>(
+                        jcp.ow, 31 / (jcp.nb_oc_blocking + 1)));
             }
         } else {
             jcp.kernel_kind = expl_bcast;
@@ -1194,14 +1201,17 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     || expl_bcast_condition) {
                 float best_thr_eff = 0.f;
                 int best_nb_oc_blocking = 1;
-                for (int i = nstl::min(jcp.nb_oc, max_nb_oc); i > 0; i--) {
+                for (int i = static_cast<int>(
+                             nstl::min<dim_t>(jcp.nb_oc, max_nb_oc));
+                        i > 0; i--) {
                     if (jcp.nb_oc % i == 0) {
                         if (expl_bcast_condition) {
                             best_nb_oc_blocking = i;
                             break;
                         } else {
-                            int ur_w = nstl::min(jcp.ow, 31 / (i + 1));
-                            int ow_block = get_ow_block(i, ur_w, jcp.nthr);
+                            int ur_w = static_cast<int>(
+                                    nstl::min<dim_t>(jcp.ow, 31 / (i + 1)));
+                            dim_t ow_block = get_ow_block(i, ur_w, jcp.nthr);
                             float thr_eff = get_thr_eff(i, ow_block, jcp.nthr);
                             if (thr_eff > 1.05f * best_thr_eff) {
                                 best_nb_oc_blocking = i;
@@ -1211,12 +1221,13 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     }
                 }
                 jcp.nb_oc_blocking = best_nb_oc_blocking;
-                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                jcp.ur_w = static_cast<int>(nstl::min<dim_t>(
+                        jcp.ow, 31 / (jcp.nb_oc_blocking + 1)));
             }
         }
     }
 
-    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+    jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
 
     bool args_ok = true && jcp.l_pad <= jcp.ur_w
             && jcp.ic <= src_d.padded_dims()[1]
@@ -1226,9 +1237,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(args_ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weight and src size mismatch");
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(r_pad_no_tail <= jcp.ur_w,
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1255,10 +1266,10 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < eff_threshold && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        dim_t ow_block = jcp.ow_block;
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
             ow_block = get_ow_block(jcp.nb_oc_blocking, jcp.ur_w, nthr);
             eff = get_thr_eff(jcp.nb_oc_blocking, ow_block, nthr);
@@ -1275,10 +1286,11 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int L2_size = platform::get_per_core_cache_size(2) / typesize;
     // Source and output data needs to fit in L2,
     // leaving some space for weights and prefetching.
-    int h_L2 = int(((0.6f * L2_size) / jcp.simd_w
-                           - nstl::min(0, jcp.kh - jcp.stride_h) * jcp.iw)
-            / (jcp.stride_h * jcp.iw + jcp.ow));
-    jcp.h_blocking = nstl::max(1, nstl::min(jcp.oh, h_L2));
+    int h_L2 = int(((0.6f * (float)L2_size) / (float)jcp.simd_w
+                           - (float)(nstl::min<dim_t>(0, jcp.kh - jcp.stride_h)
+                                   * jcp.iw))
+            / (float)(jcp.stride_h * jcp.iw + jcp.ow));
+    jcp.h_blocking = nstl::max<dim_t>(1, nstl::min<dim_t>(jcp.oh, h_L2));
 
     if (is_data_layout_nxc) {
         // TODO: improve L2 blocking for large IC
@@ -1286,7 +1298,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         if (jcp.nb_ic > nb_ic_theshold_L2 && jcp.nb_ic < 2 * nb_ic_theshold_L2)
             jcp.nb_ic_L2 = div_up(jcp.nb_ic, 2);
         else
-            jcp.nb_ic_L2 = nstl::min(nb_ic_theshold_L2, jcp.nb_ic);
+            jcp.nb_ic_L2 = nstl::min<dim_t>(nb_ic_theshold_L2, jcp.nb_ic);
     }
 
     // A rough check on code size
@@ -1295,9 +1307,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const int max_code_size = 256 * 1024; // default size of jit generator
         int mult = 1 + (jcp.l_pad > 0) + (r_pad > 0);
         const float max_instruction_size = 15;
-        float ur_fac
-                = (float)jcp.kw * jcp.ic_block * jcp.nb_oc_blocking * jcp.ur_w;
-        float code_size = mult * ur_fac * max_instruction_size;
+        float ur_fac = (float)jcp.kw * (float)jcp.ic_block
+                * (float)jcp.nb_oc_blocking * (float)jcp.ur_w;
+        float code_size = (float)mult * ur_fac * max_instruction_size;
         VDISPATCH_CONV_IC(
                 code_size <= max_code_size, "code size limit exceeded");
     }
@@ -1358,23 +1370,23 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::store_output(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
-        int ur_w, int l_overflow, int r_overflow) {
+        int ur_w, dim_t l_overflow, dim_t r_overflow) {
     Label kh_label, kd_label;
-    int kw = jcp.kw;
-    int ow = jcp.ow;
+    dim_t kw = jcp.kw;
+    dim_t ow = jcp.ow;
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    dim_t stride_w = jcp.stride_w;
+    dim_t stride_h = jcp.stride_h;
 
     int ker_pipeline_depth = 4;
     assert(ker_reg_base_idx + ker_pipeline_depth <= 32);
     assert(oc_block >= ker_pipeline_depth);
 
-    int num_ker_loads = oc_block * kw;
+    const int num_ker_loads = static_cast<int>(oc_block * kw);
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
     const bool ocb_loop_in_compute_function = ddst_layout_nxc;
 
     const int ic_tail = jcp.ic_tail;
@@ -1428,7 +1440,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                 }
                 if (step == 0) {
                     for (int i = 0; i < ker_pipeline_depth; i++) {
-                        int aux_kernel_offset = typesize
+                        dim_t aux_kernel_offset = typesize
                                 * ((oc + i) * oc_block
                                         + ki * ic_block * oc_block);
                         vmovups(vmm_ker(i),
@@ -1439,7 +1451,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                     int load_offset = ker_pipeline_depth - 1;
                     int ker_load_reg_idx
                             = (step + load_offset) % ker_pipeline_depth;
-                    int aux_kernel_offset = typesize
+                    dim_t aux_kernel_offset = typesize
                             * ((oc + load_offset) * oc_block
                                     + ki * ic_block * oc_block);
                     vmovups(vmm_ker(ker_load_reg_idx),
@@ -1448,24 +1460,24 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
 
                 auto vmm_kernel = vmm_ker(step % ker_pipeline_depth);
 
-                int jj_start = get_iw_start(ki, l_overflow);
-                int jj_end = get_iw_end(ur_w, ki, r_overflow);
-                const int dil_w = jcp.dilate_w + 1;
-                const int ref_jj_start
-                        = nstl::max(0, l_overflow - (kw - 1 - ki) * dil_w);
-                const int ref_jj_end
-                        = ur_w - nstl::max(0, r_overflow - ki * dil_w);
+                const dim_t jj_start = get_iw_start(ki, l_overflow);
+                const dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
+                const dim_t dil_w = jcp.dilate_w + 1;
+                const dim_t ref_jj_start = nstl::max<dim_t>(
+                        0, l_overflow - (kw - 1 - ki) * dil_w);
+                const dim_t ref_jj_end
+                        = ur_w - nstl::max<dim_t>(0, r_overflow - ki * dil_w);
                 assert(IMPLICATION(stride_w == 1,
                         jj_start == ref_jj_start && jj_end == ref_jj_end));
                 UNUSED(dil_w);
                 UNUSED(ref_jj_start);
                 UNUSED(ref_jj_end);
 
-                for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * (jcp.dilate_w + 1)) % stride_w
                             == 0);
-                    int aux_dst_offset = get_dst_offset(jj, oc, ki);
-                    vfmadd231ps(vmm_out(jj, 0), vmm_kernel,
+                    dim_t aux_dst_offset = get_dst_offset(jj, oc, ki);
+                    vfmadd231ps(vmm_out(static_cast<int>(jj), 0), vmm_kernel,
                             EVEX_compress_addr(
                                     aux_reg_dst, aux_dst_offset, true));
                 }
@@ -1474,9 +1486,9 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
             L(oc_tail_jmp[ki]);
         }
 
-        const int ker_shift = typesize * stride_h * kw * oc_block * ic_block;
+        const dim_t ker_shift = typesize * stride_h * kw * oc_block * ic_block;
         add(aux_reg_ker, ker_shift);
-        const int ddst_shift = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+        const dim_t ddst_shift = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
         sub(aux_reg_dst, ddst_shift);
 
         dec(reg_kj);
@@ -1484,10 +1496,10 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
         jg(kh_label, T_NEAR);
     }
     if (jcp.ndims == 5) {
-        const int depth_ddst_shift
+        const dim_t depth_ddst_shift
                 = typesize * (jcp.dilate_d + 1) * jcp.oh * ow * oc_mult;
         sub(aux_reg_dst_d, depth_ddst_shift);
-        const int depth_ker_shift = typesize * jcp.stride_d * jcp.kw * jcp.kh
+        const dim_t depth_ker_shift = typesize * jcp.stride_d * jcp.kw * jcp.kh
                 * oc_block * ic_block;
         add(aux_reg_ker_d, depth_ker_shift);
 
@@ -1502,29 +1514,29 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
-        Vmm>::compute_loop_fma_core(int ur_w, int l_overflow, int r_overflow,
-        int k_offset) {
-    int kw = jcp.kw;
-    int ow = jcp.ow;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_ic_block = jcp.nb_ic_blocking;
+        Vmm>::compute_loop_fma_core(int ur_w, dim_t l_overflow,
+        dim_t r_overflow, int k_offset) {
+    dim_t kw = jcp.kw;
+    dim_t ow = jcp.ow;
+    dim_t stride_w = jcp.stride_w;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_ic_block = jcp.nb_ic_blocking;
     Label kh_label, kd_label;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    int shift_ker_ptr = typesize * kw * oc_block * ic_block;
-    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
-    int shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+    dim_t shift_ker_ptr = typesize * kw * oc_block * ic_block;
+    dim_t oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
 
     const int oc_tail = jcp.oc_tail;
     const int max_filter_size = 20;
     Label oc_tail_jmp[max_filter_size];
 
-    auto kernel_offset = [this](int icb, int oc, int ki) {
-        int blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
-        int blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
-        int oc_offset = oc * jcp.oc_block;
+    auto kernel_offset = [this](dim_t icb, dim_t oc, dim_t ki) -> dim_t {
+        const dim_t blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
+        const dim_t blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
+        const dim_t oc_offset = oc * jcp.oc_block;
         return typesize * (blk_offset + oc_offset);
     };
 
@@ -1562,8 +1574,8 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow);
-            int jj_end = get_iw_end(ur_w, ki, r_overflow);
+            const dim_t jj_start = get_iw_start(ki, l_overflow);
+            const dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
             for (int oc = 0; oc < oc_block; oc++) {
                 if (oc_tail && oc >= oc_tail) {
                     // if src has only tails to compute, skip early
@@ -1575,25 +1587,27 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                     }
                 }
                 if (jcp.kernel_kind == expl_bcast) {
-                    for (int jj = jj_start; jj < jj_end; jj++) {
-                        int aux_output_offset = get_dst_offset(jj, oc, ki);
-                        vbroadcastss(vmm_inp(jj, nb_ic_block),
+                    for (dim_t jj = jj_start; jj < jj_end; jj++) {
+                        dim_t aux_output_offset = get_dst_offset(jj, oc, ki);
+                        vbroadcastss(vmm_inp(static_cast<int>(jj), nb_ic_block),
                                 ptr[aux_reg_dst + aux_output_offset]);
                     }
                 }
                 for (int ii = 0; ii < nb_ic_block; ii++) {
-                    int aux_kernel_offset
+                    dim_t aux_kernel_offset
                             = kernel_offset(ii, oc, ki + k_offset);
                     if (jj_end - jj_start > 0)
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(
                                         aux_reg_ker, aux_kernel_offset));
-                    for (int jj = jj_start; jj < jj_end; jj += stride_w)
+                    for (dim_t jj = jj_start; jj < jj_end; jj += stride_w)
                         if (jcp.kernel_kind == expl_bcast)
-                            vfmadd231ps(vmm_out(jj, ii),
-                                    vmm_inp(jj, nb_ic_block), vmm_wei);
+                            vfmadd231ps(vmm_out(static_cast<int>(jj), ii),
+                                    vmm_inp(static_cast<int>(jj), nb_ic_block),
+                                    vmm_wei);
                         else
-                            vfmadd231ps(vmm_out(jj, ii), vmm_wei,
+                            vfmadd231ps(vmm_out(static_cast<int>(jj), ii),
+                                    vmm_wei,
                                     EVEX_compress_addr(aux_reg_dst,
                                             get_dst_offset(jj, oc, ki), true));
                 }
@@ -1623,7 +1637,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
 
 template <typename Vmm>
 inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
-        int ur_w, int l_overflow, int r_overflow, int k_offset) {
+        int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset) {
     if (jcp.ndims == 5) push(reg_oi);
 
     prepare_output(ur_w);
@@ -1655,7 +1669,7 @@ inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
 
     if (generate_ocb_loop) {
         add(reg_dst, jcp.oc_block * typesize);
-        const int ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
+        const dim_t ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
                 * jcp.ic_block * jcp.oc_block * typesize;
         add(reg_ker, ker_shift);
         sub(reg_channel, jcp.oc_block);
@@ -1672,20 +1686,20 @@ inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int kw = jcp.kw;
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
     int ur_w = jcp.ur_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_iw = jcp.nb_iw;
-    int iw_block = jcp.iw_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_iw = jcp.nb_iw;
+    const dim_t iw_block = jcp.iw_block;
     int ur_w_tail = jcp.ur_w_tail;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    int dilate_w = static_cast<int>(jcp.dilate_w) + 1;
+    int stride_w = static_cast<int>(jcp.stride_w);
 
-    int dst_shift = jcp.typesize_in * (ur_w / stride_w)
+    dim_t dst_shift = jcp.typesize_in * (ur_w / stride_w)
             * (is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block);
-    int src_shift = jcp.typesize_out * ur_w
+    dim_t src_shift = jcp.typesize_out * ur_w
             * (is_dsrc_layout_nxc() ? jcp.ngroups * jcp.ic : ic_block);
 
     preamble();
@@ -1710,15 +1724,16 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
         L(masking_done);
     }
 
-    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
-    int r_overflow = nstl::max(
-            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
-    int r_overflow_no_tail = nstl::max(0,
-            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
-                    / stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w));
+    int r_overflow = static_cast<int>(nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad)) / stride_w));
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad + ur_w_tail))
+                    / stride_w));
 
     int body_l_overflow = 0, body_r_overflow = 0;
-    int n_oi = iw / ur_w;
+    int n_oi = static_cast<int>(iw / ur_w);
     int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
     int head_thread = 0, pretail_thread = 0, tail_thread = 0;
     bool threaded = is_iw_threading_on(jcp);
@@ -1746,12 +1761,12 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
         // Setup for threaded code generation, and jump into the correct
         // portion of code for execution.
         head_thread = 0;
-        tail_thread = nb_iw - 1;
+        tail_thread = static_cast<int>(nb_iw - 1);
         pretail_thread = tail_thread;
 
-        int base_n_oi = iw_block / ur_w;
+        int base_n_oi = static_cast<int>(iw_block / ur_w);
         head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
-        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        tail_n_oi = static_cast<int>((iw - iw_block * (nb_iw - 1)) / ur_w);
         pretail_n_oi = tail_n_oi;
         if (r_overflow_no_tail > 0) {
             if (tail_n_oi > 0) {
@@ -1920,9 +1935,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -2033,11 +2048,11 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ur_w = jcp.stride_w;
+    jcp.ur_w = static_cast<int>(jcp.stride_w);
 
     int regs = 28;
     if (jcp.iw <= regs)
-        jcp.ur_w = jcp.iw;
+        jcp.ur_w = static_cast<int>(jcp.iw);
     else {
         for (int ur_w = regs; ur_w > 0; --ur_w)
             if (ur_w % jcp.stride_w == 0) {
@@ -2045,13 +2060,13 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 break;
             }
     }
-    int l_overflow = nstl::max(
-            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
-    int r_overflow_no_tail = nstl::max(0,
+    int l_overflow = static_cast<int>(nstl::max<dim_t>(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w));
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.iw % jcp.ur_w))
-                    / jcp.stride_w);
-    int n_oi = jcp.iw / jcp.ur_w;
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.iw % jcp.ur_w))
+                    / jcp.stride_w));
+    dim_t n_oi = jcp.iw / jcp.ur_w;
     if (r_overflow_no_tail > 0) n_oi--;
 
     jcp.typesize_in = typesize;
@@ -2065,12 +2080,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             && (r_overflow_no_tail > 0) && (l_overflow > 0);
     if (large_code_size) {
         const int max_code_size = 24 * 1024;
-        const int num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
+        const dim_t num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
         int mult = 1;
         if (l_overflow > 0) mult += 1;
         if (r_overflow_no_tail > 0) mult += 1;
         for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
-            if ((ur_w / jcp.stride_w) * mult * num_ops_per_reg * 9.2
+            if ((double)((ur_w / jcp.stride_w) * mult * num_ops_per_reg) * 9.2
                     < max_code_size) {
                 if (ur_w % jcp.stride_w == 0) {
                     jcp.ur_w = ur_w;
@@ -2098,13 +2113,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
     if (mayiuse(avx512_core)) {
         int try_nb_ic_blocking = 2;
-        unsigned int ker_inp_size = typesize * jcp.iw * jcp.ic_block
+        const size_t ker_inp_size = typesize * jcp.iw * jcp.ic_block
                 * try_nb_ic_blocking * jcp.kh;
-        unsigned int ker_out_size = typesize * jcp.ow * jcp.oc_block;
-        unsigned int ker_wei_size = typesize * jcp.kh * jcp.kw * jcp.ic_block
+        const size_t ker_out_size = typesize * jcp.ow * jcp.oc_block;
+        const size_t ker_wei_size = typesize * jcp.kh * jcp.kw * jcp.ic_block
                 * jcp.oc_block * try_nb_ic_blocking;
-        unsigned int ker_total_size
-                = ker_inp_size + ker_out_size + ker_wei_size;
+        size_t ker_total_size = ker_inp_size + ker_out_size + ker_wei_size;
         bool use_expl_bcast
                 = !(jcp.kw == 1 || (jcp.kw == 5 && jcp.iw < 8)
                           || (jcp.kw < 5
@@ -2114,7 +2128,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 || jcp.stride_h > 1 || jcp.stride_d > 1;
         if (use_expl_bcast && !jcp.large_w_filter) {
             jcp.kernel_kind = embd_bcast;
-            jcp.ur_w = nstl::min(jcp.iw, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.iw, regs));
             jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
             if (!(jcp.kw > 3
                         || (jcp.kw == 3 && ker_total_size < L1_cache_size
@@ -2123,13 +2137,14 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 if (jcp.nb_ic % try_nb_ic_blocking == 0) {
                     jcp.nb_ic_blocking = try_nb_ic_blocking;
                     jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
-                    if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+                    if (jcp.iw < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.iw);
                 }
         } else {
             jcp.kernel_kind = expl_bcast;
             jcp.nb_oc_blocking = 1;
             jcp.nb_ic_blocking = jcp.large_w_filter ? 2 : 4;
-            if (jcp.nb_ic < jcp.nb_ic_blocking) jcp.nb_ic_blocking = jcp.nb_ic;
+            if (jcp.nb_ic < jcp.nb_ic_blocking)
+                jcp.nb_ic_blocking = static_cast<int>(jcp.nb_ic);
             if (jcp.nb_ic % jcp.nb_ic_blocking != 0)
                 for (int i = jcp.nb_ic_blocking; i > 0; i--)
                     if (jcp.nb_ic % i == 0) {
@@ -2137,34 +2152,35 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                         break;
                     }
             jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
-            if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+            if (jcp.iw < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.iw);
         }
     }
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
     auto is_iw_threading_applicable = [&]() { return one_of(jcp.ndims, 3, 4); };
 
-    auto get_thr_eff = [&](int nb_ic_blocking, int iw_block, int nthr) {
+    auto get_thr_eff = [&](int nb_ic_blocking, dim_t iw_block, int nthr) {
         // Cost heuristic for threading overhead. Determined using OMP.
         const float iw_block_cost = 32.0;
 
-        int nb_iw = div_up(jcp.iw, iw_block);
-        int nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
-        int work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
-        float disbalance = (float)jcp.iw / rnd_up(jcp.iw, iw_block);
-        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        const dim_t nb_iw = div_up(jcp.iw, iw_block);
+        const dim_t nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
+        const dim_t work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
+        float disbalance = (float)jcp.iw / (float)rnd_up(jcp.iw, iw_block);
+        float block_overhead
+                = nstl::max(0.0f, 1.0f - iw_block_cost / (float)iw_block);
         float thr_eff = block_overhead * disbalance
-                * ((float)work_amount / rnd_up(work_amount, nthr));
+                * ((float)work_amount / (float)rnd_up(work_amount, nthr));
         return thr_eff;
     };
 
     auto get_iw_block
             = [&](int nb_ic_blocking, int ur_w, float &eff, int nthr) {
-        int res_iw_block = jcp.iw;
+        int res_iw_block = static_cast<int>(jcp.iw);
         if (!is_iw_threading_applicable()) return res_iw_block;
 
-        int max_nb_iw = div_up(jcp.iw, 2 * ur_w);
-        int iw_block_thr;
+        const dim_t max_nb_iw = div_up(jcp.iw, 2 * ur_w);
+        dim_t iw_block_thr;
 
         if (jcp.ndims == 3) {
             // Blocking optimization to prevent data from leaving cache This
@@ -2174,14 +2190,15 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             // the height dimension.
             int L2_part
                     = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
-            int size_diff_src_chunk = jcp.ic_block * nb_ic_blocking * ur_w;
-            int size_diff_dst_chunk = jcp.oc_block * ur_w;
-            int size_wei_chunk
+            const dim_t size_diff_src_chunk
+                    = jcp.ic_block * nb_ic_blocking * ur_w;
+            const dim_t size_diff_dst_chunk = jcp.oc_block * ur_w;
+            const dim_t size_wei_chunk
                     = jcp.ic_block * nb_ic_blocking * jcp.oc_block * jcp.kw;
-            int nurw_cache = (L2_part - 2 * size_wei_chunk)
+            const dim_t nurw_cache = (L2_part - 2 * size_wei_chunk)
                     / (2 * size_diff_dst_chunk + 2 * size_diff_src_chunk);
             // current design of generate() requires iw_block >= 2 * ur_w
-            int iw_block_cache = ur_w * nstl::max(2, nurw_cache);
+            const dim_t iw_block_cache = ur_w * nstl::max<dim_t>(2, nurw_cache);
 
             iw_block_thr = iw_block_cache;
         } else
@@ -2189,12 +2206,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         eff = get_thr_eff(nb_ic_blocking, iw_block_thr, nthr);
 
         // Search for most efficient threading over iw_blocks.
-        int start_nb_iw = div_up(jcp.iw, iw_block_thr);
-        for (int nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
+        const dim_t start_nb_iw = div_up(jcp.iw, iw_block_thr);
+        for (dim_t nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
             float eff_threshold = 0.98f;
             if (eff > eff_threshold) break;
-            int iw_block
-                    = nstl::min(rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
+            const dim_t iw_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
             if (div_up(jcp.iw, iw_block) != nb_iw) continue;
             float thr_eff = get_thr_eff(nb_ic_blocking, iw_block, nthr);
             if (iw_block >= 2 * ur_w && thr_eff > eff) {
@@ -2202,7 +2219,8 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 eff = thr_eff;
             }
         }
-        res_iw_block = nstl::min(jcp.iw, nstl::max(2 * ur_w, iw_block_thr));
+        res_iw_block = static_cast<int>(nstl::min<dim_t>(
+                jcp.iw, nstl::max<dim_t>(2 * ur_w, iw_block_thr)));
         return res_iw_block;
     };
 
@@ -2223,8 +2241,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     size_t total_size = jcp.ngroups * (wei_size + out_size + inp_size);
 
     if (jcp.ngroups < jcp.nthr && (total_size < L1_cache_size)) {
-        int iw_block = jcp.iw_block;
-        int end_nthr = with_groups ? jcp.ngroups : ndims - 2;
+        int iw_block = static_cast<int>(jcp.iw_block);
+        const int end_nthr
+                = with_groups ? static_cast<int>(jcp.ngroups) : ndims - 2;
         float eff = -1.0f;
         float best_thr_eff = -1.0f;
         // When thr_eff equals zero (cannot get the proper effciency)
@@ -2252,10 +2271,10 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             !(l_overflow * jcp.stride_w > jcp.ur_w && !jcp.large_w_filter),
             VERBOSE_BAD_PARAM, "stride, unroll width");
 
-    r_overflow_no_tail = nstl::max(0,
+    r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
-                    / jcp.stride_w);
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.ur_w_tail))
+                    / jcp.stride_w));
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
             || r_overflow_no_tail * jcp.stride_w > jcp.ur_w
@@ -2275,7 +2294,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         if (jcp.nb_oc > nb_oc_theshold_L2 && jcp.nb_oc < 2 * nb_oc_theshold_L2)
             jcp.nb_oc_L2 = div_up(jcp.nb_oc, 2);
         else
-            jcp.nb_oc_L2 = nstl::min(nb_oc_theshold_L2, jcp.nb_oc);
+            jcp.nb_oc_L2 = nstl::min<dim_t>(nb_oc_theshold_L2, jcp.nb_oc);
     }
 
     bool args_ok = true && jcp.ic <= diff_src_d.padded_dims()[1]
@@ -2291,9 +2310,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         const int max_code_size = 256 * 1024; // default size of jit generator
         int mult = 1 + (l_overflow > 0) + (r_overflow_no_tail > 0);
         const float max_instruction_size = 15;
-        float ur_fac
-                = (float)jcp.kw * jcp.oc_block * jcp.nb_ic_blocking * jcp.ur_w;
-        float code_size = mult * ur_fac * max_instruction_size;
+        float ur_fac = (float)jcp.kw * (float)jcp.oc_block
+                * (float)jcp.nb_ic_blocking * (float)jcp.ur_w;
+        float code_size = (float)mult * ur_fac * max_instruction_size;
         VDISPATCH_CONV_IC(!(code_size > max_code_size && !jcp.large_w_filter),
                 "code size limit exceeded");
     }
@@ -2319,10 +2338,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kd_count);
     L(kd_comeback_label);
     {
-        int inp_mult = is_src_layout_nxc()
+        const dim_t inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.iw;
+        const dim_t iw = jcp.iw;
         sub(reg_input,
                 jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * iw * inp_mult);
         sub(reg_kernel,
@@ -2340,11 +2359,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kh);
     L(kh_comeback_label);
     {
-        int kw = jcp.is_hw_transp ? 1 : jcp.kw;
-        int inp_mult = is_src_layout_nxc()
+        const dim_t kw = jcp.is_hw_transp ? 1 : jcp.kw;
+        const dim_t inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+        const dim_t iw = jcp.is_hw_transp ? 1 : jcp.iw;
         sub(reg_input, jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mult);
         sub(reg_kernel, jcp.typesize_out * kw * jcp.ic_block * jcp.oc_block);
         dec(kj);
@@ -2354,15 +2373,16 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset, bool input_wraparound) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset,
+        bool input_wraparound) {
 
-    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
-    int iw = jcp.is_hw_transp ? jcp.tr_iw : jcp.iw;
-    int kw_tr_mult = jcp.is_hw_transp ? jcp.kw : 1;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    auto get_ker_offt = [&](int i_kw, int i_ic) {
+    const dim_t kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    const dim_t iw = jcp.is_hw_transp ? jcp.tr_iw : jcp.iw;
+    const dim_t kw_tr_mult = jcp.is_hw_transp ? jcp.kw : 1;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    auto get_ker_offt = [&](dim_t i_kw, dim_t i_ic) {
         return typesize * (i_kw * kw_tr_mult * ic_block + i_ic) * jcp.oc_block
                 + kernel_offset;
     };
@@ -2370,11 +2390,13 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
         for (int i_ic = 0; i_ic < ic_block_step; i_ic++)
             vmovups(Zmm(i_kw * ic_block_step + i_ic),
                     EVEX_compress_addr(reg_kernel, get_ker_offt(i_kw, i_ic)));
-    const int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    const dim_t out_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
     const int oc_tail = jcp.oc_tail;
 
     for (int i_ur = 0; i_ur < ur_w; i_ur++) {
-        const int ddst_pipeline_start_idx = ic_block_step * kw;
+        const int ddst_pipeline_start_idx
+                = static_cast<int>(ic_block_step * kw);
         static constexpr int ddst_pipeline_len = 4;
         auto get_ddst_reg_idx = [ddst_pipeline_start_idx](int ur_idx) {
             return ddst_pipeline_start_idx + (ur_idx) % ddst_pipeline_len;
@@ -2402,7 +2424,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
         }
 
         for (int i_kw = 0; i_kw < kw; i_kw++) {
-            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, i_kw, pad_l);
             if (i_iw < 0 || i_iw > get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r
                     || get_iw_idx(i_ur, i_kw, jcp.l_pad) >= iw)
                 continue;
@@ -2423,29 +2445,30 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_fma_expl(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int input_offset, int kernel_offset,
-                int output_offset, bool input_wraparound) {
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+        compute_ic_block_step_fma_expl(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+                dim_t output_offset, bool input_wraparound) {
+    dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
     const int oc_tail = jcp.oc_tail;
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const int max_regs = 32;
-    const int ddst_pipeline_start_idx = 2 * ic_block_step * kw;
+    const int ddst_pipeline_start_idx
+            = static_cast<int>(2 * ic_block_step * kw);
     const int ddst_pipeline_len
             = ddst_layout_nxc ? 1 : max_regs - ddst_pipeline_start_idx;
-    const int iw_last_value = get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r;
+    const dim_t iw_last_value = get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r;
     assert(jcp.stride_w == 1 && jcp.dilate_w == 0 && ddst_pipeline_len > 0
             && jcp.kernel_kind == expl_bcast);
 
-    const int out_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    const dim_t out_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
     auto get_diff_wei_reg_idx = [ic_block_step](int i_kw, int i_ic) {
         return i_kw * ic_block_step + i_ic;
     };
-    auto get_src_reg_idx = [&](int i_iw, int i_ic) {
-        return kw * ic_block_step + ((i_iw + pad_l) % kw) * ic_block_step
-                + i_ic;
+    auto get_src_reg_idx = [&](dim_t i_iw, int i_ic) {
+        return static_cast<int>(kw * ic_block_step
+                + ((i_iw + pad_l) % kw) * ic_block_step + i_ic);
     };
     auto get_diff_dst_reg_idx
             = [ddst_pipeline_start_idx, ddst_pipeline_len](int i_ur) {
@@ -2469,7 +2492,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             }
 
             for (int i_kw = 0; i_kw < kw; i_kw++) {
-                int i_iw = get_iw_idx(0, i_kw, pad_l);
+                dim_t i_iw = get_iw_idx(0, i_kw, pad_l);
                 if (i_iw < 0 || i_iw > iw_last_value) continue;
 
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
@@ -2490,7 +2513,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
                 vmovups(zmm_ddst, addr_out);
             }
 
-            int i_iw = get_iw_idx(i_ur, kw - 1, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, kw - 1, pad_l);
             if (i_iw >= 0 && i_iw <= iw_last_value) {
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
                     auto addr_inp = EVEX_compress_addr_safe(reg_input,
@@ -2501,7 +2524,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             }
         }
         for (int i_kw = 0; i_kw < kw; i_kw++) {
-            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, i_kw, pad_l);
             if (i_iw < 0 || i_iw > iw_last_value) continue;
             for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
                 vfmadd231ps(Zmm(get_diff_wei_reg_idx(i_kw, i_ic)),
@@ -2529,8 +2552,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset, bool input_wraparound) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset,
+        bool input_wraparound) {
     if (jcp.kernel_kind == expl_bcast)
         compute_ic_block_step_fma_expl(ur_w, pad_l, pad_r, ic_block_step,
                 input_offset, kernel_offset, output_offset, input_wraparound);
@@ -2545,15 +2569,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
 
     Label kh_label, kd_label;
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
     const bool src_layout_nxc = is_src_layout_nxc();
-    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
-                                 : (!jcp.is_1stconv ? ic_block : 1);
-    int iw = jcp.iw;
+    dim_t inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                   : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t iw = jcp.iw;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    dim_t l_pad = jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2594,7 +2618,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
         L(icb_block_label_end);
 
-        const int input_icb_shift = jcp.typesize_in * ic_block;
+        const dim_t input_icb_shift = jcp.typesize_in * ic_block;
         const size_t kernel_icb_shift = (size_t)jcp.typesize_out * jcp.kd
                 * jcp.kh * jcp.kw * ic_block * oc_block;
 
@@ -2662,19 +2686,19 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w) {
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
     const bool src_layout_nxc = is_src_layout_nxc();
-    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
-                                 : (!jcp.is_1stconv ? jcp.ic_block : 1);
+    dim_t inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                   : (!jcp.is_1stconv ? jcp.ic_block : 1);
     const int ic_tail = jcp.ic_tail;
     UNUSED(max_ur_w);
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
 
-    int inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    dim_t l_pad = jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2703,7 +2727,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         mov(b_ic, ic_block);
         L(ic_block_label);
         {
-            compute_ic_block_step(ow, l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(
+                    static_cast<int>(ow), l_pad, r_pad, ic_block_step, 0, 0, 0);
             size_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
                     ? (size_t)jcp.ih * jcp.iw * jcp.id
                     : 1;
@@ -2718,7 +2743,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
         L(icb_block_label_end);
 
-        const int input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
+        const dim_t input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
                 * inp_icb_sp_stride * inp_mul;
 
         if (generate_icb_loop || ic_tail) {
@@ -2761,8 +2786,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
                 if (ic_tail % ic_block_step) {
                     cmp(reg_icb, 0);
                     jle(skip_ic_tail, T_NEAR);
-                    compute_ic_block_step(
-                            ow, l_pad, r_pad, ic_tail % ic_block_step, 0, 0, 0);
+                    compute_ic_block_step(static_cast<int>(ow), l_pad, r_pad,
+                            ic_tail % ic_block_step, 0, 0, 0);
                 }
                 L(skip_ic_tail);
             }
@@ -2807,16 +2832,16 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
 
     const bool src_layout_nxc = is_src_layout_nxc();
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    int r_pad = max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int ow = static_cast<int>(jcp.is_hw_transp ? jcp.oh : jcp.ow);
+    int r_pad = static_cast<int>(max<dim_t>(0, jcp.r_pad));
+    int l_pad = static_cast<int>(jcp.l_pad);
 
-    int ur_w = min(ow, max_ur_w);
-    int ur_w_trips = ow / ur_w;
-    int ur_w_tail = ow % ur_w;
+    int ur_w = static_cast<int>(min<dim_t>(ow, max_ur_w));
+    dim_t ur_w_trips = ow / ur_w;
+    dim_t ur_w_tail = ow % ur_w;
     if ((ur_w_tail == 0 && r_pad != 0) || (r_pad > 0 && r_pad >= ur_w_tail)) {
         if (ur_w_trips > 1) {
             ur_w_tail += ur_w;
@@ -2828,26 +2853,27 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
     }
 
     assert(l_pad <= max_ur_w);
-    int inp_mult = src_layout_nxc
+    dim_t inp_mult = src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : ic_block * (jcp.is_hw_transp ? jcp.iw : 1));
-    int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
-    int input_comeback
-            = max((ur_w_trips * ur_w * jcp.stride_w - l_pad), 0) * inp_mult;
-    int output_comeback = ur_w_trips * ur_w * out_mult;
+    dim_t out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t input_comeback
+            = max<dim_t>(ur_w_trips * ur_w * jcp.stride_w - l_pad, 0)
+            * inp_mult;
+    dim_t output_comeback = ur_w_trips * ur_w * out_mult;
     const int ic_tail = jcp.ic_tail;
     const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
 
     auto ic_loop = [&](int ic_block_step) {
         Label ow_block_label, ic_block_inner_label;
-        int ur_w_blocks = ur_w_trips;
+        int ur_w_blocks = static_cast<int>(ur_w_trips);
 
-        int l_pad_tail = max(l_pad - ur_w, 0);
+        dim_t l_pad_tail = max<dim_t>(l_pad - ur_w, 0);
         L(ic_block_inner_label);
         if (l_pad != 0) {
             ur_w_blocks--;
             compute_ic_block_step(ur_w, l_pad, 0, ic_block_step, 0, 0, 0);
-            int iw_offset = ur_w * jcp.stride_w - l_pad;
+            dim_t iw_offset = ur_w * jcp.stride_w - l_pad;
             if (iw_offset > 0)
                 add(reg_input, jcp.typesize_in * iw_offset * inp_mult);
             add(reg_output, jcp.typesize_in * ur_w * out_mult);
@@ -2868,13 +2894,13 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
                 inc(reg_ur_w_trips);
                 cmp(reg_ur_w_trips, ur_w_blocks);
                 jl(ow_block_label, T_NEAR);
-                l_pad_tail = max(l_pad_tail - ur_w, 0);
+                l_pad_tail = max<dim_t>(l_pad_tail - ur_w, 0);
             }
         }
 
         if (ur_w_tail > 0)
-            compute_ic_block_step(
-                    ur_w_tail, l_pad_tail, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(ur_w_tail), l_pad_tail,
+                    r_pad, ic_block_step, 0, 0, 0);
 
         sub(reg_output, jcp.typesize_in * output_comeback);
     };
@@ -2908,7 +2934,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
         {
             ic_loop(ic_block_step);
             sub(reg_input, jcp.typesize_in * input_comeback);
-            int inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
+            dim_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
                     ? jcp.ih * jcp.iw * jcp.id
                     : 1;
             size_t input_offset
@@ -2922,7 +2948,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
         }
         L(ic_block_label_end);
 
-        const int input_shift
+        const dim_t input_shift
                 = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mult;
 
         if (generate_icb_loop || ic_tail) {
@@ -3012,14 +3038,14 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_disp() {
     if (jcp.is_1stconv) {
         bool large_code = jcp.kw >= 7 && (jcp.l_pad > 0 || jcp.t_pad > 0);
         ic_block_step = (jcp.kw * jcp.ic_block <= 28 && !large_code)
-                ? jcp.ic_block
+                ? static_cast<int>(jcp.ic_block)
                 : 1;
     }
 
     bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
             && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
     if (jcp.ndims == 5) {
         /* NOTE: reg_kd_count = aux_reg_input = r12. The following order of
          * 'movs' must be guaranteed. */
@@ -3076,11 +3102,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
                             + ic1 * jcp.oc_block * jcp.typesize_out],
                     zero);
         add(reg_tmp, jcp.ic_block * jcp.oc_block * jcp.typesize_out);
-        cmp(reg_tmp, kernel_block_bytes);
+        cmp(reg_tmp, static_cast<uint32_t>(kernel_block_bytes));
         jnz(zeroing_loop);
     }
     if (generate_icb_loop) {
-        add(reg_kernel, kernel_block_bytes);
+        add(reg_kernel, static_cast<uint32_t>(kernel_block_bytes));
         sub(reg_icb, jcp.ic_block);
         cmp(reg_icb, 0);
         jg(icb_block_label, T_NEAR);
@@ -3111,7 +3137,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_2d() {
         if (oc_tail) zmm_out = zmm_out | k_oc_mask | T_z;
         vmovups(zmm_out, ptr[reg_output + reg_tmp]);
         vaddps(Zmm(0), Zmm(0), Zmm(1));
-        const int oc_stride
+        const dim_t oc_stride
                 = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
         add(reg_tmp, jcp.typesize_out * oc_stride);
         dec(reg_oi);
@@ -3159,7 +3185,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
         if (oc_tail) zmm_out = zmm_out | k_oc_mask | T_z;
         vmovups(zmm_out, ptr[reg_output + reg_tmp]);
         vaddps(Zmm(1), Zmm(1), Zmm(0));
-        add(reg_tmp, oc_mult * jcp.typesize_out);
+        add(reg_tmp, static_cast<uint32_t>(oc_mult * jcp.typesize_out));
         cmp(reg_tmp, reg_oi);
         jl(bias_loop);
     }
@@ -3171,27 +3197,27 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         compute_oh_loop_common() {
     assert(one_of(jcp.harness, harness_mb_reduction, harness_3d_reduction));
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    dim_t b_pad = jcp.b_pad;
+    dim_t t_pad = jcp.t_pad;
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
-    const int inp_mult = is_src_layout_nxc()
+    dim_t dilate_h = jcp.dilate_h + 1;
+    dim_t stride_h = jcp.stride_h;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
-    int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+    dim_t iw = jcp.is_hw_transp ? 1 : jcp.iw;
     Label oh_label, oh_label_end, oh_tpad_label, oh_tpad_tail_label,
             oh_bpad_label, oh_bpad_label_end, oh_dilate_label_shift,
             oh_dilate_label_noshift, oh_dilate_label_end;
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    int oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
-    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
-    int kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
-    int ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
-    int ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
+    dim_t kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    dim_t kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
+    dim_t ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
+    dim_t ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
 
     assert(IMPLICATION(jcp.is_hw_transp,
             everyone_is(1, oh, stride_h, dilate_h)
@@ -3201,10 +3227,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
     xor_(reg_oj, reg_oj);
     /* Compute 'top' edge */
     if (t_pad > 0) {
-        const int kh_range = 1 + (kh - 1) * dilate_h;
-        const int overflow = nstl::max(0, kh - div_up(t_pad + ih, dilate_h));
-        const int underflow = div_up(t_pad, dilate_h);
-        const int initial_inp_ker_overlap = kh - overflow - underflow;
+        const dim_t kh_range = 1 + (kh - 1) * dilate_h;
+        const dim_t overflow
+                = nstl::max<dim_t>(0, kh - div_up(t_pad + ih, dilate_h));
+        const dim_t underflow = div_up(t_pad, dilate_h);
+        const dim_t initial_inp_ker_overlap = kh - overflow - underflow;
         mov(reg_kh, initial_inp_ker_overlap);
         add(reg_kernel,
                 jcp.typesize_out * underflow * kw * jcp.ic_block
@@ -3212,8 +3239,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         // generate loop to process kernel while it remains within t_pad + ih
         if (kh_range < t_pad + ih) {
             if (is_dilated) {
-                const int tail = t_pad % dilate_h;
-                const int shift = tail == 0 ? 0 : dilate_h - tail;
+                const int tail = static_cast<int>(t_pad % dilate_h);
+                const int shift
+                        = tail == 0 ? 0 : static_cast<int>(dilate_h - tail);
                 mov(reg_tmp, shift);
                 if (tail != 0)
                     add(reg_input, jcp.typesize_in * shift * iw * inp_mult);
@@ -3249,8 +3277,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
                 inc(reg_oj);
 
                 // final number of kernel elements that overlap with input
-                const int final_inp_ker_overlap
-                        = nstl::min(kh, div_up(ih, dilate_h));
+                const int final_inp_ker_overlap = static_cast<int>(
+                        nstl::min<dim_t>(kh, div_up(ih, dilate_h)));
                 cmp(reg_kh, final_inp_ker_overlap);
                 jl(oh_tpad_label, T_NEAR);
             }
@@ -3284,7 +3312,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
             // kernel has moved beyond padding (adjust for stride effects)
             if (t_pad % stride_h != 0) {
                 assert(!is_dilated);
-                int inp_corr = stride_h - t_pad % stride_h;
+                const dim_t inp_corr = stride_h - t_pad % stride_h;
                 add(reg_kernel,
                         jcp.typesize_out * inp_corr * kw * jcp.ic_block
                                 * jcp.oc_block);
@@ -3299,9 +3327,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
     }
 
-    const int oj_end_value = nstl::min(oh,
+    const int oj_end_value = static_cast<int>(nstl::min<dim_t>(oh,
             utils::div_up(
-                    nstl::max(0, ihp - b_pad - (kh - 1) * dilate_h), stride_h));
+                    nstl::max<dim_t>(0, ihp - b_pad - (kh - 1) * dilate_h),
+                    stride_h)));
     cmp(reg_oj, oj_end_value);
     jge(oh_label_end, T_NEAR);
 
@@ -3359,16 +3388,17 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         compute_oh_loop_partial() {
     assert(jcp.harness == harness_2d_reduction);
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    const int inp_mult = is_src_layout_nxc()
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
-    const int input_bottom_padding_overlap = div_up(
-            nstl::max(0, jcp.ih + jcp.t_pad - (jcp.kh - 1)), jcp.stride_h);
-    const int bottom_pad_input_correction
+    const dim_t input_bottom_padding_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.ih + jcp.t_pad - (jcp.kh - 1)),
+                    jcp.stride_h);
+    const dim_t bottom_pad_input_correction
             = jcp.ih + jcp.t_pad - input_bottom_padding_overlap * jcp.stride_h;
 
     const size_t filter_shift = jcp.typesize_out * jcp.kw * ic_block * oc_block;
@@ -3417,11 +3447,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_kernel, filter_shift * jcp.stride_h);
+        sub(reg_kernel, static_cast<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3429,13 +3459,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_kernel, filter_shift * inp_corr);
-                add(reg_input, input_shift * inp_corr);
+                dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add(reg_kernel, static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_input, static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+            sub(reg_kernel,
+                    static_cast<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Set filter element count for outside the t_pad region */
@@ -3473,11 +3505,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     }
 
     /* Compute middle block */
-    add(reg_input, input_shift * jcp.stride_h);
+    add(reg_input, static_cast<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_output, output_shift);
+    add(reg_output, static_cast<uint32_t>(output_shift));
     inc(reg_oj);
     cmp(reg_oj, ptr[param + GET_OFF(os_index_end)]);
     jl(loop_begin_label, T_NEAR);
@@ -3488,19 +3520,20 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         compute_od_loop_partial() {
     assert(jcp.harness == harness_3d_reduction);
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    const int inp_mult = is_src_layout_nxc()
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    const int input_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
-    const int back_pad_input_correction
+    dim_t iw = jcp.iw;
+    dim_t ow = jcp.ow;
+    const dim_t input_backpad_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d);
+    const dim_t back_pad_input_correction
             = jcp.id + jcp.f_pad - input_backpad_overlap * jcp.stride_d;
 
     const size_t filter_shift
@@ -3549,11 +3582,12 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
-        sub(reg_kernel, filter_shift * jcp.stride_d);
+        sub(reg_kernel, static_cast<uint32_t>(filter_shift * jcp.stride_d));
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const int inp_ker_overlap
+                = static_cast<int>(nstl::min<dim_t>(jcp.kd, jcp.id));
         cmp(reg_kd_count, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3561,13 +3595,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
-                add(reg_kernel, filter_shift * inp_corr);
-                add(reg_input_d, input_shift * inp_corr);
+                const dim_t inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                add(reg_kernel, static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_input_d, static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.f_pad - jcp.od * jcp.stride_d) * filter_shift);
+            sub(reg_kernel,
+                    static_cast<uint32_t>((jcp.f_pad - jcp.od * jcp.stride_d)
+                            * filter_shift));
         }
 
         /* Set filter element count for outside the f_pad region */
@@ -3605,11 +3641,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     }
 
     /* Compute middle block */
-    add(reg_input_d, input_shift * jcp.stride_d);
+    add(reg_input_d, static_cast<uint32_t>(input_shift * jcp.stride_d));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_output_d, output_shift);
+    add(reg_output_d, static_cast<uint32_t>(output_shift));
     inc(reg_d_index);
     cmp(reg_d_index, ptr[param + GET_OFF(os_index_end)]);
     jl(d_loop_label, T_NEAR);
@@ -3667,33 +3703,33 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
     MAYBE_UNUSED(ddst_reg_count);
     assert(ker_reg_count + src_reg_count + ddst_reg_count <= 32);
 
-    auto dwei_offset = [&](int i_kw, int i_ic) {
-        const int oc_block_size = sizeof(float);
-        const int ic_block_size = jcp.oc_block * oc_block_size;
-        const int kw_block_size = jcp.ic_block * ic_block_size;
-        const int kh_block_size = jcp.kw * kw_block_size;
-        const int kd_block_size = jcp.kh * kh_block_size;
-        const int icb_block_size = jcp.kd * kd_block_size;
+    auto dwei_offset = [&](dim_t i_kw, dim_t i_ic) {
+        const dim_t oc_block_size = sizeof(float);
+        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
+        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
+        const dim_t kh_block_size = jcp.kw * kw_block_size;
+        const dim_t kd_block_size = jcp.kh * kh_block_size;
+        const dim_t icb_block_size = jcp.kd * kd_block_size;
 
-        int icb = i_ic / jcp.ic_block;
+        const dim_t icb = i_ic / jcp.ic_block;
         i_ic = i_ic % jcp.ic_block;
 
         return icb * icb_block_size + i_kw * kw_block_size
                 + i_ic * ic_block_size;
     };
 
-    auto src_offset = [&](int i_ic, int i_iw) {
+    auto src_offset = [&](int i_ic, dim_t i_iw) -> dim_t {
         const int ic_block_size = sizeof(float);
-        const int g_block_size = jcp.ic * ic_block_size;
-        const int iw_block_size = jcp.ngroups * g_block_size;
+        const dim_t g_block_size = jcp.ic * ic_block_size;
+        const dim_t iw_block_size = jcp.ngroups * g_block_size;
 
         return i_iw * iw_block_size + i_ic * ic_block_size;
     };
 
     auto ddst_offset = [&](int i_ow) {
         const int oc_block_size = sizeof(float);
-        const int g_block_size = jcp.oc * oc_block_size;
-        const int ow_block_size = jcp.ngroups * g_block_size;
+        const dim_t g_block_size = jcp.oc * oc_block_size;
+        const dim_t ow_block_size = jcp.ngroups * g_block_size;
 
         return i_ow * ow_block_size;
     };
@@ -3762,7 +3798,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
                 }
             }
             for (int i_ic = 0; i_ic < ur_ic; i_ic++) {
-                int ker_offset = dwei_offset(i_kw, i_ic);
+                const dim_t ker_offset = dwei_offset(i_kw, i_ic);
                 vaddps(get_ker_zmm(i_ic), zword[reg_dwei + ker_offset]);
                 vmovups(zword[reg_dwei + ker_offset], get_ker_zmm(i_ic));
             }
@@ -3773,8 +3809,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
     auto kw_loop = [&](int ur_ow, int ur_ic, int is_iw_edge) {
         Label kwb_loop_begin, kwb_loop_end;
-        int kw_tail = jcp.kw % kw_unroll;
-        int kw_iter = jcp.kw / kw_unroll;
+        const int kw_tail = static_cast<int>(jcp.kw % kw_unroll);
+        const int kw_iter = static_cast<int>(jcp.kw / kw_unroll);
 
         if (kw_iter > 0) {
             if (kw_iter > 1) {
@@ -3785,7 +3821,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
             if (kw_iter > 1 || kw_tail) {
                 add(reg_iw_base, (jcp.dilate_w + 1) * kw_unroll);
-                add(reg_src, src_offset(0, (jcp.dilate_w + 1) * kw_unroll));
+                add(reg_src,
+                        static_cast<uint32_t>(
+                                src_offset(0, (jcp.dilate_w + 1) * kw_unroll)));
                 add(reg_dwei, dwei_offset(kw_unroll, 0));
             }
 
@@ -3802,8 +3840,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
     auto ic_loop = [&](int ur_ow, int is_iw_edge) {
         Label icb_loop_begin, icb_loop_end;
-        int ic_tail = jcp.ic % ic_unroll;
-        int ic_iter = jcp.ic / ic_unroll;
+        const int ic_tail = static_cast<int>(jcp.ic % ic_unroll);
+        const int ic_iter = static_cast<int>(jcp.ic / ic_unroll);
 
         if (ic_iter > 0) {
             if (ic_iter > 1 || ic_tail) {
@@ -3858,7 +3896,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
     auto ic_loop_dispatch = [&](int ur_ow) {
         Label iw_edge_case, ic_end;
 
-        const int iw_overflow_bound = jcp.iw - (ur_ow - 1) * jcp.stride_w
+        const dim_t iw_overflow_bound = jcp.iw - (ur_ow - 1) * jcp.stride_w
                 - (jcp.kw - 1) * (jcp.dilate_w + 1);
         cmp(reg_iw_base, iw_overflow_bound);
         jge(iw_edge_case, T_NEAR);
@@ -3983,9 +4021,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -3997,13 +4035,13 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4091,7 +4129,7 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
@@ -4104,8 +4142,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     if (!jcp.is_hw_transp && jcp.kw > 14) return status::unimplemented;
 
     /* setting register strategy */
-    const int unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    for (int ur_w = nstl::min(max_ur_w, unroll_dim); ur_w > 0; --ur_w) {
+    const dim_t unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    for (int ur_w = static_cast<int>(nstl::min<dim_t>(max_ur_w, unroll_dim));
+            ur_w > 0; --ur_w) {
         if (unroll_dim % ur_w == 0) {
             jcp.ur_w = ur_w;
             break;
@@ -4234,7 +4273,7 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
         jcp.ur_ic = 2 - jcp.ic % 2;
         jcp.ur_kw = 1;
         if (jcp.stride_w == jcp.dilate_w + 1) {
-            jcp.ur_kw = jcp.kw;
+            jcp.ur_kw = static_cast<int>(jcp.kw);
             if (jcp.kw > 7) {
                 // Blocking by kw is more effective than by ic in the compute
                 // kernel since neighbor kw operations share src data
@@ -4246,11 +4285,11 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
 
         // Unroll by ow to decrease updates to diff_weights. In practice, this
         // should be approximately 1/4 - 1/2 of the zmm registers
-        jcp.ur_ow = nstl::min(
-                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow);
+        jcp.ur_ow = static_cast<int>(nstl::min<dim_t>(
+                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow));
 
-        int work_amount_base = jcp.mb * jcp.od * jcp.oh;
-        int ow_iter = div_up(jcp.ow, jcp.ur_ow);
+        int work_amount_base = static_cast<int>(jcp.mb * jcp.od * jcp.oh);
+        int ow_iter = static_cast<int>(div_up(jcp.ow, jcp.ur_ow));
         int nthr_ow = nstl::min(
                 jcp.nthr / math::gcd(work_amount_base, jcp.nthr), ow_iter);
         int ow_block = div_up(ow_iter, nthr_ow) * jcp.ur_ow;
@@ -4260,8 +4299,8 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
 
         // Choose a simple parallelization method. A more advance may need made
         // later
-        int work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
-        nthr_mb = nstl::min(jcp.nthr, work_amount);
+        const dim_t work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
+        nthr_mb = nstl::min(jcp.nthr, static_cast<int>(work_amount));
         nthr_g = 1;
         nthr_oc_b = 1;
         nthr_ic_b = 1;
@@ -4285,7 +4324,8 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.nb_ic_blocking_max = 1;
     if (is_data_layout_nxc && (jcp.ow > max_ur_w || jcp.ndims == 5)) {
         assert(!jcp.is_hw_transp);
-        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+        jcp.nb_ic_blocking_max = static_cast<int>(
+                nstl::min<dim_t>(8, div_up(jcp.nb_ic, jcp.nthr_ic_b)));
     }
 
     return status::success;
@@ -4325,17 +4365,18 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = nthreads / nthr_g_;
 
-    const int ih = j.is_hw_transp ? j.tr_ih : j.ih;
-    const int oh = j.is_hw_transp ? j.ow : j.oh;
+    const dim_t ih = j.is_hw_transp ? j.tr_ih : j.ih;
+    const dim_t oh = j.is_hw_transp ? j.ow : j.oh;
 
-    int ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
-    int oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
-    int ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
-    int oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
-    int nthr_oh_reduce = nstl::max(1, oh_reduce / min_oh_reduce);
+    const dim_t ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
+    const dim_t oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
+    const dim_t ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
+    const dim_t oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
+    const int nthr_oh_reduce
+            = static_cast<int>(nstl::max<dim_t>(1, oh_reduce / min_oh_reduce));
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
         /* calculate per thread memory cost (read/write). high level optimizer
@@ -4370,12 +4411,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     dim_t best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, j.mb * j.od * nthr_oh_reduce);
+    const int nthr_mb_max = static_cast<int>(
+            nstl::min<dim_t>(nthr, j.mb * j.od * nthr_oh_reduce));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
 
             dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -4402,15 +4446,17 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     dim_t best_comp_cost = calc_comp_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
             dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             dim_t comp_cost = calc_comp_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
             const bool opt1 = comp_cost <= best_comp_cost
-                    && IMPLICATION(
-                            !j.is_hw_transp, mem_cost < 1.1 * best_mem_cost);
+                    && IMPLICATION(!j.is_hw_transp,
+                            (double)mem_cost < 1.1 * (double)best_mem_cost);
             const bool opt2 = 4 * comp_cost <= 3 * best_comp_cost;
 
             if (opt1 || opt2) {
@@ -4423,7 +4469,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     }
 
     if (nthr_mb_ > nthreads / 2 && nthr_mb_ < nthreads)
-        nthr_mb_ = nstl::min(j.mb * j.od * nthr_oh_reduce, nthreads);
+        nthr_mb_ = static_cast<int>(
+                nstl::min<dim_t>(j.mb * j.od * nthr_oh_reduce, nthreads));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= nthreads);

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -807,31 +807,34 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nthr = jcp.aligned_threads = nthreads;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -1900,36 +1903,39 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(diff_src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
 
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(diff_src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(diff_src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
     VDISPATCH_CONV_IC(!((jcp.dilate_w != 0 && jcp.stride_w != 1)
                               || (jcp.dilate_d != 0 && jcp.stride_d != 1)
                               || (jcp.dilate_h != 0 && jcp.stride_h != 1)),
@@ -3991,36 +3997,40 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(diff_weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5)
+            ? static_cast<int>(diff_weights_d.dims()[with_groups + 2])
+            : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -569,11 +569,11 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
-    const dim_t iw = jcp.iw;
+    const int iw = jcp.iw;
     const dim_t ow = jcp.ow;
     dim_t ow_block = jcp.ow_block;
     dim_t nb_ow = jcp.nb_ow;
-    const dim_t kw = jcp.kw;
+    const int kw = jcp.kw;
     const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
@@ -617,7 +617,8 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
 
     const dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
     dim_t n_oi = ow / ur_w;
-    const dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    const dim_t r_pad1 = calculate_end_padding(static_cast<int>(l_pad),
+            static_cast<int>(ur_w * n_oi), iw, static_cast<int>(stride_w),
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -832,9 +833,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1012,8 +1013,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Need to try for other topologies
     if (jcp.ow > 150 && jcp.ur_w < regs / 2) jcp.ur_w = regs;
 
-    dim_t n_oi = jcp.ow / jcp.ur_w;
-    dim_t r_pad = calculate_end_padding(
+    int n_oi = jcp.ow / jcp.ur_w;
+    int r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ur_w * n_oi, jcp.iw, jcp.stride_w, ext_kw);
     if (jcp.l_pad > 0 && r_pad > 0) n_oi--;
 
@@ -1060,7 +1061,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     };
 
     auto get_ow_block = [&](int nb_oc_blocking, int ur_w, int nthr) {
-        dim_t res_ow_block = jcp.ow;
+        int res_ow_block = jcp.ow;
         float eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         if (!is_ow_threading_applicable()) return res_ow_block;
 
@@ -1211,7 +1212,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                         } else {
                             int ur_w = static_cast<int>(
                                     nstl::min<dim_t>(jcp.ow, 31 / (i + 1)));
-                            dim_t ow_block = get_ow_block(i, ur_w, jcp.nthr);
+                            int ow_block = get_ow_block(i, ur_w, jcp.nthr);
                             float thr_eff = get_thr_eff(i, ow_block, jcp.nthr);
                             if (thr_eff > 1.05f * best_thr_eff) {
                                 best_nb_oc_blocking = i;
@@ -1237,9 +1238,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(args_ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weight and src size mismatch");
 
-    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
+    int r_pad_no_tail = nstl::max(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw)));
+                    jcp.stride_w, ext_kw));
     VDISPATCH_CONV_IC(r_pad_no_tail <= jcp.ur_w,
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1266,7 +1267,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < eff_threshold && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        dim_t ow_block = jcp.ow_block;
+        int ow_block = jcp.ow_block;
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
         const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
@@ -1290,7 +1291,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                            - (float)(nstl::min<dim_t>(0, jcp.kh - jcp.stride_h)
                                    * jcp.iw))
             / (float)(jcp.stride_h * jcp.iw + jcp.ow));
-    jcp.h_blocking = nstl::max<dim_t>(1, nstl::min<dim_t>(jcp.oh, h_L2));
+    jcp.h_blocking = nstl::max(1, nstl::min(jcp.oh, h_L2));
 
     if (is_data_layout_nxc) {
         // TODO: improve L2 blocking for large IC
@@ -1298,7 +1299,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         if (jcp.nb_ic > nb_ic_theshold_L2 && jcp.nb_ic < 2 * nb_ic_theshold_L2)
             jcp.nb_ic_L2 = div_up(jcp.nb_ic, 2);
         else
-            jcp.nb_ic_L2 = nstl::min<dim_t>(nb_ic_theshold_L2, jcp.nb_ic);
+            jcp.nb_ic_L2 = nstl::min(nb_ic_theshold_L2, jcp.nb_ic);
     }
 
     // A rough check on code size
@@ -1935,9 +1936,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -2294,7 +2295,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         if (jcp.nb_oc > nb_oc_theshold_L2 && jcp.nb_oc < 2 * nb_oc_theshold_L2)
             jcp.nb_oc_L2 = div_up(jcp.nb_oc, 2);
         else
-            jcp.nb_oc_L2 = nstl::min<dim_t>(nb_oc_theshold_L2, jcp.nb_oc);
+            jcp.nb_oc_L2 = nstl::min(nb_oc_theshold_L2, jcp.nb_oc);
     }
 
     bool args_ok = true && jcp.ic <= diff_src_d.padded_dims()[1]
@@ -3358,7 +3359,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
             mov(reg_tmp, 0);
         } else {
             mov(reg_kh, ihp - b_pad);
-            imul(reg_tmp, reg_oj, stride_h);
+            imul(reg_tmp, reg_oj, static_cast<int>(stride_h));
             sub(reg_kh, reg_tmp);
         }
         L(oh_bpad_label);
@@ -4021,9 +4022,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -4035,13 +4036,13 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    jcp.r_pad = nstl::max<dim_t>(0,
+    jcp.r_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max<dim_t>(0,
+    jcp.b_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max<dim_t>(0,
+    jcp.back_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -102,7 +102,7 @@ jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const std::size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_args_static_params {

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -86,25 +86,25 @@ private:
     Xbyak::Opmask k_oc_tail_mask = Xbyak::Opmask(2);
     const Xbyak::Opmask postops_mask = Xbyak::Opmask(3);
 
-    inline Vmm vmm_ker(int i_ic) {
+    inline Vmm vmm_ker(dim_t i_ic) {
         assert(i_ic < 4);
-        return Vmm(ker_reg_base_idx + i_ic);
+        return Vmm(static_cast<int>(ker_reg_base_idx + i_ic));
     }
 
-    inline int vmm_out_idx(int i_ur, int i_oc) {
-        const int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+    inline int vmm_out_idx(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < ker_reg_base_idx);
-        return idx;
+        return static_cast<int>(idx);
     }
 
-    inline Vmm vmm_out(int i_ur, int i_oc) {
+    inline Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
         return Vmm(vmm_out_idx(i_ur, i_oc));
     }
 
-    inline Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    inline Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
     Xbyak::Reg64 imm_addr64 = r15;
@@ -116,13 +116,13 @@ private:
     inline void prepare_output(int ur_w);
     inline void apply_postops(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop_fma(int ur_w, int pad_l, int pad_r);
-    inline void compute_loop_fma_core(int ur_w, int pad_l, int pad_r);
-    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop_fma(int ur_w, dim_t pad_l, dim_t pad_r);
+    inline void compute_loop_fma_core(int ur_w, dim_t pad_l, dim_t pad_r);
+    inline void compute_loop(int ur_w, dim_t pad_l, dim_t pad_r);
 
     void generate() override;
 
-    inline size_t get_output_offset(int oi, int n_oc_block) {
+    inline size_t get_output_offset(dim_t oi, dim_t n_oc_block) {
         const bool is_nxc_layout = is_dst_layout_nxc();
         size_t ow_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
         size_t ocb_str = is_nxc_layout
@@ -132,35 +132,36 @@ private:
         return jcp.typesize_out * (n_oc_block * ocb_str + oi * ow_str);
     }
 
-    inline size_t get_input_offset(int ki, int ic, int oi, int pad_l) {
+    inline dim_t get_input_offset(dim_t ki, dim_t ic, dim_t oi, dim_t pad_l) {
         const bool is_nxc_layout = is_src_layout_nxc();
-        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
-                                      : (!jcp.is_1stconv ? jcp.ic_block : 1);
-        size_t ic_str = !jcp.is_1stconv || is_nxc_layout
+        dim_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
+                                     : (!jcp.is_1stconv ? jcp.ic_block : 1);
+        dim_t ic_str = !jcp.is_1stconv || is_nxc_layout
                 ? 1
-                : (size_t)jcp.iw * jcp.ih * jcp.id;
-        size_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
+                : jcp.iw * jcp.ih * jcp.id;
+        dim_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
 
         return jcp.typesize_in * (iw_idx * iw_str + ic * ic_str);
     }
 
-    inline int get_kernel_offset(
-            int ki, int ic, int n_oc_block, int ker_number) {
+    inline dim_t get_kernel_offset(
+            dim_t ki, dim_t ic, dim_t n_oc_block, dim_t ker_number) {
         return jcp.typesize_in * jcp.oc_block
                 * (n_oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
                                 * jcp.kd
                         + (ic + ker_number) + ki * jcp.ic_block);
     }
 
-    inline int get_ow_start(int ki, int pad_l) {
+    inline dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    inline int get_ow_end(int ur_w, int ki, int pad_r) {
+    inline dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -271,34 +272,34 @@ private:
 
     Xbyak::Opmask k_ic_tail_mask = Xbyak::Opmask(1);
 
-    inline Vmm vmm_ker(int i_ic) {
+    inline Vmm vmm_ker(dim_t i_ic) {
         assert(i_ic < 4);
-        return Vmm(ker_reg_base_idx + i_ic);
+        return Vmm(static_cast<int>(ker_reg_base_idx + i_ic));
     }
-    inline Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    inline Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    inline Vmm vmm_out(int i_ur, int i_oc) {
-        int idx = i_ur + i_oc * jcp.ur_w;
+    inline Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur + i_oc * jcp.ur_w;
         assert(idx < ker_reg_base_idx);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
     Vmm vmm_wei = Vmm(31);
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop_fma(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop_fma(int ur_w, dim_t l_overflow, dim_t r_overflow);
     inline void compute_loop_fma_core(
-            int ur_w, int l_overflow, int r_overflow, int k_offset);
+            int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset);
     inline void compute_loop(
-            int ur_w, int l_overflow, int r_overflow, int k_offset = 0);
+            int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset = 0);
     void generate() override;
 
-    inline int get_iw_start(int ki, int l_overflow) {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    inline dim_t get_iw_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -307,10 +308,10 @@ private:
         return res;
     }
 
-    inline int get_iw_end(int ur_w, int ki, int r_overflow) {
+    inline dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -318,7 +319,7 @@ private:
         return ur_w - res;
     }
 
-    inline size_t get_diff_src_offset(int iw, int icb) {
+    inline size_t get_diff_src_offset(dim_t iw, dim_t icb) {
         const bool is_nxc_layout = is_dsrc_layout_nxc();
         size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
         size_t icb_str = is_nxc_layout
@@ -328,7 +329,7 @@ private:
         return typesize * (icb * icb_str + iw * iw_str);
     }
 
-    inline ptrdiff_t get_dst_offset(int iw, int oc, int kw) {
+    inline ptrdiff_t get_dst_offset(dim_t iw, dim_t oc, dim_t kw) {
         ptrdiff_t ow
                 = (iw + jcp.l_pad - kw * (jcp.dilate_w + 1)) / jcp.stride_w;
         ptrdiff_t ow_str = is_ddst_layout_nxc()
@@ -460,15 +461,15 @@ private:
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
     inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound = false);
-    inline void compute_ic_block_step_fma(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound);
-    inline void compute_ic_block_step_fma_expl(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset, bool input_wraparound = false);
+    inline void compute_ic_block_step_fma(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset, bool input_wraparound);
+    inline void compute_ic_block_step_fma_expl(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t input_offset,
+            dim_t kernel_offset, dim_t output_offset, bool input_wraparound);
     inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
     inline void compute_oh_step_disp();
     inline void compute_oh_loop_common();
@@ -486,7 +487,7 @@ private:
     }
 
     inline ptrdiff_t get_full_src_offset(
-            int i_iw, int i_ic, ptrdiff_t input_offset) {
+            dim_t i_iw, int i_ic, ptrdiff_t input_offset) {
         const bool is_nxc_layout = is_src_layout_nxc();
         const size_t w_shift_st = (jcp.is_hw_transp ? jcp.iw : 1)
                 * (jcp.is_1stconv ? 1 : jcp.ic_block);
@@ -499,7 +500,7 @@ private:
         return input_offset + typesize * local_input_offset;
     }
 
-    inline int get_iw_idx(int ow, int kw, int l_pad) const {
+    inline dim_t get_iw_idx(dim_t ow, dim_t kw, dim_t l_pad) const {
         return ow * jcp.stride_w + kw * (jcp.dilate_w + 1) - l_pad;
     }
 

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -118,7 +118,7 @@ inline void jit_conv_ker_pipeline_bwd_w(const jit_conv_ker_t ker,
         const void *bias, int channel, int kh_padding, size_t reduce_work,
         size_t load_work) {
     jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
-            static_cast<int>(reduce_work), static_cast<int>(load_work));
+            reduce_work, load_work);
 }
 
 void jit_conv_2d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
@@ -203,14 +203,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    dim_t nb_groups = jcp.ngroups / g_blocking;
-    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        dim_t start {0}, end {0}, start_copy;
+        int start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -221,9 +221,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t src_c_stride = src_d.blk_off<false, true>(0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            dim_t n {0}, gg {0}, occ {0}, owb {0};
+            int n {0}, gg {0}, occ {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
@@ -241,20 +241,20 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
             }
 
             while (start < end) {
-                dim_t ocb = occ * jcp.nb_oc_blocking;
-                dim_t g = gg * g_blocking;
-                dim_t g_ocb = g * jcp.nb_oc + ocb;
-                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                int ocb = occ * jcp.nb_oc_blocking;
+                int g = gg * g_blocking;
+                int g_ocb = g * jcp.nb_oc + ocb;
+                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                dim_t ow_s = owb * jcp.ow_block;
-                dim_t iw_s = ow_s * jcp.stride_w;
+                int ow_s = owb * jcp.ow_block;
+                int iw_s = ow_s * jcp.stride_w;
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const dim_t oc_off_idx = is_dst_layout_nxc
+                const int oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const dim_t ic_off_idx = is_src_layout_nxc
+                const int ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src + src_d.blk_off(n, ic_off_idx, iw_s);
@@ -264,18 +264,16 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                dim_t icb_end
-                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                dim_t ic_work = icb_step * jcp.ic_block;
+                int ic_work = icb_step * jcp.ic_block;
 
-                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = static_cast<int>(
-                            nstl::min<dim_t>(icb_step, icb_end - icb));
+                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -284,9 +282,7 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                 jcp.ic, icb_step * jcp.ic_block);
                     }
                     jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv, src_w,
-                            dst_w, wht_w, bias_w, static_cast<int>(icb), 1,
-                            static_cast<int>(owb), static_cast<int>(ic_work),
-                            static_cast<int>(oc_work),
+                            dst_w, wht_w, bias_w, icb, 1, owb, ic_work, oc_work,
                             post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                     src_w += src_c_stride;
@@ -333,14 +329,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    dim_t nb_groups = jcp.ngroups / g_blocking;
-    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        dim_t start {0}, end {0}, start_copy;
+        int start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -354,9 +350,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+            int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -371,52 +367,49 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                dim_t ocb = occ * jcp.nb_oc_blocking;
-                dim_t g = gg * g_blocking;
-                dim_t g_ocb = g * jcp.nb_oc + ocb;
-                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                int ocb = occ * jcp.nb_oc_blocking;
+                int g = gg * g_blocking;
+                int g_ocb = g * jcp.nb_oc + ocb;
+                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                dim_t work_rem = end - start;
+                int work_rem = end - start;
 
-                dim_t ow_s = owb * jcp.ow_block;
-                dim_t iw_s = ow_s * jcp.stride_w;
-                dim_t oh_e
-                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                int ow_s = owb * jcp.ow_block;
+                int iw_s = ow_s * jcp.stride_w;
+                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                for (dim_t oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
-                    dim_t ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
+                for (int oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
+                    int ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
                     const bool is_dst_layout_nxc
                             = jcp.dst_tag == format_tag::nhwc;
-                    const dim_t oc_off_idx = is_dst_layout_nxc
+                    const int oc_off_idx = is_dst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g_ocb;
                     auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, oh_b, ow_s);
                     const bool is_src_layout_nxc
                             = jcp.src_tag == format_tag::nhwc;
-                    const dim_t ic_off_idx = is_src_layout_nxc
+                    const int ic_off_idx = is_src_layout_nxc
                             ? g * jcp.ic + icb_l2 * jcp.ic_block
                             : g_icb + icb_l2;
                     auto src_w = src + src_d.blk_off(n, ic_off_idx, ih_b, iw_s);
                     auto wht_w
                             = weights + wht_blk_off(weights_d, g, ocb, icb_l2);
 
-                    dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                    dim_t icb_end = nstl::min<dim_t>(
-                            jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                    int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                    int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
                     auto bias_w = bias ? bias
                                     + oc_off_idx
                                             * (is_dst_layout_nxc ? 1
                                                                  : jcp.oc_block)
                                        : nullptr;
-                    const dim_t oc_work = utils::this_block_size(
+                    const int oc_work = utils::this_block_size(
                             ocb * jcp.oc_block, jcp.oc_without_padding,
                             jcp.nb_oc_blocking * jcp.oc_block);
-                    dim_t ic_work = icb_step * jcp.ic_block;
-                    for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
-                        int curr_nb_ic = static_cast<int>(
-                                nstl::min<dim_t>(icb_step, icb_end - icb));
+                    int ic_work = icb_step * jcp.ic_block;
+                    for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
+                        int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
                         int flags = 0;
                         if (icb == 0) flags |= FLAG_IC_FIRST;
                         if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -426,19 +419,18 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                         }
                         auto src_c = src_w;
                         auto dst_c = dst_w;
-                        for (dim_t oj = oh_b, ij = ih_b; oj
-                                < nstl::min<dim_t>(oh_e, oh_b + jcp.h_blocking);
+                        for (int oj = oh_b, ij = ih_b;
+                                oj < min(oh_e, oh_b + jcp.h_blocking);
                                 ++oj, ij += jcp.stride_h) {
-                            dim_t dilate_h = jcp.dilate_h + 1;
-                            dim_t i_t_overflow
-                                    = div_up(max<dim_t>(0, -ij), dilate_h);
-                            dim_t i_b_overflow = div_up(
-                                    max<dim_t>(0,
+                            int dilate_h = jcp.dilate_h + 1;
+                            int i_t_overflow = div_up(max(0, -ij), dilate_h);
+                            int i_b_overflow = div_up(
+                                    max(0,
                                             ij - jcp.ih
                                                     + (jcp.kh - 1) * dilate_h
                                                     + 1),
                                     dilate_h);
-                            dim_t kh_padding = nstl::max<dim_t>(
+                            int kh_padding = nstl::max(
                                     0, jcp.kh - i_t_overflow - i_b_overflow);
 
                             auto aux_src = src_c
@@ -446,12 +438,8 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                             auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
                             jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv,
-                                    aux_src, dst_c, aux_wht, bias_w,
-                                    static_cast<int>(icb),
-                                    static_cast<int>(kh_padding),
-                                    static_cast<int>(owb),
-                                    static_cast<int>(ic_work),
-                                    static_cast<int>(oc_work),
+                                    aux_src, dst_c, aux_wht, bias_w, icb,
+                                    kh_padding, owb, ic_work, oc_work,
                                     post_ops_binary_rhs_arg_vec.data(), dst,
                                     flags);
 
@@ -500,15 +488,15 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    dim_t nb_groups = jcp.ngroups / g_blocking;
-    dim_t work_amount
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        dim_t start {0}, end {0}, start_copy;
+        int start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -524,9 +512,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
+            int n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -541,38 +529,36 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                dim_t ocb = occ * jcp.nb_oc_blocking;
-                dim_t g = gg * g_blocking;
-                dim_t g_ocb = g * jcp.nb_oc + ocb;
-                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                int ocb = occ * jcp.nb_oc_blocking;
+                int g = gg * g_blocking;
+                int g_ocb = g * jcp.nb_oc + ocb;
+                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                dim_t work_rem = end - start;
-                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                dim_t ow_s = owb * jcp.ow_block;
-                dim_t iw_s = ow_s * jcp.stride_w;
-                dim_t oh_e
-                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                int work_rem = end - start;
+                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                int ow_s = owb * jcp.ow_block;
+                int iw_s = ow_s * jcp.stride_w;
+                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
 
-                dim_t dilate_d = jcp.dilate_d + 1;
-                dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
-                dim_t d_b_overflow = div_up(
-                        max<dim_t>(
-                                0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                int dilate_d = jcp.dilate_d + 1;
+                int d_t_overflow = div_up(max(0, -id_s), dilate_d);
+                int d_b_overflow = div_up(
+                        max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                         dilate_d);
-                dim_t kd_padding = nstl::max<dim_t>(
-                        0, jcp.kd - d_t_overflow - d_b_overflow);
+                int kd_padding
+                        = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-                const dim_t oc_off_idx = is_dst_layout_nxc
+                const int oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w
                         = dst + dst_d.blk_off(n, oc_off_idx, od_s, oh_s, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-                const dim_t ic_off_idx = is_src_layout_nxc
+                const int ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src
@@ -585,17 +571,15 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                const dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                dim_t icb_end
-                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                const int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                dim_t ic_work = icb_step * jcp.ic_block;
-                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = static_cast<int>(
-                            nstl::min<dim_t>(icb_step, icb_end - icb));
+                int ic_work = icb_step * jcp.ic_block;
+                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -605,27 +589,22 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                     }
                     auto src_c = src_w;
                     auto dst_c = dst_w;
-                    for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
+                    for (int oj = oh_s, ij = ih_s; oj < oh_e;
                             ++oj, ij += jcp.stride_h) {
-                        dim_t dilate_h = jcp.dilate_h + 1;
-                        dim_t i_t_overflow
-                                = div_up(max<dim_t>(0, -ij), dilate_h);
-                        dim_t i_b_overflow = div_up(
-                                max<dim_t>(0,
+                        int dilate_h = jcp.dilate_h + 1;
+                        int i_t_overflow = div_up(max(0, -ij), dilate_h);
+                        int i_b_overflow = div_up(
+                                max(0,
                                         ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                 + 1),
                                 dilate_h);
-                        dim_t kh_padding = nstl::max<dim_t>(
+                        int kh_padding = nstl::max(
                                 0, jcp.kh - i_t_overflow - i_b_overflow);
                         jit_conv_3d_ker_pipeline_ow_thr(jit_ker, par_conv,
                                 src_c + i_t_overflow * dilate_h * src_h_stride,
                                 dst_c, wht_w + i_t_overflow * wht_h_stride,
-                                bias_w, static_cast<int>(icb),
-                                static_cast<int>(kh_padding),
-                                static_cast<int>(kd_padding),
-                                static_cast<int>(owb),
-                                static_cast<int>(ic_work),
-                                static_cast<int>(oc_work),
+                                bias_w, icb, kh_padding, kd_padding, owb,
+                                ic_work, oc_work,
                                 post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                         src_c += src_h_stride * jcp.stride_h;
@@ -671,14 +650,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    dim_t nb_groups = jcp.ngroups / g_blocking;
-    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        dim_t start {0}, end {0}, start_copy;
+        int start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -689,9 +668,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         size_t diff_dst_c_stride = diff_dst_d.blk_off<false, true>(0, 1);
         size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
 
-        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            dim_t n {0}, gg {0}, icc {0}, iwb {0};
+            int n {0}, gg {0}, icc {0}, iwb {0};
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -708,47 +687,42 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
             }
 
             while (start < end) {
-                dim_t icb = icc * jcp.nb_ic_blocking;
-                dim_t g = gg * g_blocking;
-                dim_t g_icb = g * jcp.nb_ic + icb;
-                dim_t g_ocb = g * jcp.nb_oc;
-                dim_t iw_s = iwb * jcp.iw_block;
-                dim_t ow_s = iw_s / jcp.stride_w;
+                int icb = icc * jcp.nb_ic_blocking;
+                int g = gg * g_blocking;
+                int g_icb = g * jcp.nb_ic + icb;
+                int g_ocb = g * jcp.nb_oc;
+                int iw_s = iwb * jcp.iw_block;
+                int ow_s = iw_s / jcp.stride_w;
 
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const dim_t ic_off_idx = is_dsrc_layout_nxc
+                const int ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const dim_t oc_off_idx = is_ddst_layout_nxc
+                const int oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                dim_t ocb_end
-                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const dim_t load_work
-                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
-                                jcp.nb_ic_blocking * jcp.ic_block);
-                dim_t reduce_work = ocb_step * jcp.oc_block;
-                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    dim_t curr_nb_oc
-                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
+                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const int load_work = utils::this_block_size(icb * jcp.ic_block,
+                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
+                int reduce_work = ocb_step * jcp.oc_block;
+                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
 
                     jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src_w,
-                            diff_dst_w, wht_w, nullptr, static_cast<int>(ocb),
-                            1, static_cast<int>(iwb),
-                            static_cast<int>(reduce_work),
-                            static_cast<int>(load_work));
+                            diff_dst_w, wht_w, nullptr, ocb, 1, iwb,
+                            reduce_work, load_work);
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
                 }
@@ -788,14 +762,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    dim_t nb_groups = jcp.ngroups / g_blocking;
-    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        dim_t start {0}, end {0}, start_copy;
+        int start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -811,9 +785,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+            int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -828,66 +802,62 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                dim_t icb = icc * jcp.nb_ic_blocking;
-                dim_t g = gg * g_blocking;
-                dim_t g_icb = g * jcp.nb_ic + icb;
-                dim_t g_ocb = g * jcp.nb_oc;
+                int icb = icc * jcp.nb_ic_blocking;
+                int g = gg * g_blocking;
+                int g_icb = g * jcp.nb_ic + icb;
+                int g_ocb = g * jcp.nb_oc;
 
-                dim_t work_rem = end - start;
-                dim_t ih_e
-                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                int work_rem = end - start;
+                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                dim_t iw_s = iwb * jcp.iw_block;
-                dim_t ow_s = iw_s / jcp.stride_w;
+                int iw_s = iwb * jcp.iw_block;
+                int ow_s = iw_s / jcp.stride_w;
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nhwc;
-                const dim_t ic_off_idx = is_dsrc_layout_nxc
+                const int ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, 0, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-                const dim_t oc_off_idx = is_ddst_layout_nxc
+                const int oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, 0, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                dim_t ocb_end
-                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const dim_t load_work
-                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
-                                jcp.nb_ic_blocking * jcp.ic_block);
-                dim_t reduce_work = ocb_step * jcp.oc_block;
-                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    dim_t curr_nb_oc
-                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
+                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const int load_work = utils::this_block_size(icb * jcp.ic_block,
+                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
+                int reduce_work = ocb_step * jcp.oc_block;
+                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
-                        dim_t oj, k_len, k_lo;
+                    for (int ij = ih_s; ij < ih_e; ++ij) {
+                        int oj, k_len, k_lo;
                         if (is_fast_path) { // dilate == 0 && stride == 1
-                            dim_t i_t_overflow = max<dim_t>(
-                                    0, jcp.kh - 1 - ij - jcp.t_pad);
-                            dim_t i_b_overflow = max<dim_t>(
-                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            int i_t_overflow
+                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
+                            int i_b_overflow
+                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            dim_t dilate_h = jcp.dilate_h + 1;
+                            int dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            dim_t i_t_overflow
-                                    = div_up(max<dim_t>(0,
+                            int i_t_overflow
+                                    = div_up(max(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            dim_t i_b_overflow = div_up(
-                                    max<dim_t>(0,
+                            int i_b_overflow = div_up(
+                                    max(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -895,16 +865,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            dim_t i_t_overflow = max<dim_t>(0,
+                            int i_t_overflow = max(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            dim_t i_b_overflow = max<dim_t>(0,
+                            int i_b_overflow = max(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            dim_t overflow_kh_hi = jcp.kh - 1
+                            int overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            dim_t overflow_kh_lo
+                            int overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -917,11 +887,8 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr,
-                                static_cast<int>(ocb), static_cast<int>(k_len),
-                                static_cast<int>(iwb),
-                                static_cast<int>(reduce_work),
-                                static_cast<int>(load_work));
+                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
+                                k_len, iwb, reduce_work, load_work);
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -959,14 +926,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    dim_t nb_groups = jcp.ngroups / g_blocking;
-    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+    int nb_groups = jcp.ngroups / g_blocking;
+    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        dim_t start {0}, end {0}, start_copy;
+        int start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -986,9 +953,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
+            int n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
             // Input width threading is not currently implemented for 3d, so it
             // is not included in the iterator.
             if (jcp.loop_order == loop_cwgn)
@@ -1004,35 +971,31 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                dim_t icb = icc * jcp.nb_ic_blocking;
-                dim_t g = gg * g_blocking;
-                dim_t g_icb = g * jcp.nb_ic + icb;
-                dim_t g_ocb = g * jcp.nb_oc;
+                int icb = icc * jcp.nb_ic_blocking;
+                int g = gg * g_blocking;
+                int g_icb = g * jcp.nb_ic + icb;
+                int g_ocb = g * jcp.nb_oc;
 
-                dim_t work_rem = end - start;
-                dim_t ih_e
-                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                int work_rem = end - start;
+                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                dim_t d_len = 0;
-                dim_t d_lo = 0, d_oj = 0;
+                int d_len = 0, d_lo = 0, d_oj = 0;
                 if (is_fast_path_d) { // dilate == 0 && stride == 1
-                    dim_t d_t_overflow
-                            = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                    dim_t d_b_overflow = max<dim_t>(
-                            0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                    int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                    int d_b_overflow
+                            = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                     d_len = jcp.kd - d_t_overflow - d_b_overflow;
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow;
                 } else if (jcp.dilate_d != 0) { // stride == 1
-                    dim_t dilate_d = jcp.dilate_d + 1;
+                    int dilate_d = jcp.dilate_d + 1;
                     // Note: use div_up to account for "holes" in filter
-                    dim_t d_t_overflow = div_up(
-                            max<dim_t>(0,
-                                    (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                    int d_t_overflow = div_up(
+                            max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                             dilate_d);
-                    dim_t d_b_overflow = div_up(
-                            max<dim_t>(0,
+                    int d_b_overflow = div_up(
+                            max(0,
                                     (jcp.kd - 1) * dilate_d + 1 - jcp.id + id_s
                                             - jcp.back_pad),
                             dilate_d);
@@ -1040,15 +1003,15 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow * dilate_d;
                 } else { // dilate == 0
-                    dim_t d_t_overflow = max<dim_t>(
+                    int d_t_overflow = max(
                             0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                    dim_t d_b_overflow = max<dim_t>(0,
+                    int d_b_overflow = max(0,
                             (jcp.kd - jcp.id + id_s - jcp.back_pad)
                                     / jcp.stride_d);
-                    dim_t overflow_kd_hi = jcp.kd - 1
+                    int overflow_kd_hi = jcp.kd - 1
                             - modulo(jcp.id - 1 + jcp.back_pad - id_s,
                                     jcp.stride_d);
-                    dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                    int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                     d_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                             - d_t_overflow - d_b_overflow;
@@ -1058,14 +1021,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
                 const bool is_dsrc_layout_nxc
                         = jcp.src_tag == format_tag::ndhwc;
-                const dim_t ic_off_idx = is_dsrc_layout_nxc
+                const int ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w = diff_src + diff_src_d.blk_off(n, ic_off_idx)
                         + id_s * diff_src_d_stride;
                 const bool is_ddst_layout_nxc
                         = jcp.dst_tag == format_tag::ndhwc;
-                const dim_t oc_off_idx = is_ddst_layout_nxc
+                const int oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_off_idx)
@@ -1073,41 +1036,37 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb)
                         + d_lo * wht_d_stride;
 
-                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                dim_t ocb_end
-                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const dim_t load_work
-                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
-                                jcp.nb_ic_blocking * jcp.ic_block);
-                dim_t reduce_work = ocb_step * jcp.oc_block;
-                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    dim_t curr_nb_oc
-                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
+                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const int load_work = utils::this_block_size(icb * jcp.ic_block,
+                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
+                int reduce_work = ocb_step * jcp.oc_block;
+                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
-                        dim_t oj, k_lo;
-                        dim_t k_len;
+                    for (int ij = ih_s; ij < ih_e; ++ij) {
+                        int oj, k_len, k_lo;
                         if (is_fast_path_h) { // dilate == 0 && stride == 1
-                            dim_t i_t_overflow = max<dim_t>(
-                                    0, jcp.kh - 1 - ij - jcp.t_pad);
-                            dim_t i_b_overflow = max<dim_t>(
-                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            int i_t_overflow
+                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
+                            int i_b_overflow
+                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            dim_t dilate_h = jcp.dilate_h + 1;
+                            int dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            dim_t i_t_overflow
-                                    = div_up(max<dim_t>(0,
+                            int i_t_overflow
+                                    = div_up(max(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            dim_t i_b_overflow = div_up(
-                                    max<dim_t>(0,
+                            int i_b_overflow = div_up(
+                                    max(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -1115,16 +1074,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            dim_t i_t_overflow = max<dim_t>(0,
+                            int i_t_overflow = max(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            dim_t i_b_overflow = max<dim_t>(0,
+                            int i_b_overflow = max(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            dim_t overflow_kh_hi = jcp.kh - 1
+                            int overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            dim_t overflow_kh_lo
+                            int overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -1138,11 +1097,8 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_3d_ker_pipeline(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr,
-                                static_cast<int>(ocb), static_cast<int>(k_len),
-                                static_cast<int>(d_len),
-                                static_cast<int>(reduce_work),
-                                static_cast<int>(load_work));
+                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
+                                k_len, d_len, reduce_work, load_work);
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -1256,23 +1212,21 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 key_conv_wei_bia_reduction_bctx);
 
         /* reduction dimension */
-        int oh_reduce = static_cast<int>(
-                jcp.harness == harness_2d_reduction ? jcp.oh : 1);
-        balance211(static_cast<int>(jcp.mb * jcp.od * oh_reduce),
-                self->nthr_mb_, ithr_mb, img_start, img_end);
+        int oh_reduce = jcp.harness == harness_2d_reduction ? jcp.oh : 1;
+        balance211(jcp.mb * jcp.od * oh_reduce, self->nthr_mb_, ithr_mb,
+                img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
-                g_start, g_end);
+        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
-                oc_b_start, oc_b_end);
+        balance211(
+                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
-                ic_b_start, ic_b_end);
+        balance211(
+                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };
@@ -1284,25 +1238,25 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const {
     const auto &jcp = kernel_->jcp;
 
-    const dim_t wei_size
+    const int wei_size
             = jcp.ngroups * jcp.oc * jcp.ic * jcp.kh * jcp.kw * jcp.kd;
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
             : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
 
-    auto diff_weights_offset = [&](dim_t g, dim_t i_kd, dim_t i_kh, dim_t i_kw,
-                                       dim_t i_ic, dim_t i_oc) {
-        const dim_t oc_block_size = 1;
-        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
-        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
-        const dim_t kh_block_size = jcp.kw * kw_block_size;
-        const dim_t kd_block_size = jcp.kh * kh_block_size;
-        const dim_t icb_block_size = jcp.kd * kd_block_size;
-        const dim_t ocb_block_size = jcp.nb_ic * icb_block_size;
-        const dim_t g_block_size = jcp.nb_oc * ocb_block_size;
+    auto diff_weights_offset
+            = [&](int g, int i_kd, int i_kh, int i_kw, int i_ic, int i_oc) {
+        const int oc_block_size = 1;
+        const int ic_block_size = jcp.oc_block * oc_block_size;
+        const int kw_block_size = jcp.ic_block * ic_block_size;
+        const int kh_block_size = jcp.kw * kw_block_size;
+        const int kd_block_size = jcp.kh * kh_block_size;
+        const int icb_block_size = jcp.kd * kd_block_size;
+        const int ocb_block_size = jcp.nb_ic * icb_block_size;
+        const int g_block_size = jcp.nb_oc * ocb_block_size;
 
-        dim_t icb = i_ic / jcp.ic_block;
-        dim_t ocb = i_oc / jcp.oc_block;
+        int icb = i_ic / jcp.ic_block;
+        int ocb = i_oc / jcp.oc_block;
         i_ic = i_ic % jcp.ic_block;
         i_oc = i_oc % jcp.oc_block;
 
@@ -1311,27 +1265,27 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 + i_kw * kw_block_size + i_ic * ic_block_size
                 + i_oc * oc_block_size;
     };
-    auto src_offset = [&](dim_t g, dim_t i_mb, dim_t i_id, dim_t i_ih,
-                              dim_t i_ic, dim_t i_iw) {
-        const dim_t ic_block_size = 1;
-        const dim_t g_block_size = jcp.ic * ic_block_size;
-        const dim_t iw_block_size = jcp.ngroups * g_block_size;
-        const dim_t ih_block_size = jcp.iw * iw_block_size;
-        const dim_t id_block_size = jcp.ih * ih_block_size;
-        const dim_t mb_block_size = jcp.id * id_block_size;
+    auto src_offset
+            = [&](int g, int i_mb, int i_id, int i_ih, int i_ic, int i_iw) {
+        const int ic_block_size = 1;
+        const int g_block_size = jcp.ic * ic_block_size;
+        const int iw_block_size = jcp.ngroups * g_block_size;
+        const int ih_block_size = jcp.iw * iw_block_size;
+        const int id_block_size = jcp.ih * ih_block_size;
+        const int mb_block_size = jcp.id * id_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_id * id_block_size
                 + i_ih * ih_block_size + i_iw * iw_block_size
                 + i_ic * ic_block_size;
     };
-    auto diff_dst_offset = [&](dim_t g, dim_t i_mb, dim_t i_od, dim_t i_oh,
-                                   dim_t i_ow, dim_t i_oc) {
-        const dim_t oc_block_size = 1;
-        const dim_t g_block_size = jcp.oc * oc_block_size;
-        const dim_t ow_block_size = jcp.ngroups * g_block_size;
-        const dim_t oh_block_size = jcp.ow * ow_block_size;
-        const dim_t od_block_size = jcp.oh * oh_block_size;
-        const dim_t mb_block_size = jcp.od * od_block_size;
+    auto diff_dst_offset
+            = [&](int g, int i_mb, int i_od, int i_oh, int i_ow, int i_oc) {
+        const int oc_block_size = 1;
+        const int g_block_size = jcp.oc * oc_block_size;
+        const int ow_block_size = jcp.ngroups * g_block_size;
+        const int oh_block_size = jcp.ow * ow_block_size;
+        const int od_block_size = jcp.oh * oh_block_size;
+        const int mb_block_size = jcp.od * od_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_od * od_block_size
                 + i_oh * oh_block_size + i_ow * ow_block_size
@@ -1343,47 +1297,47 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_wei[i] = 0;
     };
 
-    dim_t kd_step = jcp.dilate_d + 1;
-    dim_t kh_step = jcp.dilate_h + 1;
-    dim_t stride_d = jcp.stride_d;
-    dim_t stride_h = jcp.stride_h;
-    dim_t f_pad = jcp.f_pad;
-    dim_t t_pad = jcp.t_pad;
+    int kd_step = jcp.dilate_d + 1;
+    int kh_step = jcp.dilate_h + 1;
+    int stride_d = jcp.stride_d;
+    int stride_h = jcp.stride_h;
+    int f_pad = jcp.f_pad;
+    int t_pad = jcp.t_pad;
 
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * jcp.od * jcp.oh * jcp.nb_ow;
     dim_t i_work {0}, i_work_end {0};
     balance211(work_amount, jcp.nthr_mb, ti->ithr_mb, i_work, i_work_end);
 
-    dim_t i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
+    int i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
     nd_iterator_init(
             i_work, i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
 
     zero_diff_weights();
     while (i_work < i_work_end) {
-        dim_t kd_start = div_up(
-                nstl::max<dim_t>(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
-        dim_t kd_end = nstl::min<dim_t>(
+        int kd_start = div_up(
+                nstl::max(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
+        int kd_end = nstl::min(
                 jcp.kd - 1, (jcp.id - 1 + f_pad - stride_d * i_od) / kd_step);
-        dim_t i_id_base = stride_d * i_od - f_pad;
-        dim_t kh_start = div_up(
-                nstl::max<dim_t>(0, jcp.t_pad - jcp.stride_h * i_oh), kh_step);
-        dim_t kh_end = nstl::min<dim_t>(
+        int i_id_base = stride_d * i_od - f_pad;
+        int kh_start = div_up(
+                nstl::max(0, jcp.t_pad - jcp.stride_h * i_oh), +kh_step);
+        int kh_end = nstl::min(
                 jcp.kh - 1, (jcp.ih - 1 + t_pad - stride_h * i_oh) / kh_step);
-        dim_t i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
-        dim_t i_ow_base = i_owb * jcp.ow_block;
-        dim_t i_ow_end = nstl::min<dim_t>(jcp.ow, i_ow_base + jcp.ow_block);
+        int i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
+        int i_ow_base = i_owb * jcp.ow_block;
+        int i_ow_end = nstl::min(jcp.ow, i_ow_base + jcp.ow_block);
 
         // The kernel is small so these loops produce measurable overhead. Since
         // these are simple loops, the compiler will likely make the loops just
         // as well as we can with the jitted assembly, so there is not
         // necessarily a reason to move these loops into assembly. Avoid placing
         // computationally heavy operations within the loops.
-        for_(dim_t i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
-        for_(dim_t i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
-        for_(dim_t g = 0; g < jcp.ngroups; g++)
-        for_(dim_t i_kd = kd_start; i_kd <= kd_end; i_kd++)
-        for (dim_t i_kh = kh_start; i_kh <= kh_end; i_kh++) {
+        for_(int i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
+        for_(int i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
+        for_(int g = 0; g < jcp.ngroups; g++)
+        for_(int i_kd = kd_start; i_kd <= kd_end; i_kd++)
+        for (int i_kh = kh_start; i_kh <= kh_end; i_kh++) {
             // Some Optimization Observations: It may be
             // worthwhile to move the kd and kh loops below the
             // icb loop in the kernel to further amortize the
@@ -1395,18 +1349,16 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             // The compiler seems to do a good job at optimizing these
             // computations. The offset functions likely need to be located
             // so that they will be inlined.
-            dim_t i_iw = i_ow * jcp.stride_w - jcp.l_pad;
-            dim_t i_id = i_id_base + i_kd * kd_step;
-            dim_t i_ih = i_ih_base + i_kh * kh_step;
-            dim_t ddst_offset
-                    = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
-            dim_t s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
-            dim_t dwei_off_base
-                    = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
+            int i_iw = i_ow * jcp.stride_w - jcp.l_pad;
+            int i_id = i_id_base + i_kd * kd_step;
+            int i_ih = i_ih_base + i_kh * kh_step;
+            int ddst_offset = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
+            int s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
+            int dwei_off_base = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
             // ensure all parameters are 64bit, to comply with windows kernel
             // param access where the params from 5th are passed using stack.
             (*kernel_)(&diff_wei[dwei_off_base], &ti->src[s_off_base],
-                    &ti->diff_dst[ddst_offset], i_iw, i_ow);
+                    &ti->diff_dst[ddst_offset], (dim_t)i_iw, (dim_t)i_ow);
         }
         nd_iterator_step(
                 i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
@@ -1425,9 +1377,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const dim_t wei_size = jcp.ngroups * padded_oc
-            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1444,27 +1396,25 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     for (int img = ti->img_start; img < ti->img_end; ++img) {
         auto p = jit_conv_args_t();
 
-        const dim_t max_oc
-                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const dim_t max_ic
-                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const dim_t _oc = g * jcp.nb_oc + oc_b;
-            const dim_t _ic = g * jcp.nb_ic + ic_b;
-            const dim_t ic_to_compute = this_block_size(
+            const int _oc = g * jcp.nb_oc + oc_b;
+            const int _ic = g * jcp.nb_ic + ic_b;
+            const int ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const dim_t oc_to_compute = this_block_size(
+            const int oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
 
-            const dim_t ic_off_idx = is_src_layout_nxc
+            const int ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const dim_t oc_off_idx = is_ddst_layout_nxc
+            const int oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
 
@@ -1489,9 +1439,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const dim_t wei_size = jcp.ngroups * padded_oc
-            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1501,10 +1451,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             : ti->wei_bia_reduction + (nthr_mb_ - 1) * wei_size
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
-    dim_t img {0}, oh_s {0};
-    dim_t img_start = ti->img_start, img_end = ti->img_end;
+    int img {0}, oh_s {0};
+    int img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, oh_s, jcp.oh);
-    const dim_t img_first = img;
+    const int img_first = img;
 
     int ic_b_step = jcp.nb_ic_blocking_max;
     int icb_work = ti->ic_b_end - ti->ic_b_start;
@@ -1513,38 +1463,35 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        dim_t work_rem = img_end - img_start;
-        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih_s);
-        const dim_t kh_bottom_overflow
-                = nstl::max<dim_t>(0, ih_s - jcp.ih + jcp.kh);
-        dim_t kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
-        dim_t kh_padding_offset = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow)
-                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        int work_rem = img_end - img_start;
+        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        const int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const int kh_top_overflow = nstl::max(0, -ih_s);
+        const int kh_bottom_overflow = nstl::max(0, ih_s - jcp.ih + jcp.kh);
+        int kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
+        int kh_padding_offset = nstl::min(jcp.kh - 1, kh_top_overflow) * jcp.kw
+                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
         auto src_h = ti->src + src_d.blk_off(img, 0, ih_s + kh_top_overflow);
         auto diff_dst_h = ti->diff_dst + diff_dst_d.blk_off(img, 0, oh_s);
 
         const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
         const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-        const dim_t max_oc
-                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const dim_t max_ic
-                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const dim_t _oc = g * jcp.nb_oc + oc_b;
-            const dim_t _ic = g * jcp.nb_ic + ic_b;
-            const dim_t ic_to_compute = this_block_size(
+            const int _oc = g * jcp.nb_oc + oc_b;
+            const int _ic = g * jcp.nb_ic + ic_b;
+            const int ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const dim_t oc_to_compute = this_block_size(
+            const int oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
-            const dim_t ic_off_idx = is_src_layout_nxc
+            const int ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const dim_t oc_off_idx = is_ddst_layout_nxc
+            const int oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = src_h + src_d.blk_off(0, ic_off_idx);
@@ -1552,10 +1499,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_2d_ker_bwd_w_pipeline(jit_ker, p, src, diff_dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia + _oc * jcp.oc_block, (img == img_first),
-                    static_cast<int>(oh_s), static_cast<int>(oh_e),
-                    static_cast<int>(kh_padding), kh_padding_offset,
-                    ic_to_compute, oc_to_compute);
+                    diff_bia + _oc * jcp.oc_block, (img == img_first), oh_s,
+                    oh_e, kh_padding, kh_padding_offset, ic_to_compute,
+                    oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, oh_s, jcp.oh);
     }
@@ -1572,9 +1518,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const dim_t wei_size = jcp.ngroups * padded_oc
-            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1585,17 +1531,17 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-    const dim_t inp_mult = is_src_layout_nxc
+    const int inp_mult = is_src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const dim_t input_step = jcp.ih * jcp.iw * inp_mult;
+    const int input_step = jcp.ih * jcp.iw * inp_mult;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const dim_t output_step = jcp.ow * jcp.oh
+    const int output_step = jcp.ow * jcp.oh
             * (is_ddst_layout_nxc ? jcp.ngroups * jcp.oc : jcp.oc_block);
-    dim_t img {0}, od_s {0};
-    dim_t img_start = ti->img_start, img_end = ti->img_end;
+    int img {0}, od_s {0};
+    int img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-    const dim_t img_first = img;
+    const int img_first = img;
 
     int ic_b_step = jcp.nb_ic_blocking_max;
     int icb_work = ti->ic_b_end - ti->ic_b_start;
@@ -1605,37 +1551,35 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        dim_t work_rem = img_end - img_start;
-        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        const dim_t id_s = od_s * jcp.stride_d;
-        const dim_t ik_overlap = nstl::max<dim_t>(0, id_s - jcp.f_pad);
-        const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad - id_s);
-        const dim_t kd_back_pad
-                = nstl::max<dim_t>(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
-        dim_t kd_pad_off = nstl::min<dim_t>(jcp.kd - 1, kd_front_pad) * jcp.kh
-                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        int work_rem = img_end - img_start;
+        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        const int id_s = od_s * jcp.stride_d;
+        const int ik_overlap = nstl::max(0, id_s - jcp.f_pad);
+        const int kd_front_pad = nstl::max(0, jcp.f_pad - id_s);
+        const int kd_back_pad
+                = nstl::max(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
+        int kd_pad_off = nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw
+                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
-        const dim_t max_oc
-                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const dim_t max_ic
-                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
 
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const dim_t _oc = g * jcp.nb_oc + oc_b;
-            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const int _oc = g * jcp.nb_oc + oc_b;
+            const int _ic = g * jcp.nb_ic + ic_b;
 
-            const dim_t ic_to_compute = this_block_size(
+            const int ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const dim_t oc_to_compute = this_block_size(
+            const int oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
 
-            const dim_t ic_off_idx = is_src_layout_nxc
+            const int ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const dim_t oc_off_idx = is_ddst_layout_nxc
+            const int oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = &ti->src[src_d.blk_off(img, ic_off_idx)
@@ -1646,10 +1590,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_3d_ker_bwd_w_pipeline(jit_ker, p, src, dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia_ptr, (img == img_first), static_cast<int>(od_s),
-                    static_cast<int>(od_e),
-                    static_cast<int>(jcp.kd - kd_front_pad - kd_back_pad),
-                    kd_pad_off, ic_to_compute, oc_to_compute);
+                    diff_bia_ptr, (img == img_first), od_s, od_e,
+                    jcp.kd - kd_front_pad - kd_back_pad, kd_pad_off,
+                    ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, od_s, jcp.od);
     }
@@ -1662,35 +1605,34 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const dim_t wei_size = jcp.ngroups * padded_oc
-            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
+    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
+            * jcp.kh * jcp.kw;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kh;
-    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const int ic_b_kh_work = ti->ic_b_work * jcp.kh;
+    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int bal_start {0}, bal_end {0};
-    balance211(
-            static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start, bal_end);
-    if (bal_start == bal_end) return;
+    int start {0}, end {0};
+    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
+    if (start == end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        dim_t w = bal_start, end = bal_end;
-        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        int w = start;
+        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const dim_t g = ti->g_start + sub_g_start;
-            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
-            const dim_t ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
-            const dim_t kh = sub_ic_b_kh_start % jcp.kh;
+            const int g = ti->g_start + sub_g_start;
+            const int oc_b = ti->oc_b_start + sub_oc_b_start;
+            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
+            const int kh = sub_ic_b_kh_start % jcp.kh;
 
-            const dim_t acc_size = nstl::min<dim_t>(end - w,
-                                           ic_b_kh_work - sub_ic_b_kh_start)
+            const int acc_size
+                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kh);
@@ -1700,7 +1642,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_weights_data_t *s
                     = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
 
-            acc_ker_->accumulate(d, s, static_cast<int>(acc_size));
+            acc_ker_->accumulate(d, s, acc_size);
 
             nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
                     ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
@@ -1716,34 +1658,33 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kd;
-    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const int ic_b_kh_work = ti->ic_b_work * jcp.kd;
+    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int bal_start {0}, bal_end {0};
-    balance211(
-            static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start, bal_end);
-    if (bal_start == bal_end) return;
+    int start {0}, end {0};
+    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
+    if (start == end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        dim_t w = bal_start, end = bal_end;
-        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        int w = start;
+        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const dim_t g = ti->g_start + sub_g_start;
-            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
-            const dim_t ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
-            const dim_t kd = sub_ic_b_kh_start % jcp.kd;
+            const int g = ti->g_start + sub_g_start;
+            const int oc_b = ti->oc_b_start + sub_oc_b_start;
+            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
+            const int kd = sub_ic_b_kh_start % jcp.kd;
 
-            const dim_t acc_size = nstl::min<dim_t>(end - w,
-                                           ic_b_kh_work - sub_ic_b_kh_start)
+            const int acc_size
+                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.kh;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kd);
@@ -1751,7 +1692,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     = (diff_weights_data_t *)ti->diff_weights + off;
             diff_weights_data_t *s
                     = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
-            acc_ker_->accumulate(d, s, static_cast<int>(acc_size));
+            acc_ker_->accumulate(d, s, acc_size);
 
             nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
                     ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
@@ -1780,22 +1721,22 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     /* reduction dimension */
     int img_start {0}, img_end {0};
-    balance211(static_cast<int>(jcp.mb), rb->balancer().nthr_per_group_,
+    balance211(jcp.mb, rb->balancer().nthr_per_group_,
             rb->balancer().id_in_group(ti->ithr), img_start, img_end);
 
     /* jobs */
     int g_start {0}, ocb_start {0};
     nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
-    for (dim_t img = img_start; img < img_end; ++img) {
+    for (int img = img_start; img < img_end; ++img) {
         int g = g_start, ocb = ocb_start;
         for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-            const dim_t _oc = g * jcp.nb_oc + ocb;
-            const dim_t max_oc
+            const size_t _oc = g * jcp.nb_oc + ocb;
+            const int max_oc
                     = this_block_size(ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                     format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-            const dim_t oc_off_idx = is_ddst_layout_nxc
+            const int oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : _oc;
             const diff_dst_data_t *d_dst
@@ -1810,7 +1751,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
                 PRAGMA_OMP_SIMD()
-                for (dim_t o = 0; o < max_oc; ++o)
+                for (int o = 0; o < max_oc; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                             : jcp.oc_block;
@@ -1832,7 +1773,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const size_t wei_size = (size_t)jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
-    const dim_t bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
+    const int bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
     const diff_weights_data_t *diff_bias_ws
             = ti->wei_bia_reduction + (size_t)(nthr_mb_ - 1) * wei_size;
 
@@ -1840,8 +1781,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     if (ti->ithr == 0) {
         for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-            acc_ker_->accumulate(
-                    ti->diff_bias, diff_bias_ws, static_cast<int>(bia_size));
+            acc_ker_->accumulate(ti->diff_bias, diff_bias_ws, bia_size);
             diff_bias_ws += bia_size;
         }
     }
@@ -1970,8 +1910,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                                              key_conv_padded_bias);
             auto diff_bias_in
                     = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
-            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const dim_t stride = jcp.oc_without_padding;
+            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const int stride = jcp.oc_without_padding;
             for (int g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -118,7 +118,7 @@ inline void jit_conv_ker_pipeline_bwd_w(const jit_conv_ker_t ker,
         const void *bias, int channel, int kh_padding, size_t reduce_work,
         size_t load_work) {
     jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
-            reduce_work, load_work);
+            static_cast<int>(reduce_work), static_cast<int>(load_work));
 }
 
 void jit_conv_2d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
@@ -203,14 +203,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -221,9 +221,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t src_c_stride = src_d.blk_off<false, true>(0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
@@ -241,20 +241,20 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
             }
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const int oc_off_idx = is_dst_layout_nxc
+                const dim_t oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const int ic_off_idx = is_src_layout_nxc
+                const dim_t ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src + src_d.blk_off(n, ic_off_idx, iw_s);
@@ -264,16 +264,18 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                dim_t icb_end
+                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                int ic_work = icb_step * jcp.ic_block;
+                dim_t ic_work = icb_step * jcp.ic_block;
 
-                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = static_cast<int>(
+                            nstl::min<dim_t>(icb_step, icb_end - icb));
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -282,7 +284,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                 jcp.ic, icb_step * jcp.ic_block);
                     }
                     jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv, src_w,
-                            dst_w, wht_w, bias_w, icb, 1, owb, ic_work, oc_work,
+                            dst_w, wht_w, bias_w, static_cast<int>(icb), 1,
+                            static_cast<int>(owb), static_cast<int>(ic_work),
+                            static_cast<int>(oc_work),
                             post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                     src_w += src_c_stride;
@@ -329,14 +333,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -350,9 +354,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -367,49 +371,52 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int work_rem = end - start;
+                dim_t work_rem = end - start;
 
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                for (int oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
-                    int ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
+                for (dim_t oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
+                    dim_t ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
                     const bool is_dst_layout_nxc
                             = jcp.dst_tag == format_tag::nhwc;
-                    const int oc_off_idx = is_dst_layout_nxc
+                    const dim_t oc_off_idx = is_dst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g_ocb;
                     auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, oh_b, ow_s);
                     const bool is_src_layout_nxc
                             = jcp.src_tag == format_tag::nhwc;
-                    const int ic_off_idx = is_src_layout_nxc
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g * jcp.ic + icb_l2 * jcp.ic_block
                             : g_icb + icb_l2;
                     auto src_w = src + src_d.blk_off(n, ic_off_idx, ih_b, iw_s);
                     auto wht_w
                             = weights + wht_blk_off(weights_d, g, ocb, icb_l2);
 
-                    int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                    int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                    dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                    dim_t icb_end = nstl::min<dim_t>(
+                            jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
                     auto bias_w = bias ? bias
                                     + oc_off_idx
                                             * (is_dst_layout_nxc ? 1
                                                                  : jcp.oc_block)
                                        : nullptr;
-                    const int oc_work = utils::this_block_size(
+                    const dim_t oc_work = utils::this_block_size(
                             ocb * jcp.oc_block, jcp.oc_without_padding,
                             jcp.nb_oc_blocking * jcp.oc_block);
-                    int ic_work = icb_step * jcp.ic_block;
-                    for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                        int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                    dim_t ic_work = icb_step * jcp.ic_block;
+                    for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                        int curr_nb_ic = static_cast<int>(
+                                nstl::min<dim_t>(icb_step, icb_end - icb));
                         int flags = 0;
                         if (icb == 0) flags |= FLAG_IC_FIRST;
                         if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -419,18 +426,19 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                         }
                         auto src_c = src_w;
                         auto dst_c = dst_w;
-                        for (int oj = oh_b, ij = ih_b;
-                                oj < min(oh_e, oh_b + jcp.h_blocking);
+                        for (dim_t oj = oh_b, ij = ih_b; oj
+                                < nstl::min<dim_t>(oh_e, oh_b + jcp.h_blocking);
                                 ++oj, ij += jcp.stride_h) {
-                            int dilate_h = jcp.dilate_h + 1;
-                            int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t dilate_h = jcp.dilate_h + 1;
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0, -ij), dilate_h);
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             ij - jcp.ih
                                                     + (jcp.kh - 1) * dilate_h
                                                     + 1),
                                     dilate_h);
-                            int kh_padding = nstl::max(
+                            dim_t kh_padding = nstl::max<dim_t>(
                                     0, jcp.kh - i_t_overflow - i_b_overflow);
 
                             auto aux_src = src_c
@@ -438,8 +446,12 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                             auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
                             jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv,
-                                    aux_src, dst_c, aux_wht, bias_w, icb,
-                                    kh_padding, owb, ic_work, oc_work,
+                                    aux_src, dst_c, aux_wht, bias_w,
+                                    static_cast<int>(icb),
+                                    static_cast<int>(kh_padding),
+                                    static_cast<int>(owb),
+                                    static_cast<int>(ic_work),
+                                    static_cast<int>(oc_work),
                                     post_ops_binary_rhs_arg_vec.data(), dst,
                                     flags);
 
@@ -488,15 +500,15 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -512,9 +524,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -529,36 +541,38 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
 
-                int dilate_d = jcp.dilate_d + 1;
-                int d_t_overflow = div_up(max(0, -id_s), dilate_d);
-                int d_b_overflow = div_up(
-                        max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                dim_t dilate_d = jcp.dilate_d + 1;
+                dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
+                dim_t d_b_overflow = div_up(
+                        max<dim_t>(
+                                0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                         dilate_d);
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+                dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_t_overflow - d_b_overflow);
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-                const int oc_off_idx = is_dst_layout_nxc
+                const dim_t oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w
                         = dst + dst_d.blk_off(n, oc_off_idx, od_s, oh_s, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-                const int ic_off_idx = is_src_layout_nxc
+                const dim_t ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src
@@ -571,15 +585,17 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                const int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                const dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                dim_t icb_end
+                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                int ic_work = icb_step * jcp.ic_block;
-                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                dim_t ic_work = icb_step * jcp.ic_block;
+                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = static_cast<int>(
+                            nstl::min<dim_t>(icb_step, icb_end - icb));
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -589,22 +605,27 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                     }
                     auto src_c = src_w;
                     auto dst_c = dst_w;
-                    for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                    for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                             ++oj, ij += jcp.stride_h) {
-                        int dilate_h = jcp.dilate_h + 1;
-                        int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                        int i_b_overflow = div_up(
-                                max(0,
+                        dim_t dilate_h = jcp.dilate_h + 1;
+                        dim_t i_t_overflow
+                                = div_up(max<dim_t>(0, -ij), dilate_h);
+                        dim_t i_b_overflow = div_up(
+                                max<dim_t>(0,
                                         ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                 + 1),
                                 dilate_h);
-                        int kh_padding = nstl::max(
+                        dim_t kh_padding = nstl::max<dim_t>(
                                 0, jcp.kh - i_t_overflow - i_b_overflow);
                         jit_conv_3d_ker_pipeline_ow_thr(jit_ker, par_conv,
                                 src_c + i_t_overflow * dilate_h * src_h_stride,
                                 dst_c, wht_w + i_t_overflow * wht_h_stride,
-                                bias_w, icb, kh_padding, kd_padding, owb,
-                                ic_work, oc_work,
+                                bias_w, static_cast<int>(icb),
+                                static_cast<int>(kh_padding),
+                                static_cast<int>(kd_padding),
+                                static_cast<int>(owb),
+                                static_cast<int>(ic_work),
+                                static_cast<int>(oc_work),
                                 post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                         src_c += src_h_stride * jcp.stride_h;
@@ -650,14 +671,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -668,9 +689,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         size_t diff_dst_c_stride = diff_dst_d.blk_off<false, true>(0, 1);
         size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, iwb {0};
+            dim_t n {0}, gg {0}, icc {0}, iwb {0};
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -687,42 +708,47 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
             }
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
-                int iw_s = iwb * jcp.iw_block;
-                int ow_s = iw_s / jcp.stride_w;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
+                dim_t iw_s = iwb * jcp.iw_block;
+                dim_t ow_s = iw_s / jcp.stride_w;
 
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc
+                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
 
                     jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src_w,
-                            diff_dst_w, wht_w, nullptr, ocb, 1, iwb,
-                            reduce_work, load_work);
+                            diff_dst_w, wht_w, nullptr, static_cast<int>(ocb),
+                            1, static_cast<int>(iwb),
+                            static_cast<int>(reduce_work),
+                            static_cast<int>(load_work));
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
                 }
@@ -762,14 +788,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -785,9 +811,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -802,62 +828,66 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
 
-                int work_rem = end - start;
-                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_e
+                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                int iw_s = iwb * jcp.iw_block;
-                int ow_s = iw_s / jcp.stride_w;
+                dim_t iw_s = iwb * jcp.iw_block;
+                dim_t ow_s = iw_s / jcp.stride_w;
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nhwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, 0, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, 0, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc
+                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (int ij = ih_s; ij < ih_e; ++ij) {
-                        int oj, k_len, k_lo;
+                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                        dim_t oj, k_len, k_lo;
                         if (is_fast_path) { // dilate == 0 && stride == 1
-                            int i_t_overflow
-                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                            int i_b_overflow
-                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            dim_t i_t_overflow = max<dim_t>(
+                                    0, jcp.kh - 1 - ij - jcp.t_pad);
+                            dim_t i_b_overflow = max<dim_t>(
+                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            int dilate_h = jcp.dilate_h + 1;
+                            dim_t dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            int i_t_overflow
-                                    = div_up(max(0,
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -865,16 +895,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            int i_t_overflow = max(0,
+                            dim_t i_t_overflow = max<dim_t>(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            int i_b_overflow = max(0,
+                            dim_t i_b_overflow = max<dim_t>(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            int overflow_kh_hi = jcp.kh - 1
+                            dim_t overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            int overflow_kh_lo
+                            dim_t overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -887,8 +917,11 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
-                                k_len, iwb, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr,
+                                static_cast<int>(ocb), static_cast<int>(k_len),
+                                static_cast<int>(iwb),
+                                static_cast<int>(reduce_work),
+                                static_cast<int>(load_work));
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -926,14 +959,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -953,9 +986,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
+            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
             // Input width threading is not currently implemented for 3d, so it
             // is not included in the iterator.
             if (jcp.loop_order == loop_cwgn)
@@ -971,31 +1004,35 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
 
-                int work_rem = end - start;
-                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_e
+                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                int d_len = 0, d_lo = 0, d_oj = 0;
+                dim_t d_len = 0;
+                dim_t d_lo = 0, d_oj = 0;
                 if (is_fast_path_d) { // dilate == 0 && stride == 1
-                    int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                    int d_b_overflow
-                            = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                    dim_t d_t_overflow
+                            = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                    dim_t d_b_overflow = max<dim_t>(
+                            0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                     d_len = jcp.kd - d_t_overflow - d_b_overflow;
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow;
                 } else if (jcp.dilate_d != 0) { // stride == 1
-                    int dilate_d = jcp.dilate_d + 1;
+                    dim_t dilate_d = jcp.dilate_d + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int d_t_overflow = div_up(
-                            max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                    dim_t d_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                             dilate_d);
-                    int d_b_overflow = div_up(
-                            max(0,
+                    dim_t d_b_overflow = div_up(
+                            max<dim_t>(0,
                                     (jcp.kd - 1) * dilate_d + 1 - jcp.id + id_s
                                             - jcp.back_pad),
                             dilate_d);
@@ -1003,15 +1040,15 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow * dilate_d;
                 } else { // dilate == 0
-                    int d_t_overflow = max(
+                    dim_t d_t_overflow = max<dim_t>(
                             0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                    int d_b_overflow = max(0,
+                    dim_t d_b_overflow = max<dim_t>(0,
                             (jcp.kd - jcp.id + id_s - jcp.back_pad)
                                     / jcp.stride_d);
-                    int overflow_kd_hi = jcp.kd - 1
+                    dim_t overflow_kd_hi = jcp.kd - 1
                             - modulo(jcp.id - 1 + jcp.back_pad - id_s,
                                     jcp.stride_d);
-                    int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                    dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                     d_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                             - d_t_overflow - d_b_overflow;
@@ -1021,14 +1058,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
                 const bool is_dsrc_layout_nxc
                         = jcp.src_tag == format_tag::ndhwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w = diff_src + diff_src_d.blk_off(n, ic_off_idx)
                         + id_s * diff_src_d_stride;
                 const bool is_ddst_layout_nxc
                         = jcp.dst_tag == format_tag::ndhwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_off_idx)
@@ -1036,37 +1073,41 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb)
                         + d_lo * wht_d_stride;
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc
+                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (int ij = ih_s; ij < ih_e; ++ij) {
-                        int oj, k_len, k_lo;
+                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                        dim_t oj, k_lo;
+                        dim_t k_len;
                         if (is_fast_path_h) { // dilate == 0 && stride == 1
-                            int i_t_overflow
-                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                            int i_b_overflow
-                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            dim_t i_t_overflow = max<dim_t>(
+                                    0, jcp.kh - 1 - ij - jcp.t_pad);
+                            dim_t i_b_overflow = max<dim_t>(
+                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            int dilate_h = jcp.dilate_h + 1;
+                            dim_t dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            int i_t_overflow
-                                    = div_up(max(0,
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -1074,16 +1115,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            int i_t_overflow = max(0,
+                            dim_t i_t_overflow = max<dim_t>(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            int i_b_overflow = max(0,
+                            dim_t i_b_overflow = max<dim_t>(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            int overflow_kh_hi = jcp.kh - 1
+                            dim_t overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            int overflow_kh_lo
+                            dim_t overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -1097,8 +1138,11 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_3d_ker_pipeline(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
-                                k_len, d_len, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr,
+                                static_cast<int>(ocb), static_cast<int>(k_len),
+                                static_cast<int>(d_len),
+                                static_cast<int>(reduce_work),
+                                static_cast<int>(load_work));
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -1212,21 +1256,23 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 key_conv_wei_bia_reduction_bctx);
 
         /* reduction dimension */
-        int oh_reduce = jcp.harness == harness_2d_reduction ? jcp.oh : 1;
-        balance211(jcp.mb * jcp.od * oh_reduce, self->nthr_mb_, ithr_mb,
-                img_start, img_end);
+        int oh_reduce = static_cast<int>(
+                jcp.harness == harness_2d_reduction ? jcp.oh : 1);
+        balance211(static_cast<int>(jcp.mb * jcp.od * oh_reduce),
+                self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
+                g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };
@@ -1238,25 +1284,25 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const {
     const auto &jcp = kernel_->jcp;
 
-    const int wei_size
+    const dim_t wei_size
             = jcp.ngroups * jcp.oc * jcp.ic * jcp.kh * jcp.kw * jcp.kd;
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
             : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
 
-    auto diff_weights_offset
-            = [&](int g, int i_kd, int i_kh, int i_kw, int i_ic, int i_oc) {
-        const int oc_block_size = 1;
-        const int ic_block_size = jcp.oc_block * oc_block_size;
-        const int kw_block_size = jcp.ic_block * ic_block_size;
-        const int kh_block_size = jcp.kw * kw_block_size;
-        const int kd_block_size = jcp.kh * kh_block_size;
-        const int icb_block_size = jcp.kd * kd_block_size;
-        const int ocb_block_size = jcp.nb_ic * icb_block_size;
-        const int g_block_size = jcp.nb_oc * ocb_block_size;
+    auto diff_weights_offset = [&](dim_t g, dim_t i_kd, dim_t i_kh, dim_t i_kw,
+                                       dim_t i_ic, dim_t i_oc) {
+        const dim_t oc_block_size = 1;
+        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
+        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
+        const dim_t kh_block_size = jcp.kw * kw_block_size;
+        const dim_t kd_block_size = jcp.kh * kh_block_size;
+        const dim_t icb_block_size = jcp.kd * kd_block_size;
+        const dim_t ocb_block_size = jcp.nb_ic * icb_block_size;
+        const dim_t g_block_size = jcp.nb_oc * ocb_block_size;
 
-        int icb = i_ic / jcp.ic_block;
-        int ocb = i_oc / jcp.oc_block;
+        dim_t icb = i_ic / jcp.ic_block;
+        dim_t ocb = i_oc / jcp.oc_block;
         i_ic = i_ic % jcp.ic_block;
         i_oc = i_oc % jcp.oc_block;
 
@@ -1265,27 +1311,27 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 + i_kw * kw_block_size + i_ic * ic_block_size
                 + i_oc * oc_block_size;
     };
-    auto src_offset
-            = [&](int g, int i_mb, int i_id, int i_ih, int i_ic, int i_iw) {
-        const int ic_block_size = 1;
-        const int g_block_size = jcp.ic * ic_block_size;
-        const int iw_block_size = jcp.ngroups * g_block_size;
-        const int ih_block_size = jcp.iw * iw_block_size;
-        const int id_block_size = jcp.ih * ih_block_size;
-        const int mb_block_size = jcp.id * id_block_size;
+    auto src_offset = [&](dim_t g, dim_t i_mb, dim_t i_id, dim_t i_ih,
+                              dim_t i_ic, dim_t i_iw) {
+        const dim_t ic_block_size = 1;
+        const dim_t g_block_size = jcp.ic * ic_block_size;
+        const dim_t iw_block_size = jcp.ngroups * g_block_size;
+        const dim_t ih_block_size = jcp.iw * iw_block_size;
+        const dim_t id_block_size = jcp.ih * ih_block_size;
+        const dim_t mb_block_size = jcp.id * id_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_id * id_block_size
                 + i_ih * ih_block_size + i_iw * iw_block_size
                 + i_ic * ic_block_size;
     };
-    auto diff_dst_offset
-            = [&](int g, int i_mb, int i_od, int i_oh, int i_ow, int i_oc) {
-        const int oc_block_size = 1;
-        const int g_block_size = jcp.oc * oc_block_size;
-        const int ow_block_size = jcp.ngroups * g_block_size;
-        const int oh_block_size = jcp.ow * ow_block_size;
-        const int od_block_size = jcp.oh * oh_block_size;
-        const int mb_block_size = jcp.od * od_block_size;
+    auto diff_dst_offset = [&](dim_t g, dim_t i_mb, dim_t i_od, dim_t i_oh,
+                                   dim_t i_ow, dim_t i_oc) {
+        const dim_t oc_block_size = 1;
+        const dim_t g_block_size = jcp.oc * oc_block_size;
+        const dim_t ow_block_size = jcp.ngroups * g_block_size;
+        const dim_t oh_block_size = jcp.ow * ow_block_size;
+        const dim_t od_block_size = jcp.oh * oh_block_size;
+        const dim_t mb_block_size = jcp.od * od_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_od * od_block_size
                 + i_oh * oh_block_size + i_ow * ow_block_size
@@ -1297,47 +1343,47 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_wei[i] = 0;
     };
 
-    int kd_step = jcp.dilate_d + 1;
-    int kh_step = jcp.dilate_h + 1;
-    int stride_d = jcp.stride_d;
-    int stride_h = jcp.stride_h;
-    int f_pad = jcp.f_pad;
-    int t_pad = jcp.t_pad;
+    dim_t kd_step = jcp.dilate_d + 1;
+    dim_t kh_step = jcp.dilate_h + 1;
+    dim_t stride_d = jcp.stride_d;
+    dim_t stride_h = jcp.stride_h;
+    dim_t f_pad = jcp.f_pad;
+    dim_t t_pad = jcp.t_pad;
 
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * jcp.od * jcp.oh * jcp.nb_ow;
     dim_t i_work {0}, i_work_end {0};
     balance211(work_amount, jcp.nthr_mb, ti->ithr_mb, i_work, i_work_end);
 
-    int i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
+    dim_t i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
     nd_iterator_init(
             i_work, i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
 
     zero_diff_weights();
     while (i_work < i_work_end) {
-        int kd_start = div_up(
-                nstl::max(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
-        int kd_end = nstl::min(
+        dim_t kd_start = div_up(
+                nstl::max<dim_t>(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
+        dim_t kd_end = nstl::min<dim_t>(
                 jcp.kd - 1, (jcp.id - 1 + f_pad - stride_d * i_od) / kd_step);
-        int i_id_base = stride_d * i_od - f_pad;
-        int kh_start = div_up(
-                nstl::max(0, jcp.t_pad - jcp.stride_h * i_oh), +kh_step);
-        int kh_end = nstl::min(
+        dim_t i_id_base = stride_d * i_od - f_pad;
+        dim_t kh_start = div_up(
+                nstl::max<dim_t>(0, jcp.t_pad - jcp.stride_h * i_oh), kh_step);
+        dim_t kh_end = nstl::min<dim_t>(
                 jcp.kh - 1, (jcp.ih - 1 + t_pad - stride_h * i_oh) / kh_step);
-        int i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
-        int i_ow_base = i_owb * jcp.ow_block;
-        int i_ow_end = nstl::min(jcp.ow, i_ow_base + jcp.ow_block);
+        dim_t i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
+        dim_t i_ow_base = i_owb * jcp.ow_block;
+        dim_t i_ow_end = nstl::min<dim_t>(jcp.ow, i_ow_base + jcp.ow_block);
 
         // The kernel is small so these loops produce measurable overhead. Since
         // these are simple loops, the compiler will likely make the loops just
         // as well as we can with the jitted assembly, so there is not
         // necessarily a reason to move these loops into assembly. Avoid placing
         // computationally heavy operations within the loops.
-        for_(int i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
-        for_(int i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
-        for_(int g = 0; g < jcp.ngroups; g++)
-        for_(int i_kd = kd_start; i_kd <= kd_end; i_kd++)
-        for (int i_kh = kh_start; i_kh <= kh_end; i_kh++) {
+        for_(dim_t i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
+        for_(dim_t i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
+        for_(dim_t g = 0; g < jcp.ngroups; g++)
+        for_(dim_t i_kd = kd_start; i_kd <= kd_end; i_kd++)
+        for (dim_t i_kh = kh_start; i_kh <= kh_end; i_kh++) {
             // Some Optimization Observations: It may be
             // worthwhile to move the kd and kh loops below the
             // icb loop in the kernel to further amortize the
@@ -1349,16 +1395,18 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             // The compiler seems to do a good job at optimizing these
             // computations. The offset functions likely need to be located
             // so that they will be inlined.
-            int i_iw = i_ow * jcp.stride_w - jcp.l_pad;
-            int i_id = i_id_base + i_kd * kd_step;
-            int i_ih = i_ih_base + i_kh * kh_step;
-            int ddst_offset = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
-            int s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
-            int dwei_off_base = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
+            dim_t i_iw = i_ow * jcp.stride_w - jcp.l_pad;
+            dim_t i_id = i_id_base + i_kd * kd_step;
+            dim_t i_ih = i_ih_base + i_kh * kh_step;
+            dim_t ddst_offset
+                    = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
+            dim_t s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
+            dim_t dwei_off_base
+                    = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
             // ensure all parameters are 64bit, to comply with windows kernel
             // param access where the params from 5th are passed using stack.
             (*kernel_)(&diff_wei[dwei_off_base], &ti->src[s_off_base],
-                    &ti->diff_dst[ddst_offset], (dim_t)i_iw, (dim_t)i_ow);
+                    &ti->diff_dst[ddst_offset], i_iw, i_ow);
         }
         nd_iterator_step(
                 i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
@@ -1377,9 +1425,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw * jcp.kd;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1396,25 +1444,27 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     for (int img = ti->img_start; img < ti->img_end; ++img) {
         auto p = jit_conv_args_t();
 
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
 
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
 
@@ -1439,9 +1489,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1451,10 +1501,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             : ti->wei_bia_reduction + (nthr_mb_ - 1) * wei_size
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
-    int img {0}, oh_s {0};
-    int img_start = ti->img_start, img_end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, oh_s, jcp.oh);
-    const int img_first = img;
+    const dim_t img_first = img;
 
     int ic_b_step = jcp.nb_ic_blocking_max;
     int icb_work = ti->ic_b_end - ti->ic_b_start;
@@ -1463,35 +1513,38 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        int work_rem = img_end - img_start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        const int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        const int kh_top_overflow = nstl::max(0, -ih_s);
-        const int kh_bottom_overflow = nstl::max(0, ih_s - jcp.ih + jcp.kh);
-        int kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
-        int kh_padding_offset = nstl::min(jcp.kh - 1, kh_top_overflow) * jcp.kw
-                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        dim_t work_rem = img_end - img_start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih_s);
+        const dim_t kh_bottom_overflow
+                = nstl::max<dim_t>(0, ih_s - jcp.ih + jcp.kh);
+        dim_t kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
+        dim_t kh_padding_offset = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow)
+                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
         auto src_h = ti->src + src_d.blk_off(img, 0, ih_s + kh_top_overflow);
         auto diff_dst_h = ti->diff_dst + diff_dst_d.blk_off(img, 0, oh_s);
 
         const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
         const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = src_h + src_d.blk_off(0, ic_off_idx);
@@ -1499,9 +1552,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_2d_ker_bwd_w_pipeline(jit_ker, p, src, diff_dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia + _oc * jcp.oc_block, (img == img_first), oh_s,
-                    oh_e, kh_padding, kh_padding_offset, ic_to_compute,
-                    oc_to_compute);
+                    diff_bia + _oc * jcp.oc_block, (img == img_first),
+                    static_cast<int>(oh_s), static_cast<int>(oh_e),
+                    static_cast<int>(kh_padding), kh_padding_offset,
+                    ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, oh_s, jcp.oh);
     }
@@ -1518,9 +1572,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw * jcp.kd;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1531,17 +1585,17 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-    const int inp_mult = is_src_layout_nxc
+    const dim_t inp_mult = is_src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int input_step = jcp.ih * jcp.iw * inp_mult;
+    const dim_t input_step = jcp.ih * jcp.iw * inp_mult;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const int output_step = jcp.ow * jcp.oh
+    const dim_t output_step = jcp.ow * jcp.oh
             * (is_ddst_layout_nxc ? jcp.ngroups * jcp.oc : jcp.oc_block);
-    int img {0}, od_s {0};
-    int img_start = ti->img_start, img_end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-    const int img_first = img;
+    const dim_t img_first = img;
 
     int ic_b_step = jcp.nb_ic_blocking_max;
     int icb_work = ti->ic_b_end - ti->ic_b_start;
@@ -1551,35 +1605,37 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        int work_rem = img_end - img_start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        const int id_s = od_s * jcp.stride_d;
-        const int ik_overlap = nstl::max(0, id_s - jcp.f_pad);
-        const int kd_front_pad = nstl::max(0, jcp.f_pad - id_s);
-        const int kd_back_pad
-                = nstl::max(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
-        int kd_pad_off = nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw
-                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        dim_t work_rem = img_end - img_start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        const dim_t id_s = od_s * jcp.stride_d;
+        const dim_t ik_overlap = nstl::max<dim_t>(0, id_s - jcp.f_pad);
+        const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad - id_s);
+        const dim_t kd_back_pad
+                = nstl::max<dim_t>(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
+        dim_t kd_pad_off = nstl::min<dim_t>(jcp.kd - 1, kd_front_pad) * jcp.kh
+                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
 
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
 
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
 
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = &ti->src[src_d.blk_off(img, ic_off_idx)
@@ -1590,9 +1646,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_3d_ker_bwd_w_pipeline(jit_ker, p, src, dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia_ptr, (img == img_first), od_s, od_e,
-                    jcp.kd - kd_front_pad - kd_back_pad, kd_pad_off,
-                    ic_to_compute, oc_to_compute);
+                    diff_bia_ptr, (img == img_first), static_cast<int>(od_s),
+                    static_cast<int>(od_e),
+                    static_cast<int>(jcp.kd - kd_front_pad - kd_back_pad),
+                    kd_pad_off, ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, od_s, jcp.od);
     }
@@ -1605,34 +1662,35 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work = ti->ic_b_work * jcp.kh;
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kh;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
-    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
-    if (start == end) return;
+    int bal_start {0}, bal_end {0};
+    balance211(
+            static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start, bal_end);
+    if (bal_start == bal_end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = bal_start, end = bal_end;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
-            const int kh = sub_ic_b_kh_start % jcp.kh;
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
+            const dim_t kh = sub_ic_b_kh_start % jcp.kh;
 
-            const int acc_size
-                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+            const dim_t acc_size = nstl::min<dim_t>(end - w,
+                                           ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kh);
@@ -1642,7 +1700,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_weights_data_t *s
                     = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
 
-            acc_ker_->accumulate(d, s, acc_size);
+            acc_ker_->accumulate(d, s, static_cast<int>(acc_size));
 
             nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
                     ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
@@ -1658,33 +1716,34 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work = ti->ic_b_work * jcp.kd;
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kd;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
-    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
-    if (start == end) return;
+    int bal_start {0}, bal_end {0};
+    balance211(
+            static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start, bal_end);
+    if (bal_start == bal_end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = bal_start, end = bal_end;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
-            const int kd = sub_ic_b_kh_start % jcp.kd;
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
+            const dim_t kd = sub_ic_b_kh_start % jcp.kd;
 
-            const int acc_size
-                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+            const dim_t acc_size = nstl::min<dim_t>(end - w,
+                                           ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.kh;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kd);
@@ -1692,7 +1751,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     = (diff_weights_data_t *)ti->diff_weights + off;
             diff_weights_data_t *s
                     = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
-            acc_ker_->accumulate(d, s, acc_size);
+            acc_ker_->accumulate(d, s, static_cast<int>(acc_size));
 
             nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
                     ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
@@ -1721,22 +1780,22 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     /* reduction dimension */
     int img_start {0}, img_end {0};
-    balance211(jcp.mb, rb->balancer().nthr_per_group_,
+    balance211(static_cast<int>(jcp.mb), rb->balancer().nthr_per_group_,
             rb->balancer().id_in_group(ti->ithr), img_start, img_end);
 
     /* jobs */
     int g_start {0}, ocb_start {0};
     nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
-    for (int img = img_start; img < img_end; ++img) {
+    for (dim_t img = img_start; img < img_end; ++img) {
         int g = g_start, ocb = ocb_start;
         for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-            const size_t _oc = g * jcp.nb_oc + ocb;
-            const int max_oc
+            const dim_t _oc = g * jcp.nb_oc + ocb;
+            const dim_t max_oc
                     = this_block_size(ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                     format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : _oc;
             const diff_dst_data_t *d_dst
@@ -1751,7 +1810,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < max_oc; ++o)
+                for (dim_t o = 0; o < max_oc; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                             : jcp.oc_block;
@@ -1773,7 +1832,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const size_t wei_size = (size_t)jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
-    const int bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
     const diff_weights_data_t *diff_bias_ws
             = ti->wei_bia_reduction + (size_t)(nthr_mb_ - 1) * wei_size;
 
@@ -1781,7 +1840,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     if (ti->ithr == 0) {
         for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-            acc_ker_->accumulate(ti->diff_bias, diff_bias_ws, bia_size);
+            acc_ker_->accumulate(
+                    ti->diff_bias, diff_bias_ws, static_cast<int>(bia_size));
             diff_bias_ws += bia_size;
         }
     }
@@ -1910,8 +1970,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                                              key_conv_padded_bias);
             auto diff_bias_in
                     = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
             for (int g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -232,8 +232,9 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
             const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
         }
     };

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -87,7 +87,7 @@ inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
     if (ndims == 4) self->rtus_.conv_d_.strides[1] = 1;
     utils::array_set(self->rtus_.conv_d_.padding[0], 0, 2);
     if (ndims == 4) utils::array_set(self->rtus_.conv_d_.padding[1], 0, 2);
-    const int ic = src_d->dims[1];
+    const dim_t ic = src_d->dims[1];
     if (self->desc()->prop_kind == prop_kind::backward_data) {
         data_type_t data_type = self->rtus_.conv_d_.diff_src_desc.data_type;
         src_d = &(self->rtus_.conv_d_.diff_src_desc = *dst_d);
@@ -113,9 +113,9 @@ inline void rtus_prepare_space_info(conv_pd_t *self,
     const bool is_nspc
             = utils::one_of(jcp.src_tag, format_tag::nhwc, format_tag::nwc);
 
-    const size_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
+    const dim_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
             jcp.nb_reduce, jcp.nb_load_blocking_max, jcp.nb_bcast_blocking);
-    size_t typesize
+    const dim_t typesize
             = types::data_type_size(self->invariant_src_md()->data_type);
 
     self->rtus_.space_per_thread_
@@ -156,19 +156,20 @@ struct rtus_driver_t : public jit_generator_t {
     Xbyak::Reg64 reg_icb_remainder = rcx;
     Xbyak::Reg64 reg_ws_copy = r15;
 
-    int iw_, stride_w_;
-    int src_step_h_, src_step_icb_, ws_step_icb_, vlen_, vlen_shift_;
+    dim_t iw_, stride_w_;
+    dim_t src_step_h_, src_step_icb_, ws_step_icb_;
+    int vlen_, vlen_shift_;
     bool src_to_ws_;
-    size_t typesize_;
-    int ic_, ic_tail_;
+    dim_t typesize_;
+    dim_t ic_, ic_tail_;
     bool is_nspc_;
 
     Xbyak::Xmm reg_zero;
     Xbyak::Xmm reg_v;
 
-    rtus_driver_t(int iw, int stride_w, int src_step_h, int src_step_icb,
-            int ws_step_icb, bool src_to_ws, size_t typesize, int ic,
-            bool is_nspc = false)
+    rtus_driver_t(dim_t iw, dim_t stride_w, dim_t src_step_h,
+            dim_t src_step_icb, dim_t ws_step_icb, bool src_to_ws,
+            dim_t typesize, dim_t ic, bool is_nspc = false)
         : jit_generator_t(jit_name(), isa)
         , iw_(iw)
         , stride_w_(stride_w)
@@ -189,7 +190,7 @@ struct rtus_driver_t : public jit_generator_t {
          * fail to work on reg_v, reg_zero because of this
          * data_type change, e.g. uni_vpxor doen't
          * work on reg_zero now*/
-        auto Vmm = [this](int idx, size_t typesize) {
+        auto Vmm = [this](int idx, dim_t typesize) {
             Xmm res;
             if (is_nspc_) {
                 switch (isa) {
@@ -235,13 +236,13 @@ struct rtus_driver_t : public jit_generator_t {
         vlen_ = reg_v.getBit() / 8;
         vlen_shift_ = 0;
 
-        int tvlen = is_nspc_ ? typesize_ : vlen_;
+        dim_t tvlen = is_nspc_ ? typesize_ : vlen_;
         while (tvlen > 1) {
             tvlen /= 2;
             vlen_shift_++;
         }
 
-        const int simd_w = vlen_ / sizeof(float);
+        const dim_t simd_w = vlen_ / sizeof(float);
         ic_tail_ = ic_ % simd_w;
     }
 
@@ -328,7 +329,7 @@ struct rtus_driver_t : public jit_generator_t {
         }
 
         auto load_reg = [this](const Xmm &vreg, const Reg64 &reg,
-                                const int64_t offset, const int load_size) {
+                                const dim_t offset, const int load_size) {
             if (isa == avx512_core) {
                 const Address &addr = ptr[reg + offset];
                 switch (typesize_) {
@@ -349,7 +350,7 @@ struct rtus_driver_t : public jit_generator_t {
         };
 
         auto store_reg = [this](const Reg64 &reg, const Xmm &vreg,
-                                 const int64_t offset, const int store_size) {
+                                 const dim_t offset, const int store_size) {
             if (isa == avx512_core) {
                 const Address &addr = ptr[reg + offset];
                 switch (typesize_) {
@@ -372,15 +373,15 @@ struct rtus_driver_t : public jit_generator_t {
         mov(reg_ws_copy, reg_ws);
         shl(reg_icb, vlen_shift_);
 
-        const size_t w_step_factor = ic_ * typesize_;
-        const size_t max_load_store_bytes = isa == sse41
-                ? typesize_ == 4 ? 16 : 8
-                : typesize_ == 4 ? 32
-                                 : 16;
-        const size_t load_store_size
+        const dim_t w_step_factor = ic_ * typesize_;
+        const int max_load_store_bytes = isa == sse41 ? typesize_ == 4 ? 16 : 8
+                : typesize_ == 4                      ? 32
+                                                      : 16;
+        const int load_store_size
                 = isa == avx512_core ? vlen_ : max_load_store_bytes;
-        size_t load_store_tail_size = (typesize_ == 1 ? max_load_store_bytes
-                                                      : ic_tail_ * typesize_);
+        const int load_store_tail_size = typesize_ == 1
+                ? max_load_store_bytes
+                : static_cast<int>(ic_tail_ * typesize_);
 
         Label is_loop, ic_loop, ic_loop_tail, ic_loop_finish;
         L(is_loop);
@@ -550,25 +551,25 @@ inline status_t init_rtus_driver(conv_t *self) {
     if (!conf.rtus_.reduce_src_) return status::success;
 
     const auto &cd = *conf.desc();
-    const int ndims = conf.ndims();
-    const int stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
-    const int stride_w = cd.strides[ndims - 3];
+    const dim_t ndims = conf.ndims();
+    const dim_t stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
+    const dim_t stride_w = cd.strides[ndims - 3];
 
     const bool is_bwd_data = cd.prop_kind == prop_kind::backward_data;
     const auto &src_d = is_bwd_data ? *conf.diff_src_md() : *conf.src_md();
 
-    const int ih = ndims == 3 ? 1 : src_d.dims[2];
-    const int iw = src_d.dims[ndims - 1];
-    const int ic = src_d.dims[1];
+    const dim_t ih = ndims == 3 ? 1 : src_d.dims[2];
+    const dim_t iw = src_d.dims[ndims - 1];
+    const dim_t ic = src_d.dims[1];
 
     const auto src_tag = memory_desc_wrapper(src_d).matches_one_of_tag(
             format_tag::nhwc, format_tag::nwc);
     const bool is_nspc = src_tag != format_tag::undef;
-    const int src_step_h = stride_h * iw;
-    const int src_step_icb = !is_nspc ? ih * iw : 1;
-    const int ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
+    const dim_t src_step_h = stride_h * iw;
+    const dim_t src_step_icb = !is_nspc ? ih * iw : 1;
+    const dim_t ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
     const bool src_to_ws = !is_bwd_data;
-    const size_t typesize
+    const dim_t typesize
             = types::data_type_size(self->pd()->invariant_src_md()->data_type);
 
     CHECK(safe_ptr_assign(self->rtus_driver_,
@@ -578,19 +579,22 @@ inline status_t init_rtus_driver(conv_t *self) {
     return self->rtus_driver_->create_kernel();
 }
 
-inline int best_divider(int value, int min_divider, int max_divider,
+inline int best_divider(dim_t value, int min_divider, dim_t max_divider,
         bool find_max, int step = 1) {
     using namespace dnnl::impl::utils;
-    max_divider = nstl::max(1, nstl::min(max_divider, value));
-    min_divider = nstl::max(1, nstl::min(min_divider, max_divider));
+    const int max_divider_int = static_cast<int>(
+            nstl::max<dim_t>(1, nstl::min<dim_t>(max_divider, value)));
+    min_divider = nstl::max(1, nstl::min(min_divider, max_divider_int));
 
-    auto loss_ratio = [](int total, int chunk) {
-        return float(rnd_up(total, chunk) - total) / rnd_up(total, chunk);
+    auto loss_ratio = [](dim_t total, int chunk) {
+        return float(rnd_up(total, chunk) - total)
+                / float(rnd_up(total, chunk));
     };
 
     float min_loss = FLT_MAX;
-    int x_divider = max_divider;
-    for (int divider = max_divider; divider >= min_divider; divider -= step) {
+    int x_divider = max_divider_int;
+    for (int divider = max_divider_int; divider >= min_divider;
+            divider -= step) {
         const float loss = loss_ratio(value, divider);
         if ((find_max && loss < min_loss) || (!find_max && loss <= min_loss)) {
             min_loss = loss;


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the AVX512-common 1x1 and general JIT convolution kernels (`jit_avx512_common_1x1_conv_kernel`, `jit_avx512_common_conv_kernel`, `jit_avx512_common_convolution`, `jit_uni_1x1_conv_utils`) to `dim_t`, eliminating implicit narrowing conversions.

Part of the ongoing dim_t/implicit-narrowing cleanup fleet; independent of the brgemm-focused PRs but stacked on top of them for review convenience.