### PR TITLE
cpu: conv: AMX: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {31, rhs_addr_reg,
@@ -90,25 +90,25 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::init_runtime_counters() {
     is_buffer_empty_ = true;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_h_shift() const {
-    return (size_t)jcp.ow * jcp.ngroups * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_h_shift() const {
+    return jcp.ow * jcp.ngroups * jcp.oc_without_padding;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_w_shift() const {
-    return (size_t)jcp.ngroups * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_w_shift() const {
+    return jcp.ngroups * jcp.oc_without_padding;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::inp_offset(
-        int h, int w, int icb) const {
-    return (size_t)jcp.typesize_in
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::inp_offset(
+        dim_t h, dim_t w, dim_t icb) const {
+    return jcp.typesize_in
             * (h * jcp.iw * jcp.ngroups * jcp.ic_without_padding
                     + w * jcp.ngroups * jcp.ic_without_padding
                     + icb * jcp.ic_block_int_np);
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
-        int h, int w, int ocb) const {
-    return (size_t)jcp.typesize_out
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
+        dim_t h, dim_t w, dim_t ocb) const {
+    return jcp.typesize_out
             * (h * jcp.ow * jcp.ngroups * jcp.oc_without_padding
                     + w * jcp.ngroups * jcp.oc_without_padding
                     + ocb * jcp.oc_block);
@@ -117,9 +117,9 @@ size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
 void jit_avx512_core_amx_1x1_fwd_kernel_t::update_buffer_pointers() {
     auto buffer_offset
             = [this](bool shift) { return ((buf_count_ + shift) % 2); };
-    int wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
+    dim_t wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
 
-    int postop_shift = wsp_shift * buffer_offset(true);
+    dim_t postop_shift = wsp_shift * buffer_offset(true);
 
     mov(reg_postop, wsp_ptr);
     add(reg_postop, postop_shift);
@@ -149,7 +149,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
                             {bin_injector_helper_reg_1,
                                     bin_injector_helper_reg_2,
                                     bin_injector_helper_reg_3});
-            const int wsp_row_offset = jcp.typesize_acc
+            const dim_t wsp_row_offset = jcp.typesize_acc
                     * (osb * jcp.nb_oc_blocking * jcp.max_width * jcp.oc_block
                             + ocb * jcp.max_width * jcp.oc_block
                             + row * jcp.oc_block);
@@ -164,7 +164,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
         if (row_count_ == exp_row_count) {
             int oh = ((jcp.nb_os_blocking * jcp.tile_width) / jcp.ow);
             int ow = ((jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
-            size_t out_offset = jcp.typesize_out
+            dim_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
             add(out_ptr, out_offset);
             row_count_ = 0;
@@ -292,7 +292,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
     }
 
     if (jcp.src_zero_point) {
-        const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
         const Zmm zmm_zp_m = zmm_mask(zmm_zp, mask_flag);
         vpmulld(zmm_zp_m, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -321,7 +321,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
         for (int j = 0; j < jcp.tile_width; j++) {
-            const int scale_offset
+            const dim_t scale_offset
                     = jcp.is_oc_scale * (sizeof(float) * ocb * jcp.oc_block);
             const Zmm zmm_r = zmm_out(j);
             const Zmm zmm_r_msk = zmm_mask(zmm_r, mask_flag);
@@ -333,7 +333,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
         for (int j = 0; j < jcp.tile_width; j++) {
@@ -446,12 +446,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
     if (jcp.src_zero_point) {
-        const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
         const Zmm zmm_zp_m = zmm_mask(zmm_zp, mask_flag);
         vpmulld(zmm_zp_m, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -468,7 +468,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        int scale_offset
+        const dim_t scale_offset
                 = jcp.is_oc_scale * (sizeof(float) * ocb * jcp.oc_block);
         const Zmm zmm_out_msk = zmm_mask(zmm_out, mask_flag);
         vmulps(zmm_out_msk, zmm_out,
@@ -517,7 +517,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_bf16(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        const int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         const auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
         for (int j = 0; j < jcp.tile_width; j++) {
@@ -583,7 +583,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_bf16(
         }
     }
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         if (jcp.bia_dt == data_type::bf16) {
             vpmovzxwd(zmm_mask(zmm_bias, mask_flag), bias_addr);
@@ -634,7 +634,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output(
         bool do_store, bool has_tail) {
 
     auto store_output_subblock = [&](int ocb, int osb) {
-        const int wsp_offset = jcp.typesize_acc
+        const dim_t wsp_offset = jcp.typesize_acc
                 * (osb * jcp.nb_oc_blocking * jcp.max_width * jcp.oc_block
                         + ocb * jcp.max_width * jcp.oc_block);
         tilestored(ptr[wsp_ptr + stride_seq + wsp_offset],
@@ -713,12 +713,13 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
         }
     };
 
-    auto tileloadd_nt = [this](const Tmm &t1, int offset) {
-        int ab_size = jcp.nb_os2_blocking * jcp.nb_os_blocking * jcp.tile_width
+    auto tileloadd_nt = [this](const Tmm &t1, dim_t offset) {
+        const dim_t ab_size = jcp.nb_os2_blocking * jcp.nb_os_blocking
+                * jcp.tile_width
                 * (jcp.nb_ic_int * jcp.ic_block_int_np
                         + jcp.nb_oc_blocking * jcp.oc_block);
-        int c_size = (jcp.nb_ic_int * jcp.ic_block_int_np * jcp.nb_oc_blocking
-                * jcp.oc_block);
+        const dim_t c_size = (jcp.nb_ic_int * jcp.ic_block_int_np
+                * jcp.nb_oc_blocking * jcp.oc_block);
         // If the size of  src + wei used in the kernel cannot fit into L1 cache,
         // use non-temporal load of weights to help keep src in L1 cache
         if (static_cast<size_t>(jcp.typesize_in * (ab_size + c_size))
@@ -730,19 +731,20 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     auto compute_block = [&](int icb, int os_b) {
         for (int osb = 0; osb < os_b; osb++) {
-            int ih = ((osb * jcp.tile_width) / jcp.ow) * jcp.stride_h;
-            int iw = ((osb * jcp.tile_width) % jcp.ow) * jcp.stride_w;
+            dim_t ih = ((osb * jcp.tile_width) / jcp.ow) * jcp.stride_h;
+            dim_t iw = ((osb * jcp.tile_width) % jcp.ow) * jcp.stride_w;
             tileloadd(Tmm(get_inp_tensor(osb)),
                     ptr[inp_ptr + stride_nhwc + inp_offset(ih, iw, icb)]);
         }
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-            const int wei_offset = jcp.typesize_in
+            const dim_t wei_offset = jcp.typesize_in
                     * (ocb
                                     * utils::rnd_up(jcp.ic_without_padding,
                                             jcp.ic_block_int)
                                     * jcp.oc_block
                             + icb * jcp.ic_block_int_np * jcp.oc_block);
-            tileloadd_nt(Tmm(get_wei_tensor(ocb)), wei_offset);
+            tileloadd_nt(
+                    Tmm(get_wei_tensor(ocb)), static_cast<int>(wei_offset));
             for (int osb = 0; osb < os_b; osb++) {
                 tdpbxxd(Tmm(get_out_tensor(osb, ocb)), Tmm(get_inp_tensor(osb)),
                         Tmm(get_wei_tensor(ocb)));
@@ -765,7 +767,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
         mov(reg_tilebuff, ptr[param1 + GET_OFF(src_prf)]);
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++)
             for (int osb = 0; osb < os_b; osb++) {
-                const int wsp_offset = jcp.typesize_acc
+                const dim_t wsp_offset = jcp.typesize_acc
                         * (osb * jcp.nb_oc_blocking * jcp.max_width
                                         * jcp.oc_block
                                 + ocb * jcp.max_width * jcp.oc_block);
@@ -788,7 +790,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     auto compute_icb_loop = [&](int os_b = 1) {
         int shift = (get_ic_tail() && os_b == 1) ? 1 : 0;
-        int nb_ic_int = jcp.nb_ic_int - shift;
+        const int nb_ic_int = static_cast<int>(jcp.nb_ic_int - shift);
 
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
@@ -814,7 +816,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     Label label_last_os, label_compute_done, label_tail, label_done;
 
-    int stride_nhwc_ = jcp.typesize_in * jcp.ngroups * jcp.ic_without_padding
+    dim_t stride_nhwc_ = jcp.typesize_in * jcp.ngroups * jcp.ic_without_padding
             * jcp.stride_w;
     mov(stride_nhwc, stride_nhwc_);
 
@@ -851,19 +853,19 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::osb_loop(int nb_os) {
         int oh = (((osi + 1) * jcp.nb_os_blocking * jcp.tile_width) / jcp.ow);
         int ow = (((osi + 1) * jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
         if (do_store) {
-            size_t out_offset = jcp.typesize_out
+            dim_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
             add(out_ptr, out_offset);
         }
 
-        int ih = oh * jcp.stride_h;
-        int iw = ow * jcp.stride_w;
+        dim_t ih = oh * jcp.stride_h;
+        dim_t iw = ow * jcp.stride_w;
         add(inp_ptr, inp_offset(ih, iw, 0));
     }
 }
 
 int jit_avx512_core_amx_1x1_fwd_kernel_t::get_ic_tail() const {
-    return (jcp.ic_without_padding % jcp.ic_block_int_np);
+    return static_cast<int>(jcp.ic_without_padding % jcp.ic_block_int_np);
 }
 
 void jit_avx512_core_amx_1x1_fwd_kernel_t::generate() {
@@ -952,12 +954,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                 tc_configure_tile(buff, get_out_tensor(s, i), Cr, Cc);
             }
 
-        buff->palette_id = amx::get_target_palette();
+        buff->palette_id = static_cast<uint8_t>(amx::get_target_palette());
     };
 
-    int Ac = jcp.typesize_in
+    int Ac = static_cast<int>(jcp.typesize_in
             * ((jcp.nb_ic_int == 1 && get_ic_tail()) ? get_ic_tail()
-                                                     : jcp.ic_block_int_np);
+                                                     : jcp.ic_block_int_np));
 
     cfg_tiles((palette_config_t *)tcfg_buff, Ac);
     if (jcp.nb_ic_int > 1 && get_ic_tail()) {
@@ -1193,15 +1195,19 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     p, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
-    jcp.nb_ic = jcp.ic / jcp.ic_block;
-    jcp.nb_oc = jcp.oc / jcp.oc_block;
-    jcp.nb_ic_int = div_up(jcp.ic_without_padding, jcp.ic_block_int_np);
+    jcp.nb_ic = static_cast<int>(jcp.ic / jcp.ic_block);
+    jcp.nb_oc = static_cast<int>(jcp.oc / jcp.oc_block);
+    jcp.nb_ic_int = static_cast<int>(
+            div_up(jcp.ic_without_padding, jcp.ic_block_int_np));
 
     jcp.max_width = amx::get_max_rows(amx::get_target_palette());
     VDISPATCH_CONV_IC(jcp.max_width > 0, VERBOSE_BAD_PARAM, "max_width = 0");
@@ -1209,8 +1215,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int size_treshold = 32;
     const int min_width
             = 1; // TODO: Possible optimizations: do not use small values
-    const int spatial = jcp.od * jcp.oh;
-    const int os = jcp.od * jcp.oh * jcp.ow;
+    const dim_t spatial = jcp.od * jcp.oh;
+    const dim_t os = jcp.od * jcp.oh * jcp.ow;
 
     jcp.tile_width = 1;
     for (int s_size = jcp.max_width; s_size >= min_width; s_size--) {
@@ -1221,8 +1227,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         }
     }
     if (jcp.tile_width == 1) {
-        jcp.tile_width = nstl::min(jcp.max_width, os);
-        jcp.tile_tail = os % jcp.max_width;
+        jcp.tile_width = static_cast<int>(nstl::min<dim_t>(jcp.max_width, os));
+        jcp.tile_tail = static_cast<int>(os % jcp.max_width);
         for (int i = jcp.max_width; i >= min_width; i--) {
             int i_tail = os % i;
             if (i_tail > jcp.tile_tail || i_tail == 0) {
@@ -1255,7 +1261,7 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc_blocking = (jcp.nb_oc % 2 == 0) ? 2 : 1;
     jcp.nb_ic_blocking = 1;
     jcp.nb_os_blocking = (os / jcp.tile_width > 2) ? 2 : 1;
-    jcp.nb_os = os / jcp.tile_width;
+    jcp.nb_os = static_cast<int>(os / jcp.tile_width);
     jcp.nb_os2_blocking = (jcp.nb_os_blocking > 1)
             ? (jcp.nb_os % jcp.nb_os_blocking == 0) ? 2 : 1
             : 1;
@@ -1265,7 +1271,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     int ops_tile_store
             = jcp.nb_oc_blocking * jcp.nb_os_blocking * jcp.tile_width;
-    int avaliable_ops = jcp.nb_ic_int * jcp.nb_oc_blocking * jcp.nb_os_blocking;
+    const dim_t avaliable_ops
+            = jcp.nb_ic_int * jcp.nb_oc_blocking * jcp.nb_os_blocking;
     jcp.per_one_pstore
             = (avaliable_ops) ? ops_tile_store / avaliable_ops + 1 : 0;
     if (jcp.per_one_pstore > 12) jcp.per_one_pstore = 0;

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -1009,27 +1009,29 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = avx512_core_amx;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = !is_1d ? src_d.dims()[ndims - 2] : 1;
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = !is_1d ? dst_d.dims()[ndims - 2] : 1;
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = !is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1;
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = !is_1d ? cd.padding[0][ndims - 4] : 0;
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = !is_1d ? cd.strides[ndims - 4] : 1;
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = !is_1d ? static_cast<int>(src_d.dims()[ndims - 2]) : 1;
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = !is_1d ? static_cast<int>(dst_d.dims()[ndims - 2]) : 1;
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = !is_1d
+            ? static_cast<int>(weights_d.dims()[with_groups + ndims - 2])
+            : 1;
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = !is_1d ? static_cast<int>(cd.padding[0][ndims - 4]) : 0;
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = !is_1d ? static_cast<int>(cd.strides[ndims - 4]) : 1;
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     VDISPATCH_CONV_IC((jcp.kd == 1 && jcp.kh == 1 && jcp.kw == 1),
@@ -1037,9 +1039,9 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC((jcp.f_pad == 0 && jcp.t_pad == 0 && jcp.l_pad == 0),
             VERBOSE_UNSUPPORTED_FEATURE, "non-zero padding");
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = is_1d ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     jcp.is_depthwise = true && with_groups && everyone_is(1, jcp.ic, jcp.oc);
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const std::size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {31, rhs_addr_reg,

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
@@ -122,10 +122,10 @@ private:
     int get_wei_tensor(int i) const;
     int get_ic_tail() const;
 
-    size_t out_h_shift() const;
-    size_t out_w_shift() const;
-    size_t inp_offset(int ih, int iw, int icb) const;
-    size_t out_row_offset(int h, int w, int ocb) const;
+    dim_t out_h_shift() const;
+    dim_t out_w_shift() const;
+    dim_t inp_offset(dim_t ih, dim_t iw, dim_t icb) const;
+    dim_t out_row_offset(dim_t h, dim_t w, dim_t ocb) const;
 
     void prepare_output();
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
@@ -121,17 +121,16 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             utils::rnd_up(jcp.ic_without_padding, jcp.ic_block_int)
             * jcp.oc_block * jcp.nb_oc_blocking);
 
-    int nb_os = (jcp.tile_tail) ? jcp.nb_os + 1 : jcp.nb_os;
-    int os_step = jcp.nb_os2_blocking * jcp.nb_os_blocking;
-    int os_chunks = div_up(nb_os, os_step);
+    const dim_t nb_os = (jcp.tile_tail) ? jcp.nb_os + 1 : jcp.nb_os;
+    const dim_t os_step = jcp.nb_os2_blocking * jcp.nb_os_blocking;
+    const dim_t os_chunks = div_up(nb_os, os_step);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
 
-    const size_t work_amount
-            = (size_t)jcp.mb * jcp.ngroups * os_chunks * oc_chunks;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * os_chunks * oc_chunks;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -153,19 +152,19 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, _osb {0}, _ocb {0};
+        dim_t mb {0}, g {0}, _osb {0}, _ocb {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, _osb, os_chunks,
                 _ocb, oc_chunks);
 
         while (start < end) {
-            int osb = _osb * os_step;
-            int ocb = _ocb * jcp.nb_oc_blocking;
+            const dim_t osb = _osb * os_step;
+            const dim_t ocb = _ocb * jcp.nb_oc_blocking;
             auto bias_w = bias
                     ? bias + (bias_d.blk_off(ocb * jcp.oc_block) * bia_dt_size)
                     : nullptr;
 
-            int oc = g * jcp.oc_without_padding + ocb * jcp.oc_block;
-            int ic = g * jcp.ic_without_padding;
+            const dim_t oc = g * jcp.oc_without_padding + ocb * jcp.oc_block;
+            const dim_t ic = g * jcp.ic_without_padding;
 
             p.acc_s32 = wsp + ithr * jcp.wsp_buffer_size;
             p.src_prf = wsp_tile + ithr * (jcp.wsp_buffer_size / 2);
@@ -191,18 +190,18 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             const bool is_overflow = (osb + os_step >= nb_os);
             if (is_overflow
                     && (os_chunks > 1 || (os_chunks == 1 && is_ic_tail))) {
-                int step = (check_last_sp) ? 1 : jcp.nb_os_blocking;
-                for (int osi = 0; osi < nb_os - osb; osi += step) {
-                    int osb_i = osi + osb;
-                    int od {0}, oh {0}, ow {0};
+                const dim_t step = (check_last_sp) ? 1 : jcp.nb_os_blocking;
+                for (dim_t osi = 0; osi < nb_os - osb; osi += step) {
+                    const dim_t osb_i = osi + osb;
+                    dim_t od {0}, oh {0}, ow {0};
                     nd_iterator_init(osb_i * jcp.tile_width, od, jcp.od, oh,
                             jcp.oh, ow, jcp.ow);
                     size_t dst_offset = md_blk_off(dst_d, mb, oc, od, oh, ow);
                     p.dst = dst + dst_dt_size * dst_offset;
 
-                    int id = od * jcp.stride_d;
-                    int ih = oh * jcp.stride_h;
-                    int iw = ow * jcp.stride_w;
+                    const dim_t id = od * jcp.stride_d;
+                    const dim_t ih = oh * jcp.stride_h;
+                    const dim_t iw = ow * jcp.stride_w;
                     size_t inp_offset = md_blk_off(src_d, mb, ic, id, ih, iw);
                     p.src = src + src_dt_size * inp_offset;
 
@@ -213,15 +212,15 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
                     (*kernel_)(&p);
                 }
             } else {
-                int od {0}, oh {0}, ow {0};
+                dim_t od {0}, oh {0}, ow {0};
                 nd_iterator_init(osb * jcp.tile_width, od, jcp.od, oh, jcp.oh,
                         ow, jcp.ow);
                 size_t dst_offset = md_blk_off(dst_d, mb, oc, od, oh, ow);
                 p.dst = dst + dst_dt_size * dst_offset;
 
-                int id = od * jcp.stride_d;
-                int ih = oh * jcp.stride_h;
-                int iw = ow * jcp.stride_w;
+                const dim_t id = od * jcp.stride_d;
+                const dim_t ih = oh * jcp.stride_h;
+                const dim_t iw = ow * jcp.stride_w;
                 size_t inp_offset = md_blk_off(src_d, mb, ic, id, ih, iw);
                 p.src = src + src_dt_size * inp_offset;
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -42,7 +42,7 @@ using namespace dnnl::impl::data_type;
 using namespace dnnl::impl::utils;
 using namespace Xbyak;
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(int ur_w) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(dim_t ur_w) {
     for (int oc = 0; oc < jcp.nb_oc_blocking; oc++)
         for (int ur = 0; ur < ur_w; ur++) {
             const Zmm zmm = zmm_out(ur, oc);
@@ -51,22 +51,22 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(int ur_w) {
 }
 
 void jit_avx512_core_amx_compute_zp_pbuff_t::store_output(
-        int ur_w, bool last_oc_block_flag) {
+        dim_t ur_w, bool last_oc_block_flag) {
     assert(jcp.is_nspc);
 
-    const int nb_oc_block = jcp.nb_oc_blocking;
-    const int oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t oc_block = jcp.oc_block;
 
     const auto src_zp_addr = EVEX_compress_addr(reg_src_zero_point, 0, true);
 
     /* write out register to output_addr */
     for (int oc = 0; oc < nb_oc_block; oc++) {
         const bool mask_flag = last_oc_block_flag && oc == nb_oc_block - 1;
-        for (int ur = 0; ur < ur_w; ur++) {
-            const int output_offset = sizeof(int32_t)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
+            const dim_t output_offset = sizeof(int32_t)
                     * (oc * oc_block
                             + ur * jcp.oc_without_padding * jcp.ngroups);
-            const Zmm zmm_dst = zmm_out(ur, oc);
+            const Zmm zmm_dst = zmm_out(static_cast<int>(ur), oc);
             const Zmm m_zmm_dst = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
             // multiply dst by src_zero_point
             vpmulld(m_zmm_dst, zmm_dst, src_zp_addr);
@@ -75,13 +75,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::store_output(
     }
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool padded) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag, bool padded) {
 
-    const int kw = jcp.kw;
-    const int ic_block = jcp.ic_block_int_np;
-    const int oc_block = jcp.oc_block;
-    const int nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block_int_np;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
 
     const bool ic_tail
             = (jcp.ic_without_padding % (jcp.ic_block / ic_inner_block)) > 0;
@@ -90,24 +90,23 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
 
     /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
-    const int icb = (last_ic_block_flag == ic_block_t::last_ic_block)
+    const dim_t icb = (last_ic_block_flag == ic_block_t::last_ic_block)
             ? div_up((jcp.ic_without_padding % jcp.ic_block_int),
                       ic_inner_block)
             : ic_block / ic_inner_block;
 
-    auto get_filter_offset = [this, oc_block](int ocb, int ic, int ki) {
-        size_t w_step = jcp.is_relo ? jcp.kh : 1;
-        size_t kw_offset = static_cast<size_t>(ki) * w_step
-                * jcp.ic_block_int_np * jcp.oc_block;
-        size_t oc_subblock_step = static_cast<size_t>(jcp.kd) * jcp.kh * jcp.kw
-                * jcp.ic_block_int_np * jcp.oc_block;
-        size_t offset = kw_offset
-                + static_cast<size_t>(ocb) * jcp.nb_ic_int * oc_subblock_step
-                + static_cast<size_t>(ic) * oc_block * ic_inner_block;
-        return sizeof(char) * offset;
+    auto get_filter_offset = [this, oc_block](dim_t ocb, dim_t ic, dim_t ki) {
+        const dim_t w_step = jcp.is_relo ? jcp.kh : 1;
+        const dim_t kw_offset
+                = ki * w_step * jcp.ic_block_int_np * jcp.oc_block;
+        const dim_t oc_subblock_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
+        return static_cast<dim_t>(sizeof(char))
+                * (kw_offset + ocb * jcp.nb_ic_int * oc_subblock_step
+                        + ic * oc_block * ic_inner_block);
     };
     auto compute_fma = [this, masked_write, icb](const Zmm zmm_accum,
-                               const int ic, const Address addr) {
+                               const dim_t ic, const Address addr) {
         if (jcp.is_relo) {
             vmovups(zmm_permb, ptr[reg_scratch]); // get permute index table
             const Zmm r_zmm = masked_write && ic == icb - 1
@@ -130,18 +129,19 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     }
     if (jcp.is_relo) mov(reg_scratch, permb_idx_label);
 
-    for (int ki = 0; ki < kw; ki++) {
-        const int ur_start = get_ow_start(ki, pad_l);
-        const int ur_end = get_ow_end(ur_w, ki, pad_r);
-        for (int ur = 0; ur < ur_w; ur++) {
+    for (dim_t ki = 0; ki < kw; ki++) {
+        const dim_t ur_start = get_ow_start(ki, pad_l);
+        const dim_t ur_end = get_ow_end(ur_w, ki, pad_r);
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             // Calculate zero_point padding as:
             // accum = is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0)
             if (ur < ur_start || ur >= ur_end || padded) {
                 for (int oc = 0; oc < nb_oc_block; oc++) {
-                    const Zmm zmm_accum = zmm_out(ur, oc);
-                    for (int ic = 0; ic < icb; ic++) {
-                        const auto addr_filt = EVEX_compress_addr(
-                                aux_reg_filt, get_filter_offset(oc, ic, ki));
+                    const Zmm zmm_accum = zmm_out(static_cast<int>(ur), oc);
+                    for (dim_t ic = 0; ic < icb; ic++) {
+                        const auto addr_filt = EVEX_compress_addr(aux_reg_filt,
+                                static_cast<int>(
+                                        get_filter_offset(oc, ic, ki)));
                         compute_fma(zmm_accum, ic, addr_filt);
                     }
                 }
@@ -150,14 +150,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     }
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(dim_t ur_w, dim_t pad_l,
+        dim_t pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
 
     Label kh_label, skip_kh_loop;
-    const size_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
-    const size_t shift_wei_h_step = sizeof(char)
-            * static_cast<size_t>(wei_h_step) * jcp.ic_block_int_np
-            * jcp.oc_block;
+    const dim_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
+    const dim_t shift_wei_h_step
+            = sizeof(char) * wei_h_step * jcp.ic_block_int_np * jcp.oc_block;
 
     // Compute zero_point compensation for the padded region. Total compute
     // area is 'overflow * kw' where 'overflow' indicates the overlap
@@ -201,14 +200,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
     if (handle_h_pad && jcp.ndims > 3) compute_kh_loop(GET_OFF(b_overflow));
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(dim_t ur_w, dim_t pad_l,
+        dim_t pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
 
     Label kd_label, skip_kd_loop;
-    const size_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
-    const size_t shift_wei_h_step = sizeof(char)
-            * static_cast<size_t>(wei_h_step) * jcp.ic_block_int_np
-            * jcp.oc_block;
+    const dim_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
+    const dim_t shift_wei_h_step
+            = sizeof(char) * wei_h_step * jcp.ic_block_int_np * jcp.oc_block;
 
     // Compute zero_point compensation for the padded region. Total compute
     // area is 'overflow * kh * kw' where 'overflow' indicates the overlap
@@ -270,7 +268,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
 }
 
 void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool handle_h_pad) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad) {
 
     Label icb_label;
     const size_t nb_ic = jcp.nb_ic_int;
@@ -308,15 +306,16 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        const size_t shift_wei_icb_step = static_cast<size_t>(jcp.kd) * jcp.kh
-                * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
-        add(reg_filt, sizeof(char) * shift_wei_icb_step);
+        const dim_t shift_wei_icb_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
+        add(reg_filt, static_cast<uint32_t>(sizeof(char) * shift_wei_icb_step));
 
         dec(reg_icb);
         cmp(reg_icb, 0);
         jg(icb_label, T_NEAR);
 
-        sub(reg_filt, sizeof(char) * shift_wei_icb_step * nb_ic);
+        sub(reg_filt,
+                static_cast<int>(sizeof(char) * shift_wei_icb_step * nb_ic));
     }
 
     if (jcp.oc_without_padding != jcp.oc) {
@@ -340,36 +339,41 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
 void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
         const bool h_padding) {
 
-    auto ur_w_shift = [&](const int ur_w) {
-        return sizeof(int32_t) * (ur_w * jcp.oc_without_padding * jcp.ngroups);
+    auto ur_w_shift = [&](const dim_t ur_w) {
+        return static_cast<dim_t>(sizeof(int32_t))
+                * (ur_w * jcp.oc_without_padding * jcp.ngroups);
     };
 
     const int max_ur_w = jit_avx512_core_amx_compute_zp_pbuff_t::max_regs_ur
             / (jcp.nb_oc_blocking);
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int l_pad = jcp.l_pad;
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t l_pad = jcp.l_pad;
 
-    const int l_pad_output = jcp.l_pad_output;
-    const int r_pad_output = jcp.r_pad_output;
+    const dim_t l_pad_output = jcp.l_pad_output;
+    const dim_t r_pad_output = jcp.r_pad_output;
 
     // a single middle element (if required) containing only height padding
-    const int no_pad = nstl::max(0, jcp.ow - l_pad_output - r_pad_output);
+    const dim_t no_pad
+            = nstl::max<dim_t>(0, jcp.ow - l_pad_output - r_pad_output);
 
-    const int ow_start = nstl::max(jcp.ow - r_pad_output, l_pad_output);
-    const int r_pad_start = nstl::min(jcp.ow_pad - l_pad_output, r_pad_output);
+    const dim_t ow_start
+            = nstl::max<dim_t>(jcp.ow - r_pad_output, l_pad_output);
+    const dim_t r_pad_start
+            = nstl::min(jcp.ow_pad - l_pad_output, r_pad_output);
 
-    int ow = 0;
-    int cur_l_pad_output = l_pad_output;
+    dim_t ow = 0;
+    dim_t cur_l_pad_output = l_pad_output;
     while (cur_l_pad_output > 0) {
-        const int ur_w = nstl::min(cur_l_pad_output, max_ur_w);
+        const dim_t ur_w
+                = nstl::min(cur_l_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
-        const int cur_r_pad = calculate_end_padding(
+        const dim_t cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, l_pad, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
-        l_pad = nstl::max(l_pad - ur_w * jcp.stride_w, 0);
-        cur_l_pad_output = nstl::max(cur_l_pad_output - ur_w, 0);
+        l_pad = nstl::max<dim_t>(l_pad - ur_w * jcp.stride_w, 0);
+        cur_l_pad_output = nstl::max<dim_t>(cur_l_pad_output - ur_w, 0);
     }
 
     if (no_pad > 0) {
@@ -380,16 +384,17 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
     assert(ow + no_pad == ow_start);
 
     ow = ow_start;
-    int cur_r_pad_output = r_pad_start;
+    dim_t cur_r_pad_output = r_pad_start;
     while (cur_r_pad_output > 0 && ow < jcp.ow) {
-        const int ur_w = nstl::min(cur_r_pad_output, max_ur_w);
+        const dim_t ur_w
+                = nstl::min(cur_r_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
-        const int cur_r_pad = calculate_end_padding(
+        const dim_t cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, 0, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
-        cur_r_pad_output = nstl::max(cur_r_pad_output - ur_w, 0);
+        cur_r_pad_output = nstl::max<dim_t>(cur_r_pad_output - ur_w, 0);
     }
 }
 
@@ -407,8 +412,8 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::generate() {
 
     if (jcp.oc_without_padding != jcp.oc) {
         const Reg32 reg_tmp = reg_scratch.cvt32();
-        const int tail_size = jcp.oc_without_padding % jcp.oc_block;
-        const int mask = (1 << tail_size) - 1;
+        const dim_t tail_size = jcp.oc_without_padding % jcp.oc_block;
+        const int mask = (1 << static_cast<int>(tail_size)) - 1;
         mov(reg_tmp, mask);
         kmovw(ktail_mask, reg_tmp);
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
@@ -455,7 +460,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::generate() {
             db(select_src2_bit | permb_idx_table[i]);
 
         // write zero-mask (permb) for ic_tail in VNNI format '..16o4i'
-        const int ic_tail_size
+        const dim_t ic_tail_size
                 = jcp.ic_without_padding % (jcp.ic_block / ic_inner_block);
         if (jcp.ic_without_padding != jcp.ic && ic_tail_size > 0) {
             align(64);
@@ -493,45 +498,48 @@ void jit_avx512_core_amx_copy_to_wbuffer_t::generate() {
         vmovdqu8(zmm_idx, ptr[reg_tmp]);
 
     const int vnni_width = is_bf16 ? 2 : 4;
-    const int r = jcp.kh * jcp.kw * jcp.ic_without_padding;
-    const int nb_r = div_up(r, vnni_width);
-    const int rtail = (r % vnni_width) * jcp.oc_block;
+    const dim_t r = jcp.kh * jcp.kw * jcp.ic_without_padding;
+    const dim_t nb_r = div_up(r, vnni_width);
+    const dim_t rtail = (r % vnni_width) * jcp.oc_block;
     if (rtail > 0) {
         uint64_t mask = (UINT64_C(1) << rtail) - 1;
         mov(reg_tmp, mask);
         kmovq(kmask_load, reg_tmp);
     }
-    const int nb_z = rnd_up(nb_r, jcp.ic_block);
+    const dim_t nb_z = rnd_up(nb_r, jcp.ic_block);
     if (nb_r < nb_z) vpxord(zmm_zero, zmm_zero, zmm_zero);
 
-    const int tile_size = jcp.ic_block_int * jcp.oc_block * jcp.typesize_in;
-    const int ocb_src_step = r * jcp.oc_block * jcp.typesize_in;
-    const int ocb_dst_step = rnd_up(ocb_src_step, tile_size);
+    const dim_t tile_size = jcp.ic_block_int * jcp.oc_block * jcp.typesize_in;
+    const dim_t ocb_src_step = r * jcp.oc_block * jcp.typesize_in;
+    const dim_t ocb_dst_step = rnd_up(ocb_src_step, tile_size);
 
     // reorder from ~Owhi16o -> ~OR16oVr with r := whi and V := vnni_width
-    for (int g = 0; g < jcp.ngroups; g++) {
-        for (int ocb = 0; ocb < jcp.nb_oc; ocb++) {
-            int offset = 0;
-            int rb = 0;
+    for (dim_t g = 0; g < jcp.ngroups; g++) {
+        for (dim_t ocb = 0; ocb < jcp.nb_oc; ocb++) {
+            dim_t offset = 0;
+            dim_t rb = 0;
             for (; rb < nb_r; offset += 64, rb++) {
                 auto zmm_src_tmp = (rtail > 0 && rb == nb_r - 1)
                         ? zmm_src | kmask_load | T_z
                         : zmm_src;
                 if (is_bf16) {
-                    vmovdqu16(zmm_src_tmp, ptr[reg_src + offset]);
+                    vmovdqu16(zmm_src_tmp,
+                            ptr[reg_src + static_cast<int>(offset)]);
                     vpermw(zmm_dst, zmm_idx, zmm_src);
-                    vmovdqu16(ptr[reg_dst + offset], zmm_dst);
+                    vmovdqu16(ptr[reg_dst + static_cast<int>(offset)], zmm_dst);
                 } else {
-                    vmovdqu8(zmm_src_tmp, ptr[reg_src + offset]);
+                    vmovdqu8(zmm_src_tmp,
+                            ptr[reg_src + static_cast<int>(offset)]);
                     vpermb(zmm_dst, zmm_idx, zmm_src);
-                    vmovdqu8(ptr[reg_dst + offset], zmm_dst);
+                    vmovdqu8(ptr[reg_dst + static_cast<int>(offset)], zmm_dst);
                 }
             }
             for (; rb < nb_z; offset += 64, rb++) {
                 if (is_bf16)
-                    vmovdqu16(ptr[reg_dst + offset], zmm_zero);
+                    vmovdqu16(
+                            ptr[reg_dst + static_cast<int>(offset)], zmm_zero);
                 else
-                    vmovdqu8(ptr[reg_dst + offset], zmm_zero);
+                    vmovdqu8(ptr[reg_dst + static_cast<int>(offset)], zmm_zero);
             }
             add(reg_src, ocb_src_step);
             add(reg_dst, ocb_dst_step);
@@ -556,92 +564,107 @@ void jit_avx512_core_amx_copy_to_wbuffer_t::generate() {
 }
 
 void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
-        int lpad, int iw_len, int icb) {
+        dim_t lpad, dim_t iw_len, dim_t icb) {
 
     const bool is_bf16 = jcp.src_dt == data_type::bf16;
-    int iwp_idx = 0;
+    dim_t iwp_idx = 0;
     // there are min(gen_kw, jcp.stride_w) continuous sets of input
     // data (for each stride idx), they are placed one by one
     // without additional padding
     const bool are_sets_interleaved
             = IMPLICATION(jcp.dilate_w != 0, jcp.stride_w == 1);
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
-    const int num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
-    for (int set_idx = 0; set_idx < num_sets; set_idx++) {
-        int set_width_padded = !jcp.is_pbuffer_strided
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
+    for (dim_t set_idx = 0; set_idx < num_sets; set_idx++) {
+        dim_t set_width_padded = !jcp.is_pbuffer_strided
                 ? (jcp.ow_block - 1) * jcp.stride_w + gen_kw
                 : are_sets_interleaved ? jcp.ow_block - 1 + gen_kw / num_sets
                         + (set_idx < gen_kw % num_sets ? 1 : 0)
                                        : jcp.ow_block;
-        for (int set_shift = 0; set_shift < set_width_padded;
+        for (dim_t set_shift = 0; set_shift < set_width_padded;
                 set_shift++, iwp_idx++) {
-            int iw_idx = set_idx * (jcp.dilate_w + 1)
+            dim_t iw_idx = set_idx * (jcp.dilate_w + 1)
                     + set_shift * (jcp.is_pbuffer_strided ? jcp.stride_w : 1)
                     - lpad;
-            size_t out_base_offset
-                    = (size_t)jcp.typesize_in * iwp_idx * jcp.ic_block_int_np;
+            const dim_t out_base_offset
+                    = jcp.typesize_in * iwp_idx * jcp.ic_block_int_np;
             if (iw_idx < 0 || iw_idx >= iw_len) {
                 // left or right padding
-                vmovups(ptr[reg_aux_out_ptr + out_base_offset], zmm_zero);
+                vmovups(ptr[reg_aux_out_ptr
+                                + static_cast<int>(out_base_offset)],
+                        zmm_zero);
             } else if (jcp.is_nspc) {
-                size_t inp_w_offset = (size_t)jcp.typesize_in * iw_idx
+                const dim_t inp_w_offset = jcp.typesize_in * iw_idx
                         * jcp.ngroups * jcp.ic_without_padding;
-                int ic = icb * jcp.ic_block_int_np;
+                const dim_t ic = icb * jcp.ic_block_int_np;
                 // TODO: use Xmm or Ymm moves for better small ic efficiency
                 auto zmm_tmp_mask
                         = ic + jcp.ic_block_int <= jcp.ic_without_padding
                         ? zmm_tmp
                         : zmm_tmp | ktail_mask | T_z;
                 if (is_bf16) {
-                    vmovdqu16(
-                            zmm_tmp_mask, ptr[reg_aux_inp_ptr + inp_w_offset]);
-                    vmovdqu16(ptr[reg_aux_out_ptr + out_base_offset], zmm_tmp);
+                    vmovdqu16(zmm_tmp_mask,
+                            ptr[reg_aux_inp_ptr
+                                    + static_cast<int>(inp_w_offset)]);
+                    vmovdqu16(ptr[reg_aux_out_ptr
+                                      + static_cast<int>(out_base_offset)],
+                            zmm_tmp);
                 } else {
-                    vmovdqu8(zmm_tmp_mask, ptr[reg_aux_inp_ptr + inp_w_offset]);
-                    vmovdqu8(ptr[reg_aux_out_ptr + out_base_offset], zmm_tmp);
+                    vmovdqu8(zmm_tmp_mask,
+                            ptr[reg_aux_inp_ptr
+                                    + static_cast<int>(inp_w_offset)]);
+                    vmovdqu8(ptr[reg_aux_out_ptr
+                                     + static_cast<int>(out_base_offset)],
+                            zmm_tmp);
                 }
             } else {
                 assert(is_bf16);
-                size_t inp_w_offset
-                        = (size_t)jcp.typesize_in * iw_idx * jcp.ic_block;
-                for (int j = 0; j < jcp.ic_block_int_np / jcp.ic_block; j++) {
-                    int ic = icb * jcp.ic_block_int_np + j * jcp.ic_block;
-                    size_t inp_c_w_offset = (size_t)jcp.typesize_in * j * jcp.ih
+                const dim_t inp_w_offset
+                        = jcp.typesize_in * iw_idx * jcp.ic_block;
+                for (dim_t j = 0; j < jcp.ic_block_int_np / jcp.ic_block; j++) {
+                    const dim_t ic
+                            = icb * jcp.ic_block_int_np + j * jcp.ic_block;
+                    const dim_t inp_c_w_offset = jcp.typesize_in * j * jcp.ih
                                     * jcp.iw * jcp.ic_block
                             + inp_w_offset;
                     if (ic + jcp.ic_block <= jcp.ic) {
-                        vmovdqu16(
-                                ymm_tmp, ptr[reg_aux_inp_ptr + inp_c_w_offset]);
+                        vmovdqu16(ymm_tmp,
+                                ptr[reg_aux_inp_ptr
+                                        + static_cast<int>(inp_c_w_offset)]);
                     } else {
                         vpxord(ymm_tmp, ymm_tmp, ymm_tmp);
                     }
-                    size_t out_offset = out_base_offset
-                            + (size_t)jcp.typesize_in * j * jcp.ic_block;
-                    vmovdqu16(ptr[reg_aux_out_ptr + out_offset], ymm_tmp);
+                    const dim_t out_offset = out_base_offset
+                            + jcp.typesize_in * j * jcp.ic_block;
+                    vmovdqu16(
+                            ptr[reg_aux_out_ptr + static_cast<int>(out_offset)],
+                            ymm_tmp);
                 }
             }
         }
     }
 }
 
-void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(int icb) {
+void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(dim_t icb) {
     if (jcp.nb_ow == 1) {
         copy_row_body(jcp.l_pad, jcp.iw, icb);
     } else {
-        auto get_iw_len_required = [&](int cur_ow_block, int cur_lpad) {
+        auto get_iw_len_required
+                = [&](dim_t cur_ow_block, dim_t cur_lpad) -> dim_t {
             return (cur_ow_block - 1) * jcp.stride_w
                     + (jcp.kw - 1) * (jcp.dilate_w + 1) + 1 - cur_lpad;
         };
 
-        auto get_iw_len_limited = [&](int owb, int cur_ow_block, int cur_lpad) {
+        auto get_iw_len_limited
+                = [&](dim_t owb, dim_t cur_ow_block, dim_t cur_lpad) -> dim_t {
             auto len_req = get_iw_len_required(cur_ow_block, cur_lpad);
             if (owb < 0) return len_req;
-            int ow_block_start = nstl::max(
+            const dim_t ow_block_start = nstl::max<dim_t>(
                     0, owb * jcp.ow_block * jcp.stride_w - jcp.l_pad);
-            return nstl::min(jcp.iw - ow_block_start, len_req);
+            return nstl::min<dim_t>(jcp.iw - ow_block_start, len_req);
         };
 
-        int general_owb_cases = jcp.nb_ow;
+        dim_t general_owb_cases = jcp.nb_ow;
         Xbyak::Label copy_row_done_label;
         bool special_first_block_case = jcp.l_pad > 0;
         if (special_first_block_case) {
@@ -665,8 +688,9 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(int icb) {
             Xbyak::Label skip_last_block_case_label;
             cmp(reg_owb, jcp.nb_ow - 1);
             jne(skip_last_block_case_label, T_NEAR);
-            int ow_block_tail = jcp.ow % jcp.ow_block;
-            int cur_ow_block = ow_block_tail > 0 ? ow_block_tail : jcp.ow_block;
+            dim_t ow_block_tail = jcp.ow % jcp.ow_block;
+            dim_t cur_ow_block
+                    = ow_block_tail > 0 ? ow_block_tail : jcp.ow_block;
             copy_row_body(
                     0, get_iw_len_limited(jcp.nb_ow - 1, cur_ow_block, 0), icb);
             jmp(copy_row_done_label, T_NEAR);
@@ -704,7 +728,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
             == 64);
     assert(jcp.is_nspc);
 
-    auto load_mask = [this](int tail, Opmask kmask) {
+    auto load_mask = [this](dim_t tail, Opmask kmask) {
         uint64_t mask = (UINT64_C(1) << tail) - 1;
         mov(reg_tmp, mask);
         kmovq(kmask, reg_tmp);
@@ -713,25 +737,26 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
     const bool is_f32 = jcp.src_dt == data_type::f32;
     const bool is_xf16 = one_of(jcp.src_dt, data_type::bf16, data_type::f16);
 
-    const int inp_w_step
+    const dim_t inp_w_step
             = jcp.ngroups * jcp.ic_without_padding * jcp.typesize_in;
-    const int inp_h_step = jcp.iw * inp_w_step;
-    const int out_h_step = jcp.ic_without_padding * jcp.typesize_in;
-    const int out_w_step = jcp.kh * out_h_step;
-    const int tail_size = jcp.ic_without_padding % jcp.ic_block_int;
+    const dim_t inp_h_step = jcp.iw * inp_w_step;
+    const dim_t out_h_step = jcp.ic_without_padding * jcp.typesize_in;
+    const dim_t out_w_step = jcp.kh * out_h_step;
+    const dim_t tail_size = jcp.ic_without_padding % jcp.ic_block_int;
     if (tail_size > 0) load_mask(tail_size, ktail_mask);
 
     auto zero_it = [this, is_f32, is_xf16](reg64_t tmp_out_ptr) {
-        for (int ic = 0; ic < jcp.ic_without_padding; ic += jcp.ic_block_int) {
-            const int offset = ic * jcp.typesize_in;
+        for (dim_t ic = 0; ic < jcp.ic_without_padding;
+                ic += jcp.ic_block_int) {
+            const dim_t offset = ic * jcp.typesize_in;
             const bool masked = ic + jcp.ic_block_int > jcp.ic_without_padding;
             Zmm zmm = masked ? zmm_zero | ktail_mask : zmm_zero;
             if (is_f32)
-                vmovdqu32(ptr[tmp_out_ptr + offset], zmm);
+                vmovdqu32(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm);
             else if (is_xf16)
-                vmovdqu16(ptr[tmp_out_ptr + offset], zmm);
+                vmovdqu16(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm);
             else
-                vmovdqu8(ptr[tmp_out_ptr + offset], zmm);
+                vmovdqu8(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm);
         }
     };
 
@@ -890,7 +915,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
         // retrieve output pointer
         mov(reg_out_ptr, reg_save_out_ptr);
         // calculate the shift
-        imul(reg_tmp, reg_kwp, out_w_step);
+        imul(reg_tmp, reg_kwp, static_cast<int>(out_w_step));
         // shift past the body
         add(reg_out_ptr, reg_tmp);
         // skip if no right overflow
@@ -920,7 +945,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
     // For int8, it is sufficient to zero-pad the weights only
     if (is_f32 || is_xf16) {
         // shift forward to align h index to end of needed buffer
-        imul(reg_tmp, reg_kht, out_h_step);
+        imul(reg_tmp, reg_kht, static_cast<int>(out_h_step));
         add(reg_out_ptr, reg_tmp);
         // shift backward to align w index to end of needed buffer
         sub(reg_out_ptr, out_w_step);
@@ -956,7 +981,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
     vpxord(zmm_zero, zmm_zero, zmm_zero);
 
     if (jcp.is_nspc && jcp.ic_without_padding % jcp.ic_block_int) {
-        int tail_size = jcp.ic_without_padding % jcp.ic_block_int;
+        int tail_size
+                = static_cast<int>(jcp.ic_without_padding % jcp.ic_block_int);
         uint64_t mask = (UINT64_C(1) << tail_size) - 1;
         mov(reg_tmp, mask);
         kmovq(ktail_mask, reg_tmp);
@@ -993,7 +1019,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 vmovups(ptr[reg_aux_out_ptr
                                 + jcp.typesize_in * iw * jcp.ic_block_int_np],
                         zmm_zero);
-            int out_h_offset = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
             add(reg_aux_out_ptr, out_h_offset);
 
             dec(reg_kh_over);
@@ -1008,12 +1035,12 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
         L(kh_label);
         {
             copy_row(icb);
-            size_t inp_h_offset = !jcp.is_nspc
-                    ? (size_t)jcp.typesize_in * jcp.iw * jcp.ic_block
-                    : (size_t)jcp.typesize_in * jcp.iw * jcp.ngroups
+            const dim_t inp_h_offset = !jcp.is_nspc
+                    ? jcp.typesize_in * jcp.iw * jcp.ic_block
+                    : jcp.typesize_in * jcp.iw * jcp.ngroups
                             * jcp.ic_without_padding;
-            size_t out_h_offset
-                    = (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
 
             add(reg_aux_inp_ptr, inp_h_offset);
             add(reg_aux_out_ptr, out_h_offset);
@@ -1034,20 +1061,21 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 vmovups(ptr[reg_aux_out_ptr
                                 + jcp.typesize_in * iw * jcp.ic_block_int_np],
                         zmm_zero);
-            int out_h_offset = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
             add(reg_aux_out_ptr, out_h_offset);
 
             dec(reg_khc);
             jnz(kh_bover_label, T_NEAR);
         }
-        size_t out_d_offset = (size_t)jcp.typesize_in
+        const dim_t out_d_offset = jcp.typesize_in
                 * (jcp.ihp * jcp.iwp * jcp.ic_block_int_np + jcp.ic_block_int);
         L(no_kh_bover_label);
         if (is_3d) {
-            size_t inp_d_offset = !jcp.is_nspc
-                    ? (size_t)jcp.typesize_in * jcp.ih * jcp.iw * jcp.ic_block
+            const dim_t inp_d_offset = !jcp.is_nspc
+                    ? jcp.typesize_in * jcp.ih * jcp.iw * jcp.ic_block
                             * (jcp.dilate_d + 1)
-                    : (size_t)jcp.typesize_in * jcp.ih * jcp.iw * jcp.ngroups
+                    : jcp.typesize_in * jcp.ih * jcp.iw * jcp.ngroups
                             * jcp.ic_without_padding * (jcp.dilate_d + 1);
             pop(reg_aux_out_ptr);
             pop(reg_aux_inp_ptr);
@@ -1058,11 +1086,11 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
             L(no_kd_label);
         }
         // End IC Loop
-        size_t inp_cb_offset = !jcp.is_nspc
-                ? (size_t)jcp.typesize_in * (jcp.ic_block_int_np / jcp.ic_block)
+        const dim_t inp_cb_offset = !jcp.is_nspc
+                ? jcp.typesize_in * (jcp.ic_block_int_np / jcp.ic_block)
                         * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
-                : (size_t)jcp.typesize_in * jcp.ic_block_int_np;
-        size_t out_cb_offset = (size_t)jcp.kd * out_d_offset;
+                : jcp.typesize_in * jcp.ic_block_int_np;
+        const dim_t out_cb_offset = jcp.kd * out_d_offset;
 
         add(reg_inp_ptr, inp_cb_offset);
         add(reg_out_ptr, out_cb_offset);
@@ -1082,7 +1110,7 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -1135,10 +1163,10 @@ int jit_avx512_core_amx_fwd_kernel_t::get_out_tensor(
     const int C_LAST = 4;
     assert(0 <= C_BASE && C_BASE < C_LAST && C_LAST <= jcp.max_tiles);
     MAYBE_UNUSED(C_LAST);
-    const int tile = C_BASE
+    const int tile = static_cast<int>(C_BASE
             + (jcp.nb_oh_blocking > 1
                             ? h * jcp.nb_oh_blocking + i
-                            : (int)is_h_tail * jcp.nb_oc_blocking + i);
+                            : (int)is_h_tail * jcp.nb_oc_blocking + i));
     assert(C_BASE <= tile && tile < C_LAST);
     return tile;
 }
@@ -1163,99 +1191,95 @@ int jit_avx512_core_amx_fwd_kernel_t::get_wei_tensor(int i) const {
 }
 
 // Shifts and offsets
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_icb_step() const {
-    return (size_t)jcp.kd * get_inp_d_step();
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_icb_step() const {
+    return jcp.kd * get_inp_d_step();
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_icb_step() const {
-    return (size_t)jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw
-            * jcp.ic_block_int_np * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_icb_step() const {
+    return jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np
+            * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_d_step() const {
-    return (size_t)jcp.typesize_in
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_d_step() const {
+    return jcp.typesize_in
             * (jcp.ihp * jcp.iwp * jcp.ic_block_int_np + jcp.ic_block_int);
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_h_step() const {
-    return (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np
-            * (jcp.dilate_h + 1);
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_h_step() const {
+    return jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np * (jcp.dilate_h + 1);
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_d_step() const {
-    return (size_t)jcp.typesize_in * jcp.kh * jcp.kw * jcp.ic_block_int_np
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_d_step() const {
+    return jcp.typesize_in * jcp.kh * jcp.kw * jcp.ic_block_int_np
             * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_h_step() const {
-    return (size_t)jcp.typesize_in * jcp.kw * jcp.ic_block_int_np
-            * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_h_step() const {
+    return jcp.typesize_in * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_ocb_offset(
-        int ohb, int ocb, size_t typesize) const {
-    size_t el_offset = jcp.is_nspc
-            ? (size_t)ocb * jcp.oc_block
-                    + (size_t)ohb * jcp.ow * jcp.ngroups
-                            * jcp.oc_without_padding
-            : (size_t)ocb * jcp.oh * jcp.ow * jcp.oc_block
-                    + (size_t)ohb * jcp.ow * jcp.oc_block;
-    return (size_t)typesize * el_offset;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_ocb_offset(
+        dim_t ohb, dim_t ocb, dim_t typesize) const {
+    dim_t el_offset = jcp.is_nspc ? ocb * jcp.oc_block
+                    + ohb * jcp.ow * jcp.ngroups * jcp.oc_without_padding
+                                  : ocb * jcp.oh * jcp.ow * jcp.oc_block
+                    + ohb * jcp.ow * jcp.oc_block;
+    return typesize * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_row_offset(
-        int ohb, int ocb, int j, size_t typesize) const {
-    size_t offset_w = jcp.is_nspc
-            ? (size_t)typesize * j * jcp.ngroups * jcp.oc_without_padding
-            : (size_t)typesize * j * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_row_offset(
+        dim_t ohb, dim_t ocb, dim_t j, dim_t typesize) const {
+    const dim_t offset_w = jcp.is_nspc
+            ? typesize * j * jcp.ngroups * jcp.oc_without_padding
+            : typesize * j * jcp.oc_block;
     return get_out_ocb_offset(ohb, ocb, typesize) + offset_w;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_shift(
-        int width, size_t typesize) const {
-    return jcp.is_nspc
-            ? (size_t)typesize * width * jcp.ngroups * jcp.oc_without_padding
-            : (size_t)typesize * width * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_shift(
+        dim_t width, dim_t typesize) const {
+    return jcp.is_nspc ? typesize * width * jcp.ngroups * jcp.oc_without_padding
+                       : typesize * width * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_ocb_offset(
-        int ohb, int ocb) const {
-    size_t el_offset = (size_t)ocb * prv_width_ * jcp.oc_block
-            + (size_t)ohb * jcp.nb_oc_blocking * jcp.full_tile_width
-                    * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_ocb_offset(
+        dim_t ohb, dim_t ocb) const {
+    dim_t el_offset = ocb * prv_width_ * jcp.oc_block
+            + ohb * jcp.nb_oc_blocking * jcp.full_tile_width * jcp.oc_block;
     return jcp.typesize_acc * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_row_offset(
-        int ohb, int ocb, int j) const {
-    return get_wsp_ocb_offset(ohb, ocb)
-            + (size_t)jcp.typesize_acc * j * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_row_offset(
+        dim_t ohb, dim_t ocb, dim_t j) const {
+    return get_wsp_ocb_offset(ohb, ocb) + jcp.typesize_acc * j * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_shift() const {
-    return (size_t)jcp.typesize_acc * jcp.nb_oh_blocking * jcp.full_tile_width
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_shift() const {
+    return jcp.typesize_acc * jcp.nb_oh_blocking * jcp.full_tile_width
             * jcp.oc_block * jcp.nb_oc_blocking;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_offset(int ocb, int kw) const {
-    size_t el_offset = (size_t)kw * jcp.ic_block_int_np * jcp.oc_block;
-    size_t raw_oc_subblock_step
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_offset(
+        dim_t ocb, dim_t kw) const {
+    dim_t el_offset = kw * jcp.ic_block_int_np * jcp.oc_block;
+    dim_t raw_oc_subblock_step
             = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
-    size_t oc_subblock_step = jcp.is_relo
+    dim_t oc_subblock_step = jcp.is_relo
             ? rnd_up(raw_oc_subblock_step, jcp.ic_block_int * jcp.oc_block)
             : raw_oc_subblock_step;
-    el_offset += (size_t)ocb * jcp.nb_ic_int * oc_subblock_step;
+    el_offset += ocb * jcp.nb_ic_int * oc_subblock_step;
     return jcp.typesize_in * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_shift() const {
-    size_t w_step = (jcp.is_relo ? jcp.stride_w * jcp.kh
-                                    : jcp.is_pbuffer_strided ? 1
-                                                             : jcp.stride_w)
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_shift() const {
+    const dim_t w_step
+            = (jcp.is_relo                             ? jcp.stride_w * jcp.kh
+                              : jcp.is_pbuffer_strided ? 1
+                                                       : jcp.stride_w)
             * jcp.ic_block_int_np;
-    return (size_t)jcp.typesize_in * jcp.tile_width * w_step;
+    return jcp.typesize_in * jcp.tile_width * w_step;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(int ohb, int kw) const {
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(
+        dim_t ohb, dim_t kw) const {
     if (jcp.is_relo)
         return ohb * jcp.iwp * jcp.kh * jcp.ic_block_int_np * jcp.typesize_in;
     // calculate offset by height dimension
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_stride_h = nstl::min(jcp.stride_h, gen_kh);
-    size_t el_offset = (size_t)ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_stride_h = nstl::min<dim_t>(jcp.stride_h, gen_kh);
+    dim_t el_offset = ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
             * jcp.ic_block_int_np;
 
     // add offset by width dimension
     if (IMPLICATION(jcp.is_pbuffer_strided, jcp.stride_w == 1)) {
-        el_offset += (size_t)kw * (jcp.dilate_w + 1) * jcp.ic_block_int_np;
+        el_offset += kw * (jcp.dilate_w + 1) * jcp.ic_block_int_np;
     } else if (jcp.dilate_w > 0) {
-        el_offset += (size_t)kw * jcp.ow_block * jcp.ic_block_int_np;
+        el_offset += kw * jcp.ow_block * jcp.ic_block_int_np;
     } else {
         // dilate_w == 0 && stride_w > 1
         // there are min(jcp.kw, jcp.stride_w) continuous sets of input data
@@ -1263,35 +1287,36 @@ size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(int ohb, int kw) const {
         // padding
 
         // calculate set idx for current kw value
-        int set_idx = kw % jcp.stride_w;
+        const dim_t set_idx = kw % jcp.stride_w;
         // calculate shift within set for current kw value
-        int set_shift = kw / jcp.stride_w;
+        const dim_t set_shift = kw / jcp.stride_w;
 
         // calculate the beginning of the current set along width, each set
         // with index set_i contains number of elements along width equal to
         // jcp.ow - 1 + jcp.kw / jcp.stride_w
         //     + (set_i < jcp.kw % jcp.stride_w)
-        size_t set_start = (jcp.ow_block - 1 + jcp.kw / jcp.stride_w) * set_idx
-                + nstl::min(set_idx, jcp.kw % jcp.stride_w);
+        const dim_t set_start
+                = (jcp.ow_block - 1 + jcp.kw / jcp.stride_w) * set_idx
+                + nstl::min<dim_t>(set_idx, jcp.kw % jcp.stride_w);
         el_offset += (set_start + set_shift) * jcp.ic_block_int_np;
     }
     return jcp.typesize_in * el_offset;
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::get_zp_comp_offset(
-        int ocb, int zp_h, int zp_w) const {
-    const size_t ocb_offset = (size_t)ocb * jcp.oc_block;
-    const size_t sp_offset = (size_t)(zp_h * jcp.ow_pad + zp_w) * jcp.ngroups
-            * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_zp_comp_offset(
+        dim_t ocb, dim_t zp_h, dim_t zp_w) const {
+    const dim_t ocb_offset = ocb * jcp.oc_block;
+    const dim_t sp_offset
+            = (zp_h * jcp.ow_pad + zp_w) * jcp.ngroups * jcp.oc_without_padding;
     return (ocb_offset + sp_offset) * sizeof(int32_t);
 }
 
-int jit_avx512_core_amx_fwd_kernel_t::get_zp_index_offset(
-        int index, int mid, int s_pad_output, int e_pad_output) {
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_zp_index_offset(
+        dim_t index, dim_t mid, dim_t s_pad_output, dim_t e_pad_output) {
     using namespace nstl;
-    const int mid_end = e_pad_output - 1;
-    int zp_mid = nstl::min(mid, nstl::max(0, index - mid_end));
-    int zp_pad_offset
+    const dim_t mid_end = e_pad_output - 1;
+    const dim_t zp_mid = nstl::min(mid, nstl::max<dim_t>(0, index - mid_end));
+    const dim_t zp_pad_offset
             = accum_with_upper_bound(index, s_pad_output, e_pad_output);
     return zp_pad_offset + zp_mid;
 }
@@ -1314,41 +1339,41 @@ void jit_avx512_core_amx_fwd_kernel_t::init_runtime_counters(
     is_buffer_empty_ = true;
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_block(
-        const int block_size, const int pad_output) {
-    return (size_t)(pad_output >= block_size ? block_size : 0)
+dim_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_block(
+        const dim_t block_size, const dim_t pad_output) {
+    return (pad_output >= block_size ? block_size : 0)
             + (pad_output % block_size);
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
-        const int dim_size, const int block_size, const int s_pad_output,
-        const int e_pad_output) {
+dim_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
+        const dim_t dim_size, const dim_t block_size, const dim_t s_pad_output,
+        const dim_t e_pad_output) {
     using namespace nstl;
 
     // start padding (s_pad)
-    int s_pad_limit = reduce_to_block(block_size, s_pad_output);
-    int s_pad_area_blk = rnd_up(s_pad_limit, block_size);
+    const dim_t s_pad_limit = reduce_to_block(block_size, s_pad_output);
+    const dim_t s_pad_area_blk = rnd_up(s_pad_limit, block_size);
 
     // middle (no padding)
-    int no_pad_area = nstl::max(
+    const dim_t no_pad_area = nstl::max<dim_t>(
             0, dim_size - rnd_up(s_pad_output, block_size) - e_pad_output);
-    int no_pad_limit = (no_pad_area >= block_size ? block_size : 0);
+    const dim_t no_pad_limit = (no_pad_area >= block_size ? block_size : 0);
 
     // end padding (e_pad)
-    int no_pad_area_shift = no_pad_area % block_size;
-    int e_pad_area_overlap
+    const dim_t no_pad_area_shift = no_pad_area % block_size;
+    const dim_t e_pad_area_overlap
             = no_pad_area_shift == 0 ? 0 : block_size - no_pad_area_shift;
     // middle and end padding shift
-    int e_pad_shift_limit
+    const dim_t e_pad_shift_limit
             = no_pad_area_shift + min(e_pad_output, e_pad_area_overlap);
-    int e_pad_area_blk = nstl::max(0, e_pad_output - e_pad_area_overlap);
+    const dim_t e_pad_area_blk
+            = nstl::max<dim_t>(0, e_pad_output - e_pad_area_overlap);
     // full end padding block
-    int e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
+    const dim_t e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
 
     // calculate reduced size of s_pad, middle and e_pad blocks.
-    return min((size_t)dim_size,
-            (size_t)s_pad_area_blk + no_pad_limit + e_pad_shift_limit
-                    + e_pad_limit);
+    return min(dim_size,
+            s_pad_area_blk + no_pad_limit + e_pad_shift_limit + e_pad_limit);
 }
 
 Ymm jit_avx512_core_amx_fwd_kernel_t::ymm_mask(
@@ -1406,7 +1431,7 @@ void jit_avx512_core_amx_fwd_kernel_t::apply_sum(const Zmm &zmm_out,
 
 void jit_avx512_core_amx_fwd_kernel_t::apply_postops(const Zmm &zmm_out,
         const float *p_sum_scale, const int32_t *p_sum_zp,
-        const Xbyak::Address &addr, const size_t off, const bool mask_flag) {
+        const Xbyak::Address &addr, const dim_t off, const bool mask_flag) {
     if (jcp.with_eltwise || jcp.with_binary
             || (jcp.with_sum && p_sum_scale != nullptr)) {
         apply_sum(zmm_out, p_sum_scale, p_sum_zp, addr, mask_flag);
@@ -1433,7 +1458,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_ymm_bf16(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
-        const Zmm &zmm_out, int ocb, int h, int w) {
+        const Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w) {
     const bool mask_flag = jcp.is_nspc && jcp.oc_without_padding != jcp.oc
             && ocb == (jcp.nb_oc_blocking - 1);
 
@@ -1454,7 +1479,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
         }
     }
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         if (jcp.bia_dt == data_type::bf16) {
             vpmovzxwd(zmm_mask(zmm_bias, mask_flag), bias_addr);
@@ -1476,10 +1501,10 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int ocb, int h, int w, const bool compute_zp,
-        const int zp_h, const int zp_w) {
-    const int nb_oc_block = jcp.nb_oc_blocking;
-    const int oc_block = jcp.oc_block;
+        const Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w, const bool compute_zp,
+        const dim_t zp_h, const dim_t zp_w) {
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t oc_block = jcp.oc_block;
     const bool mask_flag = true && jcp.oc_without_padding != jcp.oc
             && ocb == (nb_oc_block - 1);
 
@@ -1504,7 +1529,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
     }
 
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
@@ -1514,13 +1539,13 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
         const Zmm m_zmm_zp = zmm_mask(zmm_zp, mask_flag);
         vmovups(m_zmm_zp,
                 EVEX_compress_addr(reg_zero_point_pbuff,
-                        get_zp_comp_offset(ocb, zp_h, zp_w)));
+                        static_cast<int>(get_zp_comp_offset(ocb, zp_h, zp_w))));
         const Zmm m_zmm_out = zmm_mask(zmm_out, mask_flag);
         vpaddd(m_zmm_out, zmm_out, zmm_zp);
     }
     if (jcp.src_zero_point) {
         // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-        int zp_offset = sizeof(int32_t) * ocb * oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * oc_block;
         const Zmm m_zmm_zp = zmm_mask(zmm_zp, mask_flag);
         vpmulld(m_zmm_zp, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -1540,10 +1565,11 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        const int scale_offset
+        const dim_t scale_offset
                 = jcp.is_oc_scale * (sizeof(float) * ocb * oc_block);
         vmulps(zmm_out_msk, zmm_out,
-                EVEX_compress_addr(reg_ptr_wei_scales, scale_offset,
+                EVEX_compress_addr(reg_ptr_wei_scales,
+                        static_cast<int>(scale_offset),
                         /* bcast = */ !jcp.is_oc_scale));
     }
 
@@ -1581,8 +1607,8 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector(const Zmm &zmm_out,
-        int ocb, int h, int w, const bool compute_zp, const int zp_h,
-        const int zp_w) {
+        dim_t ocb, dim_t h, dim_t w, const bool compute_zp, const dim_t zp_h,
+        const dim_t zp_w) {
     /*
     Output:
               jcp.is_nspc              !jcp.is_nspc
@@ -1597,23 +1623,25 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector(const Zmm &zmm_out,
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
-        bool do_store, const bool handle_h_blk, const int t_pad_output,
-        const int b_pad_output, const int l_pad_output, const int r_pad_output,
-        const bool is_last_oh_block, const bool zp_3d_pad) {
-    auto store_output_block
-            = [&](int width, int tail, bool do_store, bool is_last_h = false) {
+void jit_avx512_core_amx_fwd_kernel_t::store_output(dim_t width, int tail,
+        bool do_store, const bool handle_h_blk, const dim_t t_pad_output,
+        const dim_t b_pad_output, const dim_t l_pad_output,
+        const dim_t r_pad_output, const bool is_last_oh_block,
+        const bool zp_3d_pad) {
+    auto store_output_block = [&](dim_t width, int tail, bool do_store,
+                                      bool is_last_h = false) {
         // Calculate the number of oh blocks; it may differ on last call
-        const int last_h_blks
-                = div_up(jcp.oh, jcp.oh_per_tile) % jcp.nb_oh_blocking;
-        const int h_blks = is_last_h && last_h_blks != 0 ? last_h_blks
-                                                         : jcp.nb_oh_blocking;
+        const int last_h_blks = static_cast<int>(
+                div_up(jcp.oh, jcp.oh_per_tile) % jcp.nb_oh_blocking);
+        const int h_blks = is_last_h && last_h_blks != 0
+                ? last_h_blks
+                : static_cast<int>(jcp.nb_oh_blocking);
         // Calculate the number of oh rows per tile; it may differ on last call
         const int h_tail = is_last_h && jcp.oh % jcp.oh_per_tile != 0
                 ? (h_blks - 1) * jcp.oh_per_tile + jcp.oh % jcp.oh_per_tile
                 : h_blks * jcp.oh_per_tile;
-        const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
-        const int owp = gen_kw + jcp.ow - 1;
+        const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+        const dim_t owp = gen_kw + jcp.ow - 1;
 
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
@@ -1644,17 +1672,17 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
 
             for (int tw = 0; tw < width && do_store; tw++) {
                 // height
-                const int oh_index = ohb * jcp.oh_per_tile + tw / owp;
+                const dim_t oh_index = ohb * jcp.oh_per_tile + tw / owp;
                 const bool zp_h_pad
                         = oh_index < t_pad_output || oh_index >= b_pad_output;
-                const int zp_h = get_zp_index_offset(
-                        oh_index, (int)jcp.oh_mid, t_pad_output, b_pad_output);
+                const dim_t zp_h = get_zp_index_offset(
+                        oh_index, jcp.oh_mid, t_pad_output, b_pad_output);
                 // width
-                const int ow_index = tw % owp;
+                const dim_t ow_index = tw % owp;
                 const bool zp_w_pad
                         = ow_index < l_pad_output || ow_index >= r_pad_output;
-                const int zp_w = get_zp_index_offset(
-                        ow_index, (int)jcp.ow_mid, l_pad_output, r_pad_output);
+                const dim_t zp_w = get_zp_index_offset(
+                        ow_index, jcp.ow_mid, l_pad_output, r_pad_output);
 
                 const bool compute_zp = jcp.req_zero_point_buffer
                         && (zp_3d_pad || zp_w_pad || zp_h_pad);
@@ -1694,17 +1722,20 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
         }
     }
     if (do_store) {
-        add(reg_out_ptr, get_out_shift(width, jcp.typesize_out));
+        add(reg_out_ptr,
+                static_cast<int>(get_out_shift(width, jcp.typesize_out)));
         if (jcp.req_zero_point_buffer) {
-            const size_t sp_shift
+            const dim_t sp_shift
                     = accum_with_upper_bound(width, l_pad_output, r_pad_output);
-            add(reg_zero_point_pbuff, get_out_shift(sp_shift, sizeof(int32_t)));
+            add(reg_zero_point_pbuff,
+                    static_cast<int>(get_out_shift(sp_shift, sizeof(int32_t))));
         }
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
-        int const t_pad_output, int const b_pad_output, const bool zp_3d_pad) {
+void jit_avx512_core_amx_fwd_kernel_t::interleave_store(dim_t width,
+        dim_t const t_pad_output, dim_t const b_pad_output,
+        const bool zp_3d_pad) {
     for (int c = 0;
             c < jcp.per_one_pstore && !is_store_done_ && !is_buffer_empty_;
             c++) {
@@ -1719,20 +1750,20 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
                         {bin_injector_helper_reg_1, bin_injector_helper_reg_2});
 
         // height
-        const int oh_index = ohb;
+        const dim_t oh_index = ohb;
         const bool zp_h_pad
                 = oh_index < t_pad_output || oh_index >= b_pad_output;
-        const int zp_h = get_zp_index_offset(
-                oh_index, (int)jcp.oh_mid, t_pad_output, b_pad_output);
+        const dim_t zp_h = get_zp_index_offset(
+                oh_index, jcp.oh_mid, t_pad_output, b_pad_output);
         // width
-        const int l_pad_output
+        const dim_t l_pad_output
                 = w_padding.empty() ? 0 : w_padding.front().l_pad_output;
-        const int r_pad_output
+        const dim_t r_pad_output
                 = w_padding.empty() ? jcp.ow : w_padding.front().r_pad_output;
 
         const bool zp_w_pad = tw < l_pad_output || tw >= r_pad_output;
-        const int zp_w = get_zp_index_offset(
-                tw, (int)jcp.ow_mid, l_pad_output, r_pad_output);
+        const dim_t zp_w = get_zp_index_offset(
+                tw, jcp.ow_mid, l_pad_output, r_pad_output);
 
         const bool compute_zp = jcp.req_zero_point_buffer
                 && (zp_3d_pad || zp_w_pad || zp_h_pad);
@@ -1744,25 +1775,29 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
 
         if (row_count_
                 == prv_width_ * jcp.nb_oc_blocking * jcp.nb_oh_blocking) {
-            add(reg_out_ptr, get_out_shift(prv_width_, jcp.typesize_out));
+            add(reg_out_ptr,
+                    static_cast<int>(
+                            get_out_shift(prv_width_, jcp.typesize_out)));
             if (jcp.req_zero_point_buffer) {
-                const size_t sp_shift = accum_with_upper_bound(
+                const dim_t sp_shift = accum_with_upper_bound(
                         prv_width_, l_pad_output, r_pad_output);
                 add(reg_zero_point_pbuff,
-                        get_out_shift(sp_shift, sizeof(int32_t)));
+                        static_cast<int>(
+                                get_out_shift(sp_shift, sizeof(int32_t))));
                 if (!w_padding.empty()) w_padding.pop();
             }
             row_count_ = 0;
             is_store_done_ = true;
-            prv_width_ = width;
+            prv_width_ = static_cast<int>(width);
         }
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
-        bool do_store, const bool handle_h_blk, const int t_pad_output,
-        const int b_pad_output, const int l_pad_output, const int r_pad_output,
-        const bool zp_3d_pad, const bool is_last_oh_block) {
+void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(dim_t width,
+        bool do_store, const bool handle_h_blk, const dim_t t_pad_output,
+        const dim_t b_pad_output, const dim_t l_pad_output,
+        const dim_t r_pad_output, const bool zp_3d_pad,
+        const bool is_last_oh_block) {
     const bool tail = width == jcp.tile_tail;
 
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
@@ -1796,13 +1831,14 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
 
     // reduced lowering path
     if (jcp.is_relo) {
-        const int nreduce = jcp.nreduce;
-        const int stride = jcp.ic_block_int; // ie 64 (32) for int8 (bf16)
+        const dim_t nreduce = jcp.nreduce;
+        const int stride = static_cast<int>(
+                jcp.ic_block_int); // ie 64 (32) for int8 (bf16)
 
         push(reg_inp_ptr);
         push(reg_wei_ptr);
 
-        for (int ireduce = 0; ireduce < nreduce; ireduce += stride) {
+        for (dim_t ireduce = 0; ireduce < nreduce; ireduce += stride) {
             for (int ohb = 0; ohb < jcp.nb_oh_blocking; ohb++) {
                 tileloadd(Tmm(get_inp_tensor(ohb, tail)),
                         ptr[reg_inp_ptr + get_inp_offset(ohb, 0)
@@ -1821,7 +1857,9 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
             }
             if (ireduce + stride < nreduce) {
                 add(reg_inp_ptr, stride * jcp.typesize_in);
-                add(reg_wei_ptr, stride * jcp.oc_block * jcp.typesize_in);
+                add(reg_wei_ptr,
+                        static_cast<int>(
+                                stride * jcp.oc_block * jcp.typesize_in));
             }
         }
         pop(reg_wei_ptr);
@@ -1835,21 +1873,21 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         return;
     }
 
-    auto wei_offset = [&](int icb, int ocb, int kd, int kh, int kw) {
-        return (size_t)icb * get_wei_icb_step() + kd * get_wei_d_step()
+    auto wei_offset = [&](dim_t icb, dim_t ocb, dim_t kd, dim_t kh, dim_t kw) {
+        return icb * get_wei_icb_step() + kd * get_wei_d_step()
                 + kh * get_wei_h_step() + get_wei_offset(ocb, kw);
     };
 
-    auto inp_offset = [&](int icb, int ohb, int kd, int kh, int kw) {
-        return (size_t)icb * get_inp_icb_step() + kd * get_inp_d_step()
+    auto inp_offset = [&](dim_t icb, dim_t ohb, dim_t kd, dim_t kh, dim_t kw) {
+        return icb * get_inp_icb_step() + kd * get_inp_d_step()
                 + kh * get_inp_h_step() + get_inp_offset(ohb, kw);
     };
 
     auto safe_tileloadd
-            = [this](const Tmm &t1, const Xbyak::Reg64 &reg_ptr, size_t offset,
+            = [this](const Tmm &t1, const Xbyak::Reg64 &reg_ptr, dim_t offset,
                       const Xbyak::Reg64 &reg_stride) {
         if (offset <= INT32_MAX) {
-            tileloadd(t1, ptr[reg_ptr + offset + reg_stride]);
+            tileloadd(t1, ptr[reg_ptr + static_cast<int>(offset) + reg_stride]);
         } else {
             safe_add(reg_ptr, offset, reg_tmp);
             tileloadd(t1, ptr[reg_ptr + reg_stride]);
@@ -1864,24 +1902,24 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         Label kd_skip_compute;
         if (check_kd_padding) mov(reg_kd, ptr[param1 + GET_OFF(kd_padding)]);
 
-        for (int kd = 0; kd < jcp.kd; kd++) {
+        for (dim_t kd = 0; kd < jcp.kd; kd++) {
             if (check_kd_padding) {
                 dec(reg_kd);
                 jl(kd_skip_compute, T_NEAR);
                 push(reg_kd);
             }
-            for (int kh = 0; kh < jcp.kh; kh++) {
-                for (int set_idx = 0; set_idx < jcp.n_stride_sets;
+            for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                for (dim_t set_idx = 0; set_idx < jcp.n_stride_sets;
                         set_idx++) { // used to optimize input memory reuse in L1$
-                    for (int kw = set_idx; kw < jcp.kw; kw += jcp.kw_step) {
+                    for (dim_t kw = set_idx; kw < jcp.kw; kw += jcp.kw_step) {
                         for (int ohb = 0; ohb < jcp.nb_oh_blocking; ohb++) {
-                            const size_t inp_off
+                            const dim_t inp_off
                                     = inp_offset(icb, ohb, kd, kh, kw);
                             safe_tileloadd(Tmm(get_inp_tensor(ohb, tail)),
                                     reg_inp_ptr, inp_off, reg_inp_stride);
                         }
                         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-                            const size_t wei_off
+                            const dim_t wei_off
                                     = wei_offset(icb, ocb, kd, kh, kw);
                             safe_tileloadd(Tmm(get_wei_tensor(ocb)),
                                     reg_wei_ptr, wei_off, reg_wei_stride);
@@ -1908,15 +1946,15 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
     add(reg_inp_ptr, get_inp_shift());
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
-        bool do_store, const int l_pad_output, const int r_pad_output,
+void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(dim_t width,
+        bool do_store, const dim_t l_pad_output, const dim_t r_pad_output,
         const bool zp_3d_pad) {
     if (jcp.req_zero_point_buffer
             && (jcp.t_pad_output > 0 || jcp.b_pad_output > 0)) {
-        const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
-        const size_t height_limit = reduce_to_blocked_dims(
+        const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+        const dim_t height_limit = reduce_to_blocked_dims(
                 jcp.oh, oh_step_size, jcp.t_pad_output, jcp.b_pad_output);
-        const int ur_h = div_up(height_limit, oh_step_size);
+        const int ur_h = static_cast<int>(div_up(height_limit, oh_step_size));
         assert(6 >= ur_h);
 
         // Use a jump-table to execute the corresponding block
@@ -1939,8 +1977,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
         const bool local_is_buffer_empty = is_buffer_empty_;
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
-        int cur_b_pad = height_limit
+        dim_t cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
+        dim_t cur_b_pad = height_limit
                 - reduce_to_block(oh_step_size, jcp.b_pad_output);
         for (int u = 0; u < ur_h; u++) {
             bool last = u == ur_h - 1;
@@ -1953,8 +1991,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
             is_buffer_empty_ = local_is_buffer_empty;
             compute_icb_loop(width, do_store, false, cur_t_pad, cur_b_pad,
                     l_pad_output, r_pad_output, zp_3d_pad, last);
-            cur_t_pad = nstl::max(0, cur_t_pad - oh_step_size);
-            cur_b_pad = nstl::max(0, cur_b_pad - oh_step_size);
+            cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step_size);
+            cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step_size);
             if (!last) jmp(h_blk_end_label, T_NEAR);
         }
         L(h_blk_end_label);
@@ -1964,8 +2002,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(int width,
-        bool do_store, const int l_pad_output, const int r_pad_output) {
+void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(dim_t width,
+        bool do_store, const dim_t l_pad_output, const dim_t r_pad_output) {
     if (jcp.req_zero_point_buffer && (jcp.f_pad > 0 || jcp.back_pad > 0)) {
         Label compute_3d_zp_label, zp_d_end_label;
         mov(reg_kd, ptr[param1 + GET_OFF(kd_padding)]);
@@ -1995,18 +2033,21 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(int width,
 
 void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     auto compute_ow_loop_body
-            = [this](bool last_owb, int num_tile_blocks, const int l_pad_output,
-                      const int r_pad_output) {
-        int cur_l_pad_output = l_pad_output;
-        int cur_r_pad_output = r_pad_output;
-        int gen_tile_tail = last_owb && jcp.tile_tail > 0 ? jcp.tile_tail
-                                                          : jcp.tile_width;
+            = [this](bool last_owb, int num_tile_blocks,
+                      const dim_t l_pad_output, const dim_t r_pad_output) {
+        dim_t cur_l_pad_output = l_pad_output;
+        dim_t cur_r_pad_output = r_pad_output;
+        const dim_t gen_tile_tail = last_owb && jcp.tile_tail > 0
+                ? jcp.tile_tail
+                : jcp.tile_width;
         init_runtime_counters(last_owb && num_tile_blocks == 1);
         for (int owb = 0; owb < num_tile_blocks - 1; owb++) {
             dispatch_zp_3d_compute(
                     jcp.tile_width, false, cur_l_pad_output, cur_r_pad_output);
-            cur_l_pad_output = nstl::max(0, cur_l_pad_output - jcp.tile_width);
-            cur_r_pad_output = nstl::max(0, cur_r_pad_output - jcp.tile_width);
+            cur_l_pad_output
+                    = nstl::max<dim_t>(0, cur_l_pad_output - jcp.tile_width);
+            cur_r_pad_output
+                    = nstl::max<dim_t>(0, cur_r_pad_output - jcp.tile_width);
         }
         dispatch_zp_3d_compute(
                 gen_tile_tail, true, cur_l_pad_output, cur_r_pad_output);
@@ -2014,23 +2055,24 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
 
     assert(jcp.nb_ow > 0);
     if (jcp.nb_ow == 1) {
-        const int ow_r_pad_start
-                = nstl::max(jcp.ow - jcp.r_pad_output, jcp.l_pad_output);
-        compute_ow_loop_body(
-                true, jcp.ow_blocks, jcp.l_pad_output, ow_r_pad_start);
+        const dim_t ow_r_pad_start
+                = nstl::max<dim_t>(jcp.ow - jcp.r_pad_output, jcp.l_pad_output);
+        compute_ow_loop_body(true, static_cast<int>(jcp.ow_blocks),
+                jcp.l_pad_output, ow_r_pad_start);
     } else if (jcp.req_zero_point_buffer
             && (jcp.l_pad_output > 0 || jcp.r_pad_output > 0)) {
 
-        const size_t zp_addr_shift
+        const dim_t zp_addr_shift
                 = jcp.ngroups * jcp.oc_without_padding * sizeof(int32_t);
-        const int ow_step_size = jcp.ow_block;
-        const int ow_blocks_per_call = div_up(ow_step_size, jcp.tile_width);
+        const int ow_step_size = static_cast<int>(jcp.ow_block);
+        const int ow_blocks_per_call
+                = static_cast<int>(div_up(ow_step_size, jcp.tile_width));
         const int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call == 0
                 ? ow_blocks_per_call
                 : jcp.ow_blocks % ow_blocks_per_call;
-        const int width_limit = reduce_to_blocked_dims(
+        const dim_t width_limit = reduce_to_blocked_dims(
                 jcp.ow, ow_step_size, jcp.l_pad_output, jcp.r_pad_output);
-        const int ur_w = div_up(width_limit, ow_step_size);
+        const int ur_w = static_cast<int>(div_up(width_limit, ow_step_size));
         assert(6 >= ur_w);
         // Use a jump-table to execute the corresponding block
         Label w_blk_label[6], w_blk_end_label, jmp_table_label;
@@ -2046,21 +2088,23 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
         }
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
-        int cur_r_pad
+        dim_t cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
+        dim_t cur_r_pad
                 = width_limit - reduce_to_block(ow_step_size, jcp.r_pad_output);
-        int zp_offset = 0;
+        dim_t zp_offset = 0;
         for (int u = 0; u < ur_w; u++) {
             const bool last = u == ur_w - 1;
             L(w_blk_label[u]);
-            if (u > 0) add(reg_zero_point_pbuff, zp_offset * zp_addr_shift);
+            if (u > 0)
+                add(reg_zero_point_pbuff,
+                        static_cast<int>(zp_offset * zp_addr_shift));
             compute_ow_loop_body(last,
                     last ? last_owb_tile_blocks : ow_blocks_per_call, cur_l_pad,
                     cur_r_pad);
             zp_offset += accum_with_upper_bound(
                     ow_step_size, cur_l_pad, cur_r_pad);
-            cur_l_pad = nstl::max(0, cur_l_pad - ow_step_size);
-            cur_r_pad = nstl::max(0, cur_r_pad - ow_step_size);
+            cur_l_pad = nstl::max<dim_t>(0, cur_l_pad - ow_step_size);
+            cur_r_pad = nstl::max<dim_t>(0, cur_r_pad - ow_step_size);
             if (!last) jmp(w_blk_end_label, T_NEAR);
         }
         L(w_blk_end_label);
@@ -2068,7 +2112,8 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     } else {
         assert(jcp.oh_per_tile == 1);
         Label label_done;
-        int ow_blocks_per_call = utils::div_up(jcp.ow_block, jcp.tile_width);
+        int ow_blocks_per_call
+                = static_cast<int>(utils::div_up(jcp.ow_block, jcp.tile_width));
         int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call;
         if (last_owb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_owb_tile_blocks = ow_blocks_per_call;
@@ -2102,11 +2147,11 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
 
-    const int fac = jcp.is_relo      ? jcp.stride_w * jcp.kh
+    const dim_t fac = jcp.is_relo    ? jcp.stride_w * jcp.kh
             : jcp.is_pbuffer_strided ? 1
                                      : jcp.stride_w;
-    const int inp_stride = fac * jcp.ic_block_int_np * jcp.typesize_in;
-    const int wei_stride = jcp.oc_block * jcp.typesize_acc;
+    const dim_t inp_stride = fac * jcp.ic_block_int_np * jcp.typesize_in;
+    const dim_t wei_stride = jcp.oc_block * jcp.typesize_acc;
     mov(reg_inp_stride, inp_stride);
     mov(reg_wei_stride, wei_stride);
 
@@ -2115,8 +2160,8 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
         // loads / stores with block index
         // ocb = occ * jcp.nb_oc_blocking + (jcp.nb_oc_blocking - 1)
         // TODO: use masked loads / stores for the last occ only
-        int current_block_size = jcp.oc_block;
-        int mask = (1 << current_block_size) - 1;
+        dim_t current_block_size = jcp.oc_block;
+        int mask = (1 << static_cast<int>(current_block_size)) - 1;
         Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
@@ -2126,7 +2171,7 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
         jne(mask_is_set, T_NEAR);
         // Reset the mask
         current_block_size = jcp.oc_without_padding % jcp.oc_block;
-        mask = (1 << current_block_size) - 1;
+        mask = (1 << static_cast<int>(current_block_size)) - 1;
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
 
@@ -2143,11 +2188,12 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
     const int vnni_width = jcp.src_dt == data_type::bf16 ? 2 : 4;
     // Input tile dimensions
-    const int a_col = jcp.is_relo ? jcp.ic_block_int
-                                  : jcp.ic_block_int_np * jcp.kw_per_tile;
+    const int a_col = static_cast<int>(jcp.is_relo
+                    ? jcp.ic_block_int
+                    : jcp.ic_block_int_np * jcp.kw_per_tile);
     // Weights tile dimensions
-    const int b_col = jcp.oc_block * vnni_width;
-    const int b_row = a_col / vnni_width;
+    const dim_t b_col = jcp.oc_block * vnni_width;
+    const dim_t b_row = a_col / vnni_width;
     // Accumulator tile dimensions
     const int c_col = 16;
 
@@ -2181,7 +2227,8 @@ void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                     c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
@@ -2196,31 +2243,33 @@ void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
     if (jcp.req_zero_point_buffer && calculate_oh_limits) {
 
         int limit_idx = 0;
-        const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+        const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
 
         // full t_pad output block
-        const int t_pad_blk_end = rnd_dn(jcp.t_pad_output, oh_step_size);
+        const dim_t t_pad_blk_end = rnd_dn(jcp.t_pad_output, oh_step_size);
         if (jcp.t_pad_output >= oh_step_size) {
             jcp.h_blk_limits[limit_idx++] = t_pad_blk_end;
         }
         // t_pad output overlap with no padding
-        const int t_pad_shift = jcp.t_pad_output % oh_step_size;
+        const dim_t t_pad_shift = jcp.t_pad_output % oh_step_size;
         if (t_pad_shift != 0) {
             jcp.h_blk_limits[limit_idx++] = t_pad_blk_end + t_pad_shift;
         }
-        const int t_pad_next_blk = rnd_up(jcp.t_pad_output, oh_step_size);
-        const int oh_blk_tail = jcp.oh % oh_step_size;
-        const int b_pad_no_tail = nstl::max(0, jcp.b_pad_output - oh_blk_tail);
-        const int b_pad_start
-                = nstl::max(jcp.t_pad_output, jcp.oh - jcp.b_pad_output);
-        const int b_pad_blk_start = rnd_dn(b_pad_start, oh_step_size);
+        const dim_t t_pad_next_blk = rnd_up(jcp.t_pad_output, oh_step_size);
+        const dim_t oh_blk_tail = jcp.oh % oh_step_size;
+        const dim_t b_pad_no_tail
+                = nstl::max<dim_t>(0, jcp.b_pad_output - oh_blk_tail);
+        const dim_t b_pad_start
+                = nstl::max<dim_t>(jcp.t_pad_output, jcp.oh - jcp.b_pad_output);
+        const dim_t b_pad_blk_start = rnd_dn(b_pad_start, oh_step_size);
         // middle block without padding
-        const int mid_blk = nstl::max(0, b_pad_blk_start - t_pad_next_blk);
+        const dim_t mid_blk
+                = nstl::max<dim_t>(0, b_pad_blk_start - t_pad_next_blk);
         if (mid_blk >= oh_step_size) {
             jcp.h_blk_limits[limit_idx++] = b_pad_blk_start;
         }
         // no padding with b_pad overlap
-        const int b_pad_shift = b_pad_no_tail % oh_step_size;
+        const dim_t b_pad_shift = b_pad_no_tail % oh_step_size;
         if (b_pad_shift != 0) {
             jcp.h_blk_limits[limit_idx++] = rnd_up(b_pad_start, oh_step_size);
         }
@@ -2241,7 +2290,7 @@ void jit_avx512_core_amx_fwd_kernel_t::set_ow_blk_limits(jit_conv_conf_t &jcp) {
     const bool calculate_ow_limits
             = jcp.nb_ow > 1 && (jcp.l_pad_output > 0 || jcp.r_pad_output > 0);
     if (jcp.req_zero_point_buffer && calculate_ow_limits) {
-        const int ow_step_size = jcp.ow_block;
+        const int ow_step_size = static_cast<int>(jcp.ow_block);
 
         // l_pad
         const int l_pad_limit
@@ -2251,16 +2300,16 @@ void jit_avx512_core_amx_fwd_kernel_t::set_ow_blk_limits(jit_conv_conf_t &jcp) {
         jcp.l_pad_blk = div_up(l_pad_limit, ow_step_size);
 
         // middle (area without padding)
-        const int no_pad_area
-                = nstl::max(0, jcp.ow - l_pad_area_blk - jcp.r_pad_output);
+        const int no_pad_area = static_cast<int>(nstl::max<dim_t>(
+                0, jcp.ow - l_pad_area_blk - jcp.r_pad_output));
         jcp.no_pad_w_blk = no_pad_area >= ow_step_size ? 1 : 0;
 
         // r_pad
         const int no_pad_area_shift = no_pad_area % ow_step_size;
         const int r_pad_area_overlap
                 = no_pad_area_shift == 0 ? 0 : ow_step_size - no_pad_area_shift;
-        const int r_pad_area
-                = nstl::max(0, jcp.r_pad_output - r_pad_area_overlap);
+        const int r_pad_area = static_cast<int>(
+                nstl::max<dim_t>(0, jcp.r_pad_output - r_pad_area_overlap));
         const int r_pad_limit = (r_pad_area >= ow_step_size ? ow_step_size : 0)
                 + (r_pad_area % ow_step_size);
         jcp.r_pad_blk = (r_pad_area_overlap > 0 ? 1 : 0)
@@ -2336,9 +2385,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -2459,7 +2508,8 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
 
     const int vnni_width = is_bf16_convolution ? 2 : 4;
-    jcp.ic_block_int = jcp.ic_block * vnni_width; // 32 for bf16, 64 for int8
+    jcp.ic_block_int = jcp.ic_block * vnni_width;
+    // 32 for bf16, 64 for int8
 
     // fallback to non-amx impl when accumulation is too small
     const dim_t total_k = static_cast<dim_t>(jcp.ic_without_padding) * jcp.kd
@@ -2470,7 +2520,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // small-ic parameters
     jcp.ic_block_int_np = jcp.is_nspc
-            ? nstl::min(jcp.ic_block_int, jcp.ic_without_padding)
+            ? nstl::min<dim_t>(jcp.ic_block_int, jcp.ic_without_padding)
             : jcp.ic_block_int;
     bool is_small_ic = jcp.ic_block_int_np < jcp.ic_block_int;
 
@@ -2586,10 +2636,13 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -2613,19 +2666,20 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const bool ok_to_pack_tile = !jcp.is_relo
             && (utils::everyone_is(1, jcp.kh, jcp.kw)
                     || utils::everyone_is(1, jcp.stride_h, jcp.stride_w));
-    const int max_oh_per_tile
-            = 1 + (jcp.full_tile_width - jcp.ow) / (jcp.ow + gen_kw - 1);
+    const int max_oh_per_tile = static_cast<int>(
+            1 + (jcp.full_tile_width - jcp.ow) / (jcp.ow + gen_kw - 1));
     jcp.oh_per_tile = ok_to_pack_tile
-            ? nstl::min(jcp.oh, nstl::max(1, max_oh_per_tile))
+            ? static_cast<int>(
+                      nstl::min<dim_t>(jcp.oh, nstl::max(1, max_oh_per_tile)))
             : 1;
-    jcp.tile_width = nstl::min<int>(
-            jcp.full_tile_width, calculate_tile_width(jcp.oh_per_tile));
+    jcp.tile_width = static_cast<int>(nstl::min<dim_t>(
+            jcp.full_tile_width, calculate_tile_width(jcp.oh_per_tile)));
     jcp.ow_blocks = utils::div_up(jcp.ow, jcp.tile_width);
 
     // Prefer to use a single tile width when possible
     // (eg ow28 => 2 tiles of 14 vs 1 of 16 and 1 of 12)
     if (jcp.oh_per_tile == 1 && jcp.ow % jcp.ow_blocks == 0)
-        jcp.tile_width = jcp.ow / jcp.ow_blocks;
+        jcp.tile_width = static_cast<int>(jcp.ow / jcp.ow_blocks);
     jcp.tile_tail = jcp.oh_per_tile == 1 ? jcp.ow % jcp.tile_width : 0;
 
     jcp.nb_oc_blocking = (jcp.nb_oc % 2 == 0) ? 2 : 1;
@@ -2643,20 +2697,23 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // TODO: tune oh blocking
     const int oh_blk_size_param = jcp.is_relo ? 1 : 10;
-    const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+    const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
     const int oh_blk_size = rnd_up(oh_blk_size_param, oh_step_size);
-    jcp.oh_blk_size = rnd_up(nstl::min(jcp.oh, oh_blk_size), oh_step_size);
+    jcp.oh_blk_size
+            = rnd_up(nstl::min<dim_t>(jcp.oh, oh_blk_size), oh_step_size);
     // Here ihp means the input buffer height including padding (ie the number
     // of input rows required for computation of jcp.oh_blk_size output rows.
     // If an input row doesn't participate in the computation of any output row,
     // it isn't copied to the buffer at all (eg jcp.stride_h > gen_kh).
     jcp.ihp = jcp.is_relo
             ? jcp.oh_blk_size
-            : (jcp.oh_blk_size - 1) * nstl::min(jcp.stride_h, gen_kh) + gen_kh;
+            : (jcp.oh_blk_size - 1) * nstl::min<dim_t>(jcp.stride_h, gen_kh)
+                    + gen_kh;
 
     // TODO: tune ow blocking
     const int ow_blocks_per_call = jcp.is_relo ? 10 : 2;
-    jcp.ow_block = nstl::min(jcp.ow, jcp.tile_width * ow_blocks_per_call);
+    jcp.ow_block
+            = nstl::min<dim_t>(jcp.ow, jcp.tile_width * ow_blocks_per_call);
     jcp.nb_ow = utils::div_up(jcp.ow, jcp.ow_block);
     // iwp includes all width elements that are really used in calculation
     // including left and right zero padding
@@ -2669,9 +2726,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Number of ops per tile store
     int ops_tile_store = jcp.tile_width;
     // Number of ops per accumulation tile
-    int avaliable_ops = jcp.is_relo
-            ? utils::div_up(jcp.nreduce, jcp.ic_block_int)
-            : jcp.nb_ic_int * jcp.kh * (jcp.kw / jcp.kw_per_tile);
+    const int avaliable_ops = static_cast<int>(jcp.is_relo
+                    ? utils::div_up(jcp.nreduce, jcp.ic_block_int)
+                    : jcp.nb_ic_int * jcp.kh * (jcp.kw / jcp.kw_per_tile));
     // Number of vectors to store per tile operation
     // NOTE: set to zero to turn off interleave store (mostly for debugging)
     jcp.per_one_pstore = utils::div_up(ops_tile_store, avaliable_ops);
@@ -2701,24 +2758,25 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.with_dst_scales = !attr.scales_.get(DNNL_ARG_DST).has_default_values();
 
     // Note: currently unsupported, results in seg-fault
-    const int l_pad_output
-            = nstl::min(jcp.ow, div_up(nstl::max(0, jcp.l_pad), jcp.stride_w));
+    const dim_t l_pad_output = nstl::min<dim_t>(
+            jcp.ow, div_up(nstl::max<dim_t>(0, jcp.l_pad), jcp.stride_w));
     VDISPATCH_CONV_IC(!(!jcp.is_relo && (l_pad_output > jcp.ow_block)),
             VERBOSE_BLOCKING_FAIL, "bad padding dimensions for blocking");
 
     // Relevant to 'zero_point padding buffer' (pbuff) jit kernel
     if (jcp.req_zero_point_buffer) {
         auto calculate_output_padding_dims
-                = [](int o_dim, int s_pad, int e_pad, int &s_pad_output,
-                          int &e_pad_output, bool &o_mid, int &o_pad,
-                          int stride, bool req_mid_area) {
-            s_pad_output
-                    = nstl::min(o_dim, div_up(nstl::max(0, s_pad), stride));
-            e_pad_output
-                    = nstl::min(o_dim, div_up(nstl::max(0, e_pad), stride));
+                = [](dim_t o_dim, dim_t s_pad, dim_t e_pad, dim_t &s_pad_output,
+                          dim_t &e_pad_output, bool &o_mid, dim_t &o_pad,
+                          dim_t stride, bool req_mid_area) {
+            s_pad_output = nstl::min<dim_t>(
+                    o_dim, div_up(nstl::max<dim_t>(0, s_pad), stride));
+            e_pad_output = nstl::min<dim_t>(
+                    o_dim, div_up(nstl::max<dim_t>(0, e_pad), stride));
             o_mid = (o_dim - s_pad_output - e_pad_output > 0) && req_mid_area;
-            o_pad = nstl::min(o_dim,
-                    nstl::max(1, s_pad_output + e_pad_output + (int)o_mid));
+            o_pad = nstl::min<dim_t>(o_dim,
+                    nstl::max<dim_t>(
+                            1, s_pad_output + e_pad_output + (dim_t)o_mid));
         };
 
         const bool mid_w_area = (jcp.l_pad > 0 || jcp.r_pad > 0)
@@ -2786,7 +2844,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_scratchpad(
         scratchpad.book(key_conv_zero_point_pad,
                 (size_t)nthr * jcp.zp_pbuff_size, sizeof(int32_t));
         if (!jcp.zp_pbuff_outer_compute) {
-            const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
             scratchpad.book<bool>(key_conv_zero_point_flag,
                     (size_t)jcp.nthr * oc_chunks * jcp.ngroups);
         }
@@ -2815,30 +2873,30 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
 
     const bool is_xf16
             = utils::one_of(jcp.ddst_dt, data_type::bf16, data_type::f16);
-    const int inp_w_step
+    const dim_t inp_w_step
             = jcp.ngroups * jcp.oc_without_padding * jcp.typesize_in;
-    const int inp_h_step = jcp.ow * inp_w_step;
-    const int out_w_step = jcp.oc_block_int * jcp.typesize_in;
-    const int out_h_step = jcp.owp * out_w_step;
+    const dim_t inp_h_step = jcp.ow * inp_w_step;
+    const dim_t out_w_step = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t out_h_step = jcp.owp * out_w_step;
 
-    auto zero_it = [this, is_xf16](reg64_t tmp_out_ptr, int offset) {
+    auto zero_it = [this, is_xf16](reg64_t tmp_out_ptr, dim_t offset) {
         // no mask as output is a padded buffer
         if (is_xf16)
-            vmovdqu16(ptr[tmp_out_ptr + offset], zmm_zero);
+            vmovdqu16(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm_zero);
         else
-            vmovdqu8(ptr[tmp_out_ptr + offset], zmm_zero);
+            vmovdqu8(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm_zero);
     };
 
-    auto copy_it = [this, is_masked, is_xf16](reg64_t tmp_inp_ptr, int inp_off,
-                           reg64_t tmp_out_ptr, int out_off) {
+    auto copy_it = [this, is_masked, is_xf16](reg64_t tmp_inp_ptr,
+                           dim_t inp_off, reg64_t tmp_out_ptr, dim_t out_off) {
         Zmm zmm_load = is_masked ? zmm_tmp | ktail_mask | T_z : zmm_tmp;
         Zmm zmm_stor = zmm_tmp; // no mask as output is padded buffer
         if (is_xf16) {
-            vmovdqu16(zmm_load, ptr[tmp_inp_ptr + inp_off]);
-            vmovdqu16(ptr[tmp_out_ptr + out_off], zmm_stor);
+            vmovdqu16(zmm_load, ptr[tmp_inp_ptr + static_cast<int>(inp_off)]);
+            vmovdqu16(ptr[tmp_out_ptr + static_cast<int>(out_off)], zmm_stor);
         } else {
-            vmovdqu8(zmm_load, ptr[tmp_inp_ptr + inp_off]);
-            vmovdqu8(ptr[tmp_out_ptr + out_off], zmm_stor);
+            vmovdqu8(zmm_load, ptr[tmp_inp_ptr + static_cast<int>(inp_off)]);
+            vmovdqu8(ptr[tmp_out_ptr + static_cast<int>(out_off)], zmm_stor);
         }
     };
 
@@ -2851,7 +2909,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
         L(label_tov_loop);
         {
             for (int ow = 0; ow < jcp.owp; ow++) {
-                const int offset = ow * out_w_step;
+                const dim_t offset = ow * out_w_step;
                 zero_it(reg_ptr_aux_out, offset);
             }
             add(reg_ptr_aux_out, out_h_step);
@@ -2912,10 +2970,11 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
                     jz(label_kwp_skip, T_NEAR);
                     // Handle Dilation-by-Stride
                     for (int sw = 0; sw < jcp.stride_w - 1; sw++) {
-                        const int offset = sw * out_w_step;
+                        const dim_t offset = sw * out_w_step;
                         zero_it(reg_ptr_aux_out, offset);
                     }
-                    add(reg_ptr_aux_out, (jcp.stride_w - 1) * out_w_step);
+                    add(reg_ptr_aux_out,
+                            static_cast<int>((jcp.stride_w - 1) * out_w_step));
                     if (jcp.stride_w == 2)
                         dec(reg_cnt_tmp);
                     else
@@ -2952,11 +3011,12 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
             // Handle Dilation-by-Stride
             for (int sh = 0; sh < jcp.stride_h - 1; sh++) {
                 for (int ow = 0; ow < jcp.owp; ow++) {
-                    const int offset = sh * out_h_step + ow * out_w_step;
+                    const dim_t offset = sh * out_h_step + ow * out_w_step;
                     zero_it(reg_ptr_aux_out, offset);
                 }
             }
-            add(reg_ptr_aux_out, (jcp.stride_h - 1) * out_h_step);
+            add(reg_ptr_aux_out,
+                    static_cast<int>((jcp.stride_h - 1) * out_h_step));
             if (jcp.stride_h == 2)
                 dec(reg_cnt_khp);
             else
@@ -2978,7 +3038,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
         L(label_bov_loop);
         {
             for (int ow = 0; ow < jcp.owp; ow++) {
-                const int offset = ow * out_w_step;
+                const dim_t offset = ow * out_w_step;
                 zero_it(reg_ptr_aux_out, offset);
             }
             add(reg_ptr_aux_out, out_h_step);
@@ -3010,11 +3070,10 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
     copy_row(is_masked);
 
     if (is_3d) {
-        const size_t inp_d_offset = static_cast<size_t>(jcp.typesize_in)
-                * (jcp.dilate_d + 1) * jcp.oh * jcp.ow * jcp.ngroups
-                * jcp.oc_without_padding;
-        const size_t out_d_offset = static_cast<size_t>(jcp.typesize_in)
-                * jcp.ohp * jcp.owp * jcp.oc_block_int;
+        const dim_t inp_d_offset = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.oh
+                * jcp.ow * jcp.ngroups * jcp.oc_without_padding;
+        const dim_t out_d_offset
+                = jcp.typesize_in * jcp.ohp * jcp.owp * jcp.oc_block_int;
         pop(reg_ptr_aux_inp_h);
         pop(reg_ptr_aux_out);
         sub(reg_ptr_aux_inp_h, inp_d_offset);
@@ -3028,10 +3087,10 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
 
 void jit_avx512_core_amx_bwd_data_copy_kernel_t::generate() {
 
-    const int inp_c_step = jcp.oc_block_int * jcp.typesize_in;
-    const int out_c_step = jcp.kd * jcp.ohp * jcp.owp * inp_c_step;
-    const int nb_oc_int_no_tail = jcp.oc_without_padding / jcp.oc_block_int;
-    const int oc_block_int_tail = jcp.oc_without_padding % jcp.oc_block_int;
+    const dim_t inp_c_step = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t out_c_step = jcp.kd * jcp.ohp * jcp.owp * inp_c_step;
+    const dim_t nb_oc_int_no_tail = jcp.oc_without_padding / jcp.oc_block_int;
+    const dim_t oc_block_int_tail = jcp.oc_without_padding % jcp.oc_block_int;
 
     preamble();
 
@@ -3091,7 +3150,7 @@ int jit_avx512_core_amx_bwd_data_kernel_t::get_out_tensor(int h, int i) const {
     const int C_LAST = 4;
     assert(0 <= C_BASE && C_BASE < C_LAST && C_LAST <= jcp.max_tiles);
     MAYBE_UNUSED(C_LAST);
-    const int tile = C_BASE + h * jcp.nb_ih_blocking + i;
+    const int tile = static_cast<int>(C_BASE + h * jcp.nb_ih_blocking + i);
     assert(C_BASE <= tile && tile < C_LAST);
     return tile;
 }
@@ -3118,85 +3177,80 @@ int jit_avx512_core_amx_bwd_data_kernel_t::get_wei_tensor(int i) const {
 // - inp is a padded buffer ~ [nb_oc_int][kd][ohp][owp]{32c,64c}
 // - weights is user buffer ~ OIdhw16o16i{2o,4o}
 // - output is tiled buffer ~ [NBIH][NBIC][tile_width][16c]
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_ocb_step() const {
-    return (size_t)jcp.typesize_in * jcp.kd * jcp.ohp * jcp.owp
-            * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_ocb_step() const {
+    return jcp.typesize_in * jcp.kd * jcp.ohp * jcp.owp * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_shift() const {
-    return (size_t)jcp.typesize_in * jcp.tile_width * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_shift() const {
+    return jcp.typesize_in * jcp.tile_width * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_d_step() const {
-    return static_cast<size_t>(jcp.typesize_in) * jcp.ohp * jcp.owp
-            * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_d_step() const {
+    return jcp.typesize_in * jcp.ohp * jcp.owp * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_offset(
-        int ihb, int kh, int kw) const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_offset(
+        dim_t ihb, dim_t kh, dim_t kw) const {
     // calculate offset by src height dimension
-    size_t sp_offset = (size_t)ihb * jcp.owp;
+    dim_t sp_offset = ihb * jcp.owp;
     // add offset by kernel height dimension
-    sp_offset += (size_t)(jcp.kh - 1 - kh) * (jcp.dilate_h + 1) * jcp.owp;
+    sp_offset += (jcp.kh - 1 - kh) * (jcp.dilate_h + 1) * jcp.owp;
     // add offset by kernel width dimension
-    sp_offset += (size_t)(jcp.kw - 1 - kw) * (jcp.dilate_w + 1);
+    sp_offset += (jcp.kw - 1 - kw) * (jcp.dilate_w + 1);
     return jcp.typesize_in * sp_offset * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_kh_step() const {
-    return (size_t)jcp.typesize_in * jcp.kw * jcp.oc_block_int * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_kh_step() const {
+    return jcp.typesize_in * jcp.kw * jcp.oc_block_int * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_ocb_step() const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_ocb_step() const {
     const bool is_deconv = jcp.prop_kind != prop_kind::backward_data;
-    return (size_t)jcp.typesize_in * (is_deconv ? 1 : jcp.nb_ic) * jcp.kd
-            * jcp.kh * jcp.kw * jcp.oc_block_int * jcp.ic_block;
+    return jcp.typesize_in * (is_deconv ? 1 : jcp.nb_ic) * jcp.kd * jcp.kh
+            * jcp.kw * jcp.oc_block_int * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_offset(
-        int icb, int kh, int kw) const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_offset(
+        dim_t icb, dim_t kh, dim_t kw) const {
     const bool is_deconv = jcp.prop_kind != prop_kind::backward_data;
-    const size_t wei_kw_stride = jcp.oc_block_int * jcp.ic_block;
-    const size_t wei_kh_stride = jcp.kw * wei_kw_stride;
-    const size_t wei_kd_stride = jcp.kh * wei_kh_stride;
-    const size_t wei_icb_stride
+    const dim_t wei_kw_stride = jcp.oc_block_int * jcp.ic_block;
+    const dim_t wei_kh_stride = jcp.kw * wei_kw_stride;
+    const dim_t wei_kd_stride = jcp.kh * wei_kh_stride;
+    const dim_t wei_icb_stride
             = (is_deconv ? jcp.nb_oc_int : 1) * jcp.kd * wei_kd_stride;
     return jcp.typesize_in
             * (icb * wei_icb_stride + kh * wei_kh_stride + kw * wei_kw_stride);
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_d_step() const {
-    const size_t wei_kd_stride
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_d_step() const {
+    const dim_t wei_kd_stride
             = jcp.kh * jcp.kw * jcp.oc_block_int * jcp.ic_block;
     // step through 'kd' weight elements by `stride_d`
-    return static_cast<size_t>(jcp.typesize_in) * jcp.stride_d * wei_kd_stride;
+    return jcp.typesize_in * jcp.stride_d * wei_kd_stride;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_icb_offset(
-        int ihb, int icb) const {
-    size_t el_offset = jcp.is_nspc
-            ? (size_t)icb * jcp.ic_block
-                    + (size_t)ihb * jcp.iw * jcp.ngroups
-                            * jcp.ic_without_padding
-            : (size_t)icb * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
-                    + (size_t)ihb * jcp.iw * jcp.ic_block;
-    return (size_t)jcp.typesize_out * el_offset;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_icb_offset(
+        dim_t ihb, dim_t icb) const {
+    dim_t el_offset = jcp.is_nspc
+            ? icb * jcp.ic_block
+                    + ihb * jcp.iw * jcp.ngroups * jcp.ic_without_padding
+            : icb * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
+                    + ihb * jcp.iw * jcp.ic_block;
+    return jcp.typesize_out * el_offset;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_row_offset(
-        int ihb, int icb, int j) const {
-    size_t offset_w = jcp.is_nspc ? (size_t)jcp.typesize_out * j * jcp.ngroups
-                    * jcp.ic_without_padding
-                                  : (size_t)jcp.typesize_out * j * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_row_offset(
+        dim_t ihb, dim_t icb, dim_t j) const {
+    const dim_t offset_w = jcp.is_nspc
+            ? jcp.typesize_out * j * jcp.ngroups * jcp.ic_without_padding
+            : jcp.typesize_out * j * jcp.ic_block;
     return get_out_icb_offset(ihb, icb) + offset_w;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_shift(int width) const {
-    return jcp.is_nspc ? (size_t)jcp.typesize_out * width * jcp.ngroups
-                    * jcp.ic_without_padding
-                       : (size_t)jcp.typesize_out * width * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_shift(dim_t width) const {
+    return jcp.is_nspc
+            ? jcp.typesize_out * width * jcp.ngroups * jcp.ic_without_padding
+            : jcp.typesize_out * width * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_icb_offset(
-        int ihb, int icb) const {
-    size_t el_offset = (size_t)icb * prv_width_ * jcp.ic_block
-            + (size_t)ihb * jcp.nb_ic_blocking * jcp.full_tile_width
-                    * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_icb_offset(
+        dim_t ihb, dim_t icb) const {
+    dim_t el_offset = icb * prv_width_ * jcp.ic_block
+            + ihb * jcp.nb_ic_blocking * jcp.full_tile_width * jcp.ic_block;
     return jcp.typesize_acc * el_offset;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_row_offset(
-        int ihb, int icb, int j) const {
-    return get_wsp_icb_offset(ihb, icb)
-            + (size_t)jcp.typesize_acc * j * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_row_offset(
+        dim_t ihb, dim_t icb, dim_t j) const {
+    return get_wsp_icb_offset(ihb, icb) + jcp.typesize_acc * j * jcp.ic_block;
 }
 
 // Code generation
@@ -3258,7 +3312,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::cvt2ps(data_type_t type_in,
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
-        const Zmm &zmm_out, int icb, int h, int w) {
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
     const bool mask_flag = jcp.is_nspc && jcp.ic_without_padding != jcp.ic
             && icb == (jcp.nb_ic_blocking - 1);
 
@@ -3284,7 +3338,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
     const int sum_idx = p.find(primitive_kind::sum);
     if (sum_idx != -1) load_and_add(jcp.dsrc_dt, zmm_prev_dst, zmm_out, addr);
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * icb * jcp.ic_block;
+        const dim_t bias_offset = jcp.typesize_bia * icb * jcp.ic_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         load_and_add(jcp.bia_dt, zmm_bias, zmm_out, bias_addr);
     }
@@ -3310,9 +3364,9 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int icb, int h, int w) {
-    const int nb_ic_block = jcp.nb_ic_blocking;
-    const int ic_block = jcp.ic_block;
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
+    const dim_t nb_ic_block = jcp.nb_ic_blocking;
+    const dim_t ic_block = jcp.ic_block;
     const bool mask_flag = true && jcp.ic_without_padding != jcp.ic
             && icb == (nb_ic_block - 1);
 
@@ -3336,7 +3390,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
     }
 
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * icb * ic_block;
+        const dim_t bias_offset = jcp.typesize_bia * icb * ic_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
@@ -3353,10 +3407,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        const int scale_offset
+        const dim_t scale_offset
                 = jcp.is_ic_scale * (sizeof(float) * icb * ic_block);
         vmulps(zmm_out_msk, zmm_out,
-                EVEX_compress_addr(reg_ptr_wei_scales, scale_offset,
+                EVEX_compress_addr(reg_ptr_wei_scales,
+                        static_cast<int>(scale_offset),
                         /* bcast = */ !jcp.is_ic_scale));
     }
 
@@ -3402,7 +3457,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector(
-        const Zmm &zmm_out, int icb, int h, int w) {
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
     /*
     Output:
               jcp.is_nspc                 !jcp.is_nspc
@@ -3418,22 +3473,24 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
-        int width, bool do_store) {
+        dim_t width, bool do_store) {
     auto store_output_block
-            = [this](int width, bool do_store, bool is_last_ih_blks) {
+            = [this](dim_t width, bool do_store, bool is_last_ih_blks) {
         // Calculate the number of ih blocks; it may differ on last call
-        const int n_ih_blks = is_last_ih_blks ? jcp.ih % jcp.nb_ih_blocking
-                                              : jcp.nb_ih_blocking;
-        for (int icb = 0; icb < jcp.nb_ic_blocking; icb++) {
-            for (int ihb = 0; ihb < n_ih_blks; ihb++) {
+        const int n_ih_blks = is_last_ih_blks
+                ? static_cast<int>(jcp.ih % jcp.nb_ih_blocking)
+                : static_cast<int>(jcp.nb_ih_blocking);
+        for (dim_t icb = 0; icb < jcp.nb_ic_blocking; icb++) {
+            for (dim_t ihb = 0; ihb < n_ih_blks; ihb++) {
                 /* Formats: Workspace: [NBIH][NBIC][W][16OC] */
                 tilestored(ptr[reg_wsp_ptr + reg_wei_stride
                                    + get_wsp_icb_offset(ihb, icb)],
-                        Tmm(get_out_tensor(ihb, icb)));
+                        Tmm(get_out_tensor(
+                                static_cast<int>(ihb), static_cast<int>(icb))));
                 is_buffer_empty_ = false;
                 is_store_done_ = false;
-                for (int tw = 0; tw < width && do_store; tw++) {
-                    Zmm zmm_out = Zmm(tw);
+                for (dim_t tw = 0; tw < width && do_store; tw++) {
+                    Zmm zmm_out = Zmm(static_cast<int>(tw));
                     vmovups(zmm_out,
                             ptr[reg_wsp_ptr
                                     + get_wsp_row_offset(ihb, icb, tw)]);
@@ -3460,7 +3517,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
     if (do_store) add(reg_out_ptr, get_out_shift(width));
 }
 
-void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
+void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(dim_t width) {
     for (int c = 0;
             c < jcp.per_one_pstore && !is_store_done_ && !is_buffer_empty_;
             c++) {
@@ -3483,7 +3540,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
 
             row_count_ = 0;
             is_store_done_ = true;
-            prv_width_ = width;
+            prv_width_ = static_cast<int>(width);
         }
     }
 }
@@ -3492,8 +3549,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
 
     if (is_store_done_save_ || is_buffer_empty_) return;
 
-    const int store_count
-            = prv_width_save_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking;
+    const int store_count = static_cast<int>(
+            prv_width_save_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking);
     for (int row_count = 0; row_count < store_count; row_count++) {
         // row_count = ihb * ICB * TW + icb * TW + tw
         int tw = row_count % prv_width_save_;
@@ -3509,7 +3566,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
-        int width, bool do_interleave_store) {
+        dim_t width, bool do_interleave_store) {
 
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         switch (jcp.ddst_dt) {
@@ -3522,11 +3579,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
         }
     };
 
-    for (int ocb = 0; ocb < jcp.nb_oc_int; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp.nb_oc_int; ocb++) {
         // reverse order through spatial components of weights so that
         // input buffer is accessed in a monotonically increasing fashion
-        for (int kh = jcp.kh - 1; kh >= 0; kh--) {
-            for (int kw = jcp.kw - 1; kw >= 0; kw--) {
+        for (dim_t kh = jcp.kh - 1; kh >= 0; kh--) {
+            for (dim_t kw = jcp.kw - 1; kw >= 0; kw--) {
                 for (int ihb = 0; ihb < jcp.nb_ih_blocking; ihb++) {
                     tileloadd(Tmm(get_inp_tensor(ihb)),
                             ptr[reg_inp_ptr + get_inp_offset(ihb, kh, kw)
@@ -3553,7 +3610,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_kd_loop(
-        int width, bool do_store, bool handle_skipped_stores) {
+        dim_t width, bool do_store, bool handle_skipped_stores) {
 
     Label skip_compute_kd_label, kd_loop_label, end_kd_compute_label;
 
@@ -3635,10 +3692,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_iw_loop() {
     };
 
     if (jcp.nb_iw == 1) {
-        compute_iw_loop_body(true, jcp.iw_blocks);
+        compute_iw_loop_body(true, static_cast<int>(jcp.iw_blocks));
     } else {
         Label label_done;
-        int iw_blocks_per_call = div_up(jcp.iw_block, jcp.tile_width);
+        int iw_blocks_per_call
+                = static_cast<int>(div_up(jcp.iw_block, jcp.tile_width));
         int last_iwb_tile_blocks = jcp.iw_blocks % iw_blocks_per_call;
         if (last_iwb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_iwb_tile_blocks = iw_blocks_per_call;
@@ -3672,8 +3730,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
 
     mov(reg_last_h, ptr[param1 + GET_OFF(last_h)]);
 
-    const int inp_stride = jcp.oc_block_int * jcp.typesize_in;
-    const int wei_stride = jcp.ic_block * jcp.typesize_acc;
+    const dim_t inp_stride = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t wei_stride = jcp.ic_block * jcp.typesize_acc;
     mov(reg_inp_stride, inp_stride);
     mov(reg_wei_stride, wei_stride);
 
@@ -3682,8 +3740,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
         // loads / stores with block index
         // icb = icc * jcp.nb_ic_blocking + (jcp.nb_ic_blocking - 1)
         // TODO: use masked loads / stores for the last icc only
-        int current_block_size = jcp.ic_block;
-        int mask = (1 << current_block_size) - 1;
+        dim_t current_block_size = jcp.ic_block;
+        int mask = (1 << static_cast<int>(current_block_size)) - 1;
         Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
@@ -3693,7 +3751,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
         jne(mask_is_set, T_NEAR);
         // Reset the mask
         current_block_size = jcp.ic_without_padding % jcp.ic_block;
-        mask = (1 << current_block_size) - 1;
+        mask = (1 << static_cast<int>(current_block_size)) - 1;
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
 
@@ -3739,13 +3797,13 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
             = utils::one_of(jcp.ddst_dt, data_type::bf16, data_type::f16) ? 2
                                                                           : 4;
     // Input tile dimensions
-    const int a_col = jcp.oc_block_int;
+    const int a_col = static_cast<int>(jcp.oc_block_int);
     const int a_row = jcp.tile_width;
     // Weights tile dimensions
-    const int b_col = jcp.ic_block * vnni_width;
-    const int b_row = a_col / vnni_width;
+    const dim_t b_col = jcp.ic_block * vnni_width;
+    const dim_t b_row = a_col / vnni_width;
     // Accumulator tile dimensions
-    const int c_col = jcp.ic_block;
+    const dim_t c_col = jcp.ic_block;
     const int c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
@@ -3765,7 +3823,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
                     get_out_tensor(h, i), c_row, c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
@@ -3847,9 +3906,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.dilate_d != 0 && jcp.stride_d != 1),
             "unsupported stride/dilation values");
 
-    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -3928,7 +3987,8 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
 
     const int vnni_width = is_xf16 ? 2 : 4;
-    jcp.oc_block_int = jcp.oc_block * vnni_width; // 32 for xf16, 64 for int8
+    jcp.oc_block_int = jcp.oc_block * vnni_width;
+    // 32 for xf16, 64 for int8
 
     VDISPATCH_CONV_IC(attr.set_default_formats(&diff_src_md) == status::success,
             VERBOSE_UNSUPPORTED_ATTR);
@@ -3972,10 +4032,13 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -3988,12 +4051,14 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.max_tiles != 8 || jcp.full_tile_width != 16),
             VERBOSE_BLOCKING_FAIL, "bad blocking parameters");
 
-    jcp.tile_width = nstl::min(jcp.full_tile_width, jcp.iw);
+    jcp.tile_width
+            = static_cast<int>(nstl::min<dim_t>(jcp.full_tile_width, jcp.iw));
     jcp.iw_blocks = div_up(jcp.iw, jcp.tile_width);
 
     // Prefer to use a single tile width when possible
     // (eg iw28 => 2 tiles of 14 vs 1 of 16 and 1 of 12)
-    if (jcp.iw % jcp.iw_blocks == 0) jcp.tile_width = jcp.iw / jcp.iw_blocks;
+    if (jcp.iw % jcp.iw_blocks == 0)
+        jcp.tile_width = static_cast<int>(jcp.iw / jcp.iw_blocks);
     jcp.tile_tail = jcp.iw % jcp.tile_width;
 
     jcp.nb_ic_blocking = (jcp.nb_ic % 2 == 0) ? 2 : 1;
@@ -4006,8 +4071,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // TODO: tune ih blocking
     const int ih_blk_size_tmp = 10;
-    const int ih_step = jcp.nb_ih_blocking;
-    jcp.ih_blk_size = rnd_up(nstl::min(jcp.ih, ih_blk_size_tmp), ih_step);
+    const dim_t ih_step = jcp.nb_ih_blocking;
+    jcp.ih_blk_size
+            = rnd_up(nstl::min<dim_t>(jcp.ih, ih_blk_size_tmp), ih_step);
     // ohp includes all elements that are really used in calculation,
     // including zero-padded "dilate-by-strides" and top and bottom overflow
     jcp.ohp = jcp.ih_blk_size + gen_kh - 1;
@@ -4023,7 +4089,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Number of ops per tile store
     int ops_tile_store = jcp.tile_width;
     // Number of ops per accumulation tile
-    int avaliable_ops = jcp.nb_oc_int * jcp.kh * jcp.kw;
+    const int avaliable_ops = static_cast<int>(jcp.nb_oc_int * jcp.kh * jcp.kw);
     // Number of vectors to store per tile operation
     // NOTE: set to zero to turn off interleave store (mostly for debugging)
     jcp.per_one_pstore = div_up(ops_tile_store, avaliable_ops);
@@ -4100,14 +4166,14 @@ int jit_avx512_core_amx_bwd_weights_kernel_t::get_ddst_tensor(int ocb) const {
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
     // Input tile dimensions
-    const int a_col = jcp.ur_w;
-    const int a_row = jcp.ic_block;
+    const dim_t a_col = jcp.ur_w;
+    const dim_t a_row = jcp.ic_block;
     // Weights tile dimensions
-    const int b_col = jcp.oc_block * 2;
-    const int b_row = a_col / 2;
+    const dim_t b_col = jcp.oc_block * 2;
+    const dim_t b_row = a_col / 2;
     // Accumulator tile dimensions
-    const int c_col = jcp.oc_block;
-    const int c_row = a_row;
+    const dim_t c_col = jcp.oc_block;
+    const dim_t c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
         tcfg_buff[i] = 0;
@@ -4125,7 +4191,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
             tc_configure_tile((palette_config_t *)tcfg_buff,
                     get_wei_tensor(ocb, icb), c_row, c_col * jcp.typesize_out);
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::od_step_comeback_pointers() {
@@ -4169,9 +4236,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
     auto ddst_row_size = get_ddst_offset(0, 1);
     auto row_size = src_row_size + ddst_row_size;
 
-    int h_block_size = jcp.oh;
+    int h_block_size = static_cast<int>(jcp.oh);
     int h_last_block_size = h_block_size;
-    int min_h_block_size = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+    int min_h_block_size = static_cast<int>(
+            nstl::max<dim_t>(1, nstl::max(jcp.b_pad, jcp.t_pad)));
     auto working_set_size = row_size * h_block_size;
 
     if (working_set_size > full_spat_max_working_set_size) {
@@ -4263,7 +4331,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         int oh_block_size = (is_last_block) ? h_last_block_size : h_block_size;
         // NB: this is correct because we only support t_pad = kh / 2 and thus
         // ih == oh
-        int ih_block_size = oh_block_size
+        const dim_t ih_block_size = oh_block_size
                 + (!is_first_block + !is_last_block) * jcp.t_pad;
 
         L(kh_loop);
@@ -4332,8 +4400,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp,
+                    static_cast<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(
+                    reg_ohs, reg_tmp, static_cast<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4422,12 +4492,12 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         add(reg_src, first_src_block_step);
         add(reg_ddst, ddst_block_step);
 
-        int num_innermost_iters
+        const dim_t num_innermost_iters
                 = (jcp.oh - h_last_block_size) / h_block_size - 1;
         if (num_innermost_iters > 0) {
             Label h_block_loop;
 
-            mov(reg_tmp_w, num_innermost_iters);
+            mov(reg_tmp_w, static_cast<int>(num_innermost_iters));
             kmovw(reg_h_block, reg_tmp_w);
             L(h_block_loop);
             {
@@ -4450,9 +4520,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
         int ic_block, int nb_ic_blocking, int nb_oc_blocking) {
     assert(jcp.ur_w % 2 == 0);
-    const int str_w = jcp.stride_w;
+    const dim_t str_w = jcp.stride_w;
     assert(jcp.tr_iw % str_w == 0);
-    const int src_stride_w_shift = jcp.tr_iw / str_w;
+    const dim_t src_stride_w_shift = jcp.tr_iw / str_w;
 
     mov(reg_b_stride, 64);
     mov(reg_a_stride, jcp.tr_iw * jcp.typesize_in);
@@ -4467,7 +4537,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
                                     + get_full_kernel_offset(
                                             ocb, icb, 0, i_kw)]);
 
-            int src_offset_l = (i_kw * (jcp.dilate_w + 1)) / str_w
+            const dim_t src_offset_l = (i_kw * (jcp.dilate_w + 1)) / str_w
                     + s * src_stride_w_shift;
 
             for (int ur_w_b = 0; ur_w_b < jcp.ur_w_blocks; ur_w_b++) {
@@ -4531,7 +4601,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_diff_bias_row(
     };
 
     Label ow_loop, ow_tail;
-    int niters = jcp.tr_ow / 2;
+    int niters = static_cast<int>(jcp.tr_ow / 2);
     if (niters > 0) {
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
@@ -4569,7 +4639,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_compute_diff_bias(
         Label bias_loop, skip_label_local;
 
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+                static_cast<int>(
+                        jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size));
 
         switch (jcp.harness) {
             case harness_2d_reduction:
@@ -4611,7 +4683,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_step_common(
         int nb_ic_blocking, int nb_oc_blocking) {
     Label kh_label, ic_block_label, ow_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    const int ic_block = static_cast<int>(jcp.ic_block);
     int ic_tail = jcp.ic_tail;
 
     auto ic_loop = [&](int nb_ic_blocking, int nb_oc_blocking) {
@@ -4740,12 +4812,12 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_zero_kernel(
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
         int nb_ic_blocking, int nb_oc_blocking, bool is_partial) {
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    int b_pad = static_cast<int>(jcp.b_pad);
+    int t_pad = static_cast<int>(jcp.t_pad);
 
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t stride_h = jcp.stride_h;
     auto filter_step_size = get_kernel_offset(0, jcp.kw);
     auto src_step_size = get_src_offset(0, 0, 1);
     auto ddst_step_size = get_ddst_offset(0, 1);
@@ -4755,17 +4827,19 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int oh_body_end
-            = div_up(nstl::max(0, t_pad + jcp.ih - ext_kh + 1), stride_h);
+    int ext_kh = static_cast<int>(
+            calculate_extended_filter_size(jcp.kh, jcp.dilate_h));
+    int oh_body_end = static_cast<int>(
+            div_up(nstl::max<dim_t>(0, t_pad + jcp.ih - ext_kh + 1), stride_h));
     int oh_head_end
             = nstl::min(div_up(nstl::max(0, t_pad), stride_h), oh_body_end);
     int oh_head_overflow_end = div_up(nstl::max(0, t_pad), stride_h);
-    int oh_tail_end = jcp.oh;
+    int oh_tail_end = static_cast<int>(jcp.oh);
 
-    int body_src_start_offset = (stride_h - (t_pad % stride_h)) % stride_h;
-    int ih_body_end
-            = nstl::max(-t_pad + oh_body_end * stride_h, body_src_start_offset);
+    const dim_t body_src_start_offset
+            = (stride_h - (t_pad % stride_h)) % stride_h;
+    const dim_t ih_body_end = nstl::max<dim_t>(
+            -t_pad + oh_body_end * stride_h, body_src_start_offset);
 
     if (is_partial)
         mov(reg_oj, ptr[param + GET_OFF(os_index_begin)]);
@@ -4778,17 +4852,20 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             cmp(reg_oj, oh_head_overflow_end);
             jge(oh_tpad_tail_label_end, T_NEAR);
         }
-        const int overflow = nstl::max(
-                0, jcp.kh - div_up(nstl::max(0, t_pad + jcp.ih), dilate_h));
-        const int underflow = div_up(nstl::max(0, t_pad), dilate_h);
-        const int initial_kh = jcp.kh - overflow - underflow;
+        const int overflow = static_cast<int>(nstl::max<dim_t>(0,
+                jcp.kh
+                        - div_up(nstl::max<dim_t>(0, t_pad + jcp.ih),
+                                dilate_h)));
+        const int underflow = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, t_pad), dilate_h));
+        const dim_t initial_kh = jcp.kh - overflow - underflow;
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
         add(reg_kernel, filter_step_size * underflow);
         if (is_dilated) {
-            const int tail = t_pad % dilate_h;
-            const int shift = tail == 0 ? 0 : dilate_h - tail;
+            const dim_t tail = t_pad % dilate_h;
+            const dim_t shift = tail == 0 ? 0 : dilate_h - tail;
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_offset], reg_ih_shift);
             add(reg_src, src_step_size * shift);
@@ -5002,15 +5079,17 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         int nb_ic_blocking, int nb_oc_blocking, bool is_partial) {
     assert(jcp.harness == harness_3d_reduction);
 
-    const int src_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
+    const int src_backpad_overlap = static_cast<int>(
+            div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d));
 
     const auto filter_shift = get_kernel_offset(0, jcp.kh * jcp.kw);
     const auto src_shift = get_src_offset(0, 0, jcp.ih);
     const auto ddst_shift = get_ddst_offset(0, jcp.oh);
 
-    const int kd_front_pad = nstl::max(0, jcp.f_pad);
-    const int kd_back_pad = nstl::max(0, jcp.kd - jcp.f_pad - jcp.id);
+    const int kd_front_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.f_pad));
+    const int kd_back_pad = static_cast<int>(
+            nstl::max<dim_t>(0, jcp.kd - jcp.f_pad - jcp.id));
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;
@@ -5024,9 +5103,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         mov(reg_d_index, ptr[param + GET_OFF(os_index_begin)]);
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
-        const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(
-                0, nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw);
+        const dim_t kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
+        const dim_t kd_offset = get_kernel_offset(0,
+                static_cast<int>(nstl::min<dim_t>(jcp.kd - 1, kd_front_pad))
+                        * jcp.kh * jcp.kw);
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -5058,7 +5138,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
     /* Compute 'front' edge */
     if (jcp.f_pad > 0) {
         /* Check if within fpad region */
-        cmp(reg_d_index, div_up(nstl::max(0, jcp.f_pad), jcp.stride_d));
+        cmp(reg_d_index,
+                static_cast<int>(
+                        div_up(nstl::max<dim_t>(0, jcp.f_pad), jcp.stride_d)));
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
@@ -5066,7 +5148,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
-        const int src_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const dim_t src_ker_overlap = nstl::min<dim_t>(jcp.kd, jcp.id);
         cmp(reg_kd_count, src_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -5074,7 +5156,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * src_corr);
                 add(reg_src_d, src_shift * src_corr);
             }
@@ -5272,9 +5354,9 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -5294,13 +5376,13 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
 
     jcp.transform_to_vnni = diff_weights_d.data_type() == data_type::bf16;
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -5372,12 +5454,14 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, format_tag::x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd;
@@ -5389,8 +5473,8 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ic_tail = jcp.ic % jcp.ic_block;
-    jcp.oc_tail = jcp.oc % jcp.oc_block;
+    jcp.ic_tail = static_cast<int>(jcp.ic % jcp.ic_block);
+    jcp.oc_tail = static_cast<int>(jcp.oc % jcp.oc_block);
 
     jcp.nb_oc_blocking = (jcp.nb_oc > 1) ? 2 : 1;
     jcp.nb_ic_blocking = (jcp.nb_ic > 1) ? 2 : 1;
@@ -5410,21 +5494,22 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     // TODO: Find more shapes (especially 3D with large spatials) for which
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    const dim_t optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
 
     jcp.global_transpose = dnnl_thr_syncable();
     jcp.spatial_blk_size = optimal_blk_size;
 
     const int tr_round = 32; // To load full tile register
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
-    jcp.tr_iw = rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
-            * jcp.stride_w;
+    const dim_t tr_pad
+            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    jcp.tr_iw = (rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
+            * jcp.stride_w);
 
     jcp.tr_src_num_guard_elems = tr_pad; // upper bound
     jcp.tr_ow = rnd_up(jcp.ow, 2);
 
     if (jcp.tr_ow <= max_ur_w) {
-        jcp.ur_w = jcp.tr_ow;
+        jcp.ur_w = static_cast<int>(jcp.tr_ow);
         jcp.ur_w_blocks = 1;
     } else {
         jcp.ur_w = 1;
@@ -5588,7 +5673,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = max_threads / nthr_g_;
 
     auto calc_mem_cost
@@ -5615,9 +5700,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         dim_t wei_size
                 = (dim_t)j.oc * j.ic * j.kd * j.kh * j.kw * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
+        float wei_compensation_scale
+                = 0.5f * (float)(dst_size + src_size) / (float)wei_size;
         float oi_channels_ratio = (float)(j.nb_oc / j.nb_oc_blocking)
-                / (j.nb_ic / j.nb_ic_blocking);
+                / (float)(j.nb_ic / j.nb_ic_blocking);
         auto get_src_coef = [oi_channels_ratio, wei_compensation_scale]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
             if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
@@ -5637,23 +5723,29 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         const float dst_coef = get_dst_coef();
         const float wei_coef = get_wei_coef();
 
-        float src_v = src_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.mb
-                * (j.ic_block * j.nb_ic_blocking) * j.id * j.ih * j.tr_iw
-                / j.nthr_mb_work / j.stride_d / j.stride_h / j.stride_w;
-        float wei_v = wei_coef * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_oc / j.nb_oc_blocking),
-                        (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
-                * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.kh * j.kw
-                * j.kd * (j.ic_block * j.nb_ic_blocking)
-                * (j.oc_block * j.nb_oc_blocking);
-        float dst_v = dst_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_oc / j.nb_oc_blocking),
-                        (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
-                * j.mb * (j.oc_block * j.nb_oc_blocking) * j.od * j.oh * j.tr_ow
-                / j.nthr_mb_work;
+        float src_v = src_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.mb
+                        * (j.ic_block * j.nb_ic_blocking) * j.id * j.ih
+                        * j.tr_iw)
+                / (float)(j.nthr_mb_work * j.stride_d * j.stride_h
+                        * j.stride_w);
+        float wei_v = wei_coef
+                * (float)(div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_oc / j.nb_oc_blocking),
+                                (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
+                        * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.kh
+                        * j.kw * j.kd * (j.ic_block * j.nb_ic_blocking)
+                        * (j.oc_block * j.nb_oc_blocking));
+        float dst_v = dst_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_oc / j.nb_oc_blocking),
+                                (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
+                        * j.mb * (j.oc_block * j.nb_oc_blocking) * j.od * j.oh
+                        * j.tr_ow)
+                / (float)j.nthr_mb_work;
 
         return src_v + dst_v + wei_v;
     };
@@ -5662,14 +5754,15 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 
     /* find the best thread distribution with lowest memory cost */
 
-    const int nthr_mb_max = nstl::min(nthr, j.nthr_mb_work);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, j.nthr_mb_work));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par,
-                (j.nb_oc / j.nb_oc_blocking)); // Amount of nb_oc_blocks
+        const int nthr_oc_b_max = static_cast<int>(nstl::min<dim_t>(nthr_par,
+                (j.nb_oc / j.nb_oc_blocking))); // Amount of nb_oc_blocks
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(
-                    nthr_par / nthr_oc_b, (j.nb_ic / j.nb_ic_blocking));
+            int nthr_ic_b = static_cast<int>(nstl::min<dim_t>(
+                    nthr_par / nthr_oc_b, (j.nb_ic / j.nb_ic_blocking)));
 
             float mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -5682,7 +5775,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
     }
 
     if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
-        nthr_mb_ = nstl::min(j.nthr_mb_work, nthr);
+        nthr_mb_ = static_cast<int>(nstl::min<dim_t>(j.nthr_mb_work, nthr));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= max_threads);
@@ -5691,7 +5784,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 // start of diff_bias kernel
 dim_t jit_avx512_core_amx_bwd_bias_kernel_t::get_ddst_offset(
         dim_t w_idx, dim_t hd_idx) const {
-    int ow_per_oc = data_type_vnni_granularity(jcp.ddst_dt);
+    const int ow_per_oc
+            = static_cast<int>(data_type_vnni_granularity(jcp.ddst_dt));
     if (ow_per_oc == 0) {
         assert(!"Invalid vnni granularity.");
         return 0;
@@ -5806,7 +5900,9 @@ void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias(
 
         // pointer to diff_dst
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+                static_cast<int>(
+                        jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size));
 
         // number of rows
         mov(reg_oj, reg_nrows);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -346,7 +346,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
 
     const int max_ur_w = jit_avx512_core_amx_compute_zp_pbuff_t::max_regs_ur
             / (jcp.nb_oc_blocking);
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     dim_t l_pad = jcp.l_pad;
 
     const dim_t l_pad_output = jcp.l_pad_output;
@@ -368,7 +368,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
                 = nstl::min(cur_l_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
         const dim_t cur_r_pad = calculate_end_padding(
-                jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
+                jcp.l_pad, static_cast<int>(ow), jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, l_pad, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
@@ -390,7 +390,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
                 = nstl::min(cur_r_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
         const dim_t cur_r_pad = calculate_end_padding(
-                jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
+                jcp.l_pad, static_cast<int>(ow), jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, 0, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
@@ -573,7 +573,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
     // without additional padding
     const bool are_sets_interleaved
             = IMPLICATION(jcp.dilate_w != 0, jcp.stride_w == 1);
-    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     const dim_t num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
     for (dim_t set_idx = 0; set_idx < num_sets; set_idx++) {
         dim_t set_width_padded = !jcp.is_pbuffer_strided
@@ -1270,7 +1270,7 @@ dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(
     if (jcp.is_relo)
         return ohb * jcp.iwp * jcp.kh * jcp.ic_block_int_np * jcp.typesize_in;
     // calculate offset by height dimension
-    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
     const dim_t gen_stride_h = nstl::min<dim_t>(jcp.stride_h, gen_kh);
     dim_t el_offset = ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
             * jcp.ic_block_int_np;
@@ -1640,7 +1640,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(dim_t width, int tail,
         const int h_tail = is_last_h && jcp.oh % jcp.oh_per_tile != 0
                 ? (h_blks - 1) * jcp.oh_per_tile + jcp.oh % jcp.oh_per_tile
                 : h_blks * jcp.oh_per_tile;
-        const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+        const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
         const dim_t owp = gen_kw + jcp.ow - 1;
 
         if (jcp.src_zero_point) {
@@ -2192,8 +2192,8 @@ void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                     ? jcp.ic_block_int
                     : jcp.ic_block_int_np * jcp.kw_per_tile);
     // Weights tile dimensions
-    const dim_t b_col = jcp.oc_block * vnni_width;
-    const dim_t b_row = a_col / vnni_width;
+    const int b_col = jcp.oc_block * vnni_width;
+    const int b_row = a_col / vnni_width;
     // Accumulator tile dimensions
     const int c_col = 16;
 
@@ -2385,9 +2385,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -2520,7 +2520,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // small-ic parameters
     jcp.ic_block_int_np = jcp.is_nspc
-            ? nstl::min<dim_t>(jcp.ic_block_int, jcp.ic_without_padding)
+            ? nstl::min(jcp.ic_block_int, jcp.ic_without_padding)
             : jcp.ic_block_int;
     bool is_small_ic = jcp.ic_block_int_np < jcp.ic_block_int;
 
@@ -2699,21 +2699,18 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int oh_blk_size_param = jcp.is_relo ? 1 : 10;
     const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
     const int oh_blk_size = rnd_up(oh_blk_size_param, oh_step_size);
-    jcp.oh_blk_size
-            = rnd_up(nstl::min<dim_t>(jcp.oh, oh_blk_size), oh_step_size);
+    jcp.oh_blk_size = rnd_up(nstl::min(jcp.oh, oh_blk_size), oh_step_size);
     // Here ihp means the input buffer height including padding (ie the number
     // of input rows required for computation of jcp.oh_blk_size output rows.
     // If an input row doesn't participate in the computation of any output row,
     // it isn't copied to the buffer at all (eg jcp.stride_h > gen_kh).
     jcp.ihp = jcp.is_relo
             ? jcp.oh_blk_size
-            : (jcp.oh_blk_size - 1) * nstl::min<dim_t>(jcp.stride_h, gen_kh)
-                    + gen_kh;
+            : (jcp.oh_blk_size - 1) * nstl::min(jcp.stride_h, gen_kh) + gen_kh;
 
     // TODO: tune ow blocking
     const int ow_blocks_per_call = jcp.is_relo ? 10 : 2;
-    jcp.ow_block
-            = nstl::min<dim_t>(jcp.ow, jcp.tile_width * ow_blocks_per_call);
+    jcp.ow_block = nstl::min(jcp.ow, jcp.tile_width * ow_blocks_per_call);
     jcp.nb_ow = utils::div_up(jcp.ow, jcp.ow_block);
     // iwp includes all width elements that are really used in calculation
     // including left and right zero padding
@@ -3800,10 +3797,10 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
     const int a_col = static_cast<int>(jcp.oc_block_int);
     const int a_row = jcp.tile_width;
     // Weights tile dimensions
-    const dim_t b_col = jcp.ic_block * vnni_width;
-    const dim_t b_row = a_col / vnni_width;
+    const int b_col = jcp.ic_block * vnni_width;
+    const int b_row = a_col / vnni_width;
     // Accumulator tile dimensions
-    const dim_t c_col = jcp.ic_block;
+    const int c_col = jcp.ic_block;
     const int c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
@@ -3906,9 +3903,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.dilate_d != 0 && jcp.stride_d != 1),
             "unsupported stride/dilation values");
 
-    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -4072,8 +4069,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // TODO: tune ih blocking
     const int ih_blk_size_tmp = 10;
     const dim_t ih_step = jcp.nb_ih_blocking;
-    jcp.ih_blk_size
-            = rnd_up(nstl::min<dim_t>(jcp.ih, ih_blk_size_tmp), ih_step);
+    jcp.ih_blk_size = rnd_up(nstl::min(jcp.ih, ih_blk_size_tmp), ih_step);
     // ohp includes all elements that are really used in calculation,
     // including zero-padded "dilate-by-strides" and top and bottom overflow
     jcp.ohp = jcp.ih_blk_size + gen_kh - 1;
@@ -4166,14 +4162,14 @@ int jit_avx512_core_amx_bwd_weights_kernel_t::get_ddst_tensor(int ocb) const {
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
     // Input tile dimensions
-    const dim_t a_col = jcp.ur_w;
-    const dim_t a_row = jcp.ic_block;
+    const int a_col = jcp.ur_w;
+    const int a_row = jcp.ic_block;
     // Weights tile dimensions
-    const dim_t b_col = jcp.oc_block * 2;
-    const dim_t b_row = a_col / 2;
+    const int b_col = jcp.oc_block * 2;
+    const int b_row = a_col / 2;
     // Accumulator tile dimensions
-    const dim_t c_col = jcp.oc_block;
-    const dim_t c_row = a_row;
+    const int c_col = jcp.oc_block;
+    const int c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
         tcfg_buff[i] = 0;
@@ -5354,9 +5350,9 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -5376,13 +5372,13 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
 
     jcp.transform_to_vnni = diff_weights_d.data_type() == data_type::bf16;
 
-    jcp.r_pad = nstl::max<dim_t>(0,
+    jcp.r_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max<dim_t>(0,
+    jcp.b_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max<dim_t>(0,
+    jcp.back_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -5494,14 +5490,13 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     // TODO: Find more shapes (especially 3D with large spatials) for which
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
-    const dim_t optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    const int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
 
     jcp.global_transpose = dnnl_thr_syncable();
     jcp.spatial_blk_size = optimal_blk_size;
 
     const int tr_round = 32; // To load full tile register
-    const dim_t tr_pad
-            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    const int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = (rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
             * jcp.stride_w);
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -2357,33 +2357,35 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = avx512_core_amx;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
 
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = !is_1d ? src_d.dims()[ndims - 2] : 1;
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = !is_1d ? dst_d.dims()[ndims - 2] : 1;
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = !is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1;
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = !is_1d ? cd.padding[0][ndims - 4] : 0;
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = !is_1d ? cd.strides[ndims - 4] : 1;
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = !is_1d ? static_cast<int>(src_d.dims()[ndims - 2]) : 1;
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = !is_1d ? static_cast<int>(dst_d.dims()[ndims - 2]) : 1;
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = !is_1d
+            ? static_cast<int>(weights_d.dims()[with_groups + ndims - 2])
+            : 1;
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = !is_1d ? static_cast<int>(cd.padding[0][ndims - 4]) : 0;
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = !is_1d ? static_cast<int>(cd.strides[ndims - 4]) : 1;
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.dilate_d = is_3d ? cd.dilates[ndims - 5] : 0;
-    jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[ndims - 5]) : 0;
+    jcp.dilate_h = !is_1d ? static_cast<int>(cd.dilates[ndims - 4]) : 0;
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
     const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
@@ -3869,36 +3871,38 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = is_f16 ? avx512_core_amx_fp16 : avx512_core_amx;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
 
-    jcp.mb = diff_src_d.dims()[0];
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.mb = static_cast<int>(diff_src_d.dims()[0]);
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(diff_src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? diff_src_d.dims()[2] : 1;
-    jcp.ih = !is_1d ? diff_src_d.dims()[ndims - 2] : 1;
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = !is_1d ? diff_dst_d.dims()[ndims - 2] : 1;
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = !is_1d ? weights_d.dims()[with_groups + ndims - 2] : 1;
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = !is_1d ? cd.padding[0][ndims - 4] : 0;
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = !is_1d ? cd.strides[ndims - 4] : 1;
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = is_3d ? static_cast<int>(diff_src_d.dims()[2]) : 1;
+    jcp.ih = !is_1d ? static_cast<int>(diff_src_d.dims()[ndims - 2]) : 1;
+    jcp.iw = static_cast<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = !is_1d ? static_cast<int>(diff_dst_d.dims()[ndims - 2]) : 1;
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = !is_1d
+            ? static_cast<int>(weights_d.dims()[with_groups + ndims - 2])
+            : 1;
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = !is_1d ? static_cast<int>(cd.padding[0][ndims - 4]) : 0;
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = !is_1d ? static_cast<int>(cd.strides[ndims - 4]) : 1;
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     // No bias for xf16 case to simplify integration with ref_deconvolution
     jcp.with_bias = bias_md && !is_xf16_convolution
             && cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.dilate_d = is_3d ? cd.dilates[ndims - 5] : 0;
-    jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[ndims - 5]) : 0;
+    jcp.dilate_h = !is_1d ? static_cast<int>(cd.dilates[ndims - 4]) : 0;
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_CONV_IC(!(jcp.dilate_d != 0 && jcp.stride_d != 1),
             "unsupported stride/dilation values");
@@ -5320,35 +5324,39 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(diff_weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5)
+            ? static_cast<int>(diff_weights_d.dims()[with_groups + 2])
+            : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1110,7 +1110,7 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -2765,17 +2765,16 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Relevant to 'zero_point padding buffer' (pbuff) jit kernel
     if (jcp.req_zero_point_buffer) {
         auto calculate_output_padding_dims
-                = [](dim_t o_dim, dim_t s_pad, dim_t e_pad, dim_t &s_pad_output,
-                          dim_t &e_pad_output, bool &o_mid, dim_t &o_pad,
-                          dim_t stride, bool req_mid_area) {
-            s_pad_output = nstl::min<dim_t>(
-                    o_dim, div_up(nstl::max<dim_t>(0, s_pad), stride));
-            e_pad_output = nstl::min<dim_t>(
-                    o_dim, div_up(nstl::max<dim_t>(0, e_pad), stride));
+                = [](int o_dim, int s_pad, int e_pad, int &s_pad_output,
+                          int &e_pad_output, bool &o_mid, int &o_pad,
+                          int stride, bool req_mid_area) {
+            s_pad_output
+                    = nstl::min(o_dim, div_up(nstl::max(0, s_pad), stride));
+            e_pad_output
+                    = nstl::min(o_dim, div_up(nstl::max(0, e_pad), stride));
             o_mid = (o_dim - s_pad_output - e_pad_output > 0) && req_mid_area;
-            o_pad = nstl::min<dim_t>(o_dim,
-                    nstl::max<dim_t>(
-                            1, s_pad_output + e_pad_output + (dim_t)o_mid));
+            o_pad = nstl::min(o_dim,
+                    nstl::max(1, s_pad_output + e_pad_output + (int)o_mid));
         };
 
         const bool mid_w_area = (jcp.l_pad > 0 || jcp.r_pad > 0)

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -80,31 +80,35 @@ private:
     const Xbyak::Opmask kmask_ic_block = Xbyak::Opmask(1);
     const Xbyak::Opmask ktail_mask = Xbyak::Opmask(2);
 
-    void prepare_output(int ur_w);
-    void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void prepare_output(dim_t ur_w);
+    void store_output(dim_t ur_w, bool last_oc_block_flag);
+    void compute_ker(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool padded);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
-            bool handle_h_pad);
-    void kd_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
-            bool handle_h_pad);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool handle_h_pad);
+    void kh_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag, bool handle_h_pad);
+    void kd_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag, bool handle_h_pad);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad);
     void unroll_width(const bool h_padding);
 
     void generate() override;
 
     Xbyak::Zmm zmm_out(int i_ur, int i_oc) const {
-        int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+        const int idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < max_regs_ur);
         return Xbyak::Zmm(idx);
     }
-    int get_ow_start(int ki, int pad_l) const {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) const {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) const {
-        int filter_overlap = pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
-        return ur_w - utils::div_up(nstl::max(0, filter_overlap), jcp.stride_w);
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) const {
+        const dim_t filter_overlap
+                = pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
+        return ur_w
+                - utils::div_up(
+                        nstl::max<dim_t>(0, filter_overlap), jcp.stride_w);
     }
 };
 
@@ -184,8 +188,8 @@ private:
     const Xbyak::Zmm &zmm_zero = zmm1;
 
     void generate() override;
-    void copy_row(int icb);
-    void copy_row_body(int lpad, int iw_len, int icb);
+    void copy_row(dim_t icb);
+    void copy_row_body(dim_t lpad, dim_t iw_len, dim_t icb);
     void copy_row_reduced_lowering();
 };
 
@@ -204,11 +208,11 @@ struct jit_avx512_core_amx_fwd_kernel_t : public jit_generator_t {
     static status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
-    inline int accum_with_upper_bound(
-            int upper_bound, int lower_value, int upper_value) {
-        return nstl::min(upper_bound,
-                nstl::min(upper_bound, lower_value)
-                        + nstl::max(0, upper_bound - upper_value));
+    inline dim_t accum_with_upper_bound(
+            dim_t upper_bound, dim_t lower_value, dim_t upper_value) {
+        return nstl::min<dim_t>(upper_bound,
+                nstl::min<dim_t>(upper_bound, lower_value)
+                        + nstl::max<dim_t>(0, upper_bound - upper_value));
     }
 
     /*  Calculate and store the limits relevant to 'ow_block'. These limits
@@ -291,9 +295,10 @@ private:
     bool is_buffer_empty_ = true;
 
     struct w_pad_output_t {
-        int l_pad_output;
-        int r_pad_output;
-        w_pad_output_t(int l_, int r_) : l_pad_output(l_), r_pad_output(r_) {}
+        dim_t l_pad_output;
+        dim_t r_pad_output;
+        w_pad_output_t(dim_t l_, dim_t r_)
+            : l_pad_output(l_), r_pad_output(r_) {}
     };
     std::queue<w_pad_output_t> w_padding;
 
@@ -346,24 +351,25 @@ private:
     const Xbyak::Reg64 bin_injector_helper_reg_3 = r11;
 
     // AUX: Steps, shifts and offsets
-    size_t get_inp_icb_step() const;
-    size_t get_wei_icb_step() const;
-    size_t get_inp_d_step() const;
-    size_t get_inp_h_step() const;
-    size_t get_wei_d_step() const;
-    size_t get_wei_h_step() const;
-    size_t get_out_ocb_offset(int ohb, int ocb, size_t typesize) const;
-    size_t get_out_row_offset(int ohb, int ocb, int j, size_t typesize) const;
-    size_t get_out_shift(int width, size_t typesize) const;
-    size_t get_wsp_ocb_offset(int ohb, int ocb) const;
-    size_t get_wsp_row_offset(int ohb, int ocb, int j) const;
-    size_t get_wsp_shift() const;
-    size_t get_wei_offset(int ocb, int kw) const;
-    size_t get_inp_shift() const;
-    size_t get_inp_offset(int ohb, int kw) const;
-    size_t get_zp_comp_offset(int ocb, int zp_h, int zp_w) const;
-    int get_zp_index_offset(
-            int index, int mid, int s_pad_output, int e_pad_output);
+    dim_t get_inp_icb_step() const;
+    dim_t get_wei_icb_step() const;
+    dim_t get_inp_d_step() const;
+    dim_t get_inp_h_step() const;
+    dim_t get_wei_d_step() const;
+    dim_t get_wei_h_step() const;
+    dim_t get_out_ocb_offset(dim_t ohb, dim_t ocb, dim_t typesize) const;
+    dim_t get_out_row_offset(
+            dim_t ohb, dim_t ocb, dim_t j, dim_t typesize) const;
+    dim_t get_out_shift(dim_t width, dim_t typesize) const;
+    dim_t get_wsp_ocb_offset(dim_t ohb, dim_t ocb) const;
+    dim_t get_wsp_row_offset(dim_t ohb, dim_t ocb, dim_t j) const;
+    dim_t get_wsp_shift() const;
+    dim_t get_wei_offset(dim_t ocb, dim_t kw) const;
+    dim_t get_inp_shift() const;
+    dim_t get_inp_offset(dim_t ohb, dim_t kw) const;
+    dim_t get_zp_comp_offset(dim_t ocb, dim_t zp_h, dim_t zp_w) const;
+    dim_t get_zp_index_offset(
+            dim_t index, dim_t mid, dim_t s_pad_output, dim_t e_pad_output);
 
     int get_out_tensor(int h, int i, bool is_h_tail = false) const;
     int get_inp_tensor(int h, bool is_h_tail = false) const;
@@ -371,9 +377,9 @@ private:
 
     void prepare_output(int tail);
     void init_runtime_counters(bool start_with_last_tile_block);
-    size_t reduce_to_block(const int block_size, const int pad_output);
-    size_t reduce_to_blocked_dims(const int dim_size, const int block_size,
-            const int s_pad_output, const int e_pad_output);
+    dim_t reduce_to_block(const dim_t block_size, const dim_t pad_output);
+    dim_t reduce_to_blocked_dims(const dim_t dim_size, const dim_t block_size,
+            const dim_t s_pad_output, const dim_t e_pad_output);
     void cvt2ps(data_type_t type_in, const Xbyak::Zmm &ymm_in,
             const Xbyak::Operand &op, bool mask_flag = false);
     Xbyak::Zmm zmm_out(const int idx) const {
@@ -393,31 +399,31 @@ private:
             const bool mask_flag);
     void apply_postops(const Xbyak::Zmm &zmm_out, const float *p_sum_scale,
             const int32_t *p_sum_zp, const Xbyak::Address &addr,
-            const size_t off, const bool mask_flag);
+            const dim_t off, const bool mask_flag);
     inline void store_output_ymm_bf16(
             const int idx, const Xbyak::Address &addr, const bool mask_flag);
     void store_output_vector_bf16(
-            const Xbyak::Zmm &zmm_out, int ocb, int h, int w);
-    void store_output_vector_int8(const Xbyak::Zmm &zmm_out, int ocb, int h,
-            int w, const bool compute_zp, const int zp_h, const int zp_w);
-    void store_output_vector(const Xbyak::Zmm &zmm_out, int ocb, int h, int w,
-            const bool compute_zp = false, const int zp_h = 0,
-            const int zp_w = 0);
-    void store_output(int width, int tail, bool do_store,
-            const bool handle_h_block, const int t_pad_output,
-            const int b_pad_output, const int l_pad_output,
-            const int r_pad_output, const bool is_last_oh_block,
+            const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w);
+    void store_output_vector_int8(const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h,
+            dim_t w, const bool compute_zp, const dim_t zp_h, const dim_t zp_w);
+    void store_output_vector(const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h,
+            dim_t w, const bool compute_zp = false, const dim_t zp_h = 0,
+            const dim_t zp_w = 0);
+    void store_output(dim_t width, int tail, bool do_store,
+            const bool handle_h_block, const dim_t t_pad_output,
+            const dim_t b_pad_output, const dim_t l_pad_output,
+            const dim_t r_pad_output, const bool is_last_oh_block,
             const bool zp_3d_pad = false);
-    void interleave_store(int width, int const t_pad_output,
-            int const b_pad_output, const bool zp_3d_pad = false);
-    void compute_icb_loop(int width, bool do_store, const bool handle_h_block,
-            const int t_pad_output, const int b_pad_output,
-            const int l_pad_output, const int r_pad_output,
+    void interleave_store(dim_t width, dim_t const t_pad_output,
+            dim_t const b_pad_output, const bool zp_3d_pad = false);
+    void compute_icb_loop(dim_t width, bool do_store, const bool handle_h_block,
+            const dim_t t_pad_output, const dim_t b_pad_output,
+            const dim_t l_pad_output, const dim_t r_pad_output,
             const bool zp_3d_pad, const bool is_last_oh_block = false);
-    void dispatch_icb_loop(int width, bool do_store, const int l_pad_output,
-            const int r_pad_output, const bool zp_3d_pad);
-    void dispatch_zp_3d_compute(int width, bool do_store,
-            const int l_pad_output, const int r_pad_output);
+    void dispatch_icb_loop(dim_t width, bool do_store, const dim_t l_pad_output,
+            const dim_t r_pad_output, const bool zp_3d_pad);
+    void dispatch_zp_3d_compute(dim_t width, bool do_store,
+            const dim_t l_pad_output, const dim_t r_pad_output);
     void compute_ow_loop();
 
     void generate() override;
@@ -560,27 +566,27 @@ private:
     const Xbyak::Zmm zmm_sum_zp = zmm28;
 
     // AUX: Steps, shifts and offsets
-    size_t get_inp_ocb_step() const;
-    size_t get_inp_offset(int ihb, int kh, int kw) const;
-    size_t get_inp_shift() const;
-    size_t get_inp_d_step() const;
-    size_t get_out_icb_offset(int ihb, int icb) const;
-    size_t get_out_row_offset(int ihb, int icb, int j) const;
-    size_t get_out_shift(int width) const;
-    size_t get_wei_kh_step() const;
-    size_t get_wei_ocb_step() const;
-    size_t get_wei_offset(int icb, int kh, int kw) const;
-    size_t get_wei_d_step() const;
-    size_t get_wsp_icb_offset(int ihb, int icb) const;
-    size_t get_wsp_row_offset(int ihb, int icb, int j) const;
-    size_t get_wsp_shift() const;
+    dim_t get_inp_ocb_step() const;
+    dim_t get_inp_offset(dim_t ihb, dim_t kh, dim_t kw) const;
+    dim_t get_inp_shift() const;
+    dim_t get_inp_d_step() const;
+    dim_t get_out_icb_offset(dim_t ihb, dim_t icb) const;
+    dim_t get_out_row_offset(dim_t ihb, dim_t icb, dim_t j) const;
+    dim_t get_out_shift(dim_t width) const;
+    dim_t get_wei_kh_step() const;
+    dim_t get_wei_ocb_step() const;
+    dim_t get_wei_offset(dim_t icb, dim_t kh, dim_t kw) const;
+    dim_t get_wei_d_step() const;
+    dim_t get_wsp_icb_offset(dim_t ihb, dim_t icb) const;
+    dim_t get_wsp_row_offset(dim_t ihb, dim_t icb, dim_t j) const;
+    dim_t get_wsp_shift() const;
 
     int get_out_tensor(int h, int i) const;
     int get_inp_tensor(int h) const;
     int get_wei_tensor(int i) const;
 
     inline bool gaps_in_store() const {
-        const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+        const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
         return gen_kd < jcp.stride_d || jcp.dilate_d > 0;
     }
 
@@ -596,16 +602,17 @@ private:
             const Xbyak::Zmm &zmm_in, bool mask_flag, bool store = false);
 
     void store_output_vector_xf16(
-            const Xbyak::Zmm &zmm_out, int icb, int ihb, int iw);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ihb, dim_t iw);
     void store_output_vector_int8(
-            const Xbyak::Zmm &zmm_out, int icb, int ihb, int iw);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ihb, dim_t iw);
     void store_output_vector(
-            const Xbyak::Zmm &zmm_out, int icb, int ih, int iw);
-    void store_output(int width, bool do_store);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ih, dim_t iw);
+    void store_output(dim_t width, bool do_store);
     void skipped_interleave_store();
-    void interleave_store(int width);
-    void compute_ocb_loop(int width, bool do_interleave_store);
-    void compute_kd_loop(int width, bool do_store, bool handle_skipped_stores);
+    void interleave_store(dim_t width);
+    void compute_ocb_loop(dim_t width, bool do_interleave_store);
+    void compute_kd_loop(
+            dim_t width, bool do_store, bool handle_skipped_stores);
     void compute_iw_loop();
 
     void generate() override;
@@ -722,7 +729,7 @@ private:
         return jcp.typesize_in * (w_off + jcp.tr_ow * jcp.oc_block * hd_idx);
     }
 
-    inline dim_t get_kernel_offset(int ic_idx, dim_t ksp_idx) const {
+    inline dim_t get_kernel_offset(dim_t ic_idx, dim_t ksp_idx) const {
         return jcp.typesize_out * jcp.oc_block
                 * (ksp_idx * jcp.ic_block + ic_idx);
     }

--- a/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
@@ -47,40 +47,43 @@ struct spatial_features_3d_t {
         , init_overflow_(0)
         , end_overflow_(0) {}
 
-    inline int get_init_overflow(const int in) const {
+    inline dim_t get_init_overflow(const dim_t in) const {
         if (is_fast_path_)
-            return nstl::max(0, filter_size_ - 1 - in - init_pad_);
+            return nstl::max<dim_t>(0, filter_size_ - 1 - in - init_pad_);
         if (dilate_ != 1)
             return div_up(
-                    nstl::max(0, (filter_size_ - 1) * dilate_ - in - init_pad_),
+                    nstl::max<dim_t>(
+                            0, (filter_size_ - 1) * dilate_ - in - init_pad_),
                     dilate_);
-        return nstl::max(0, (filter_size_ - 1 - in - init_pad_) / stride_);
+        return nstl::max<dim_t>(
+                0, (filter_size_ - 1 - in - init_pad_) / stride_);
     }
 
-    inline int get_end_overflow(const int in) const {
+    inline dim_t get_end_overflow(const dim_t in) const {
         if (is_fast_path_)
-            return nstl::max(0, filter_size_ - input_size_ + in - end_pad_);
+            return nstl::max<dim_t>(
+                    0, filter_size_ - input_size_ + in - end_pad_);
         if (dilate_ != 1)
-            return div_up(nstl::max(0,
+            return div_up(nstl::max<dim_t>(0,
                                   (filter_size_ - 1) * dilate_ + 1 - input_size_
                                           + in - end_pad_),
                     dilate_);
-        return nstl::max(
+        return nstl::max<dim_t>(
                 0, (filter_size_ - input_size_ + in - end_pad_) / stride_);
     }
 
-    void update_params(const int in) {
+    void update_params(const dim_t in) {
 
         init_overflow_ = get_init_overflow(in);
         end_overflow_ = get_end_overflow(in);
 
         // overflow_kd_hi
-        const int overflow_filter_hi_ = compute_extended_features_
+        const dim_t overflow_filter_hi_ = compute_extended_features_
                 ? filter_size_ - 1
                         - nstl::modulo(input_size_ - 1 + end_pad_ - in, stride_)
                 : 0;
         // overflow_kd_lo
-        const int overflow_filter_lo_
+        const dim_t overflow_filter_lo_
                 = compute_extended_features_ ? (in + init_pad_) % stride_ : 0;
 
         filter_ = compute_extended_features_
@@ -96,30 +99,30 @@ struct spatial_features_3d_t {
                 : in + init_pad_ - end_overflow_ * dilate_;
     }
 
-    inline int get_filter_padding() const {
+    inline dim_t get_filter_padding() const {
         return filter_ - init_overflow_ - end_overflow_;
     }
 
-    inline int get_lower_offset() const { return lower_offset_; }
+    inline dim_t get_lower_offset() const { return lower_offset_; }
 
-    inline int get_output_offset() const { return output_offset_; }
+    inline dim_t get_output_offset() const { return output_offset_; }
 
 private:
-    int input_size_;
-    int filter_size_;
-    int dilate_;
-    int stride_;
-    int init_pad_; // f_pad
-    int end_pad_; // back_pad
+    dim_t input_size_;
+    dim_t filter_size_;
+    dim_t dilate_;
+    dim_t stride_;
+    dim_t init_pad_; // f_pad
+    dim_t end_pad_; // back_pad
     bool is_fast_path_; // 'dilate_ == 1 && stride_ == 1'
     bool compute_extended_features_; // eq. '(!is_fast_path_) && dilate_ == 1'
 
-    int filter_;
-    int lower_offset_; // d_lo
-    int output_offset_; // d_oj
+    dim_t filter_;
+    dim_t lower_offset_; // d_lo
+    dim_t output_offset_; // d_oj
 
-    int init_overflow_; // d_t_overflow
-    int end_overflow_; // d_b_overflow
+    dim_t init_overflow_; // d_t_overflow
+    dim_t end_overflow_; // d_b_overflow
 };
 
 } // namespace amx_utils

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -963,32 +963,32 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
                     const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
                     const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
                     const dim_t delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow
-                            = static_cast<int>(0 < doh_s && doh_s < doh_l
-                                            ? nstl::additive_inverse_modulo(
-                                                      static_cast<dim_t>(doh_s),
-                                                      jcp.stride_h)
-                                            : nstl::max<dim_t>(0, -doh_s));
+                    const int doh_t_overflow = static_cast<int>(
+                            0 < doh_s && doh_s < doh_l
+                                    ? nstl::additive_inverse_modulo(
+                                              static_cast<dim_t>(doh_s),
+                                              static_cast<dim_t>(jcp.stride_h))
+                                    : nstl::max<dim_t>(0, -doh_s));
                     const int doh_b_overflow = static_cast<int>(
                             0 < doh_f && doh_f < doh_l
                                     ? nstl::modulo(static_cast<dim_t>(doh_f),
-                                              jcp.stride_h)
+                                              static_cast<dim_t>(jcp.stride_h))
                                     : nstl::max<dim_t>(0,
                                               nstl::min<dim_t>(
                                                       delta_h, doh_f - doh_l)));
                     dim_t dow_s = dow;
                     dim_t dow_f = dow + jcp.owp - 1;
                     const dim_t delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow
-                            = static_cast<int>(0 < dow_s && dow_s < dow_l
-                                            ? nstl::additive_inverse_modulo(
-                                                      static_cast<dim_t>(dow_s),
-                                                      jcp.stride_w)
-                                            : nstl::max<dim_t>(0, -dow_s));
+                    const int dow_l_overflow = static_cast<int>(
+                            0 < dow_s && dow_s < dow_l
+                                    ? nstl::additive_inverse_modulo(
+                                              static_cast<dim_t>(dow_s),
+                                              static_cast<dim_t>(jcp.stride_w))
+                                    : nstl::max<dim_t>(0, -dow_s));
                     const int dow_r_overflow = static_cast<int>(
                             0 < dow_f && dow_f < dow_l
                                     ? nstl::modulo(static_cast<dim_t>(dow_f),
-                                              jcp.stride_w)
+                                              static_cast<dim_t>(jcp.stride_w))
                                     : nstl::max<dim_t>(0,
                                               nstl::min<dim_t>(
                                                       delta_w, dow_f - dow_l)));

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -48,7 +48,7 @@ using namespace nstl;
 
 template <typename T>
 static inline T accum_with_upper_bound(T ub, T lv, T uv) {
-    return nstl::min(ub, nstl::min(ub, lv) + nstl::max(0, ub - uv));
+    return nstl::min<T>(ub, nstl::min<T>(ub, lv) + nstl::max<T>(0, ub - uv));
 }
 
 void jit_avx512_core_amx_convolution_fwd_t::prepare_padded_bias(
@@ -123,18 +123,19 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             ? reinterpret_cast<int32_t *>(w + offset)
             : nullptr;
 
-    const int t_pad_output = jcp.t_pad_output;
-    const int b_pad_output = jcp.b_pad_output;
-    const int b_pad_start = nstl::max(jcp.oh - b_pad_output, t_pad_output);
-    const int zp_buff_b_pad_start
-            = nstl::max(jcp.oh_pad - b_pad_output, t_pad_output);
+    const dim_t t_pad_output = jcp.t_pad_output;
+    const dim_t b_pad_output = jcp.b_pad_output;
+    const int b_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.oh - b_pad_output, t_pad_output));
+    const dim_t zp_buff_b_pad_start
+            = nstl::max<dim_t>(jcp.oh_pad - b_pad_output, t_pad_output);
 
-    const int ngroups = jcp.ngroups;
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
-    const int work_amount
+    const dim_t ngroups = jcp.ngroups;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * oh_chunks * jcp.nb_ow * oc_chunks;
-    const int zp_pbuff_size = jcp.zp_pbuff_size;
+    const dim_t zp_pbuff_size = jcp.zp_pbuff_size;
 
     // reorder weights from (g)Owhi16o to (g)OR16r16o4r, where r := whi
     auto p = jit_conv_args_t();
@@ -156,27 +157,29 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     if (req_zero_point_buffer && zp_pbuff_outer_compute) {
         const size_t wei_oc_step = (size_t)jcp.kh * jcp.kw * jcp.ic_block_int_np
                 * jcp.nb_oc_blocking * jcp.oc_block;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
-        const int oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
         parallel_nd(ngroups, oc_chunks, oh_work,
                 [= COMPAT_THIS_CAPTURE](dim_t g, dim_t occ, dim_t oh) {
             auto p = jit_conv_args_t();
 
-            const int oh_ = oh >= zp_buff_b_pad_start
+            const dim_t oh_ = oh >= zp_buff_b_pad_start
                     ? b_pad_start + oh - zp_buff_b_pad_start
                     : oh;
-            const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-            const int t_overflow
-                    = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-            const int b_overflow = nstl::min(jcp.kh,
-                    div_up(nstl::max(0, ih + gen_kh - jcp.ih), dilate_h));
+            const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+            const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+            const int b_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kh,
+                    div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                            dilate_h)));
             p.t_overflow = t_overflow;
             p.b_overflow = b_overflow;
-            p.kh_padding = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+            p.kh_padding
+                    = nstl::max<dim_t>(0, jcp.kh - t_overflow - b_overflow);
 
-            const int ocb
+            const dim_t ocb
                     = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
             const size_t ch_offset = dst_d.blk_off(0, ocb);
             const size_t sp_offset = oh * jcp.ow_pad * sp_stride;
@@ -194,7 +197,7 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     // input data reuse and parallelize input data reorders
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        balance211(static_cast<int>(work_amount), nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
                                   ? zero_point_pbuff
@@ -205,7 +208,7 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 : nullptr;
         if (zp_pbuff_parallel_block) {
             PRAGMA_OMP_SIMD()
-            for (int oc = 0; oc < oc_chunks * ngroups; oc++)
+            for (dim_t oc = 0; oc < oc_chunks * ngroups; oc++)
                 zp_flags[oc] = true;
         }
 
@@ -225,31 +228,31 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        const int oh_work = jcp.oh_pad;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
         const size_t wei_oc_step = (size_t)jcp.kh * jcp.kw * jcp.ic_block_int_np
                 * jcp.nb_oc_blocking * jcp.oc_block;
         size_t oc_stride = dst_d.blk_off(0, 1);
-        const int owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
+        const dim_t owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
 
-        int mb {0}, g {0}, ohc {0}, owb {0}, occ {0};
+        dim_t mb {0}, g {0}, ohc {0}, owb {0}, occ {0};
         // need "inner" oh blocks w.r.t. ow blocks to allow pbuffer reuse
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, owb, jcp.nb_ow, ohc,
                 oh_chunks, occ, oc_chunks);
-        int last_copied_mb = -1;
-        int last_copied_ohc = -1;
-        int last_copied_owb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_ohc = -1;
+        dim_t last_copied_owb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + src_dt_size * ithr * jcp.inp_buffer_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            int oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
-            int ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
+            dim_t oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
+            dim_t ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
             const char *bias_w = bias
                     ? bias + (bias_d.blk_off(oc) * bia_dt_size)
                     : nullptr;
@@ -258,8 +261,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             p.src_zero_point = src_zero_points;
             p.dst_zero_point = dst_zero_points;
 
-            int oh_s = ohc * jcp.oh_blk_size;
-            int oh_e = nstl::min(jcp.oh, oh_s + jcp.oh_blk_size);
+            dim_t oh_s = ohc * jcp.oh_blk_size;
+            dim_t oh_e = nstl::min<dim_t>(jcp.oh, oh_s + jcp.oh_blk_size);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_ohc == ohc && last_copied_owb == owb
                     && last_copied_g == g;
@@ -270,11 +273,12 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                     ? zp_flags[g * oc_chunks + occ] // already computed?
                     : false;
 
-            int cur_t_pad = nstl::max(0, t_pad_output - oh_s);
-            int cur_b_pad = nstl::max(
-                    nstl::max(0, jcp.oh - b_pad_output - oh_s), cur_t_pad);
-            size_t zp_oh
-                    = accum_with_upper_bound(oh_s, t_pad_output, b_pad_start);
+            dim_t cur_t_pad = nstl::max<dim_t>(0, t_pad_output - oh_s);
+            dim_t cur_b_pad = nstl::max<dim_t>(
+                    nstl::max<dim_t>(0, jcp.oh - b_pad_output - oh_s),
+                    cur_t_pad);
+            size_t zp_oh = accum_with_upper_bound<dim_t>(
+                    oh_s, t_pad_output, b_pad_start);
 
             int limit_idx = 0;
             constexpr int limit_size = 5;
@@ -288,19 +292,20 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 assert(!zp_pbuff_outer_compute);
                 zp_flags[g * oc_chunks + occ] = false;
                 for (int oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
-                    const int oh_ = oh_pad >= zp_buff_b_pad_start
+                    const dim_t oh_ = oh_pad >= zp_buff_b_pad_start
                             ? b_pad_start + oh_pad - zp_buff_b_pad_start
                             : oh_pad;
-                    const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-                    const int t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-                    const int b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0, ih + gen_kh - jcp.ih),
-                                    dilate_h));
+                    const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+                    const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+                    const int b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh,
+                            div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                                    dilate_h)));
                     p.t_overflow = t_overflow;
                     p.b_overflow = b_overflow;
-                    p.kh_padding
-                            = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+                    p.kh_padding = nstl::max<dim_t>(
+                            0, jcp.kh - t_overflow - b_overflow);
 
                     const size_t ch_offset = dst_d.blk_off(0, oc);
                     const size_t sp_offset = oh_pad * jcp.ow_pad * sp_stride;
@@ -314,50 +319,51 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 }
             }
 
-            int oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
-            for (int oh = oh_s; oh < oh_e; oh += oh_step) {
-                const int inp_buffer_h_step
+            dim_t oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
+            for (dim_t oh = oh_s; oh < oh_e; oh += oh_step) {
+                const dim_t inp_buffer_h_step
                         = jcp.stride_h * jcp.ic_without_padding;
                 assert(jcp.is_nspc);
                 assert(jcp.stride_h <= jcp.kh);
 
-                int ow = owb * jcp.ow_block;
+                dim_t ow = owb * jcp.ow_block;
 
                 char *inp_buffer_oh
                         = inp_buffer + src_dt_size * oh * inp_buffer_h_step;
 
                 if (!is_inp_buffer_relevant) {
                     // prepare padded input buffer
-                    const int icb = g * jcp.ic;
+                    const dim_t icb = g * jcp.ic;
                     size_t inp_offset = src_d.blk_off(mb, icb);
-                    const int iw_step = jcp.ngroups * jcp.ic_without_padding;
+                    const dim_t iw_step = jcp.ngroups * jcp.ic_without_padding;
                     const char *psrc = src + src_dt_size * inp_offset;
                     // calculate overlap...
-                    const int ih_overlap = has_inp_buffer_overlap
-                            * nstl::max(0, jcp.kh - oh_step * jcp.stride_h);
-                    const int kh_eff = jcp.kh - ih_overlap;
+                    const dim_t ih_overlap = has_inp_buffer_overlap
+                            * nstl::max<dim_t>(
+                                    0, jcp.kh - oh_step * jcp.stride_h);
+                    const dim_t kh_eff = jcp.kh - ih_overlap;
                     // prepare padded input buffer
                     char *pdst = inp_buffer_oh
                             + src_dt_size * ih_overlap * jcp.ic_without_padding;
                     for (int doh = 0; doh < oh_step; doh++) {
-                        const int ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad
+                        const dim_t ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad
                                 + ih_overlap;
-                        const int ih_e = ih_s + kh_eff;
-                        const int ih = nstl::max(0, ih_s);
-                        p.t_overflow = nstl::max(0, -ih_s);
-                        p.b_overflow = nstl::min<int>(
-                                kh_eff, nstl::max(0, ih_e - jcp.ih));
-                        p.kh_padding = nstl::max<int>(
-                                0, (kh_eff - p.t_overflow - p.b_overflow));
-                        p.kh_offset = kh_eff;
+                        const dim_t ih_e = ih_s + kh_eff;
+                        const dim_t ih = nstl::max<dim_t>(0, ih_s);
+                        p.t_overflow = nstl::max<dim_t>(0, -ih_s);
+                        p.b_overflow = nstl::min<dim_t>(
+                                kh_eff, nstl::max<dim_t>(0, ih_e - jcp.ih));
+                        p.kh_padding = static_cast<int>(nstl::max<dim_t>(
+                                0, kh_eff - p.t_overflow - p.b_overflow));
+                        p.kh_offset = static_cast<int>(kh_eff);
 
-                        const int iw_s = ow * jcp.stride_w - jcp.l_pad;
-                        const int iw_e = iw_s + jcp.iwp;
-                        const int iw = nstl::max(0, iw_s);
-                        p.f_overflow = nstl::max(0, -iw_s);
-                        p.back_overflow = nstl::max(0, iw_e - jcp.iw);
-                        p.kw_padding = nstl::max<int>(
-                                0, jcp.iwp - p.f_overflow - p.back_overflow);
+                        const dim_t iw_s = ow * jcp.stride_w - jcp.l_pad;
+                        const dim_t iw_e = iw_s + jcp.iwp;
+                        const dim_t iw = nstl::max<dim_t>(0, iw_s);
+                        p.f_overflow = nstl::max<dim_t>(0, -iw_s);
+                        p.back_overflow = nstl::max<dim_t>(0, iw_e - jcp.iw);
+                        p.kw_padding = static_cast<int>(nstl::max<dim_t>(
+                                0, jcp.iwp - p.f_overflow - p.back_overflow));
 
                         p.src = psrc
                                 + src_dt_size * (ih * jcp.iw + iw) * iw_step;
@@ -395,8 +401,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                     limit_idx++;
                 p.ohb = limit_idx;
                 p.last_h = (oh + oh_step <= oh_e);
-                const int zp_owb = nstl::min(jcp.l_pad_blk, owb)
-                        + nstl::max(0, owb - owb_limit);
+                const dim_t zp_owb = nstl::min<dim_t>(jcp.l_pad_blk, owb)
+                        + nstl::max<dim_t>(0, owb - owb_limit);
                 p.owb = req_zero_point_buffer ? zp_owb : owb;
 
                 p.oc_blocks = occ * jcp.nb_oc_blocking;
@@ -410,8 +416,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 if (req_zero_point_buffer) {
                     zp_oh += accum_with_upper_bound(
                             oh_step, cur_t_pad, cur_b_pad);
-                    cur_t_pad = nstl::max(0, cur_t_pad - oh_step);
-                    cur_b_pad = nstl::max(0, cur_b_pad - oh_step);
+                    cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step);
+                    cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step);
                 }
             }
             last_copied_mb = mb;
@@ -494,24 +500,25 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             ? reinterpret_cast<int32_t *>(&w[offset])
             : nullptr;
 
-    const int f_pad_output = jcp.f_pad_output;
-    const int back_pad_output = jcp.back_pad_output;
-    const int back_pad_start
-            = nstl::max(jcp.od - back_pad_output, f_pad_output);
-    const int zp_buff_back_pad_start
-            = nstl::max(jcp.od_pad - back_pad_output, f_pad_output);
-    const int t_pad_output = jcp.t_pad_output;
-    const int b_pad_output = jcp.b_pad_output;
-    const int b_pad_start = nstl::max(jcp.oh - b_pad_output, t_pad_output);
-    const int zp_buff_b_pad_start
-            = nstl::max(jcp.oh_pad - b_pad_output, t_pad_output);
+    const dim_t f_pad_output = jcp.f_pad_output;
+    const dim_t back_pad_output = jcp.back_pad_output;
+    const int back_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.od - back_pad_output, f_pad_output));
+    const dim_t zp_buff_back_pad_start
+            = nstl::max<dim_t>(jcp.od_pad - back_pad_output, f_pad_output);
+    const dim_t t_pad_output = jcp.t_pad_output;
+    const dim_t b_pad_output = jcp.b_pad_output;
+    const int b_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.oh - b_pad_output, t_pad_output));
+    const dim_t zp_buff_b_pad_start
+            = nstl::max<dim_t>(jcp.oh_pad - b_pad_output, t_pad_output);
 
-    const int ngroups = jcp.ngroups;
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
-    const size_t work_amount = (size_t)jcp.mb * jcp.ngroups * jcp.od * oh_chunks
-            * jcp.nb_ow * oc_chunks;
-    const int zp_pbuff_size = jcp.zp_pbuff_size;
+    const dim_t ngroups = jcp.ngroups;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
+    const dim_t work_amount
+            = jcp.mb * jcp.ngroups * jcp.od * oh_chunks * jcp.nb_ow * oc_chunks;
+    const dim_t zp_pbuff_size = jcp.zp_pbuff_size;
 
     // init zero_point padding buffer
     const bool req_zero_point_buffer = jcp.req_zero_point_buffer;
@@ -519,42 +526,46 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     const bool zp_pbuff_parallel_block
             = req_zero_point_buffer && !zp_pbuff_outer_compute;
     if (req_zero_point_buffer && zp_pbuff_outer_compute) {
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_d = jcp.dilate_d + 1;
-        const int gen_kd = (jcp.kd - 1) * dilate_d + 1;
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
-        const int od_work = jcp.od_pad;
-        const int oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_d = jcp.dilate_d + 1;
+        const dim_t gen_kd = (jcp.kd - 1) * dilate_d + 1;
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t od_work = jcp.od_pad;
+        const dim_t oh_work = jcp.oh_pad;
         parallel_nd(ngroups, oc_chunks, od_work, oh_work,
                 [= COMPAT_THIS_CAPTURE](
                         dim_t g, dim_t occ, dim_t od, dim_t oh) {
             auto p = jit_conv_args_t();
 
-            const int od_ = od >= zp_buff_back_pad_start
+            const dim_t od_ = od >= zp_buff_back_pad_start
                     ? back_pad_start + od - zp_buff_back_pad_start
                     : od;
-            const int id = od_ * jcp.stride_d - jcp.f_pad;
-            const int f_overflow
-                    = nstl::min(jcp.kd, div_up(max(0, -id), dilate_d));
-            const int back_overflow = nstl::min(jcp.kd,
-                    div_up(nstl::max(0, id + gen_kd - jcp.id), dilate_d));
+            const dim_t id = od_ * jcp.stride_d - jcp.f_pad;
+            const int f_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd, div_up(max<dim_t>(0, -id), dilate_d)));
+            const int back_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kd,
+                    div_up(nstl::max<dim_t>(0, id + gen_kd - jcp.id),
+                            dilate_d)));
             p.f_overflow = f_overflow;
             p.back_overflow = back_overflow;
-            p.kd_padding = nstl::max(0, jcp.kd - f_overflow - back_overflow);
-            const int oh_ = oh >= zp_buff_b_pad_start
+            p.kd_padding
+                    = nstl::max<dim_t>(0, jcp.kd - f_overflow - back_overflow);
+            const dim_t oh_ = oh >= zp_buff_b_pad_start
                     ? b_pad_start + oh - zp_buff_b_pad_start
                     : oh;
-            const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-            const int t_overflow
-                    = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-            const int b_overflow = nstl::min(jcp.kh,
-                    div_up(nstl::max(0, ih + gen_kh - jcp.ih), dilate_h));
+            const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+            const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+            const int b_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kh,
+                    div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                            dilate_h)));
             p.t_overflow = t_overflow;
             p.b_overflow = b_overflow;
-            p.kh_padding = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+            p.kh_padding
+                    = nstl::max<dim_t>(0, jcp.kh - t_overflow - b_overflow);
 
-            const int ocb
+            const dim_t ocb
                     = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
             const size_t ch_offset = dst_d.blk_off(0, ocb);
             auto sp_offset = (od * jcp.oh_pad + oh) * jcp.ow_pad * sp_stride;
@@ -571,7 +582,7 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     // TODO: implement 2D parallelization driver (g * spatial x oc) to increase
     // input data reuse and parallelize input data reorders
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
@@ -583,7 +594,7 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 : nullptr;
         if (zp_pbuff_parallel_block) {
             PRAGMA_OMP_SIMD()
-            for (int oc = 0; oc < oc_chunks * ngroups; oc++)
+            for (dim_t oc = 0; oc < oc_chunks * ngroups; oc++)
                 zp_flags[oc] = true;
         }
 
@@ -604,30 +615,30 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        const int oh_work = jcp.oh_pad;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_d = jcp.dilate_d + 1;
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_d = jcp.dilate_d + 1;
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
         size_t oc_stride = dst_d.blk_off(0, 1);
-        const int owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
+        const dim_t owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
 
-        int mb {0}, g {0}, odc {0}, ohc {0}, owb {0}, occ {0};
+        dim_t mb {0}, g {0}, odc {0}, ohc {0}, owb {0}, occ {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, odc, jcp.od, ohc,
                 oh_chunks, owb, jcp.nb_ow, occ, oc_chunks);
-        int last_copied_mb = -1;
-        int last_copied_odc = -1;
-        int last_copied_ohc = -1;
-        int last_copied_owb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_odc = -1;
+        dim_t last_copied_ohc = -1;
+        dim_t last_copied_owb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + src_dt_size * ithr * jcp.inp_buffer_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            int oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
-            int ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
+            dim_t oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
+            int ocb = static_cast<int>(jcp.is_nspc ? oc : oc / jcp.oc_block);
             const char *bias_w = bias
                     ? bias + (bias_d.blk_off(oc) * bia_dt_size)
                     : nullptr;
@@ -637,8 +648,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             p.dst_zero_point = dst_zero_points;
 
             const size_t inp_src_d_stride = mem_blk_off(src_d, 0, 0, 1, 0, 0);
-            int oh_s = ohc * jcp.oh_blk_size;
-            int oh_e = nstl::min(jcp.oh, oh_s + jcp.oh_blk_size);
+            dim_t oh_s = ohc * jcp.oh_blk_size;
+            dim_t oh_e = nstl::min<dim_t>(jcp.oh, oh_s + jcp.oh_blk_size);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_odc == odc && last_copied_ohc == ohc
                     && last_copied_owb == owb && last_copied_g == g;
@@ -646,14 +657,15 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                     ? zp_flags[g * oc_chunks + occ] // already computed?
                     : false;
 
-            int cur_t_pad = nstl::max(0, t_pad_output - oh_s);
-            int cur_b_pad = nstl::max(
-                    nstl::max(0, jcp.oh - b_pad_output - oh_s), cur_t_pad);
+            dim_t cur_t_pad = nstl::max<dim_t>(0, t_pad_output - oh_s);
+            dim_t cur_b_pad = nstl::max<dim_t>(
+                    nstl::max<dim_t>(0, jcp.oh - b_pad_output - oh_s),
+                    cur_t_pad);
             const size_t zp_od = odc >= back_pad_start
                     ? odc - back_pad_start + zp_buff_back_pad_start
-                    : nstl::min(f_pad_output, odc);
-            size_t zp_oh
-                    = accum_with_upper_bound(oh_s, t_pad_output, b_pad_start);
+                    : nstl::min<dim_t>(f_pad_output, odc);
+            size_t zp_oh = accum_with_upper_bound<dim_t>(
+                    oh_s, t_pad_output, b_pad_start);
 
             int limit_idx = 0;
             constexpr int limit_size = 5;
@@ -667,20 +679,21 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 assert(pd()->ndims() != 5);
                 assert(!zp_pbuff_outer_compute);
                 zp_flags[g * oc_chunks + occ] = false;
-                for (int oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
-                    const int oh_ = oh_pad >= zp_buff_b_pad_start
+                for (dim_t oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
+                    const dim_t oh_ = oh_pad >= zp_buff_b_pad_start
                             ? b_pad_start + oh_pad - zp_buff_b_pad_start
                             : oh_pad;
-                    const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-                    const int t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-                    const int b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0, ih + gen_kh - jcp.ih),
-                                    dilate_h));
+                    const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+                    const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+                    const int b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh,
+                            div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                                    dilate_h)));
                     p.t_overflow = t_overflow;
                     p.b_overflow = b_overflow;
-                    p.kh_padding
-                            = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+                    p.kh_padding = nstl::max<dim_t>(
+                            0, jcp.kh - t_overflow - b_overflow);
 
                     const size_t ch_offset = dst_d.blk_off(0, oc);
                     const size_t sp_offset = oh_pad * jcp.ow_pad * sp_stride;
@@ -695,38 +708,43 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 }
             }
 
-            const int id_s = odc * jcp.stride_d - jcp.f_pad;
-            const int d_f_overflow
-                    = nstl::min(jcp.kd, div_up(max(0, -id_s), dilate_d));
-            const int d_back_overflow = nstl::min(jcp.kd,
-                    div_up(max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
-                            dilate_d));
-            p.kd_padding
-                    = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+            const dim_t id_s = odc * jcp.stride_d - jcp.f_pad;
+            const int d_f_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd, div_up(max<dim_t>(0, -id_s), dilate_d)));
+            const int d_back_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd,
+                    div_up(max<dim_t>(0,
+                                   id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                            dilate_d)));
+            p.kd_padding = nstl::max<dim_t>(
+                    0, jcp.kd - d_f_overflow - d_back_overflow);
 
-            int oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
-            for (int oh = oh_s; oh < oh_e; oh += oh_step) {
-                const int gen_kh = ((jcp.kh - 1) * (jcp.dilate_h + 1) + 1);
-                const int gen_stride_h = nstl::min(jcp.stride_h, gen_kh);
+            dim_t oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
+            for (dim_t oh = oh_s; oh < oh_e; oh += oh_step) {
+                const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                const int gen_stride_h = static_cast<int>(
+                        nstl::min<dim_t>(jcp.stride_h, gen_kh));
                 if (!is_inp_buffer_relevant) {
-                    const int iw = nstl::max(
+                    const dim_t iw = nstl::max<dim_t>(
                             0, owb * jcp.ow_block * jcp.stride_w - jcp.l_pad);
 
                     assert(IMPLICATION(
                             jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-                    const int icb = g * (jcp.is_nspc ? jcp.ic : jcp.nb_ic);
+                    const dim_t icb = g * (jcp.is_nspc ? jcp.ic : jcp.nb_ic);
 
                     // generalized kh including dilation
                     // the current implementation of copy routine is not
                     // optimal for small jcp.oh_blk_size as it copies
                     // dilation rows to buffer
                     const bool continuous_copy = gen_kh >= jcp.stride_h;
-                    int current_oh_block = nstl::min(oh_e - oh, oh_step);
-                    int num_copy_calls = continuous_copy ? 1 : current_oh_block;
+                    dim_t current_oh_block
+                            = nstl::min<dim_t>(oh_e - oh, oh_step);
+                    dim_t num_copy_calls
+                            = continuous_copy ? 1 : current_oh_block;
                     for (int ohi = 0; ohi < num_copy_calls; ohi++) {
-                        int ih_copy_start
+                        dim_t ih_copy_start
                                 = (oh + ohi) * jcp.stride_h - jcp.t_pad;
-                        int ih_copy_end = ih_copy_start + gen_kh;
+                        dim_t ih_copy_end = ih_copy_start + gen_kh;
                         if (continuous_copy) {
                             ih_copy_end
                                     += jcp.stride_h * (current_oh_block - 1);
@@ -737,21 +755,23 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                                 //     (oh - 1) * str_h - t_pad + kh
                                 ih_copy_start += gen_kh - jcp.stride_h;
                         }
-                        int ih_zero_top = nstl::max(0, -ih_copy_start);
-                        int ih_zero_bottom = nstl::max(0, ih_copy_end - jcp.ih);
+                        dim_t ih_zero_top = nstl::max<dim_t>(0, -ih_copy_start);
+                        dim_t ih_zero_bottom
+                                = nstl::max<dim_t>(0, ih_copy_end - jcp.ih);
                         // how many real data rows to copy (including padding)
-                        int rows_to_copy = ih_copy_end - ih_copy_start;
-                        p.kh_padding = max(0, rows_to_copy);
-                        p.t_overflow = ih_zero_top;
-                        p.b_overflow = ih_zero_bottom;
-                        p.owb = owb;
-                        int ih = nstl::max(ih_copy_start, 0);
+                        dim_t rows_to_copy = ih_copy_end - ih_copy_start;
+                        p.kh_padding = static_cast<int>(
+                                nstl::max<dim_t>(0, rows_to_copy));
+                        p.t_overflow = static_cast<int>(ih_zero_top);
+                        p.b_overflow = static_cast<int>(ih_zero_bottom);
+                        p.owb = static_cast<int>(owb);
+                        dim_t ih = nstl::max<dim_t>(ih_copy_start, 0);
                         size_t inp_offset
                                 = mem_blk_off(src_d, mb, icb, id_s, ih, iw)
                                 + d_f_overflow * dilate_d * inp_src_d_stride;
                         p.src = src + src_dt_size * inp_offset;
                         // inp_buffer has physical padding
-                        int ih_buf = continuous_copy
+                        dim_t ih_buf = continuous_copy
                                 ? ih_copy_start + jcp.t_pad
                                         - oh_s * jcp.stride_h
                                 : gen_stride_h * (oh + ohi - oh_s);
@@ -762,8 +782,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                         kernel_->copy_to_pbuffer()(&p);
                     }
                 }
-                int ih_buf = gen_stride_h * (oh - oh_s);
-                int ow = owb * jcp.ow_block;
+                dim_t ih_buf = gen_stride_h * (oh - oh_s);
+                dim_t ow = owb * jcp.ow_block;
                 p.src = inp_buffer
                         + src_dt_size * ih_buf * jcp.iwp * jcp.ic_block_int_np;
 
@@ -795,9 +815,9 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 assert(limit_idx < 6);
                 p.ohb = limit_idx;
                 p.last_h = (oh + oh_step <= oh_e);
-                const int zp_owb = nstl::min(jcp.l_pad_blk, owb)
-                        + nstl::max(0, owb - owb_limit);
-                p.owb = req_zero_point_buffer ? zp_owb : owb;
+                const dim_t zp_owb = nstl::min<dim_t>(jcp.l_pad_blk, owb)
+                        + nstl::max<dim_t>(0, owb - owb_limit);
+                p.owb = static_cast<int>(req_zero_point_buffer ? zp_owb : owb);
 
                 p.oc_blocks = occ * jcp.nb_oc_blocking;
 
@@ -808,10 +828,10 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 (*kernel_)(&p);
 
                 if (req_zero_point_buffer) {
-                    zp_oh += accum_with_upper_bound(
+                    zp_oh += accum_with_upper_bound<dim_t>(
                             oh_step, cur_t_pad, cur_b_pad);
-                    cur_t_pad = nstl::max(0, cur_t_pad - oh_step);
-                    cur_b_pad = nstl::max(0, cur_b_pad - oh_step);
+                    cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step);
+                    cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step);
                 }
             }
             last_copied_mb = mb;
@@ -864,9 +884,9 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);
 
-    const int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-    const int ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
-    const int work_amount
+    const dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    const dim_t ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * jcp.id * ih_chunks * jcp.nb_iw * ic_chunks;
 
     const bool is_1d = jcp.ndims == 3;
@@ -874,7 +894,7 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        balance211(static_cast<int>(work_amount), nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
 
@@ -895,84 +915,100 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
+        dim_t mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,
                 ih_chunks, iwb, jcp.nb_iw, icc, ic_chunks);
-        int last_copied_mb = -1;
-        int last_copied_id = -1;
-        int last_copied_ihc = -1;
-        int last_copied_iwb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_id = -1;
+        dim_t last_copied_ihc = -1;
+        dim_t last_copied_iwb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer = inp_p_buffer
                     + ithr * jcp.inp_buffer_size * diff_dst_dt_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-            int ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
-            int icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
+            dim_t ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
+            dim_t icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            const int ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
+            const dim_t ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
 
-            const int ih_b = ihc * jcp.ih_blk_size;
-            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
-            const int iw = iwb * jcp.iw_block;
+            const dim_t ih_b = ihc * jcp.ih_blk_size;
+            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
+            const dim_t iw = iwb * jcp.iw_block;
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
 
             sfd.update_params(id_s);
             p.kd_padding = sfd.get_filter_padding();
-            const int d_lo = sfd.get_lower_offset();
-            const int d_oj = sfd.get_output_offset();
+            const dim_t d_lo = sfd.get_lower_offset();
+            const dim_t d_oj = sfd.get_output_offset();
 
-            int ih_step = jcp.nb_ih_blocking;
-            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
+            dim_t ih_step = jcp.nb_ih_blocking;
+            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
-                    const int dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
+                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h;
+                    const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w;
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const int delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow = 0 < doh_s && doh_s < doh_l
-                            ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max(0, -doh_s);
-                    const int doh_b_overflow = 0 < doh_f && doh_f < doh_l
-                            ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
-                    int dow_s = dow;
-                    int dow_f = dow + jcp.owp - 1;
-                    const int delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow = 0 < dow_s && dow_s < dow_l
-                            ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)
-                            : nstl::max(0, -dow_s);
-                    const int dow_r_overflow = 0 < dow_f && dow_f < dow_l
-                            ? nstl::modulo(dow_f, jcp.stride_w)
-                            : nstl::max(0, nstl::min(delta_w, dow_f - dow_l));
-                    const int oh_s
-                            = utils::div_up(nstl::max(0, doh_s), jcp.stride_h);
-                    const int ow_s
-                            = utils::div_up(nstl::max(0, dow_s), jcp.stride_w);
+                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const int doh_t_overflow
+                            = static_cast<int>(0 < doh_s && doh_s < doh_l
+                                            ? nstl::additive_inverse_modulo(
+                                                      static_cast<dim_t>(doh_s),
+                                                      jcp.stride_h)
+                                            : nstl::max<dim_t>(0, -doh_s));
+                    const int doh_b_overflow = static_cast<int>(
+                            0 < doh_f && doh_f < doh_l
+                                    ? nstl::modulo(static_cast<dim_t>(doh_f),
+                                              jcp.stride_h)
+                                    : nstl::max<dim_t>(0,
+                                              nstl::min<dim_t>(
+                                                      delta_h, doh_f - doh_l)));
+                    dim_t dow_s = dow;
+                    dim_t dow_f = dow + jcp.owp - 1;
+                    const dim_t delta_w = dow_f - dow_s + 1;
+                    const int dow_l_overflow
+                            = static_cast<int>(0 < dow_s && dow_s < dow_l
+                                            ? nstl::additive_inverse_modulo(
+                                                      static_cast<dim_t>(dow_s),
+                                                      jcp.stride_w)
+                                            : nstl::max<dim_t>(0, -dow_s));
+                    const int dow_r_overflow = static_cast<int>(
+                            0 < dow_f && dow_f < dow_l
+                                    ? nstl::modulo(static_cast<dim_t>(dow_f),
+                                              jcp.stride_w)
+                                    : nstl::max<dim_t>(0,
+                                              nstl::min<dim_t>(
+                                                      delta_w, dow_f - dow_l)));
+                    const dim_t oh_s = utils::div_up(
+                            nstl::max<dim_t>(0, doh_s), jcp.stride_h);
+                    const dim_t ow_s = utils::div_up(
+                            nstl::max<dim_t>(0, dow_s), jcp.stride_w);
                     // how many real data rows to copy (including padding)
-                    p.t_overflow = nstl::min(delta_h, doh_t_overflow);
-                    p.b_overflow = nstl::min<size_t>(
-                            delta_h - p.t_overflow, doh_b_overflow);
-                    p.kh_padding = nstl::max<size_t>(
-                            0, delta_h - p.t_overflow - p.b_overflow);
-                    p.l_overflow = nstl::min(delta_w, dow_l_overflow);
-                    p.kw_padding = nstl::max<size_t>(
-                            0, delta_w - dow_l_overflow - dow_r_overflow);
-                    p.r_overflow = nstl::min<size_t>(
-                            delta_w - dow_l_overflow, dow_r_overflow);
+                    p.t_overflow = static_cast<int>(
+                            nstl::min<dim_t>(delta_h, doh_t_overflow));
+                    p.b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            delta_h - p.t_overflow, doh_b_overflow));
+                    p.kh_padding = static_cast<int>(nstl::max<dim_t>(
+                            0, delta_h - p.t_overflow - p.b_overflow));
+                    p.l_overflow = static_cast<int>(
+                            nstl::min<dim_t>(delta_w, dow_l_overflow));
+                    p.kw_padding = static_cast<int>(nstl::max<dim_t>(
+                            0, delta_w - dow_l_overflow - dow_r_overflow));
+                    p.r_overflow = static_cast<int>(nstl::min<dim_t>(
+                            delta_w - dow_l_overflow, dow_r_overflow));
                     size_t inp_offset = is_1d
                             ? diff_dst_d.blk_off(mb, ocb, ow_s)
                             : is_3d
@@ -1049,8 +1085,11 @@ status_t jit_avx512_core_amx_convolution_bwd_weights_t::init(engine_t *engine) {
     }
     if (j.transform_to_vnni) {
         CHECK(safe_ptr_assign(diff_wei_trans_kernel_,
-                new jit_diff_wei_trans_to_vnni_t(j.wei_dt, j.kd, j.kh, j.kw,
-                        j.ic_block, j.oc_block, j.nb_ic)));
+                new jit_diff_wei_trans_to_vnni_t(j.wei_dt,
+                        static_cast<int>(j.kd), static_cast<int>(j.kh),
+                        static_cast<int>(j.kw), static_cast<int>(j.ic_block),
+                        static_cast<int>(j.oc_block),
+                        static_cast<int>(j.nb_ic))));
         CHECK(diff_wei_trans_kernel_->create_kernel());
     }
     return status::success;
@@ -1134,21 +1173,22 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
         ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
                 + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        int work_amount = static_cast<int>(jcp.nthr_mb_work);
         /* reduction dimension */
         balance211(work_amount, self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
+                g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         if (jcp.transform_to_vnni) {
             if (ic_b_start % 2 != 0) ic_b_start++;
             if (ic_b_end != jcp.nb_ic && ic_b_end % 2 != 0) ic_b_end++;
@@ -1158,7 +1198,7 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
 };
 
 size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_src_buf_number(
-        const thread_info_t *ti, int g, int ic) const {
+        const thread_info_t *ti, dim_t g, dim_t ic) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + ic
@@ -1166,7 +1206,7 @@ size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_src_buf_number(
 }
 
 size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_diff_dst_buf_number(
-        const thread_info_t *ti, int g, int oc) const {
+        const thread_info_t *ti, dim_t g, dim_t oc) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_oc * jcp.ngroups + g * jcp.nb_oc + oc
@@ -1174,27 +1214,29 @@ size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_diff_dst_buf_number(
 }
 
 void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
-        src_data_t *tr_src, const src_data_t *src_base, int spatial_start,
-        dim_t spatial_start_offset, int icb_start, dim_t chb_stride,
-        int row_count) const {
+        src_data_t *tr_src, const src_data_t *src_base, dim_t spatial_start,
+        dim_t spatial_start_offset, dim_t icb_start, dim_t chb_stride,
+        dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int src_stride = jcp.iw * jcp.ngroups * jcp.ic;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
-    int work_rest = row_count;
-    int max_spatial_work = jcp.id * jcp.ih;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    dim_t work_rest = row_count;
+    const dim_t max_spatial_work = jcp.id * jcp.ih;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *src = src_base + spatial_start_offset;
-    int icb = 0;
-    const int ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
+    dim_t icb = 0;
+    const dim_t ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = src;
             ctx.tr_src = tr_src;
             assert(icb_start + icb < jcp.nb_ic);
-            ctx.ch_work = (icb_start + icb + 1) == jcp.nb_ic ? ic_tail_work
-                                                             : jcp.ic_block;
+            ctx.ch_work = static_cast<int>((icb_start + icb + 1) == jcp.nb_ic
+                            ? ic_tail_work
+                            : jcp.ic_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_kernel_)(&ctx);
@@ -1202,7 +1244,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
             tr_src += tr_src_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         icb++;
         src = src_base + icb * chb_stride;
     }
@@ -1210,25 +1252,27 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
 
 void jit_avx512_core_amx_convolution_bwd_weights_t::trans_dst_nxc(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst_base,
-        int spatial_start, dim_t spatial_start_offset, int ocb_start,
-        dim_t chb_stride, int row_count) const {
+        dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+        dim_t chb_stride, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
-    int work_rest = row_count;
-    int max_spatial_work = jcp.od * jcp.oh;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    const dim_t diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    dim_t work_rest = row_count;
+    const dim_t max_spatial_work = jcp.od * jcp.oh;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *diff_dst = diff_dst_base + spatial_start_offset;
-    int ocb = 0;
-    const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+    dim_t ocb = 0;
+    const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = diff_dst;
             ctx.tr_src = tr_diff_dst;
             assert(ocb_start + ocb < jcp.nb_oc);
-            ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                             : jcp.oc_block;
+            ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                            ? oc_tail_work
+                            : jcp.oc_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_dst_kernel_)(&ctx);
@@ -1236,7 +1280,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_dst_nxc(
             tr_diff_dst += tr_diff_dst_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         ocb++;
         diff_dst = diff_dst_base + ocb * chb_stride;
     }
@@ -1249,10 +1293,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_hblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_hblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1272,7 +1316,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * adj
@@ -1280,23 +1324,23 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                 + oj * tr_row_size;
     };
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
-        const int ih_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        dim_t ih_s = nstl::max<dim_t>(0, -jcp.t_pad + oh_s * jcp.stride_h);
+        const dim_t ih_e = nstl::min<dim_t>(
                 jcp.ih, -jcp.t_pad + (oh_e - 1) * jcp.stride_h + ext_kh);
 
-        auto tr_src_off = [&](int g, int ic, int ih_end, int ij) {
+        auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ih_end, dim_t ij) {
             const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
             // Aligned to buffer end to use guard elements
@@ -1308,24 +1352,25 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][ih][16][~iw~] <- src[nb_ic][ih][iw][16] */
-            int j {0};
-            int work_amount = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
-            int tr_start {0}, tr_end {0};
+            dim_t j {0};
+            dim_t work_amount = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
+            dim_t tr_start {0}, tr_end {0};
             balance211(
                     work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, ic_b {0};
+            dim_t g {0}, ic_b {0};
             nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work, j,
                     ih_e - ih_s);
 
             if (nthr_oc_b_ > 1)
                 barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int ic_b_ = ic_b + ti->ic_b_start;
-                int j_s = j + ih_s;
-                int j_e = j_s + nstl::min(tr_end - tr_start, ih_e - j_s);
-                const int ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t ic_b_ = ic_b + ti->ic_b_start;
+                dim_t j_s = j + ih_s;
+                dim_t j_e
+                        = j_s + nstl::min<dim_t>(tr_end - tr_start, ih_e - j_s);
+                const dim_t ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
                 const src_data_t *src
                         = &ti->src[src_d.blk_off(img, ic_off_idx, j_s)];
                 src_data_t *tr_src
@@ -1345,18 +1390,19 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start, tr_end);
 
             g = 0;
-            int oc_b = 0;
+            dim_t oc_b = 0;
             nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work, j,
                     oh_e - oh_s);
 
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int oc_b_ = oc_b + ti->oc_b_start;
-                int j_s = j + oh_s;
-                int j_e = j_s + nstl::min(tr_end - tr_start, oh_e - j_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t oc_b_ = oc_b + ti->oc_b_start;
+                dim_t j_s = j + oh_s;
+                dim_t j_e
+                        = j_s + nstl::min<dim_t>(tr_end - tr_start, oh_e - j_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
                 const diff_dst_data_t *diff_dst
                         = &ti->diff_dst[diff_dst_d.blk_off(
                                 img, oc_off_idx, j_s)];
@@ -1371,31 +1417,35 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
 
-        for_(int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int ohb_e = nstl::min(ohb_s + height_block, oh_e);
-            const int ihb_s = nstl::max(0, -jcp.t_pad + ohb_s * jcp.stride_h);
-            const int ihb_e = nstl::min(
+            const dim_t ohb_e = nstl::min<dim_t>(ohb_s + height_block, oh_e);
+            const dim_t ihb_s
+                    = nstl::max<dim_t>(0, -jcp.t_pad + ohb_s * jcp.stride_h);
+            const dim_t ihb_e = nstl::min<dim_t>(
                     jcp.ih, -jcp.t_pad + (ohb_e - 1) * jcp.stride_h + ext_kh);
             assert(IMPLICATION(jcp.global_transpose,
                     oh_s == ohb_s && oh_e == ohb_e && ih_s == ihb_s
                             && ih_e == ihb_e));
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
@@ -1403,8 +1453,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                 src_data_t *tr_src
                         = &ti->tr_src[tr_src_off(0, 0, ihb_e, ihb_s)];
 
-                for (int icb = 0; icb < nb_ic_blocks; icb++) {
-                    const int ic_off_idx
+                for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+                    const dim_t ic_off_idx
                             = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
                     const src_data_t *src
                             = (src_data_t *)&ti->src[src_d.blk_off(
@@ -1422,8 +1472,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             if (!jcp.global_transpose) {
                 diff_dst_data_t *tr_diff_dst
                         = &ti->tr_diff_dst[tr_diff_dst_off(0, 0, 0)];
-                for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-                    const int oc_off_idx
+                for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+                    const dim_t oc_off_idx
                             = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
                     const diff_dst_data_t *diff_dst
                             = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1445,10 +1495,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     + oc_b * jcp.oc_block;
             p.channel = (start == ti->img_start) && (ohb_s == oh_s);
 
-            p.reduce_work = ic_to_compute;
-            p.load_work = oc_to_compute; // it's only for mask
-            p.os_index_begin = ohb_s;
-            p.os_index_end = ohb_e;
+            p.reduce_work = static_cast<int>(ic_to_compute);
+            p.load_work = static_cast<int>(oc_to_compute); // it's only for mask
+            p.os_index_begin = static_cast<int>(ohb_s);
+            p.os_index_end = static_cast<int>(ohb_e);
             p.flags = 0 | (ic_b == 0 ? FLAG_IC_FIRST : 0);
             p.last_ic_block = (nb_ic_blocks == jcp.nb_ic_blocking) ? 0 : 1;
             p.last_oc_block = (nb_oc_blocks == jcp.nb_oc_blocking) ? 0 : 1;
@@ -1466,10 +1516,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_dblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_dblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1489,7 +1539,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od) {
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
@@ -1497,22 +1547,22 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size;
     };
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
-        const int id_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        dim_t id_s = nstl::max<dim_t>(0, -jcp.f_pad + od_s * jcp.stride_d);
+        const dim_t id_e = nstl::min<dim_t>(
                 jcp.id, -jcp.f_pad + (od_e - 1) * jcp.stride_d + ext_kd);
 
-        auto tr_src_off_3d = [&](int g, int ic, int id_end, int id) {
+        auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id_end, dim_t id) {
             const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             const size_t tr_3d_size = tr_row_size * jcp.ih;
             int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
@@ -1525,15 +1575,15 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][id][16][~iw~] <- src[nb_ic][id][iw][16] */
-            int d {0};
+            dim_t d {0};
 
-            int work_amount = ti->g_work * ti->ic_b_work * (id_e - id_s);
+            dim_t work_amount = ti->g_work * ti->ic_b_work * (id_e - id_s);
 
-            int tr_start {0}, tr_end {0};
+            dim_t tr_start {0}, tr_end {0};
             balance211(
                     work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, ic_b {0};
+            dim_t g {0}, ic_b {0};
 
             nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work, d,
                     id_e - id_s);
@@ -1541,12 +1591,13 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (nthr_oc_b_ > 1)
                 barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int ic_b_ = ic_b + ti->ic_b_start;
-                int d_s = d + id_s;
-                int d_e = d_s + nstl::min(tr_end - tr_start, id_e - d_s);
+                dim_t g_ = g + ti->g_start;
+                dim_t ic_b_ = ic_b + ti->ic_b_start;
+                dim_t d_s = d + id_s;
+                dim_t d_e
+                        = d_s + nstl::min<dim_t>(tr_end - tr_start, id_e - d_s);
 
-                const int ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
+                const dim_t ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
                 const src_data_t *src
                         = &ti->src[src_d.blk_off(img, ic_off_idx, d_s)];
                 src_data_t *tr_src
@@ -1568,7 +1619,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                     work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start, tr_end);
 
             g = 0;
-            int oc_b = 0;
+            dim_t oc_b = 0;
 
             nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work, d,
                     od_e - od_s);
@@ -1576,11 +1627,12 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int oc_b_ = oc_b + ti->oc_b_start;
-                int d_s = d + od_s;
-                int d_e = d_s + nstl::min(tr_end - tr_start, od_e - d_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t oc_b_ = oc_b + ti->oc_b_start;
+                dim_t d_s = d + od_s;
+                dim_t d_e
+                        = d_s + nstl::min<dim_t>(tr_end - tr_start, od_e - d_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
 
                 const diff_dst_data_t *diff_dst
                         = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1598,40 +1650,43 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
 
-        int depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
+        dim_t depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
 
-        for_(int odb_s = od_s; odb_s < od_e; odb_s += depth_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t odb_s = od_s; odb_s < od_e; odb_s += depth_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int odb_e = nstl::min(odb_s + depth_block, od_e);
-            const int idb_s = nstl::max(0, -jcp.f_pad + odb_s * jcp.stride_d);
-            const int idb_e = nstl::min(
+            const dim_t odb_e = nstl::min<dim_t>(odb_s + depth_block, od_e);
+            const dim_t idb_s
+                    = nstl::max<dim_t>(0, -jcp.f_pad + odb_s * jcp.stride_d);
+            const dim_t idb_e = nstl::min<dim_t>(
                     jcp.id, -jcp.f_pad + (odb_e - 1) * jcp.stride_d + ext_kd);
-            const int kdb_front_pad
-                    = nstl::max(0, jcp.f_pad - odb_s * jcp.stride_d);
+            const dim_t kdb_front_pad
+                    = nstl::max<dim_t>(0, jcp.f_pad - odb_s * jcp.stride_d);
             // Assumes kd_back_pad = 0 when kernel is dilated
-            const int kdb_back_pad = nstl::max(
+            const dim_t kdb_back_pad = nstl::max<dim_t>(
                     0, odb_s * jcp.stride_d + jcp.kd - jcp.f_pad - jcp.id);
-            const int kdb_pad_off = nstl::min(jcp.kd - 1, kdb_front_pad)
-                    * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
-                    * jcp.typesize_out;
+            const dim_t kdb_pad_off
+                    = nstl::min<dim_t>(jcp.kd - 1, kdb_front_pad) * jcp.kh
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
             assert(IMPLICATION(jcp.global_transpose,
                     od_s == odb_s && od_e == odb_e && id_s == idb_s
                             && id_e == idb_e));
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
@@ -1639,8 +1694,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 src_data_t *tr_src
                         = &ti->tr_src[tr_src_off_3d(0, 0, idb_e, idb_s)];
 
-                for (int icb = 0; icb < nb_ic_blocks; icb++) {
-                    const int ic_off_idx
+                for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+                    const dim_t ic_off_idx
                             = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
                     const src_data_t *src
                             = (src_data_t *)&ti->src[src_d.blk_off(
@@ -1658,8 +1713,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (!jcp.global_transpose) {
                 diff_dst_data_t *tr_diff_dst
                         = &ti->tr_diff_dst[tr_diff_dst_off_3d(0, 0, 0)];
-                for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-                    const int oc_off_idx
+                for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+                    const dim_t oc_off_idx
                             = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
                     const diff_dst_data_t *diff_dst
                             = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1704,9 +1759,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1726,23 +1781,24 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_src_off = [&](int g, int ic, int nb_ic_block, int ij) {
+    auto tr_src_off = [&](dim_t g, dim_t ic, dim_t nb_ic_block, dim_t ij) {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size * adj
                 + ij * tr_row_size + nb_ic_block * jcp.tr_src_buf_size;
     };
 
-    auto tr_src_off_3d = [&](int g, int ic, int nb_ic_block, int id, int ij) {
+    auto tr_src_off_3d
+            = [&](dim_t g, dim_t ic, dim_t nb_ic_block, dim_t id, dim_t ij) {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         const size_t tr_3d_size = tr_row_size * jcp.ih;
-        int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
+        dim_t adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size * adj
                 + id * tr_3d_size + ij * tr_row_size
                 + nb_ic_block * jcp.tr_src_buf_size;
     };
 
-    auto tr_diff_dst_off = [&](int g, int oc, int nb_oc_block, int oj) {
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t nb_oc_block, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
@@ -1751,26 +1807,26 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
     };
 
     auto tr_diff_dst_off_3d
-            = [&](int g, int oc, int nb_oc_block, int od, int oj) {
+            = [&](dim_t g, dim_t oc, dim_t nb_oc_block, dim_t od, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh;
-        int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
+        dim_t adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 * adj
                 + od * tr_3d_size + oj * tr_row_size
                 + nb_oc_block * jcp.tr_src_buf_size;
     };
 
-    auto uker_trans
-            = [&](int img, int g = 0, int ic_b = 0, int nb_ic_block = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.ih * jcp.id;
-        int ic;
-        int icb_start = ic_b;
+    auto uker_trans = [&](dim_t img, dim_t g = 0, dim_t ic_b = 0,
+                              dim_t nb_ic_block = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.ih * jcp.id;
+        dim_t ic;
+        dim_t icb_start = ic_b;
         if (jcp.global_transpose) {
-            const int work_amount = ti->ic_b_work * jcp.ih * jcp.id;
+            const dim_t work_amount = ti->ic_b_work * jcp.ih * jcp.id;
 
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, start, end);
             my_work = end - start;
 
@@ -1792,7 +1848,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
         const bool need_local_gwork = jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) ic = gg * jcp.ic + ic_b * jcp.ic_block;
             src_data_t *tr_src = (jcp.ndims == 5)
                     ? &ti->tr_src[tr_src_off_3d(gg, ic_b, nb_ic_block, d, j)]
@@ -1803,23 +1859,23 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
             dim_t sp_start_offset = (jcp.ndims == 5) ? src_d.blk_off(0, 0, d, j)
                                                      : src_d.blk_off(0, 0, j);
             dim_t ch_shift = src_d.blk_off(0, jcp.ic_block);
-            int sp_start_idx = d * jcp.ih + j;
+            dim_t sp_start_idx = d * jcp.ih + j;
             trans_src_nxc(tr_src, src, sp_start_idx, sp_start_offset, icb_start,
                     ch_shift, my_work);
         }
     };
 
-    auto diff_dst_trans
-            = [&](int img, int g = 0, int oc_b = 0, int nb_oc_block = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.oh * jcp.od;
-        int oc;
-        int ocb_start = oc_b;
+    auto diff_dst_trans = [&](dim_t img, dim_t g = 0, dim_t oc_b = 0,
+                                  dim_t nb_oc_block = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.oh * jcp.od;
+        dim_t oc;
+        dim_t ocb_start = oc_b;
 
         if (jcp.global_transpose) {
-            const size_t work_amount = ti->oc_b_work * jcp.oh * jcp.od;
+            const dim_t work_amount = ti->oc_b_work * jcp.oh * jcp.od;
 
-            size_t start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, start, end);
             my_work = end - start;
 
@@ -1841,7 +1897,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
         const bool need_local_gwork = jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(
@@ -1855,7 +1911,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                     ? diff_dst_d.blk_off(0, 0, d, j)
                     : diff_dst_d.blk_off(0, 0, j);
             dim_t ch_shift = diff_dst_d.blk_off(0, jcp.oc_block);
-            int sp_start_idx = d * jcp.oh + j;
+            dim_t sp_start_idx = d * jcp.oh + j;
             trans_dst_nxc(tr_diff_dst, diff_dst, sp_start_idx, sp_start_offset,
                     ocb_start, ch_shift, my_work);
         }
@@ -1884,22 +1940,24 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                 oc_b += jcp.nb_oc_blocking)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
 
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
             if (!jcp.global_transpose) {
-                for (int nib = 0; nib < nb_ic_blocks; nib++)
+                for (dim_t nib = 0; nib < nb_ic_blocks; nib++)
                     uker_trans(img, g, ic_b + nib, nib);
             }
             if (jcp.ndims == 5) {
@@ -1981,7 +2039,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1);
 
     const bool is_bf16_out = diff_weights_d.data_type() == data_type::bf16;
@@ -1993,8 +2051,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
             if (jcp.transform_to_vnni) {
                 store_in_vnni_format(ti);
             } else {
-                for_(int g = ti->g_start; g < ti->g_end; g++)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+                for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh
                             * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1)
                             * jcp.ic_block * jcp.oc_block;
@@ -2007,12 +2065,12 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
             }
         }
         if (is_bf16_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx = g * jcp.oc_without_padding
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx = g * jcp.oc_without_padding
                         + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
                 bfloat16_t *diff_bias
@@ -2028,26 +2086,26 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, nthr_mb_, ti->ithr_mb, start, end);
     if (!jcp.transform_to_vnni && start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
@@ -2086,18 +2144,18 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
                 float *bias_reduced = is_bf16_bias ? ti->bia_reduction
                                                    : (float *)(ti->diff_bias);
                 int thr_mb_buffer_idx = is_bf16_bias ? thr_mb : thr_mb - 1;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (is_bf16_bias && thr_mb == nthr_mb_ - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx = g * jcp.oc_without_padding
+                    dim_t diff_bias_idx = g * jcp.oc_without_padding
                             + ti->oc_b_start * jcp.oc_block;
                     add_floats_and_cvt_to_bfloat16(
                             (bfloat16_t *)(ti->diff_bias) + diff_bias_idx,
@@ -2132,7 +2190,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::prepare_scratchpad_data(
     for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
         src_data_t *ts
                 = &tr_src[ithr * jcp.tr_src_buf_size * jcp.nb_ic_blocking];
-        for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
+        for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
             ts[i] = 0;
     }
 
@@ -2228,9 +2286,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -260,15 +260,16 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    size_t tr_src_buf_number(const thread_info_t *ti, int g, int ic) const;
-    size_t tr_diff_dst_buf_number(const thread_info_t *ti, int g, int oc) const;
+    size_t tr_src_buf_number(const thread_info_t *ti, dim_t g, dim_t ic) const;
+    size_t tr_diff_dst_buf_number(
+            const thread_info_t *ti, dim_t g, dim_t oc) const;
     void trans_src_nxc(src_data_t *tr_src, const src_data_t *src_base,
-            int spatial_start, dim_t spatial_start_offset, int icb_start,
-            dim_t chb_stride, int my_work) const;
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t icb_start,
+            dim_t chb_stride, dim_t my_work) const;
     void trans_dst_nxc(diff_dst_data_t *tr_diff_dst,
-            const diff_dst_data_t *diff_dst_base, int spatial_start,
-            dim_t spatial_start_offset, int ocb_start, dim_t chb_stride,
-            int my_work) const;
+            const diff_dst_data_t *diff_dst_base, dim_t spatial_start,
+            dim_t spatial_start_offset, dim_t ocb_start, dim_t chb_stride,
+            dim_t my_work) const;
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 
@@ -280,7 +281,8 @@ private:
     std::unique_ptr<jit_trans_src_t> trans_kernel_;
     std::unique_ptr<jit_trans_dst_t> trans_dst_kernel_;
 
-    inline dim_t wei_offset_int(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_int(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = kernel_->jcp;
         const dim_t const_extra_offset = jcp.kw * jcp.ic_block * jcp.oc_block;
         dim_t extra_offset = (jcp.ndims == 5) ? kX * jcp.kh * const_extra_offset
@@ -289,9 +291,10 @@ private:
                 * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
                 + extra_offset;
     }
-    inline dim_t wei_offset_ext(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_ext(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = kernel_->jcp;
-        const int nb_ic = utils::div_up(jcp.ic, 2 * jcp.ic_block);
+        const dim_t nb_ic = utils::div_up(jcp.ic, 2 * jcp.ic_block);
         const dim_t const_extra_offset
                 = static_cast<dim_t>(jcp.kw) * jcp.ic_block * jcp.oc_block * 2;
         dim_t extra_offset = (jcp.ndims == 5) ? kX * jcp.kh * const_extra_offset

--- a/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
@@ -75,7 +75,7 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
 
     const dim_t wei_g_shift = wht_blk_off(weights_d, 1, 0);
     const dim_t wei_ic_shift = wht_blk_off(weights_d, 0, jcp.nb_ic_blocking);
-    const size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+    const dim_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
     auto inp_p_buffer = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_inp_buffer);
@@ -84,9 +84,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);
 
-    const int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-    const int ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
-    const int work_amount
+    const dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    const dim_t ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * jcp.id * ih_chunks * jcp.nb_iw * ic_chunks;
 
     const bool is_1d = jcp.ndims == 3;
@@ -108,7 +108,7 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     });
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -130,88 +130,90 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
+        dim_t mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,
                 ih_chunks, iwb, jcp.nb_iw, icc, ic_chunks);
-        int last_copied_mb = -1;
-        int last_copied_id = -1;
-        int last_copied_ihc = -1;
-        int last_copied_iwb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_id = -1;
+        dim_t last_copied_ihc = -1;
+        dim_t last_copied_iwb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + ithr * jcp.inp_buffer_size * src_dt_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-            int ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
-            int icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
+            dim_t ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
+            dim_t icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            const int ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
+            const dim_t ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
             auto bias_w = bias_ptr
                     ? bias_ptr + (bias_d.blk_off(ic) * bia_dt_size)
                     : nullptr;
 
-            const int ih_b = ihc * jcp.ih_blk_size;
-            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
-            const int iw = iwb * jcp.iw_block;
+            const dim_t ih_b = ihc * jcp.ih_blk_size;
+            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
+            const dim_t iw = iwb * jcp.iw_block;
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
 
             sfd.update_params(id_s);
             p.kd_padding = sfd.get_filter_padding();
-            const int d_lo = sfd.get_lower_offset();
-            const int d_oj = sfd.get_output_offset();
+            const dim_t d_lo = sfd.get_lower_offset();
+            const dim_t d_oj = sfd.get_output_offset();
 
-            int ih_step = jcp.nb_ih_blocking;
-            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
+            const dim_t ih_step = jcp.nb_ih_blocking;
+            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
-                    const int dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
+                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
+                    const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const int delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow = 0 < doh_s && doh_s < doh_l
+                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const dim_t doh_t_overflow = 0 < doh_s && doh_s < doh_l
                             ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max(0, -doh_s);
-                    const int doh_b_overflow = 0 < doh_f && doh_f < doh_l
+                            : nstl::max<dim_t>(0, -doh_s);
+                    const dim_t doh_b_overflow = 0 < doh_f && doh_f < doh_l
                             ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
-                    int dow_s = dow;
-                    int dow_f = dow + jcp.owp - 1;
-                    const int delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow = 0 < dow_s && dow_s < dow_l
+                            : nstl::max<dim_t>(0,
+                                      nstl::min<dim_t>(delta_h, doh_f - doh_l));
+                    dim_t dow_s = dow;
+                    dim_t dow_f = dow + jcp.owp - 1;
+                    const dim_t delta_w = dow_f - dow_s + 1;
+                    const dim_t dow_l_overflow = 0 < dow_s && dow_s < dow_l
                             ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)
-                            : nstl::max(0, -dow_s);
-                    const int dow_r_overflow = 0 < dow_f && dow_f < dow_l
+                            : nstl::max<dim_t>(0, -dow_s);
+                    const dim_t dow_r_overflow = 0 < dow_f && dow_f < dow_l
                             ? nstl::modulo(dow_f, jcp.stride_w)
-                            : nstl::max(0, nstl::min(delta_w, dow_f - dow_l));
-                    const int oh_s
-                            = utils::div_up(nstl::max(0, doh_s), jcp.stride_h);
-                    const int ow_s
-                            = utils::div_up(nstl::max(0, dow_s), jcp.stride_w);
+                            : nstl::max<dim_t>(0,
+                                      nstl::min<dim_t>(delta_w, dow_f - dow_l));
+                    const dim_t oh_s = utils::div_up(
+                            nstl::max<dim_t>(0, doh_s), jcp.stride_h);
+                    const dim_t ow_s = utils::div_up(
+                            nstl::max<dim_t>(0, dow_s), jcp.stride_w);
                     // how many real data rows to copy (including padding)
-                    p.t_overflow = nstl::min(delta_h, doh_t_overflow);
-                    p.b_overflow = nstl::min<size_t>(
+                    p.t_overflow = nstl::min<dim_t>(delta_h, doh_t_overflow);
+                    p.b_overflow = nstl::min<dim_t>(
                             delta_h - p.t_overflow, doh_b_overflow);
-                    p.kh_padding = nstl::max<size_t>(
+                    p.kh_padding = nstl::max<dim_t>(
                             0, delta_h - p.t_overflow - p.b_overflow);
-                    p.l_overflow = nstl::min(delta_w, dow_l_overflow);
-                    p.kw_padding = nstl::max<size_t>(
+                    p.l_overflow = nstl::min<dim_t>(delta_w, dow_l_overflow);
+                    p.kw_padding = nstl::max<dim_t>(
                             0, delta_w - dow_l_overflow - dow_r_overflow);
-                    p.r_overflow = nstl::min<size_t>(
+                    p.r_overflow = nstl::min<dim_t>(
                             delta_w - dow_l_overflow, dow_r_overflow);
-                    size_t inp_offset = is_1d ? src_d.blk_off(mb, ocb, ow_s)
+                    dim_t inp_offset = is_1d ? src_d.blk_off(mb, ocb, ow_s)
                             : is_3d ? src_d.blk_off(mb, ocb, d_oj, oh_s, ow_s)
                                     : src_d.blk_off(mb, ocb, oh_s, ow_s);
                     p.src = src + src_dt_size * inp_offset;
@@ -222,9 +224,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
                     kernel_->bwd_data_copy_kernel()(&p);
                 }
 
-                size_t dst_offset = is_1d ? dst_d.blk_off(mb, icb, iw)
-                        : is_3d           ? dst_d.blk_off(mb, icb, id_s, ih, iw)
-                                          : dst_d.blk_off(mb, icb, ih, iw);
+                dim_t dst_offset = is_1d ? dst_d.blk_off(mb, icb, iw)
+                        : is_3d          ? dst_d.blk_off(mb, icb, id_s, ih, iw)
+                                         : dst_d.blk_off(mb, icb, ih, iw);
                 p.dst = inp_buffer
                         + (size_t)(ih - ih_b) * jcp.owp * jcp.oc_block_int
                                 * src_dt_size;

--- a/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
@@ -153,9 +153,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
                     ? bias_ptr + (bias_d.blk_off(ic) * bia_dt_size)
                     : nullptr;
 
-            const dim_t ih_b = ihc * jcp.ih_blk_size;
-            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
-            const dim_t iw = iwb * jcp.iw_block;
+            const int ih_b = static_cast<int>(ihc * jcp.ih_blk_size);
+            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
+            const int iw = static_cast<int>(iwb * jcp.iw_block);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
@@ -165,31 +165,30 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
             const dim_t d_lo = sfd.get_lower_offset();
             const dim_t d_oj = sfd.get_output_offset();
 
-            const dim_t ih_step = jcp.nb_ih_blocking;
-            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
+            const int ih_step = jcp.nb_ih_blocking;
+            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
+                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
                     const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const int delta_h = doh_f - doh_s + 1;
                     const dim_t doh_t_overflow = 0 < doh_s && doh_s < doh_l
                             ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max<dim_t>(0, -doh_s);
+                            : nstl::max(0, -doh_s);
                     const dim_t doh_b_overflow = 0 < doh_f && doh_f < doh_l
                             ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max<dim_t>(0,
-                                      nstl::min<dim_t>(delta_h, doh_f - doh_l));
-                    dim_t dow_s = dow;
-                    dim_t dow_f = dow + jcp.owp - 1;
+                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
+                    int dow_s = dow;
+                    int dow_f = dow + jcp.owp - 1;
                     const dim_t delta_w = dow_f - dow_s + 1;
                     const dim_t dow_l_overflow = 0 < dow_s && dow_s < dow_l
                             ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the AMX 1x1/general JIT convolution and deconvolution kernels (`jit_avx512_core_amx_1x1_conv_kernel`, `jit_avx512_core_amx_conv_kernel`, `jit_avx512_core_amx_conv_utils`, `jit_avx512_core_amx_convolution`, `jit_avx512_core_amx_deconvolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5661 for review convenience; independently reviewable.