### PR TITLE
cpu: conv: BF16: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -41,9 +41,9 @@ using namespace dnnl::impl::cpu::x64::bf16_support;
 // "declared with greater visibility than the type of its field"
 // when one lambda function is delcared whithin the other one
 void store_bfloat16_in_parallel(bfloat16_t *output_data, const float *acc_data,
-        size_t parallel_work, size_t parallel_work_size, bool do_in_parallel) {
+        dim_t parallel_work, dim_t parallel_work_size, bool do_in_parallel) {
     parallel(do_in_parallel ? 0 : 1, [&](const int ithr, const int nthr) {
-        size_t start = 0, end = 0;
+        dim_t start = 0, end = 0;
         balance211(parallel_work, nthr, ithr, start, end);
         if (start < end)
             cvt_float_to_bfloat16(&output_data[start * parallel_work_size],
@@ -52,11 +52,11 @@ void store_bfloat16_in_parallel(bfloat16_t *output_data, const float *acc_data,
     });
 }
 
-void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, size_t g_start, size_t g_end,
+void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, dim_t g_start, dim_t g_end,
         const float *acc_base, bfloat16_t *diff_weights) {
-    const size_t parallel_work_size = jcp.ic * jcp.ks;
+    const dim_t parallel_work_size = jcp.ic * jcp.ks;
     parallel(jcp.nthr == 1 ? 0 : 1, [&](const int ithr, const int nthr) {
-        size_t w_start = 0, w_end = 0;
+        dim_t w_start = 0, w_end = 0;
         balance211(parallel_work_size, nthr, ithr, w_start, w_end);
         for_(auto w = w_start; w < w_end; ++w)
         for (auto g = g_start; g < g_end; ++g) {
@@ -135,7 +135,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 
 template <data_type_t dst_data_type>
 void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::apply_postops(
-        const bool apply_mask, const size_t out_offset, const int vmm_idx) {
+        const bool apply_mask, const dim_t out_offset, const int vmm_idx) {
 #define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
@@ -178,7 +178,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
 
     // Load accumulated value, apply sum (if any), bias (if any)
     // and relu (if any); then convert to destination type and store
-    auto compute = [&](size_t offset, int idx, bool apply_mask) {
+    auto compute = [&](dim_t offset, int idx, bool apply_mask) {
         auto acc_addr = ptr[reg_acc + offset * sizeof(acc_data_t)];
         auto vreg_dst_ = vreg_dst(idx);
 
@@ -231,9 +231,9 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
     };
 
     // Advance all pointers by an immediate
-    auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * sizeof(dst_data_t));
-        add(reg_acc, offset * sizeof(acc_data_t));
+    auto advance_ptrs_imm = [&](dim_t offset) {
+        add(reg_dst, offset * static_cast<dim_t>(sizeof(dst_data_t)));
+        add(reg_acc, offset * static_cast<dim_t>(sizeof(acc_data_t)));
     };
 
     Xbyak::Label oc_loop, oc_loop_end;
@@ -258,7 +258,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
         const int unroll = 1 << i; // 4, 2, 1
         L(l_simd_loop[i + 1]);
         {
-            const int loop_len = unroll * vlen_;
+            const int loop_len = static_cast<int>(unroll * vlen_);
             cmp(reg_len_iter, loop_len);
             jl(l_simd_loop[i], T_NEAR);
             for (int j = 0; j < unroll; j++)
@@ -393,17 +393,15 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Src Format: mb-spatial-groups-input_channels
-    const size_t src_mb_stride = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw
-            * jcp.ngroups * jcp.ic;
-    const size_t src_g_stride = jcp.ic;
+    const dim_t src_mb_stride = jcp.id * jcp.ih * jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t src_g_stride = jcp.ic;
     // Wei Format: spatial-input_channels-groups-output_channels
-    const size_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
+    const dim_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
 
     // Dst Format: mb-spatial-groups-output_channels
-    const size_t dst_mb_stride = static_cast<size_t>(jcp.od) * jcp.oh * jcp.ow
-            * jcp.ngroups * jcp.oc;
-    const size_t dst_g_stride = jcp.oc;
-    const size_t dst_os_stride = jcp.ngroups * jcp.oc;
+    const dim_t dst_mb_stride = jcp.od * jcp.oh * jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t dst_g_stride = jcp.oc;
+    const dim_t dst_os_stride = jcp.ngroups * jcp.oc;
 
     src_data_t *__restrict col = scratchpad.get<src_data_t>(key_conv_gemm_col)
             + (ptrdiff_t)ithr * jcp.im2col_sz;
@@ -439,18 +437,18 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
         constexpr uint16_t zero_val = 0;
 
         PRAGMA_OMP_SIMD()
-        for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+        for (dim_t i = 0; i < jcp.im2col_sz; i++)
             col_r[i] = zero_val;
     }
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        int oh = ohb * jcp.oh_block;
-        int ow = owb * jcp.ow_block;
+        dim_t oh = ohb * jcp.oh_block;
+        dim_t ow = owb * jcp.ow_block;
         const src_data_t *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const wei_data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
 
@@ -488,7 +486,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
             const bool do_postprocess = pd()->is_postprocess_required();
             if (do_postprocess) {
                 parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, N,
-                        [&](size_t ithr, size_t nthr, size_t os) {
+                        [&](int ithr, int nthr, dim_t os) {
                     const float *__restrict acc_arr = acc + os * jcp.oc;
                     const float *__restrict bia_arr = (bia_base == nullptr)
                             ? nullptr
@@ -550,22 +548,21 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
     const float sum_scale = do_sum ? post_ops.entry_[0].sum.scale : 0;
 
     const dim_t M = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * M;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-    const size_t weights_oc_size = jcp.ic * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * M;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+    const dim_t weights_oc_size = jcp.ic * jcp.ks;
 
     const dim_t LDB = weights_oc_size;
-    const dim_t work_amount
-            = (size_t)jcp.ngroups * jcp.mb * jcp.od * jcp.os_nb_block;
+    const dim_t work_amount = jcp.ngroups * jcp.mb * jcp.od * jcp.os_nb_block;
     const bool is_problem_3d = pd()->ndims() == 5;
     std::atomic<status_t> st(status::success);
 
-    auto inner_ker = [&](const int ic, const int oc, const int groups,
-                             const int od, const int spatial,
+    auto inner_ker = [&](const dim_t ic, const dim_t oc, const dim_t groups,
+                             const dim_t od, const dim_t spatial,
                              const src_data_t *src, const wei_data_t *weights,
                              src_data_t *col, dst_data_t *dst_im,
-                             acc_data_t *acc, int ic_block, int oc_block) {
+                             acc_data_t *acc, dim_t ic_block, dim_t oc_block) {
         const dim_t os_block = nstl::min(
                 (dim_t)jcp.os_block, (dim_t)jcp.os - spatial * jcp.os_block);
 
@@ -600,8 +597,8 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
         }
 
         if (this->pd()->is_postprocess_required() && ic + ic_block >= jcp.ic) {
-            size_t acc_str = LDC;
-            size_t dst_str = M;
+            const dim_t acc_str = LDC;
+            const dim_t dst_str = M;
             float *bias_ptr = bias ? bias + groups * jcp.oc + oc : nullptr;
             (*pp_ker_)(dst_local, acc, bias_ptr, sum_scale, dst_str, acc_str, m,
                     oc_block, post_ops_binary_rhs_arg_vec.data(), dst,
@@ -614,7 +611,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
         if (is_problem_3d) {
             // jit_gemm_convolution_utils::im2col_3d() requires external
             // data initialization by zeroes
-            for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+            for (dim_t i = 0; i < jcp.im2col_sz; i++)
                 _col[i] = (src_data_t)0;
         }
         dim_t g {0}, n {0}, od {0}, nb_os {0};
@@ -691,18 +688,18 @@ status_t gemm_bf16_convolution_bwd_data_t<
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Diff_dst Format: mb-spatial-groups-output_channels
-    const size_t diff_dst_mb_stride = static_cast<size_t>(jcp.od) * jcp.oh
-            * jcp.ow * jcp.ngroups * jcp.oc;
-    const size_t diff_dst_g_stride = jcp.oc;
+    const dim_t diff_dst_mb_stride
+            = jcp.od * jcp.oh * jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t diff_dst_g_stride = jcp.oc;
 
     // Wei Format: spatial-input_channels-groups-output_channels
-    const size_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
+    const dim_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
 
     // Diff_src Format: mb-spatial-groups-input_channels
-    const size_t diff_src_mb_stride = static_cast<size_t>(jcp.id) * jcp.ih
-            * jcp.iw * jcp.ngroups * jcp.ic;
-    const size_t diff_src_g_stride = jcp.ic;
-    const size_t diff_src_os_stride = jcp.ngroups * jcp.ic;
+    const dim_t diff_src_mb_stride
+            = jcp.id * jcp.ih * jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t diff_src_g_stride = jcp.ic;
+    const dim_t diff_src_os_stride = jcp.ngroups * jcp.ic;
 
     // threads share work across mini-batch and groups
     const dim_t work_amount = jcp.ngroups * jcp.mb;
@@ -743,11 +740,10 @@ status_t gemm_bf16_convolution_bwd_data_t<
 
         if (is_diff_src_bf16 && jcp.ngroups == 1 && jcp.nthr != 1) {
             cvt_float_to_bfloat16((bfloat16_t *)diff_src, (const float *)acc,
-                    static_cast<size_t>(jcp.is) * jcp.id * jcp.ic);
+                    jcp.is * jcp.id * jcp.ic);
         } else if (is_diff_src_bf16) {
-            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1,
-                    static_cast<size_t>(jcp.is) * jcp.id,
-                    [&](size_t ithr, size_t nthr, size_t is) {
+            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, jcp.is * jcp.id,
+                    [&](int ithr, int nthr, dim_t is) {
                 diff_src_data_t *__restrict diff_src_loc
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
@@ -756,9 +752,8 @@ status_t gemm_bf16_convolution_bwd_data_t<
             });
         } else {
             assert(diff_src_data_type == data_type::f32);
-            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1,
-                    static_cast<size_t>(jcp.is) * jcp.id,
-                    [&](size_t ithr, size_t nthr, size_t is) {
+            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, jcp.is * jcp.id,
+                    [&](int ithr, int nthr, dim_t is) {
                 diff_src_data_t *__restrict diff_src_loc
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
@@ -789,15 +784,15 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
     const conv_gemm_conf_t &jcp = this->pd()->jcp_;
 
     const dim_t M = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * M;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * M;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
 
     const dim_t m = jcp.os_block;
     const dim_t K = jcp.oc;
     const dim_t N = jcp.ic * jcp.ks;
 
-    const dim_t work_amount = (size_t)jcp.ngroups * jcp.mb;
+    const dim_t work_amount = jcp.ngroups * jcp.mb;
     const bool is_problem_3d = pd()->ndims() == 5;
 
     std::atomic<status_t> st(status::success);
@@ -820,7 +815,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
             if (is_problem_3d && jcp.im2col_sz > 0) {
                 // jit_gemm_convolution_utils::col2im_3d() assumes that the
                 // accumulator is initialized by zeroes
-                for (size_t i = 0; i < src_step; i++)
+                for (dim_t i = 0; i < src_step; i++)
                     acc[i] = (acc_data_t)0;
             }
 
@@ -854,7 +849,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
                 }
             }
             if (diff_src_data_type == data_type::bf16) {
-                size_t spatial_size = (size_t)jcp.ih * jcp.iw * jcp.id;
+                const dim_t spatial_size = jcp.ih * jcp.iw * jcp.id;
                 store_bfloat16_in_parallel((bfloat16_t *)diff_src_local,
                         (const float *)acc, jcp.ic, spatial_size,
                         jcp.nthr == 1);
@@ -869,7 +864,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
 template <data_type_t diff_wei_data_type>
 void gemm_bf16_convolution_bwd_weights_t<
         diff_wei_data_type>::bf16_bwd_weights_reduction_par_nspc(int ithr_mb,
-        int nthr_mb, size_t g_start, size_t g_end, const conv_gemm_conf_t &jcp,
+        int nthr_mb, dim_t g_start, dim_t g_end, const conv_gemm_conf_t &jcp,
         const acc_data_t *weights_reduce_base,
         diff_wei_data_t *weights_base) const {
     assert(nthr_mb > 1); // no reduction for nthr_mb == 1
@@ -911,20 +906,20 @@ void gemm_bf16_convolution_bwd_weights_t<
     assert(nthr_mb > 1); // no reduction for nthr_mb == 1
 
     const bool is_bf16_out = diff_wei_data_type == data_type::bf16;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-    size_t weights_start {0}, weights_end {0};
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+    dim_t weights_start {0}, weights_end {0};
     balance211(weights_g_size, nthr_mb, ithr_mb, weights_start, weights_end);
 
     if (weights_start >= weights_end) return; // nothing to do
 
-    size_t acc_size = weights_end - weights_start;
+    const dim_t acc_size = weights_end - weights_start;
     float *wei_reduced = is_bf16_out
             ? (float *)weights_reduce_base + weights_start
             : (float *)weights_base + weights_start;
     if (!is_bf16_out) {
         // f32 diff_weights require initialization by weights_reduce
         // for thr_mb = 0
-        for (size_t i = 0; i < acc_size; i++)
+        for (dim_t i = 0; i < acc_size; i++)
             wei_reduced[i] = ((float *)weights_reduce_base + weights_start)[i];
     }
 
@@ -970,11 +965,10 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             diff_bias = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
     }
 
-    const dim_t K = jcp.os * static_cast<size_t>(jcp.od);
-    const size_t src_step
-            = static_cast<size_t>(jcp.ic) * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = jcp.oc * K;
-    const size_t weights_g_size = jcp.oc;
+    const dim_t K = jcp.os * jcp.od;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * K;
+    const dim_t weights_g_size = jcp.oc;
 
     const dim_t k = jcp.os;
     const dim_t M = jcp.oc;
@@ -987,11 +981,14 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                ngroups_for_balance, mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -1002,8 +999,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 + (ptrdiff_t)ithr * jcp.id * jcp.ic * jcp.is;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1017,7 +1014,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 constexpr uint16_t zero_val = 0;
 
                 PRAGMA_OMP_SIMD()
-                for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+                for (dim_t i = 0; i < jcp.im2col_sz; i++)
                     _col_r[i] = zero_val;
             }
 
@@ -1028,7 +1025,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
             const bool use_diff_wei
                     = ithr_mb == 0 && diff_wei_data_type == data_type::f32;
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 acc_data_t *_diff_weights = use_diff_wei
                         ? (acc_data_t *)diff_weights + g * weights_g_size
                         : need_reduction ? weights_reduce
@@ -1036,7 +1033,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 const dim_t LDC = use_diff_wei ? jcp.ngroups * jcp.oc
                         : need_reduction       ? jcp.oc
                                                : jcp.ngroups * jcp.oc;
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + mb * jcp.ngroups * src_step + g * jcp.ic;
                     if (jcp.im2col_sz && is_problem_3d)
@@ -1094,19 +1091,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     if (jcp.need_wei_reduction && !dnnl_thr_syncable()) {
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
-            size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+            dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    ngroups_for_balance, mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1178,9 +1177,9 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     }
 
     const dim_t K = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * K;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * K;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
 
     const dim_t k = jcp.os_block;
     const dim_t N = jcp.oc;
@@ -1190,18 +1189,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     std::atomic<status_t> st(status::success);
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                ngroups_for_balance, mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1210,7 +1212,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             // external data initialization by zeroes
             const bool outer_padding = jcp.os_nb_block == 1;
             if (outer_padding && is_problem_3d) {
-                for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+                for (dim_t i = 0; i < jcp.im2col_sz; i++)
                     _col[i] = (src_data_t)0;
             }
 
@@ -1219,11 +1221,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             acc_data_t *weights_reduce
                     = weights_reduce_base + ithr_mb * weights_g_size;
 
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 acc_data_t *acc = need_reduction
                         ? weights_reduce
                         : (acc_base + g * weights_g_size);
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + (mb * jcp.ngroups + g) * src_step;
                     for_(dim_t od = 0; od < jcp.od; ++od)
@@ -1275,8 +1277,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                         weights_reduce_base, weights_base);
             } else if (diff_wei_data_type == data_type::bf16
                     && g_end > g_start) {
-                const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-                const size_t work_size = (g_end - g_start) * weights_g_size;
+                const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+                const dim_t work_size = (g_end - g_start) * weights_g_size;
                 bfloat16_t *diff_weights_local
                         = (bfloat16_t *)diff_weights + g_start * weights_g_size;
                 const float *acc_local
@@ -1294,19 +1296,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     if (jcp.need_wei_reduction && !dnnl_thr_syncable()) {
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
-            size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+            dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    ngroups_for_balance, mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1322,7 +1326,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     }
 
     if (jcp.with_bias) {
-        parallel_nd(jcp.ngroups, jcp.oc, [&](size_t g, size_t oc) {
+        parallel_nd(jcp.ngroups, jcp.oc, [&](dim_t g, dim_t oc) {
             acc_data_t db = 0;
             dim_t offset_ = g * dst_step + oc * K;
             for (dim_t mb = 0; mb < jcp.mb; ++mb) {

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -205,7 +205,7 @@ private:
         std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
                 postops_injector_;
 
-        void apply_postops(const bool apply_mask, const size_t out_offset,
+        void apply_postops(const bool apply_mask, const dim_t out_offset,
                 const int vmm_idx);
         void generate() override;
         int vreg_dst_idx(int iter) {
@@ -369,7 +369,7 @@ private:
             const conv_gemm_conf_t &jcp, const acc_data_t *weights_reduce_base,
             diff_wei_data_t *weights_base) const;
     void bf16_bwd_weights_reduction_par_nspc(int ithr_mb, int nthr_mb,
-            size_t g_start, size_t g_end, const conv_gemm_conf_t &jcp,
+            dim_t g_start, dim_t g_end, const conv_gemm_conf_t &jcp,
             const acc_data_t *weights_reduce_base,
             diff_wei_data_t *weights_base) const;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -51,7 +51,7 @@ jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
@@ -92,7 +92,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const int num_substeps = static_cast<int>(jcp.bcast_block / jcp.ur);
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
             if (i + 1 == num_substeps) L(long_tail);
@@ -151,11 +151,11 @@ Address jit_avx512_core_bf16_1x1_conv_kernel_t::output_ptr(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift = is_output_layout_nxc
+        dim_t i_load_shift = is_output_layout_nxc
                 ? jcp.load_block
                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
-        int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
+        dim_t i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
         return EVEX_compress_addr(aux_reg_output_data, offset);
     } else
@@ -194,7 +194,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::apply_postops(
             iterate(load_loop_blk, ur, mask_tail,
                     [&](const bool mask_flag, const int i_load,
                             const int i_ur) {
-                const int aux_output_l_off
+                const dim_t aux_output_l_off
                         = get_output_offset(i_load, i_ur, true);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -254,8 +254,9 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
         int load_loop_blk, int ur, int substep, bool wraparound) {
     const bool load_layout_nxc = is_load_layout_nxc();
     const bool bcast_layout_nxc = is_bcast_layout_nxc();
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const int reduce_dim_tail
+            = static_cast<int>(jcp.reduce_dim % jcp.reduce_block);
+    const int load_dim_tail = static_cast<int>(jcp.load_dim % jcp.load_block);
 
     auto vreg_load = [ur, load_loop_blk](int i_load) {
         int idx = ur * load_loop_blk + i_load;
@@ -275,22 +276,22 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto bcast_ptr
-            = [this, bcast_layout_nxc](int i_reduce, int i_ur, bool bcast) {
+            = [this, bcast_layout_nxc](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
-        int offt;
+        dim_t offt;
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const dim_t reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                      : jcp.reduce_loop_unroll;
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
         } else {
             if (jcp.uses_permw_transposition) {
-                int rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
-                                            : jcp.ic_block;
+                dim_t rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
+                                              : jcp.ic_block;
                 offt = i_reduce * rmul + i_ur;
             } else {
                 offt = (i_reduce / 2) * 2 * jcp.ic_block + 2 * i_ur;
@@ -303,22 +304,22 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     auto load_ptr = [this, load_layout_nxc](int i_reduce, int i_load) {
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+        dim_t lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
                                              jcp.reduce_dim, jcp.reduce_block));
-        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offt = i_load * lmul + u0 * rmul;
+        dim_t rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
     };
 
     auto store_buffer_ptr = [this](int i_load, int i_ur) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift
+        dim_t i_load_shift
                 = jcp.load_block * (is_output_layout_nxc ? 1 : jcp.bcast_dim);
-        int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
+        dim_t i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_acc;
         return EVEX_compress_addr(aux_reg_store_buf, offset);
     };
@@ -540,11 +541,12 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block_bwd_w = [&](bool is_tail) {
-        int n_reduce_tail = jcp.reduce_dim % jcp.reduce_loop_unroll;
-        int n_reduce
+        const int n_reduce_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_loop_unroll);
+        const int n_reduce
                 = is_tail && n_reduce_tail > 0 && !jcp.uses_permw_transposition
                 ? n_reduce_tail
-                : jcp.reduce_loop_unroll;
+                : static_cast<int>(jcp.reduce_loop_unroll);
         int bcast_count = 0;
         int pipeline_length_max = 1;
         if (isa_has_bf16(jcp.isa)) {
@@ -557,7 +559,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
             assert(regs_for_pipeline_total >= regs_for_pipeline_iter);
             pipeline_length_max = nstl::min(
                     regs_for_pipeline_total / regs_for_pipeline_iter,
-                    n_reduce / 2);
+                    static_cast<int>(n_reduce / 2));
         }
 
         const int pipeline = saturate(1, 4, pipeline_length_max);
@@ -743,9 +745,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block_fwd_bwd_d = [&](bool is_tail) {
-        int n_reduce_tail = jcp.reduce_dim % jcp.reduce_loop_unroll;
-        int n_reduce = is_tail && n_reduce_tail > 0 ? n_reduce_tail
-                                                    : jcp.reduce_loop_unroll;
+        const int n_reduce_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_loop_unroll);
+        const int n_reduce = is_tail && n_reduce_tail > 0
+                ? n_reduce_tail
+                : static_cast<int>(jcp.reduce_loop_unroll);
         const int reduce_step = 2;
         for (int i_reduce = 0; i_reduce < n_reduce; i_reduce += 2) {
             if (isa_has_bf16(jcp.isa)) {
@@ -972,7 +976,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::compute_diff_bias(
     test(reg_reduce_pos_flag, FLAG_REDUCE_FIRST); // If FLAG_REDUCE_FIRST
     jnz(skip_reading, T_NEAR);
 
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(jcp.load_dim % jcp.load_block);
     for (int i_load = 0; i_load < load_loop_blk; i_load++) {
         bool mask_flag = load_dim_tail && i_load + 1 == load_loop_blk;
         auto vacc = vreg_acc(i_load);
@@ -1013,11 +1017,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
     mov(reg_trans_tmp.cvt32(), 0xffff0000);
     kmovd(half_mask_hi, reg_trans_tmp.cvt32());
 
-    const int load_dim_tail
-            = (one_of(jcp.prop_kind, forward_training, forward_inference)
-                              ? jcp.oc_without_padding
-                              : jcp.load_dim)
-            % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(
+            (one_of(jcp.prop_kind, forward_training, forward_inference)
+                            ? jcp.oc_without_padding
+                            : jcp.load_dim)
+            % jcp.load_block);
     if (load_dim_tail) {
         mov(reg_trans_tmp.cvt32(), (1 << load_dim_tail) - 1);
         kmovw(k_load_dim_tail_mask, reg_trans_tmp.cvt32());
@@ -1076,12 +1080,12 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
         mov(reg_load_loop_work, ptr[rsp + reg_load_loop_work_off]);
 
         add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
-        const size_t off_with_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t off_with_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc()
                                 ? 1
                                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim));
-        const size_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out * (is_out_layout_nxc() ? 1 : jcp.bcast_dim);
         switch (jcp.prop_kind) {
             case forward_training:
@@ -1245,7 +1249,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             ? pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.data_type,
                       data_type::undef, cd.diff_bias_desc.data_type)
             : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
     jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
@@ -1343,15 +1349,20 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
     jcp.typesize_acc = sizeof(float);
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
-        jcp.typesize_out = types::data_type_size(dst_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
+        jcp.typesize_out
+                = static_cast<int>(types::data_type_size(dst_d.data_type()));
         jcp.dst_dt = dst_d.data_type();
     } else if (jcp.prop_kind == backward_data) {
-        jcp.typesize_in = types::data_type_size(dst_d.data_type());
-        jcp.typesize_out = types::data_type_size(src_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(dst_d.data_type()));
+        jcp.typesize_out
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jcp.dst_dt = src_d.data_type();
     } else if (jcp.prop_kind == backward_weights) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
         jcp.dst_dt = weights_d.data_type();
     }
@@ -1388,7 +1399,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 backward_data)) {
         jcp.nthr = nthreads;
         if (one_of(jcp.prop_kind, forward_inference, forward_training)) {
-            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            if (jcp.with_dw_conv)
+                jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
             jcp.reduce_dim = jcp.ic;
             jcp.reduce_block = jcp.ic_block;
 
@@ -1416,11 +1428,12 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold, ur_step;
-        const int spatial
+        const dim_t spatial
                 = (one_of(jcp.prop_kind, forward_training, forward_inference))
                 ? jcp.od * jcp.oh
                 : jcp.id * jcp.ih;
-        const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+        const int reduce_dim_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_block);
         if (reduce_dim_tail % 2 == 0 // cannot expl_bcast odd tail
                 && (8 * jcp.mb) / jcp.nthr >= 1) {
             max_regs = 9;
@@ -1454,10 +1467,10 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            int os_tail = static_cast<int>(jcp.os % max_regs);
             for (int i = max_regs; i >= min_regs; i -= ur_step) {
-                int i_tail = jcp.os % i;
+                int i_tail = static_cast<int>(jcp.os % i);
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -1467,7 +1480,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
 
         jcp.bcast_block = jcp.ur;
-        jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur;
+        jcp.ur_tail = static_cast<int>(
+                (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur);
 
         jcp.bcast_loop_output_step
                 = jcp.ur * (is_data_layout_nxc ? jcp.load_dim : jcp.load_block);
@@ -1483,22 +1497,26 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
-        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+        int nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+        int nb_reduce
+                = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
+        int nb_load = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
 
         if (is_data_layout_nxc
                 || (jcp.prop_kind == backward_data && reduce_src)) {
-            reduce_blocking = jcp.reduce_dim;
+            reduce_blocking = static_cast<int>(jcp.reduce_dim);
         } else {
             if (jcp.expl_bcast) {
                 if (jcp.load_dim <= BIG_LOAD_DIM && spatial > SMALL_SPATIAL
                         && spatial < BIG_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 160);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 160));
                 else if (spatial > SMALL_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 1024);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 1024));
                 else
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 512);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 512));
             } else {
                 reduce_blocking = nb_reduce;
                 if (spatial <= SMALL_SPATIAL
@@ -1520,14 +1538,15 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             int max_hits = 7;
             if (jcp.bcast_dim * reduce_blocking > way_size * max_hits) {
                 int nrb = reduce_blocking / simd_w;
-                int sp = jcp.bcast_dim;
-                int wl = way_size / simd_w;
+                dim_t sp = jcp.bcast_dim;
+                dim_t wl = way_size / simd_w;
                 for (int start_off = 0; start_off < jcp.ur; start_off++) {
-                    for (int off = start_off, hits = 0; off < sp * nrb;
+                    for (dim_t off = start_off, hits = 0; off < sp * nrb;
                             off += wl) {
                         if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                        int max_r_blocking
-                                = simd_w * nstl::max(1, (off + wl) / sp);
+                        int max_r_blocking = simd_w
+                                * static_cast<int>(
+                                        nstl::max<dim_t>(1, (off + wl) / sp));
                         reduce_blocking
                                 = nstl::min(reduce_blocking, max_r_blocking);
                         break;
@@ -1535,10 +1554,10 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 }
             }
         }
-        load_blocking = jcp.load_dim;
+        load_blocking = static_cast<int>(jcp.load_dim);
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
-        auto bcast_size
+        dim_t load_size = jcp.load_dim * jcp.reduce_dim;
+        const dim_t bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
         if (jcp.nthr <= 28 && jcp.mb < jcp.nthr
@@ -1549,11 +1568,11 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             float ratio = (float)load_size / (float)bcast_size;
             int best_lgc = ratio > 1 ? n_lgc : 1;
             auto calc_job_cost = [&](int lb, int tg, float mem_k) {
-                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+                dim_t bb_size = jcp.mb * div_up(nb_bcast, tg);
                 float calc_size = (float)(bb_size * jcp.ur)
-                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                        * (float)(lb * jcp.load_block) * (float)jcp.reduce_dim;
                 float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
-                        * jcp.reduce_dim;
+                        * (float)jcp.reduce_dim;
                 return calc_koef * calc_size + mem_k * mem_size;
             };
             for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
@@ -1579,8 +1598,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 }
             }
             jcp.load_grp_count = best_lgc;
-            load_blocking
-                    = div_up(nb_load, jcp.load_grp_count) * jcp.load_block;
+            load_blocking = static_cast<int>(
+                    div_up(nb_load, jcp.load_grp_count) * jcp.load_block);
         } else {
             jcp.load_grp_count
                     = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
@@ -1593,24 +1612,27 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         } else if (jcp.bcast_dim <= 49 && jcp.mb <= jcp.nthr
                 && jcp.load_dim > 512 && jcp.load_dim / jcp.reduce_dim >= 4) {
             jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
-            load_blocking = jcp.load_block;
+            load_blocking = static_cast<int>(jcp.load_block);
         }
 
-        bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                                 div_up(jcp.nthr, jcp.load_grp_count))
-                * jcp.bcast_block;
-        bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
-        bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                           div_up(jcp.nthr, jcp.load_grp_count))
+                        * jcp.bcast_block);
+        bcast_blocking = static_cast<int>(
+                nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
+        bcast_blocking
+                = static_cast<int>(rnd_up(bcast_blocking, jcp.bcast_block));
 
-        int space_for_bcast = (L2_capacity - /* kernel_size - */
+        dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
                 2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
                 - 3 * 1024);
         if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
 
-        int bcast_in_cache
-                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-        bcast_blocking = nstl::min(
-                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+        const dim_t bcast_in_cache = nstl::max<dim_t>(
+                jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
         load_blocking_max = load_blocking;
         bcast_blocking_max = bcast_blocking * 3 / 2;
@@ -1629,7 +1651,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 && IMPLICATION(ndims == 5, jcp.oc <= 64);
 
         if (jcp.uses_permw_transposition) {
-            int rdim = nstl::min<dim_t>(256, jcp.reduce_dim);
+            int rdim = static_cast<int>(nstl::min<dim_t>(256, jcp.reduce_dim));
             jcp.reduce_block = best_divider(jcp.reduce_dim, 7, rdim, true, 2);
         } else
             jcp.reduce_block = best_divider(jcp.reduce_dim, 8, 16, true, 2);
@@ -1648,8 +1670,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_dim = jcp.ic;
         jcp.bcast_block = jcp.ic_block;
 
-        jcp.ur = jcp.bcast_block;
-        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.ur = static_cast<int>(jcp.bcast_block);
+        jcp.ur_tail = static_cast<int>(jcp.bcast_dim % jcp.bcast_block);
         // TODO: try to enable jcp.expl_bcast version
         jcp.expl_bcast = false;
 
@@ -1681,16 +1703,18 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         /* --- */
         balance(jcp, jcp.nthr);
 
-        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
         load_blocking = best_divider(load_blocking, 16, load_blocking, false);
         load_blocking *= jcp.load_block;
 
         load_blocking_max = load_blocking;
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int max_bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         int min_bcast_blocking = 5;
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         bcast_blocking = best_divider(
                 bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
         bcast_blocking *= jcp.bcast_block;
@@ -1701,14 +1725,14 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
 
         // for reduction balance
-        int max_reduce_blocking
-                = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
-        int min_reduce_blocking
-                = nstl::min(L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+        int max_reduce_blocking = static_cast<int>(
+                nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim));
+        int min_reduce_blocking = static_cast<int>(nstl::min<dim_t>(
+                L1_capacity / jcp.ur, nstl::max<dim_t>(jcp.iw, jcp.ih)));
         reduce_blocking = best_divider(
                 jcp.reduce_dim, min_reduce_blocking, max_reduce_blocking, true);
-        reduce_blocking = nstl::max(
-                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block);
+        reduce_blocking = static_cast<int>(nstl::max<dim_t>(
+                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block));
 
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
     } else
@@ -1758,7 +1782,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             && jcp.typesize_in * bcast_size < 8192 && jcp.ngroups < jcp.nthr
             && jcp.nb_bcast * jcp.nb_load < jcp.nthr;
     if (is_adjust_thread) {
-        int nthr = nstl::max(jcp.nb_bcast, jcp.nb_load);
+        int nthr = static_cast<int>(nstl::max(jcp.nb_bcast, jcp.nb_load));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 
@@ -1855,11 +1879,13 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_bcast
+            = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    const int nb_load = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
+    const int nb_reduce
+            = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
-    jcp.nthr_g = jcp.ngroups;
+    jcp.nthr_g = static_cast<int>(jcp.ngroups);
     const int nthr = nthreads / jcp.nthr_g;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -1877,7 +1903,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
 
         if (jcp.prop_kind == backward_weights) {
             int mult = (jcp.stride_h == 1 && jcp.stride_w == 1)
-                    ? nstl::max(1, (jcp.oc / jcp.ic))
+                    ? static_cast<int>(nstl::max<dim_t>(1, (jcp.oc / jcp.ic)))
                     : 1;
             output_koeff = 4 * mult;
         }
@@ -1899,7 +1925,8 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
     auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, jcp.mb * nb_reduce));
     for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
         const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
@@ -1915,7 +1942,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         }
     }
     if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
-        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(jcp.mb, nthreads));
 
     jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
     assert(jcp.nthr <= nthreads);

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -1214,32 +1214,35 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                                         : bf16_emulation_t::get_isa();
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.oc_without_padding = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
+    jcp.ic_without_padding = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
@@ -1422,9 +1425,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 * (is_data_layout_nxc ? 1 : jcp.bcast_dim);
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
-        jcp.load_loop_load_step
-                = utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
-                * jcp.load_block * jcp.typesize_in;
+        jcp.load_loop_load_step = static_cast<int>(
+                utils::rnd_up(jcp.reduce_dim, jcp.reduce_block) * jcp.load_block
+                * jcp.typesize_in);
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold, ur_step;
@@ -1486,8 +1489,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_loop_output_step
                 = jcp.ur * (is_data_layout_nxc ? jcp.load_dim : jcp.load_block);
         jcp.bcast_loop_output_substep = -1; // unused
-        jcp.bcast_loop_bcast_step = jcp.typesize_in * jcp.ur
-                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block);
+        jcp.bcast_loop_bcast_step = static_cast<int>(jcp.typesize_in * jcp.ur
+                * (is_data_layout_nxc ? jcp.reduce_dim : jcp.reduce_block));
         jcp.bcast_loop_bcast_substep = -1; // unused
 
         jcp.load_loop_iter_step = jcp.load_block;
@@ -1688,16 +1691,18 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_loop_output_step = jcp.oc_block * jcp.ic_block;
         jcp.bcast_loop_output_substep
                 = jcp.oc_block * jcp.ur * jcp.typesize_out;
-        jcp.bcast_loop_bcast_step = jcp.typesize_in * jcp.ic_block
+        jcp.bcast_loop_bcast_step = static_cast<int>(jcp.typesize_in
+                * jcp.ic_block
                 * (jcp.uses_permw_transposition
                                 ? (is_data_layout_nxc ? 1 : jcp.reduce_dim)
-                                : rnd_up(jcp.reduce_dim, 2));
+                                : rnd_up(jcp.reduce_dim, 2)));
         jcp.bcast_loop_bcast_substep = jcp.typesize_in * jcp.ur
                 * (jcp.uses_permw_transposition ? 1 : 2);
-        jcp.load_loop_load_step = jcp.typesize_in * jcp.oc_block
-                * (jcp.uses_permw_transposition
-                                ? (is_data_layout_nxc ? 1 : jcp.os)
-                                : rnd_up(jcp.reduce_dim, 2));
+        jcp.load_loop_load_step
+                = static_cast<int>(jcp.typesize_in * jcp.oc_block
+                        * (jcp.uses_permw_transposition
+                                        ? (is_data_layout_nxc ? 1 : jcp.os)
+                                        : rnd_up(jcp.reduce_dim, 2)));
         jcp.load_loop_iter_step = jcp.oc_block;
 
         /* --- */
@@ -1766,9 +1771,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
     jcp.nb_reduce_blocking_max
             = utils::div_up(reduce_blocking_max, jcp.reduce_block);
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     /* adjust the thread decomposition
      * to improve the perf for small size problem

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -51,7 +51,7 @@ jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const std::size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
@@ -182,14 +182,14 @@ private:
         return ymm;
     }
 
-    inline size_t get_output_offset(
+    inline dim_t get_output_offset(
             const int i_load, const int i_ur, bool ignore_dw_conv) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        const size_t i_load_shift = is_output_layout_nxc
+        const dim_t i_load_shift = is_output_layout_nxc
                 ? jcp.load_block
                 : (!ignore_dw_conv && jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
                         * jcp.load_block;
-        const size_t i_ur_shift
+        const dim_t i_ur_shift
                 = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
         return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
     }

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -44,7 +44,7 @@ namespace {
  * not used here ?*/
 template <typename T, typename U>
 void balance2D(U nthr, U ithr, T ny, T &ny_start, T &ny_end, T nx, T &nx_start,
-        T &nx_end, T nx_divider) {
+        T &nx_end, U nx_divider) {
     const T grp_size = utils::div_up(nthr, nx_divider);
     const T grp_count = utils::div_up(nthr, grp_size);
 
@@ -77,7 +77,8 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_ != nullptr
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -145,26 +146,27 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     float *store_buffer = scratchpad.template get<float>(key_conv_store_wsp);
 
     const int ndims = src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -172,7 +174,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     dst_data_t *pbuf; //bf16->bf16 fusion
     size_t row_offset;
     const auto jcp_dw = pd()->jcp_dw_;
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<decltype(pbuf)> addrs;
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
@@ -181,23 +183,23 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
     auto start_off = dst_d.off_l(0);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -210,16 +212,16 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
-        const auto max_oc
-                = nstl::min(ocb_end * jcp.oc_block, jcp.oc_without_padding);
+        const auto max_oc = nstl::min<dim_t>(
+                ocb_end * jcp.oc_block, jcp.oc_without_padding);
         p.load_dim = this_block_size(
                 ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
     };
 
-    auto init_reduce = [&](int icb) {
-        const int nb_ic_blocking_step
+    auto init_reduce = [&](dim_t icb) {
+        const dim_t nb_ic_blocking_step
                 = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
         p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
@@ -229,12 +231,13 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t icb, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
 
         void *output_data = jcp.with_dw_conv
                 ? (void *)(pbuf + (oh % jcp_dw->kh) * row_offset)
@@ -247,7 +250,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
 
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
         if (pd()->rtus_.reduce_src_) {
@@ -278,21 +281,22 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -302,17 +306,18 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                        id {0}, ih {0}, iw {0};
+                dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                        iw {0};
+                dim_t bcast_step {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -326,8 +331,9 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
 
         for (int i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw->kh) * row_offset;
@@ -336,22 +342,22 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw->iw)
                 * jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
 
-        const int dil_h = jcp_dw->dilate_h + 1;
-        const int str_h = jcp_dw->stride_h;
-        const int ch_num = jcp_dw->nb_ch_blocking;
+        const dim_t dil_h = jcp_dw->dilate_h + 1;
+        const dim_t str_h = jcp_dw->stride_h;
+        const dim_t ch_num = jcp_dw->nb_ch_blocking;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw->t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw->ih,
-                              (int)(dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
-                                      - jcp_dw->t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw->t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw->ih,
+                              dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
+                                      - jcp_dw->t_pad + 1)
                     - jcp_dw->ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
+            const int kh = static_cast<int>(div_up(i_t_overflow, dil_h));
+            const dim_t kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             const int ow = 0;
@@ -360,7 +366,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw->ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -373,9 +379,11 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw->ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw->nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw->nb_ch) - ch)
                     * jcp_dw->ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -402,33 +410,34 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
                 bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -444,8 +453,8 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
                 ocb_start, ocb_end, jcp.load_grp_count);
 
@@ -491,13 +500,13 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
             : nullptr;
     float *store_buffer = scratchpad.template get<float>(key_conv_store_wsp);
     const int ndims = diff_src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -505,26 +514,27 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+    dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
     balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
             icb_start, icb_end, jcp.load_grp_count);
 
-    auto init_bcast = [&](int iwork, int &n, int &g, int &bcast_step, int &od,
-                              int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast
+            = [&](dim_t iwork, dim_t &n, dim_t &g, dim_t &bcast_step, dim_t &od,
+                      dim_t &oh, dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, jcp.nb_bcast);
         bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
                 jcp.nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
         id = od * stride_d;
@@ -536,17 +546,17 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int icb, int &load_step) {
+    auto init_load = [&](dim_t icb, dim_t &load_step) {
         load_step = step(
                 jcp.nb_load_blocking, icb_end - icb, jcp.nb_load_blocking_max);
-        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+        const dim_t max_ic = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
         p.load_dim = this_block_size(
                 icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
         rp.icb = p.load_dim;
     };
 
-    auto init_reduce = [&](int ocb) {
-        const int nb_oc_blocking_step
+    auto init_reduce = [&](dim_t ocb) {
+        const dim_t nb_oc_blocking_step
                 = nstl::min(ocb + nb_oc_blocking, nb_oc) - ocb;
         p.first_last_flag = 0 | (ocb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (ocb + nb_oc_blocking_step >= nb_oc ? FLAG_REDUCE_LAST : 0);
@@ -555,14 +565,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
                 ocb * jcp.oc_block, jcp.oc, nb_oc_blocking_step * jcp.oc_block);
     };
 
-    auto inner_ker = [&](int icb, int ocb, int n, int g, int od, int oh, int ow,
-                             int id, int ih, int iw) {
+    auto inner_ker = [&](dim_t icb, dim_t ocb, dim_t n, dim_t g, dim_t od,
+                             dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
         const bool is_dsrc_layout_nxc = utils::one_of(jcp.src_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        const int ic_off_idx = is_dsrc_layout_nxc
+        const dim_t ic_off_idx = is_dsrc_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
-        const size_t diff_src_off
+        const dim_t diff_src_off
                 = data_blk_off(diff_src_d, n, ic_off_idx, id, ih, iw);
 
         rp.src = diff_src + diff_src_off;
@@ -577,7 +587,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
 
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        const int oc_off_idx = is_ddst_layout_nxc
+        const dim_t oc_off_idx = is_ddst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
         p.bcast_data = diff_dst
@@ -596,15 +606,16 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     };
 
     if (jcp.loop_order == loop_lbr) {
-        int icb = icb_start;
+        dim_t icb = icb_start;
         while (icb < icb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(icb, load_step);
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, n, g, bcast_step, od, oh, ow, id, ih, iw);
-                for (int ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
+                for (dim_t ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
                     init_reduce(ocb);
                     inner_ker(icb, ocb, n, g, od, oh, ow, id, ih, iw);
                 }
@@ -652,13 +663,13 @@ jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::init(
             CHECK(tr_reorder_->create_kernel());
         }
         if (is_src_layout_nxc) {
-            int ic = pd()->jcp_.ic * pd()->jcp_.ngroups;
+            int ic = static_cast<int>(pd()->jcp_.ic * pd()->jcp_.ngroups);
             CHECK(safe_ptr_assign(tr_reorder_nhwc_src_,
                     new jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(ic)));
             CHECK(tr_reorder_nhwc_src_->create_kernel());
         }
         if (is_ddst_layout_nxc) {
-            int oc = pd()->jcp_.oc * pd()->jcp_.ngroups;
+            int oc = static_cast<int>(pd()->jcp_.oc * pd()->jcp_.ngroups);
             CHECK(safe_ptr_assign(tr_reorder_nhwc_ddst_,
                     new jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(oc)));
             CHECK(tr_reorder_nhwc_ddst_->create_kernel());
@@ -700,7 +711,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             : nullptr;
 
     const int ndims = src_d.ndims();
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block);
     const int n_wei_buffers
             = jcp.dst_dt == data_type::bf16 ? jcp.nthr_mb : jcp.nthr_mb - 1;
@@ -715,18 +726,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const int sp_nb = jcp.nb_reduce;
-    const int mb_sp_work = jcp.mb * sp_nb;
+    const dim_t sp_nb = jcp.nb_reduce;
+    const dim_t mb_sp_work = jcp.mb * sp_nb;
 
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -735,22 +746,22 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = jcp.nb_bcast - 1;
-                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const dim_t z_icb = jcp.nb_bcast - 1;
+                const dim_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
                         + ic_tail * jcp.oc_block;
                 diff_wei_data_t *z_wei = diff_weights + off;
-                const int zero_work
+                const dim_t zero_work
                         = (jcp.nb_bcast * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -766,13 +777,15 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0};
+        dim_t oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0};
+        dim_t oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
@@ -790,7 +803,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
         float *diff_bia = nullptr;
         if (jcp.with_bias) {
-            const int bias_size = jcp.ngroups * jcp.nb_load * jcp.oc_block;
+            const dim_t bias_size = jcp.ngroups * jcp.nb_load * jcp.oc_block;
             if (jcp.bia_dt == data_type::bf16) {
                 diff_bia = bia_reduction + (ithr_mb)*bias_size;
             } else {
@@ -800,42 +813,42 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
         }
 
-        int sp_b_step = 0;
-        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+        dim_t sp_b_step = 0;
+        for (dim_t mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
                 mb_sp_b += sp_b_step) {
-            int img {0}, sp_b {0};
+            dim_t img {0}, sp_b {0};
             nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
             sp_b_step = step(jcp.nb_reduce_blocking,
                     nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
                     jcp.nb_reduce_blocking_max);
 
-            for (int g = g_start; g < g_end; ++g) {
-                int load_step = 0;
-                int bcast_step = 0;
-                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+            for (dim_t g = g_start; g < g_end; ++g) {
+                dim_t load_step = 0;
+                dim_t bcast_step = 0;
+                for (dim_t ic_b = ic_b_start; ic_b < ic_b_end;
                         ic_b += bcast_step) {
                     bcast_step = step(nb_ic_blocking, ic_b_end - ic_b,
                             jcp.nb_bcast_blocking_max);
-                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                    for (dim_t oc_b = oc_b_start; oc_b < oc_b_end;
                             oc_b += load_step) {
                         load_step = step(nb_oc_blocking, oc_b_end - oc_b,
                                 jcp.nb_load_blocking_max);
 
                         float *store_to;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         store_to = diff_wei + off;
 
                         const bool is_src_layout_nxc
                                 = utils::one_of(jcp.src_tag, format_tag::nwc,
                                         format_tag::nhwc, format_tag::ndhwc);
-                        const int ic_off_idx = is_src_layout_nxc
+                        const dim_t ic_off_idx = is_src_layout_nxc
                                 ? g * jcp.ic + ic_b * jcp.ic_block
                                 : g * nb_oc + ic_b;
                         const src_data_t *diff_src
                                 = &src[src_d.blk_off(img, ic_off_idx)];
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + oc_b * jcp.oc_block
                                 : g * nb_oc + oc_b;
                         const diff_dst_data_t *pdiff_dst
@@ -870,17 +883,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                                             : 0)
                                 | (ic_b == 0 ? FLAG_COMPUTE_BIAS : 0);
 
-                        int sp = sp_b * jcp.reduce_block;
-                        int oc_mult = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
-                                                         : jcp.oc_block;
+                        dim_t sp = sp_b * jcp.reduce_block;
+                        dim_t oc_mult = is_ddst_layout_nxc
+                                ? jcp.ngroups * jcp.oc
+                                : jcp.oc_block;
                         p.load_data = pdiff_dst + sp * oc_mult;
 
                         if (pd()->rtus_.reduce_src_) {
-                            const int oh = sp / jcp.ow;
-                            const int ow = sp % jcp.ow;
+                            const dim_t oh = sp / jcp.ow;
+                            const dim_t ow = sp % jcp.ow;
 
-                            const int ih = oh * stride_h;
-                            const int iw = ow * stride_w;
+                            const dim_t ih = oh * stride_h;
+                            const dim_t iw = ow * stride_w;
                             rp.iw_start = iw;
 
                             rp.ws = rtus_space
@@ -898,7 +912,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                             p.bcast_data = rp.ws;
                         } else {
-                            int ic_mult = is_src_layout_nxc
+                            dim_t ic_mult = is_src_layout_nxc
                                     ? jcp.ngroups * jcp.ic
                                     : jcp.ic_block;
                             p.bcast_data = local_src + sp * ic_mult;
@@ -906,22 +920,23 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                         if (!jcp.uses_permw_transposition) {
                             bf16_support::jit_call_t ptr;
                             ptr.nelems = p.reduce_dim;
-                            int thr_src_block_size = rnd_up(jcp.reduce_dim, 2)
+                            dim_t thr_src_block_size = rnd_up(jcp.reduce_dim, 2)
                                     * jcp.ic_block * jcp.nb_bcast_blocking_max;
                             src_data_t *tr_src
                                     = &tr_src_buffer[ithr * thr_src_block_size];
-                            for (int bs = 0; bs < bcast_step; bs++) {
-                                size_t src_off = bs * jcp.ic_block
+                            for (dim_t bs = 0; bs < bcast_step; bs++) {
+                                dim_t src_off = bs * jcp.ic_block
                                         * (is_src_layout_nxc ? 1
                                                              : jcp.reduce_dim);
-                                size_t src_tr_off = bs
+                                dim_t src_tr_off = bs
                                         * rnd_up(jcp.reduce_dim, 2)
                                         * jcp.ic_block;
                                 src_data_t *curr_inp = &(
                                         (src_data_t *)p.bcast_data)[src_off];
                                 src_data_t *curr_out = &tr_src[src_tr_off];
-                                int ch_work = nstl::min<int>(
-                                        p.bcast_dim - bs * jcp.bcast_block, 16);
+                                int ch_work = static_cast<int>(nstl::min<dim_t>(
+                                        p.bcast_dim - bs * jcp.bcast_block,
+                                        16));
                                 assert(ch_work <= 16);
                                 ptr.mask = (1 << ch_work) - 1;
                                 ptr.inp = (void *)curr_inp;
@@ -933,14 +948,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                             }
 
                             p.bcast_data = (void *)tr_src;
-                            int thr_dst_block_size = rnd_up(jcp.reduce_dim, 2)
+                            dim_t thr_dst_block_size = rnd_up(jcp.reduce_dim, 2)
                                     * jcp.oc_block * jcp.nb_load_blocking_max;
                             diff_dst_data_t *tr_diff_dst = &tr_diff_buffer[ithr
                                     * thr_dst_block_size];
-                            for (int ls = 0; ls < load_step; ls++) {
-                                size_t ddst_off = ls * jcp.oc_block
+                            for (dim_t ls = 0; ls < load_step; ls++) {
+                                dim_t ddst_off = ls * jcp.oc_block
                                         * (is_ddst_layout_nxc ? 1 : jcp.os);
-                                size_t ddst_tr_off = ls
+                                dim_t ddst_tr_off = ls
                                         * rnd_up(jcp.reduce_dim, 2)
                                         * jcp.oc_block;
                                 diff_dst_data_t *curr_inp
@@ -948,8 +963,8 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                                         p.load_data)[ddst_off];
                                 diff_dst_data_t *curr_out
                                         = &tr_diff_dst[ddst_tr_off];
-                                int ch_work = nstl::min<int>(
-                                        p.load_dim - ls * jcp.load_block, 16);
+                                int ch_work = static_cast<int>(nstl::min<dim_t>(
+                                        p.load_dim - ls * jcp.load_block, 16));
                                 ptr.mask = (1 << ch_work) - 1;
                                 ptr.inp = (void *)curr_inp;
                                 ptr.out = (void *)curr_out;
@@ -983,17 +998,17 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
         balance211(
                 jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
 
-        const int g_work = g_end - g_start;
-        const int oc_b_work = oc_b_end - oc_b_start;
-        const int ic_b_work = ic_b_end - ic_b_start;
+        const dim_t g_work = g_end - g_start;
+        const dim_t oc_b_work = oc_b_end - oc_b_start;
+        const dim_t ic_b_work = ic_b_end - ic_b_start;
 
         const int _start_nthr_mb = 1;
         const bool is_bf16_out = diff_weights_type == data_type::bf16;
@@ -1003,24 +1018,25 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         if (jcp.nthr_mb > _start_nthr_mb) {
             if (dnnl_thr_syncable())
                 simple_barrier::barrier(reduction_barrier, jcp.nthr);
-            const int work = g_work * oc_b_work * ic_b_work;
-            int start {0}, end {0};
+            const dim_t work = g_work * oc_b_work * ic_b_work;
+            dim_t start {0}, end {0};
             balance211(work, jcp.nthr_mb, ithr_mb, start, end);
             if (start == end) return;
 
             for (int thr_mb = _start_nthr_mb; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                int w = start;
-                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                dim_t w = start;
+                dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
                 nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                         oc_b_work, sub_ic_b_start, ic_b_work);
                 while (w < end) {
-                    const int g = g_start + sub_g_start;
-                    const int oc_b = oc_b_start + sub_oc_b_start;
-                    const int ic_b = ic_b_start + sub_ic_b_start;
-                    const int ic_to_accumulate
-                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
+                    const dim_t g = g_start + sub_g_start;
+                    const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                    const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                    const dim_t ic_to_accumulate
+                            = nstl::min<dim_t>(
+                                      end - w, ic_b_work - sub_ic_b_start)
                             * jcp.ic_block;
-                    const int acc_size
+                    const size_t acc_size
                             = this_block_size(ic_b * jcp.ic_block,
                                       jcp.ic_without_padding, ic_to_accumulate)
                             * jcp.oc_block;
@@ -1051,12 +1067,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                 if (jcp.with_bias && ithr_ic_b == 0 && ic_b_work > 0
                         && ithr_mb == 0) {
-                    for (int g = g_start; g < g_end; g++) {
+                    for (dim_t g = g_start; g < g_end; g++) {
                         float *bias_reduced
                                 = is_bf16_bias ? bia_reduction : diff_bias;
                         int thr_mb_buffer_idx
                                 = is_bf16_bias ? thr_mb : thr_mb - 1;
-                        int bias_buf_size
+                        dim_t bias_buf_size
                                 = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
                         float *bias_to_reduce = bia_reduction
                                 + thr_mb_buffer_idx * bias_buf_size;
@@ -1064,12 +1080,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                 = this_block_size(oc_b_start * jcp.oc_block,
                                         jcp.oc_without_padding,
                                         (oc_b_end - oc_b_start) * jcp.oc_block);
-                        int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                        dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                                 + oc_b_start * jcp.oc_block;
                         if (is_bf16_bias && thr_mb == jcp.nthr_mb - 1) {
                             // the last iteration for bfloat16 requires conversion and
                             // store to diff_weights array
-                            int diff_bias_idx = g * jcp.oc_without_padding
+                            dim_t diff_bias_idx = g * jcp.oc_without_padding
                                     + oc_b_start * jcp.oc_block;
                             bfloat16_t *diff_bias_result
                                     = CTX_OUT_MEM(
@@ -1087,10 +1103,11 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
         } else {
             if (is_bf16_out) {
-                const auto ic_work = nstl::min(jcp.ic, ic_b_end * jcp.ic_block)
+                const dim_t ic_work
+                        = nstl::min<dim_t>(jcp.ic, ic_b_end * jcp.ic_block)
                         - ic_b_start * jcp.ic_block;
-                for_(int g = g_start; g < g_end; g++)
-                for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+                for_(dim_t g = g_start; g < g_end; g++)
+                for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ic_work * jcp.oc_block;
                     const size_t off
                             = wht_blk_off(diff_weights_d, g, oc_b, ic_b_start);
@@ -1101,13 +1118,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
 
             if (is_bf16_bias && ithr_ic_b == 0 && ic_b_work > 0) {
-                for (int g = g_start; g < g_end; g++) {
-                    int result_start_idx = g * jcp.oc_without_padding
+                for (dim_t g = g_start; g < g_end; g++) {
+                    dim_t result_start_idx = g * jcp.oc_without_padding
                             + oc_b_start * jcp.oc_block;
-                    int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                    dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                             + oc_b_start * jcp.oc_block;
-                    const size_t acc_size = nstl::min(jcp.oc_without_padding,
-                                                    oc_b_end * jcp.oc_block)
+                    const size_t acc_size
+                            = nstl::min<dim_t>(jcp.oc_without_padding,
+                                      oc_b_end * jcp.oc_block)
                             - oc_b_start * jcp.oc_block;
                     bfloat16_t *diff_bias_result
                             = CTX_OUT_MEM(bfloat16_t *, DNNL_ARG_DIFF_BIAS)

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -154,7 +154,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_ic = jcp.nb_reduce;
     const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -410,7 +410,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
                 bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
 
@@ -453,8 +453,8 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
                 ocb_start, ocb_end, jcp.load_grp_count);
 
@@ -504,7 +504,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
     const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
@@ -514,12 +514,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const dim_t nb_ic = jcp.nb_load;
-    const dim_t nb_oc = jcp.nb_reduce;
-    const dim_t os_block = jcp.bcast_block;
-    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
+    const int nb_ic = jcp.nb_load;
+    const int nb_oc = jcp.nb_reduce;
+    const int os_block = jcp.bcast_block;
+    const int nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+    int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
     balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
             icb_start, icb_end, jcp.load_grp_count);
 
@@ -546,16 +546,16 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](dim_t icb, dim_t &load_step) {
-        load_step = step(
-                jcp.nb_load_blocking, icb_end - icb, jcp.nb_load_blocking_max);
-        const dim_t max_ic = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
+    auto init_load = [&](int icb, int &load_step) {
+        load_step = static_cast<int>(step(
+                jcp.nb_load_blocking, icb_end - icb, jcp.nb_load_blocking_max));
+        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
         p.load_dim = this_block_size(
                 icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
         rp.icb = p.load_dim;
     };
 
-    auto init_reduce = [&](dim_t ocb) {
+    auto init_reduce = [&](int ocb) {
         const dim_t nb_oc_blocking_step
                 = nstl::min(ocb + nb_oc_blocking, nb_oc) - ocb;
         p.first_last_flag = 0 | (ocb == 0 ? FLAG_REDUCE_FIRST : 0)
@@ -606,16 +606,16 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     };
 
     if (jcp.loop_order == loop_lbr) {
-        dim_t icb = icb_start;
+        int icb = icb_start;
         while (icb < icb_end) {
-            dim_t load_step;
+            int load_step;
             init_load(icb, load_step);
             dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
                 dim_t n, g, od, oh, ow, id, ih, iw;
                 dim_t bcast_step;
                 init_bcast(iwork, n, g, bcast_step, od, oh, ow, id, ih, iw);
-                for (dim_t ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
+                for (int ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
                     init_reduce(ocb);
                     inner_ker(icb, ocb, n, g, od, oh, ow, id, ih, iw);
                 }
@@ -728,11 +728,11 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
     const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const dim_t sp_nb = jcp.nb_reduce;
-    const dim_t mb_sp_work = jcp.mb * sp_nb;
+    const int sp_nb = jcp.nb_reduce;
+    const int mb_sp_work = jcp.mb * sp_nb;
 
     const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
     const dim_t stride_w = pd()->desc()->strides[ndims - 3];
@@ -777,15 +777,15 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
+        int mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        dim_t g_start {0};
-        dim_t oc_b_start {0}, ic_b_start {0};
-        dim_t g_end {0};
-        dim_t oc_b_end {0}, ic_b_end {0};
+        int g_start {0};
+        int oc_b_start {0}, ic_b_start {0};
+        int g_end {0};
+        int oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
@@ -998,8 +998,8 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* independent dimensions */
-        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
-        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
+        int g_start {0}, oc_b_start {0}, ic_b_start {0};
+        int g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -300,8 +300,8 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw->nb_ch_blocking != 0)
                 --jcp_dw->nb_ch_blocking;
 
-            jcp_dw->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
 
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -89,8 +89,8 @@ inline bool is_iw_threading_on(const jit_conv_conf_t &jcp) {
 }
 inline bool is_1stconv(const jit_conv_conf_t &jcp) {
     const bool no_big_offt = nstl::max<size_t>(jcp.ic, jcp.oc)
-                    * nstl::max(jcp.typesize_in, jcp.typesize_out) * jcp.id
-                    * jcp.ih * jcp.iw
+                    * nstl::max<dim_t>(jcp.typesize_in, jcp.typesize_out)
+                    * jcp.id * jcp.ih * jcp.iw
             < INT_MAX;
     return jcp.ic < 16 && jcp.ngroups == 1 && no_big_offt;
 }
@@ -106,8 +106,8 @@ jit_avx512_core_bf16_fwd_kernel_vmm_t<
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const size_t tail_size = oc_block_tail
+        const dim_t oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const dim_t tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
@@ -199,7 +199,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w) {
             if (mask_tail || oc_blk_is_smaller_than_vmm) {
                 Label postops_no_tail;
                 if (mask_tail) {
-                    test(byte[param1 + GET_OFF(load_work)], jcp.oc_block - 1);
+                    test(byte[param1 + GET_OFF(load_work)],
+                            static_cast<uint32_t>(jcp.oc_block - 1));
                     jz(postops_no_tail, T_NEAR);
                 }
                 postops_injector_->compute_vector_range(
@@ -251,7 +252,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::store_dst(int ur_w) {
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
         for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-            int bias_offset = jcp.typesize_bia * k * jcp.oc_block;
+            dim_t bias_offset = jcp.typesize_bia * k * jcp.oc_block;
             for (int j = 0; j < ur_w; j++) {
                 // mask only needed for last oc_block
                 bool mask_flag = oc_tail && k + 1 == jcp.nb_oc_blocking;
@@ -359,7 +360,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::store_dst(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     Label kh_label, kd_label;
     const int ic_tail = jcp.ic_tail;
     const int ic_step = 2;
@@ -376,12 +377,12 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     dim_t max_src_offset = 0;
     if (jcp.is_1stconv || ic_tail) {
         for (int ki = 0; ki < jcp.kw; ki++) {
-            int ow_fst = get_ow_start(ki, pad_l);
-            int ow_last = get_ow_end(ur_w, ki, pad_r) - 1;
+            dim_t ow_fst = get_ow_start(ki, pad_l);
+            dim_t ow_last = get_ow_end(ur_w, ki, pad_r) - 1;
             if (ow_fst > ow_last) continue;
-            int ic_last = rnd_up(nstl::min(jcp.ic_block,
-                                         nstl::max(jcp.ic, ic_tail)),
-                                  ic_step)
+            dim_t ic_last = rnd_up(nstl::min<dim_t>(jcp.ic_block,
+                                           nstl::max<dim_t>(jcp.ic, ic_tail)),
+                                    ic_step)
                     - ic_step;
 
             dim_t src_offset = get_src_offset(
@@ -397,7 +398,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
         mov(reg_kj, ptr[param1 + GET_OFF(kd_padding)]);
         if ((jcp.dilate_d >= jcp.id)
                 || (jcp.kd - 1) * (jcp.dilate_d + 1)
-                        < nstl::max(jcp.f_pad, jcp.back_pad)) {
+                        < nstl::max<dim_t>(jcp.f_pad, jcp.back_pad)) {
             cmp(reg_kj, 0);
             je(skip_compute_loop, T_NEAR);
         }
@@ -405,7 +406,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     mov(reg_kj, reg_kh);
     if ((jcp.dilate_h >= jcp.ih)
             || (jcp.kh - 1) * (jcp.dilate_h + 1)
-                    < nstl::max(jcp.t_pad, jcp.b_pad)) {
+                    < nstl::max<dim_t>(jcp.t_pad, jcp.b_pad)) {
         cmp(reg_kj, 0);
         je(skip_compute_loop, T_NEAR);
     }
@@ -432,20 +433,21 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     L(kh_label);
     {
         for (int ki = 0; ki < jcp.kw; ki++) {
-            int ow_start = get_ow_start(ki, pad_l);
-            int ow_end = get_ow_end(ur_w, ki, pad_r);
-            for (int ic = 0;
-                    ic < rnd_up(nstl::min(jcp.ic_block, jcp.ic), ic_step);
+            dim_t ow_start = get_ow_start(ki, pad_l);
+            dim_t ow_end = get_ow_end(ur_w, ki, pad_r);
+            for (int ic = 0; ic
+                    < rnd_up(nstl::min<dim_t>(jcp.ic_block, jcp.ic), ic_step);
                     ic += ic_step) {
                 if (ic_tail && ic == rnd_up(ic_tail, ic_step)) {
                     // insert this check at most once per icb, no more.
                     cmp(reg_ic, ic_tail);
                     je(ic_tail_jmp[ki], T_NEAR);
                 }
-                for (int oi = ow_start; oi < ow_end; oi++) {
+                for (dim_t oi = ow_start; oi < ow_end; oi++) {
                     dim_t src_offset = get_src_offset(
                             ic, filter_w_to_src(ki, oi, pad_l));
-                    auto vmm_in = vmm_src(oi, jcp.nb_oc_blocking);
+                    auto vmm_in
+                            = vmm_src(static_cast<int>(oi), jcp.nb_oc_blocking);
                     const auto addr_base = EVEX_compress_addr_safe(
                             aux_reg_src, src_offset, reg_long_offt);
                     const bool tail_load
@@ -520,9 +522,10 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
                     vmovups(vmm_wei,
                             EVEX_compress_addr_safe(
                                     aux_reg_ker, wei_off, reg_long_offt));
-                    for (int oi = ow_start; oi < ow_end; oi++) {
-                        auto acc = vmm_dst(oi, kk);
-                        auto src = vmm_src(oi, jcp.nb_oc_blocking);
+                    for (dim_t oi = ow_start; oi < ow_end; oi++) {
+                        auto acc = vmm_dst(static_cast<int>(oi), kk);
+                        auto src = vmm_src(
+                                static_cast<int>(oi), jcp.nb_oc_blocking);
                         if (isa_has_bf16(jcp.isa)) {
                             vdpbf16ps(acc, vmm_wei, src);
                         } else
@@ -555,7 +558,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
     // End of IC Loop
     dim_t src_step = get_src_offset(jcp.ic_block, 0);
-    const size_t ker_step = get_kernel_offset(0, jcp.ic_block, 0);
+    const dim_t ker_step = get_kernel_offset(0, jcp.ic_block, 0);
     safe_add(reg_src, src_step, reg_long_offt);
     safe_add(reg_ker, ker_step, reg_long_offt);
 
@@ -572,15 +575,15 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int ow_block = jcp.ow_block;
-    int nb_ow = jcp.nb_ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    dim_t iw = jcp.iw;
+    dim_t ow = jcp.ow;
+    int ow_block = static_cast<int>(jcp.ow_block);
+    dim_t nb_ow = jcp.nb_ow;
+    dim_t kw = jcp.kw;
+    dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    dim_t stride_w = jcp.stride_w;
 
     auto src_shift = get_src_offset(0, filter_w_to_src(0, ur_w));
     auto dst_shift = get_dst_offset(ur_w, 0);
@@ -622,7 +625,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
             kxnord(k_oc_tail_mask_extended, k_oc_tail_mask_extended,
                     k_oc_tail_mask_extended);
 
-        test(byte[param1 + GET_OFF(load_work)], jcp.oc_block - 1);
+        test(byte[param1 + GET_OFF(load_work)],
+                static_cast<uint32_t>(jcp.oc_block - 1));
         jz(done, T_NEAR);
         auto reg_tail_32 = reg_oc.cvt32();
         mov(reg_tail_32, (1 << jcp.oc_tail) - 1);
@@ -652,9 +656,9 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
     mov(reg_ker, ptr[param1 + GET_OFF(filt)]);
     mov(reg_kh, ptr[param1 + GET_OFF(kh_padding)]);
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
+    dim_t n_oi = ow / ur_w;
+    dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -714,7 +718,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+        int n_oi_last_ow_block
+                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -879,15 +884,19 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1054,7 +1063,7 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
     jcp.kernel_kind = expl_bcast;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--) {
         int ur_w = regs / (jcp.nb_oc_blocking + 1);
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
@@ -1064,27 +1073,27 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     }
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
-    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
+    jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
 
     jcp.ow_block = jcp.ow;
     if (is_ow_threading_available(jcp)) {
         const int L1_part = platform::get_per_core_cache_size(1) * 5 / 8;
-        int size_src_chunk = jcp.typesize_in * jcp.ic_block * jcp.ur_w;
-        int size_dst_chunk = jcp.typesize_out * jcp.oc_block
+        dim_t size_src_chunk = jcp.typesize_in * jcp.ic_block * jcp.ur_w;
+        dim_t size_dst_chunk = jcp.typesize_out * jcp.oc_block
                 * jcp.nb_oc_blocking * jcp.ur_w;
-        int size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
+        dim_t size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
                 * jcp.nb_oc_blocking * jcp.kw;
-        int nurw = (L1_part - size_wei_chunk)
+        dim_t nurw = (L1_part - size_wei_chunk)
                 / (size_dst_chunk + size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        jcp.ow_block = jcp.ur_w * nstl::max(2, nurw);
+        jcp.ow_block = jcp.ur_w * nstl::max<dim_t>(2, nurw);
     }
     jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1104,10 +1113,11 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     size_t total_size = jcp.ngroups * (wei_size + inp_size + out_size);
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
-    // The factor for 1d=1, 2d=2, 3d=4;
+    // The factor for 1d=1, 2d=2, 3d=4; a small fixed code-generation
+    // constant, not a tensor-scale value.
     int factor = nstl::max(1, (2 * (ndims - 3)));
     if (jcp.ngroups < jcp.nthr && total_size < L1_cache_size / factor) {
-        jcp.nthr = nstl::min(jcp.nthr, 4);
+        jcp.nthr = static_cast<int>(nstl::min<dim_t>(jcp.nthr, 4));
     }
 
     pick_loop_order(jcp);
@@ -1233,11 +1243,11 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::store_output(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int l_overflow, int r_overflow) {
-    int kw = jcp.kw;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+        int ur_w, dim_t l_overflow, dim_t r_overflow) {
+    dim_t kw = jcp.kw;
+    dim_t dilate_w = jcp.dilate_w + 1;
+    dim_t stride_w = jcp.stride_w;
+    dim_t stride_h = jcp.stride_h;
     const int oc_tail = jcp.oc_tail;
     Label kh_label, skip_compute_label;
 
@@ -1277,29 +1287,29 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow);
-            int jj_end = get_iw_end(ur_w, ki, r_overflow);
-            const int ref_jj_start
-                    = nstl::max(0, l_overflow - (kw - 1 - ki) * dilate_w);
-            const int ref_jj_end
-                    = ur_w - nstl::max(0, r_overflow - ki * dilate_w);
+            dim_t jj_start = get_iw_start(ki, l_overflow);
+            dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
+            const dim_t ref_jj_start = nstl::max<dim_t>(
+                    0, l_overflow - (kw - 1 - ki) * dilate_w);
+            const dim_t ref_jj_end
+                    = ur_w - nstl::max<dim_t>(0, r_overflow - ki * dilate_w);
             assert(IMPLICATION(stride_w == 1,
                     jj_start == ref_jj_start && jj_end == ref_jj_end));
             UNUSED(ref_jj_start);
             UNUSED(ref_jj_end);
             const int oc_step = 2;
-            for (int oc = 0;
-                    oc < rnd_up(nstl::min(jcp.oc_block, jcp.oc), oc_step);
+            for (int oc = 0; oc
+                    < rnd_up(nstl::min<dim_t>(jcp.oc_block, jcp.oc), oc_step);
                     oc += oc_step) {
                 if (oc_tail && oc == rnd_up(oc_tail, oc_step)) {
                     cmp(reg_oc, oc_tail);
                     je(oc_tail_jmp[ki], T_NEAR);
                 }
-                for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * dilate_w) % stride_w == 0);
-                    int ow_idx = (jj + jcp.l_pad - ki * dilate_w) / stride_w;
+                    dim_t ow_idx = (jj + jcp.l_pad - ki * dilate_w) / stride_w;
                     auto aux_ddst_offset = get_diff_dst_offset(ow_idx, oc);
-                    auto ddst = vmm_ddst(jj / stride_w);
+                    auto ddst = vmm_ddst(static_cast<int>(jj / stride_w));
                     const bool tail_load = oc_tail && oc == rnd_dn(oc_tail, 2);
                     const bool need_single_load = oc + 1 == oc_tail;
 
@@ -1323,9 +1333,9 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
                     vmovups(vmm_wei,
                             EVEX_compress_addr(aux_reg_ker, aux_kernel_offset));
 
-                    for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        auto ddst = vmm_ddst(jj / stride_w);
-                        auto acc = vmm_dsrc(jj, kk);
+                    for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
+                        auto ddst = vmm_ddst(static_cast<int>(jj / stride_w));
+                        auto acc = vmm_dsrc(static_cast<int>(jj), kk);
 
                         if (isa_has_bf16(jcp.isa)) {
                             vdpbf16ps(acc, vmm_wei, ddst);
@@ -1374,14 +1384,14 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int kw = jcp.kw;
+    const dim_t iw = jcp.iw;
+    const int kw = static_cast<int>(jcp.kw);
     int ur_w = jcp.ur_w;
-    int nb_iw = jcp.nb_iw;
-    int iw_block = jcp.iw_block;
+    dim_t nb_iw = jcp.nb_iw;
+    int iw_block = static_cast<int>(jcp.iw_block);
     int ur_w_tail = jcp.ur_w_tail;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dst_shift = get_diff_dst_offset(ur_w / stride_w, 0);
     const auto src_shift = get_diff_src_offset(ur_w, 0);
@@ -1407,7 +1417,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
             kxnord(k_ic_tail_mask_extended, k_ic_tail_mask_extended,
                     k_ic_tail_mask_extended);
 
-        test(byte[param1 + GET_OFF(load_work)], jcp.ic_block - 1);
+        test(byte[param1 + GET_OFF(load_work)],
+                static_cast<uint32_t>(jcp.ic_block - 1));
         jz(done, T_NEAR);
         Reg32 reg_tail_32 = reg_ic.cvt32();
         mov(reg_tail_32, (1 << jcp.ic_tail) - 1);
@@ -1425,15 +1436,16 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
 
     mov(reg_kh, ptr[param + GET_OFF(kh_padding)]);
 
-    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
-    int r_overflow = nstl::max(
-            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
-    int r_overflow1 = nstl::max(0,
-            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
+    dim_t l_overflow
+            = nstl::max<dim_t>(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
+    dim_t r_overflow = nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad)) / stride_w);
+    dim_t r_overflow1 = nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad + ur_w_tail))
                     / stride_w);
 
     int body_l_overflow = 0, body_r_overflow = 0;
-    int n_oi = iw / ur_w;
+    int n_oi = static_cast<int>(iw / ur_w);
     int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
     int head_thread = 0, pretail_thread = 0, tail_thread = 0;
     bool threaded = is_iw_threading_on(jcp);
@@ -1445,8 +1457,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
     if (n_oi < 0) {
         // l_overflow and r_overflow1 are handled in the same compute_loop.
         // Perform one iteration of body handling l_overflow and r_overflow1.
-        body_l_overflow = l_overflow;
-        body_r_overflow = r_overflow1;
+        body_l_overflow = static_cast<int>(l_overflow);
+        body_r_overflow = static_cast<int>(r_overflow1);
         n_oi = 1;
         l_overflow = 0;
         r_overflow1 = 0;
@@ -1458,12 +1470,12 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         // Setup for threaded code generation, and jump into the correct
         // portion of code for execution.
         head_thread = 0;
-        tail_thread = nb_iw - 1;
+        tail_thread = static_cast<int>(nb_iw - 1);
         pretail_thread = tail_thread;
 
-        int base_n_oi = iw_block / ur_w;
+        int base_n_oi = static_cast<int>(iw_block / ur_w);
         head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
-        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        tail_n_oi = static_cast<int>((iw - iw_block * (nb_iw - 1)) / ur_w);
         pretail_n_oi = tail_n_oi;
         if (r_overflow1 > 0) {
             if (tail_n_oi > 0) {
@@ -1485,8 +1497,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         // n_oi is used to determine how much control flow in the body portion
         // of the code needs generated. As such, n_oi needs to be set to the
         // maximum number of iterations it will be used the body code section.
-        n_oi = nstl::max(body_n_oi, head_n_oi);
-        n_oi = nstl::max(n_oi, pretail_n_oi);
+        n_oi = static_cast<int>(nstl::max<dim_t>(body_n_oi, head_n_oi));
+        n_oi = static_cast<int>(nstl::max<dim_t>(n_oi, pretail_n_oi));
 
         assert(iw_block % ur_w == 0);
         mov(reg_iwb, ptr[param1 + GET_OFF(iwb)]);
@@ -1623,9 +1635,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(dilate_ok, VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1738,7 +1750,7 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ur_w = jcp.stride_w;
+    jcp.ur_w = static_cast<int>(jcp.stride_w);
 
     /* Maximum number of registers available for result accumulation and delta
        dst data. One additional register is reserved for weights data. */
@@ -1746,11 +1758,13 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             = isa_has_bf16(jcp.isa) ? 31 : 26; /* In case of cpx emulation
                                                   additional 5 registers are
                                                   reserved */
-    int l_overflow = nstl::max(
+    const dim_t l_overflow = nstl::max<dim_t>(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
 
     /* Find the best blocking with maximum number of compute instructions
        per ur_w * nb_ic_blocking compute loops. Number of required registers
@@ -1767,10 +1781,10 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
         for (int b = 1; b <= max_ic_blocks; b++) {
             if (jcp.nb_ic % b != 0) continue;
 
-            for (int u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
+            for (dim_t u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
                     && u < jcp.iw + jcp.stride_w;
                     u += jcp.stride_w) {
-                int ur_w = nstl::min(u, jcp.iw);
+                const int ur_w = static_cast<int>(nstl::min<dim_t>(u, jcp.iw));
                 /* maximum 1 step with l_overflow so far */
                 if (l_overflow * jcp.stride_w > ur_w && ur_w != jcp.iw)
                     continue;
@@ -1790,23 +1804,24 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
     if (is_iw_threading_available(jcp)) {
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-        int work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih;
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih;
 
         auto efficiency = [](dim_t size, dim_t block) {
             // avoid msvc warning 'potential divide by zero'
             if (size <= 0 || block == 0) return 0.f;
-            return (float)size / rnd_up(size, block);
+            return (float)size / (float)rnd_up(size, block);
         };
 
         float no_iw_block_eff = efficiency(work_units, jcp.nthr);
 
         // current design of generate() requires iw_block >= 2 * ur_w
         const int min_iw_block = jcp.ur_w * 2;
-        int iw_threads = jcp.nthr / math::gcd(work_units, jcp.nthr);
-        int iw_block = nstl::max(min_iw_block,
-                rnd_up(jcp.iw, jcp.ur_w * iw_threads) / iw_threads);
-        int nb_iw = div_up(jcp.iw, iw_block);
+        int iw_threads
+                = jcp.nthr / math::gcd(static_cast<int>(work_units), jcp.nthr);
+        int iw_block = static_cast<int>(nstl::max<dim_t>(min_iw_block,
+                rnd_up(jcp.iw, jcp.ur_w * iw_threads) / iw_threads));
+        const int nb_iw = static_cast<int>(div_up(jcp.iw, iw_block));
 
         float block_eff = efficiency(jcp.iw, iw_block);
         work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih * nb_iw;
@@ -1815,7 +1830,8 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
         const int iw_thread_min_size = 16 * 128;
         const float iw_block_cost = 20.0;
-        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        float block_overhead
+                = nstl::max(0.0f, 1.0f - iw_block_cost / (float)iw_block);
 
         bool iw_thread_useful = no_iw_block_eff < block_overhead * iw_block_eff
                 && jcp.ic_block * jcp.iw > iw_thread_min_size;
@@ -1829,9 +1845,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(l_overflow * jcp.stride_w <= jcp.ur_w,
             VERBOSE_BLOCKING_FAIL, "failing boundary conditions");
 
-    int r_overflow_no_tail = nstl::max(0,
+    const dim_t r_overflow_no_tail = nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.ur_w_tail))
                     / jcp.stride_w);
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
@@ -1858,9 +1874,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
     //The factor for 1d: 1, 2d: 2, 3d: 4;
-    int factor = nstl::max(1, (2 * (ndims - 3)));
+    const int factor = static_cast<int>(nstl::max<dim_t>(1, 2 * (ndims - 3)));
     if (jcp.ngroups < jcp.nthr && total_size < L1_cache_size / factor) {
-        jcp.nthr = nstl::min(jcp.nthr, 4);
+        jcp.nthr = static_cast<int>(nstl::min<dim_t>(jcp.nthr, 4));
     }
 
     pick_loop_order(jcp);
@@ -1899,18 +1915,18 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_extern(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_extern(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!is_src_layout_nxc() && !is_ddst_layout_nxc());
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     bool no_src_pad = jcp.is_1stconv && !jcp.transpose_src;
     static constexpr int ddst_zmm_base_idx = 24;
     const int num_ddst_zmm_regs = !isa_has_bf16(jcp.isa) ? 2 : 4;
     const int zmm_src_reg = ddst_zmm_base_idx + num_ddst_zmm_regs;
 
-    auto zmm_ker = [ic_block_step](int i_kw, int i_ic) {
-        return Zmm(i_kw * ic_block_step + i_ic);
+    auto zmm_ker = [ic_block_step](dim_t i_kw, dim_t i_ic) {
+        return Zmm(static_cast<int>(i_kw * ic_block_step + i_ic));
     };
     auto zmm_ddst = [num_ddst_zmm_regs](int i_iw) {
         // TODO: move reg calc to global member funcs
@@ -1922,8 +1938,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         return EVEX_compress_addr(reg_kernel, local_offset + kernel_offset);
     };
     auto src_addr
-            = [this, src_offset](int i_iw, int i_ic, ptrdiff_t extra_offset = 0,
-                      bool vnni_bcast = false) {
+            = [this, src_offset](dim_t i_iw, int i_ic,
+                      ptrdiff_t extra_offset = 0, bool vnni_bcast = false) {
         auto local_offset = get_src_offset(i_ic, i_iw);
         return EVEX_compress_addr(
                 reg_src, local_offset + src_offset + extra_offset, vnni_bcast);
@@ -1942,22 +1958,23 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     assert(ur_w % 2 == 0);
     auto steps = ur_w / 2;
 
-    const int str_w = jcp.stride_w;
+    const dim_t str_w = jcp.stride_w;
     const int underflow_boundary = -1;
-    int i_iw_shift = jcp.tr_ow - ur_w - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
-    const int overflow_boundary = jcp.iw - 1 - i_iw_shift;
+    const dim_t i_iw_shift
+            = jcp.tr_ow - ur_w - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
+    const dim_t overflow_boundary = jcp.iw - 1 - i_iw_shift;
 
     for (int s = 0; s < str_w; s++) {
         const int kw_start = s;
         assert(jcp.tr_iw % str_w == 0);
-        const int src_stride_w_shift = jcp.tr_iw / str_w;
+        const int src_stride_w_shift = static_cast<int>(jcp.tr_iw / str_w);
         for (int i_ur = 0; i_ur < steps; i_ur++) {
             auto zmm = zmm_ddst(i_ur);
             vmovdqu16(zmm, ddst_addr(i_ur));
 
             for (int i_kw = kw_start; i_kw < kw; i_kw += str_w) {
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
-                    int i_iw = 2 * i_ur + (i_kw * (jcp.dilate_w + 1)) / str_w
+                    dim_t i_iw = 2 * i_ur + (i_kw * (jcp.dilate_w + 1)) / str_w
                             + s * src_stride_w_shift;
                     bool underflow = false;
                     bool overflow = false;
@@ -2011,7 +2028,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         interleave_w_reorder_size(int ur_w) const {
     const int reorder_block = 16;
-    return rnd_up(jcp.stride_w * (ur_w - 1) + jcp.kw, reorder_block);
+    return static_cast<int>(
+            rnd_up(jcp.stride_w * (ur_w - 1) + jcp.kw, reorder_block));
 }
 int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         interleave_w_reorder_bytes(int ur_w) {
@@ -2022,12 +2040,12 @@ int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::interleave_stack_size(
     return ic_block_step * interleave_w_reorder_bytes(ur_w);
 }
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_interleave(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_interleave(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     // Only supports nchw format src
     assert(jcp.is_1stconv && !jcp.transpose_src);
-    int kw = jcp.kw;
+    const dim_t kw = jcp.kw;
     static constexpr int ddst_zmm_base_idx = 24;
     static constexpr int in_zmm_base_idx = 24;
     const int num_ddst_zmm_regs = !isa_has_bf16(jcp.isa) ? 2 : 4;
@@ -2060,9 +2078,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         return EVEX_compress_addr(reg_kernel, local_offset + kernel_offset);
     };
     auto src_addr
-            = [this, reorder_bytes](int i_iw, int i_ic,
+            = [this, reorder_bytes](dim_t i_iw, int i_ic,
                       ptrdiff_t extra_offset = 0, bool vnni_bcast = false) {
-        int local_offset = i_ic * reorder_bytes + 2 * jcp.typesize_in * i_iw;
+        const dim_t local_offset
+                = i_ic * reorder_bytes + 2 * jcp.typesize_in * i_iw;
         return EVEX_compress_addr(rsp, local_offset, vnni_bcast);
     };
     auto ddst_addr = [this, ddst_offset](int i_ur) {
@@ -2071,14 +2090,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 reg_ddst, get_ddst_offset(ow_scale * i_ur) + ddst_offset);
     };
     auto load_src_to_stack
-            = [&](int i_iw, int i_ic, Opmask mask, bool mask_empty,
+            = [&](dim_t i_iw, int i_ic, Opmask mask, bool mask_empty,
                       Opmask stride_mask, bool stride_mask_empty) {
         auto local_offset = get_src_offset(i_ic, i_iw);
-        int stack_offset
+        const dim_t stack_offset
                 = i_ic * reorder_bytes + 2 * jcp.typesize_in * (i_iw + pad_l);
 
-        auto zmm = zmm_in(i_iw, i_ic, false);
-        auto zmm_stride = zmm_in(i_iw, i_ic, true);
+        auto zmm = zmm_in(static_cast<int>(i_iw), i_ic, false);
+        auto zmm_stride = zmm_in(static_cast<int>(i_iw), i_ic, true);
         auto base_addr
                 = EVEX_compress_addr(reg_src, local_offset + src_offset, false);
         auto stride_addr = EVEX_compress_addr(reg_src,
@@ -2101,19 +2120,21 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     assert(ur_w % 2 == 0);
     auto steps = ur_w / 2;
 
-    const int str_w = jcp.stride_w;
-    int i_iw_shift = str_w * (jcp.tr_ow - ur_w)
+    const dim_t str_w = jcp.stride_w;
+    const dim_t i_iw_shift = str_w * (jcp.tr_ow - ur_w)
             - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
-    const int overflow_boundary
+    const dim_t overflow_boundary
             = is_tail ? jcp.iw - i_iw_shift : str_w * (ur_w - 1) + kw - pad_l;
 
     // Calculate padding required by the data reorder using 32 byte loads
-    int reorder_overflow = reorder_size - pad_l - overflow_boundary;
-    int reorder_stride_overflow = reorder_overflow + str_w;
-    reorder_overflow = nstl::max(0, reorder_overflow);
-    reorder_stride_overflow = nstl::max(0, reorder_stride_overflow);
-    int reorder_pad_r = reorder_overflow % reorder_block;
-    int reorder_stride_pad_r = reorder_stride_overflow % reorder_block;
+    dim_t reorder_overflow = reorder_size - pad_l - overflow_boundary;
+    dim_t reorder_stride_overflow = reorder_overflow + str_w;
+    reorder_overflow = nstl::max<dim_t>(0, reorder_overflow);
+    reorder_stride_overflow = nstl::max<dim_t>(0, reorder_stride_overflow);
+    const int reorder_pad_r
+            = static_cast<int>(reorder_overflow % reorder_block);
+    int reorder_stride_pad_r
+            = static_cast<int>(reorder_stride_overflow % reorder_block);
     if (reorder_stride_overflow >= reorder_size && reorder_stride_pad_r == 0) {
         assert(reorder_stride_overflow == reorder_size);
         reorder_stride_pad_r = reorder_block;
@@ -2133,18 +2154,21 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         // Overflow and underflow happen in different data reorder rounds
         kxnorw(overflow_stride_mask, overflow_stride_mask,
                 overflow_stride_mask);
-        kshiftlw(underflow_mask, overflow_stride_mask, pad_l);
+        kshiftlw(underflow_mask, overflow_stride_mask,
+                static_cast<uint8_t>(pad_l));
         kshiftlw(underflow_stride_mask, overflow_stride_mask,
-                pad_l >= str_w ? pad_l - str_w : 0);
-        kshiftrw(overflow_mask, overflow_stride_mask, reorder_pad_r);
+                static_cast<uint8_t>(pad_l >= str_w ? pad_l - str_w : 0));
+        kshiftrw(overflow_mask, overflow_stride_mask,
+                static_cast<uint8_t>(reorder_pad_r));
         kshiftrw(overflow_stride_mask, overflow_stride_mask,
-                reorder_stride_pad_r);
+                static_cast<uint8_t>(reorder_stride_pad_r));
     } else if (reorder_size - reorder_overflow > reorder_block) {
         // Overflow and underflow happen in the same round for loading the data
         // at the stride offset.
         kxnorw(overflow_mask, overflow_mask, overflow_mask);
-        kshiftlw(underflow_mask, overflow_mask, pad_l);
-        kshiftrw(overflow_mask, overflow_mask, reorder_pad_r);
+        kshiftlw(underflow_mask, overflow_mask, static_cast<uint8_t>(pad_l));
+        kshiftrw(overflow_mask, overflow_mask,
+                static_cast<uint8_t>(reorder_pad_r));
         mov(reg_tmp.cvt32(), pad_l_mask_strided & pad_r_mask_strided);
         kmovw(underflow_stride_mask, reg_tmp.cvt32());
     } else {
@@ -2156,9 +2180,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     }
 
     // Load and reorder data to the stack
-    int reorder_start = -pad_l;
-    int reorder_end = reorder_size - pad_l;
-    for (int i_iw = reorder_start; i_iw < reorder_end; i_iw += reorder_block) {
+    const dim_t reorder_start = -pad_l;
+    const dim_t reorder_end = reorder_size - pad_l;
+    for (dim_t i_iw = reorder_start; i_iw < reorder_end;
+            i_iw += reorder_block) {
         for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
             Opmask mask, stride_mask;
             bool mask_empty, stride_mask_empty;
@@ -2222,7 +2247,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
         for (int i_kw = 0; i_kw < kw; i_kw++) {
             for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
-                int i_iw = 2 * i_ur * str_w + i_kw;
+                const dim_t i_iw = 2 * i_ur * str_w + i_kw;
                 auto acc = zmm_ker(i_kw, i_ic);
                 auto ddst = zmm_ddst(i_ur);
 
@@ -2260,7 +2285,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         convert_src_to_vnni_format(
-                int ur_w, int pad_l, int pad_r, int src_offset) {
+                int ur_w, dim_t pad_l, dim_t pad_r, dim_t src_offset) {
     Reg64 reg_trans_tmp = r11;
     const int ic_tail = jcp.ic_tail;
     mov(EVEX_compress_addr(rsp, trans_tmp_offset), reg_trans_tmp);
@@ -2281,7 +2306,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     for (int src_count = 0;
             sizeof_cacheline * src_count < permw_stack_size(ur_w);
             src_count++) {
-        int i_ur = nstl::min(src_count, ur_w - 2);
+        const int i_ur
+                = static_cast<int>(nstl::min<dim_t>(src_count, ur_w - 2));
         int i_kw = src_count - i_ur;
         int buffer_offset = permw_buffer_start + src_count * 64;
         auto bcast_values = Zmm(src_count % max_regs);
@@ -2350,15 +2376,16 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_vpermw_expl(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_vpermw_expl(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!jcp.is_1stconv); // This method does not support nchw data
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     int src_count = 0;
-    int ic_block_step_idx = src_offset / (jcp.typesize_in * ic_block_step);
+    const int ic_block_step_idx
+            = static_cast<int>(src_offset / (jcp.typesize_in * ic_block_step));
     const int max_regs = (!isa_has_bf16(jcp.isa)) ? 26 : 31;
-    int src_pl_len = kw;
+    const int src_pl_len = kw;
     const int diff_dst_pl_start_reg_idx = ic_block_step * (kw + src_pl_len);
     const int diff_dst_pl_len = max_regs - diff_dst_pl_start_reg_idx;
 
@@ -2408,8 +2435,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     int src_count_last = 0;
     for (int i_ur = 0; i_ur < ur_w; i_ur += 2) {
         if (i_ur == 0) {
-            for (int dst_count = 0;
-                    dst_count < nstl::min(diff_dst_pl_len, div_up(ur_w, 2));
+            for (int dst_count = 0; dst_count
+                    < nstl::min<dim_t>(diff_dst_pl_len, div_up(ur_w, 2));
                     dst_count++) {
                 load_dst(dst_count);
             }
@@ -2476,18 +2503,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_vpermw(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_vpermw(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!jcp.is_1stconv); // This method does not support nchw data
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
 
     int dst_count = 0;
 
-    int ic_block_step_idx = src_offset / (jcp.typesize_in * ic_block_step);
+    const int ic_block_step_idx
+            = static_cast<int>(src_offset / (jcp.typesize_in * ic_block_step));
 
-    int pipeline_length = (isa_has_bf16(jcp.isa))
-            ? nstl::max(1, nstl::min(4, ur_w / 2))
+    const int pipeline_length = isa_has_bf16(jcp.isa)
+            ? static_cast<int>(
+                      nstl::max<dim_t>(1, nstl::min<dim_t>(4, ur_w / 2)))
             : 1;
     may_be_set_oc_tail_mask();
 
@@ -2610,7 +2639,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_diff_bias_row(
     };
 
     Label ow_loop, ow_tail;
-    int niters = jcp.tr_ow / 2;
+    int niters = static_cast<int>(jcp.tr_ow / 2);
     if (niters > 0) {
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
@@ -2679,8 +2708,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int src_offset,
-        int kernel_offset, int ddst_offset, bool is_tail) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step, dim_t src_offset,
+        dim_t kernel_offset, dim_t ddst_offset, bool is_tail) {
 
     if (jcp.uses_permw_transposition)
         if (jcp.kernel_kind == expl_bcast)
@@ -2700,7 +2729,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
         int &ur_w, int &ur_w_tail, int &ur_w_trips) const {
     if (jcp.tr_ow <= max_ur_w) {
-        ur_w = jcp.tr_ow;
+        ur_w = static_cast<int>(jcp.tr_ow);
         ur_w_tail = 0;
         ur_w_trips = 1;
         return;
@@ -2709,14 +2738,15 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        r_pad = nstl::max(0,
-                calculate_end_padding(
-                        jcp.l_pad, jcp.tr_ow, jcp.tr_iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(jcp.l_pad, jcp.tr_ow, jcp.tr_iw,
+                        jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
     ur_w = max_ur_w;
-    ur_w_trips = jcp.tr_ow / ur_w;
+    ur_w_trips = static_cast<int>(jcp.tr_ow / ur_w);
     ur_w_tail = jcp.tr_ow % ur_w;
     if ((ur_w_tail == 0 && jcp.r_pad != 0) || r_pad >= ur_w_tail) {
         if (ur_w_trips > 1) {
@@ -2728,7 +2758,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
                                               : ur_w_tail / 2 + 1;
             ur_w_tail = ur_w_tail_total - ur_w;
             if (l_pad > ur_w / 2) {
-                ur_w = (l_pad % 2 == 0) ? l_pad : l_pad + 1;
+                ur_w = static_cast<int>((l_pad % 2 == 0) ? l_pad : l_pad + 1);
                 ur_w_tail = ur_w_tail_total - ur_w;
             } else if (r_pad > ur_w_tail) {
                 ur_w_tail = (r_pad % 2 == 0) ? r_pad : r_pad + 1;
@@ -2742,9 +2772,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow_icblock(int ic_block_step) {
     Label kh_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -2752,12 +2782,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2787,7 +2819,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         const int ic_tail_loop_work = rnd_up(ic_tail, ic_block_step);
         for (int i_b_ic = 0; i_b_ic < jcp.ic_block; i_b_ic += ic_block_step) {
-            const int src_offset = get_src_offset(i_b_ic, 0);
+            const dim_t src_offset = get_src_offset(i_b_ic, 0);
             compute_ic_block_step(ur_w, l_pad, r_pad, ic_block_step, src_offset,
                     get_kernel_offset(i_b_ic, 0), 0, true);
             if (generate_icb_loop || ic_tail) sub(reg_icb, ic_block_step);
@@ -2843,9 +2875,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow(int ic_block_step) {
     Label kh_label, ic_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     const int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
 
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
@@ -2854,12 +2886,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2886,7 +2920,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         xor_(b_ic, b_ic);
         if (jcp.uses_permw_transposition) {
-            convert_src_to_vnni_format(ow, l_pad, r_pad, 0);
+            convert_src_to_vnni_format(static_cast<int>(ow), l_pad, r_pad, 0);
             xor_(b_ic, b_ic);
         }
 
@@ -2975,18 +3009,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step) {
     Label kh_label, ic_block_label, ow_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     int ur_w, ur_w_trips, ur_w_tail;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -3113,7 +3149,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         auto src_icbstep_shift = get_src_offset(1, 0);
 
         auto ic_loop = [&](int ic_block_step) {
-            int ic_work = ic_block;
+            dim_t ic_work = ic_block;
             Label ow_block_label, ic_block_label_padl, ic_block_label_general,
                     ic_block_label_tail;
             int ur_w_blocks = ur_w_trips;
@@ -3254,12 +3290,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         compute_oh_step_disp() {
-    int ic_block_step = jcp.ic_block_step;
+    const int ic_block_step = static_cast<int>(jcp.ic_block_step);
 
     bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
             && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
 
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     if (jcp.ndims == 5) {
         /* NOTE: reg_kd_count = aux_reg_src = r12. The following order of
          * 'movs' must be guaranteed. */
@@ -3336,12 +3372,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
             vmovups(ptr[reg_kernel + reg_tmp + get_kernel_offset(ic1, 0)],
                     zero);
         add(reg_tmp, get_kernel_offset(jcp.ic_block, 0));
-        cmp(reg_tmp, kernel_block_bytes);
+        cmp(reg_tmp, static_cast<uint32_t>(kernel_block_bytes));
         jnz(zeroing_loop);
     }
 
     if (generate_icb_loop) {
-        add(reg_kernel, kernel_block_bytes);
+        add(reg_kernel, static_cast<uint32_t>(kernel_block_bytes));
         sub(reg_icb, jcp.ic_block);
         cmp(reg_icb, 0);
         jg(icb_block_label, T_NEAR);
@@ -3354,11 +3390,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_loop_common(bool is_partial) {
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    dim_t b_pad = jcp.b_pad;
+    dim_t t_pad = jcp.t_pad;
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
+    dim_t dilate_h = jcp.dilate_h + 1;
+    dim_t stride_h = jcp.stride_h;
     auto filter_step_size = get_kernel_offset(0, jcp.kw);
     auto src_step_size = get_src_offset(0, 0, 1);
     auto ddst_step_size = get_ddst_offset(0, 1);
@@ -3368,15 +3404,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
-    int oh_head_end = nstl::min(div_up(t_pad, stride_h), oh_body_end);
-    int oh_head_overflow_end = div_up(t_pad, stride_h);
-    int oh_tail_end = jcp.oh;
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
+    const dim_t oh_head_end
+            = nstl::min<dim_t>(div_up(t_pad, stride_h), oh_body_end);
+    const dim_t oh_head_overflow_end = div_up(t_pad, stride_h);
+    const dim_t oh_tail_end = jcp.oh;
 
-    int body_src_start_offset = (stride_h - (t_pad % stride_h)) % stride_h;
-    int ih_body_end
-            = nstl::max(-t_pad + oh_body_end * stride_h, body_src_start_offset);
+    const dim_t body_src_start_offset
+            = (stride_h - (t_pad % stride_h)) % stride_h;
+    const dim_t ih_body_end = nstl::max<dim_t>(
+            -t_pad + oh_body_end * stride_h, body_src_start_offset);
 
     if (is_partial)
         mov(reg_oj, ptr[param + GET_OFF(os_index_begin)]);
@@ -3389,17 +3427,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             cmp(reg_oj, oh_head_overflow_end);
             jge(oh_tpad_tail_label_end, T_NEAR);
         }
-        const int overflow
-                = nstl::max(0, jcp.kh - div_up(t_pad + jcp.ih, dilate_h));
-        const int underflow = div_up(t_pad, dilate_h);
-        const int initial_kh = jcp.kh - overflow - underflow;
+        const dim_t overflow = nstl::max<dim_t>(
+                0, jcp.kh - div_up(t_pad + jcp.ih, dilate_h));
+        const dim_t underflow = div_up(t_pad, dilate_h);
+        const dim_t initial_kh = jcp.kh - overflow - underflow;
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
         add(reg_kernel, filter_step_size * underflow);
         if (is_dilated) {
-            const int tail = t_pad % dilate_h;
-            const int shift = tail == 0 ? 0 : dilate_h - tail;
+            const int tail = static_cast<int>(t_pad % dilate_h);
+            const int shift = tail == 0 ? 0 : static_cast<int>(dilate_h - tail);
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_shift], reg_ih_shift);
             add(reg_src, src_step_size * shift);
@@ -3556,7 +3594,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         }
         if (is_partial) {
             lea(reg_oj_setup,
-                    ptr[reg_oj - nstl::max(oh_body_end, oh_head_overflow_end)]);
+                    ptr[reg_oj
+                            - nstl::max<dim_t>(
+                                    oh_body_end, oh_head_overflow_end)]);
             if (stride_h == 1 && !is_dilated) {
                 sub(reg_kh, reg_oj_setup);
             } else {
@@ -3613,8 +3653,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_od_loop_common(bool is_partial) {
     assert(jcp.harness == harness_3d_reduction);
 
-    const int src_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
+    const dim_t src_backpad_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d);
 
     const auto filter_shift
             = get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw);
@@ -3622,8 +3663,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
     const auto ddst_shift = get_ddst_offset(0, jcp.oh);
     const dim_t src_common_shift = src_shift * jcp.stride_d;
 
-    const int kd_front_pad = nstl::max(0, jcp.f_pad);
-    const int kd_back_pad = nstl::max(0, jcp.kd - jcp.f_pad - jcp.id);
+    const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad);
+    const dim_t kd_back_pad = nstl::max<dim_t>(0, jcp.kd - jcp.f_pad - jcp.id);
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;
@@ -3637,10 +3678,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         mov(reg_d_index, ptr[param + GET_OFF(os_index_begin)]);
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
-        const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(0,
-                nstl::min(jcp.kd - 1, kd_front_pad) * static_cast<dim_t>(jcp.kh)
-                        * jcp.kw);
+        const dim_t kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
+        const dim_t kd_offset = get_kernel_offset(0,
+                nstl::min<dim_t>(jcp.kd - 1, kd_front_pad)
+                        * static_cast<dim_t>(jcp.kh) * jcp.kw);
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -3680,7 +3721,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
-        const int src_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const dim_t src_ker_overlap = nstl::min<dim_t>(jcp.kd, jcp.id);
         cmp(reg_kd_count, src_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3688,7 +3729,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * src_corr);
                 // for src, subtract src_common_shift that gets added later.
                 add(reg_src_d, src_shift * src_corr - src_common_shift);
@@ -3759,9 +3800,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     auto ddst_row_size = get_ddst_offset(0, 1);
     auto row_size = src_row_size + ddst_row_size;
 
-    int h_block_size = jcp.oh;
-    int h_last_block_size = h_block_size;
-    int min_h_block_size = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+    dim_t h_block_size = jcp.oh;
+    dim_t h_last_block_size = h_block_size;
+    const dim_t min_h_block_size
+            = nstl::max<dim_t>(1, nstl::max<dim_t>(jcp.b_pad, jcp.t_pad));
     auto working_set_size = row_size * h_block_size;
 
     if (working_set_size > full_spat_max_working_set_size) {
@@ -3769,7 +3811,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
         while (working_set_size > full_spat_opt_working_set_size
                 && h_block_size >= min_h_block_size) {
-            for (int i = 2; i <= h_block_size; i++)
+            for (dim_t i = 2; i <= h_block_size; i++)
                 if (i == h_block_size)
                     h_block_size = h_block_size / 2;
                 else if (h_block_size % i == 0) {
@@ -3778,7 +3820,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 }
             working_set_size = row_size * h_block_size;
         }
-        h_block_size = nstl::max(min_h_block_size, h_block_size);
+        h_block_size = nstl::max<dim_t>(min_h_block_size, h_block_size);
         h_last_block_size = jcp.oh % h_block_size;
         if (h_last_block_size < jcp.b_pad) h_last_block_size += h_block_size;
     }
@@ -3846,10 +3888,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         };
 
         if (full_w_unroll) {
-            emit_step(pad_ow, true);
+            emit_step(static_cast<int>(pad_ow), true);
         } else {
             Label w_loop;
-            int num_w_iters = pad_ow / def_step_size;
+            int num_w_iters = static_cast<int>(pad_ow / def_step_size);
             mov(reg_i, num_w_iters);
             L(w_loop);
             {
@@ -3892,10 +3934,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         xor_(reg_kh, reg_kh);
         Label kh_loop, kh_loop_end;
 
-        int oh_block_size = (is_last_block) ? h_last_block_size : h_block_size;
+        const dim_t oh_block_size
+                = (is_last_block) ? h_last_block_size : h_block_size;
         // NB: this is correct because we only support t_pad = kh / 2 and thus
         // ih == oh
-        int ih_block_size = oh_block_size
+        const dim_t ih_block_size = oh_block_size
                 + (!is_first_block + !is_last_block) * jcp.t_pad;
 
         L(kh_loop);
@@ -3962,8 +4005,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp,
+                    static_cast<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(
+                    reg_ohs, reg_tmp, static_cast<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4046,8 +4091,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         add(reg_src, first_src_block_step);
         add(reg_ddst, ddst_block_step);
 
-        int num_innermost_iters
-                = (jcp.oh - h_last_block_size) / h_block_size - 1;
+        const int num_innermost_iters = static_cast<int>(
+                (jcp.oh - h_last_block_size) / h_block_size - 1);
         if (num_innermost_iters > 0) {
             Label h_block_loop;
 
@@ -4129,10 +4174,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::setup_stack_space() {
             || jcp.uses_permw_transposition) {
         int ur_w, ur_w_tail, ur_w_trips;
         get_ur_w(ur_w, ur_w_tail, ur_w_trips);
-        ur_w = nstl::max(ur_w, ur_w_tail);
+        ur_w = static_cast<int>(nstl::max<dim_t>(ur_w, ur_w_tail));
         ic_block_step_stack_size = jcp.uses_permw_transposition
-                ? permw_stack_size(ur_w)
-                : interleave_stack_size(ur_w, jcp.ic_block_step);
+                ? static_cast<int>(permw_stack_size(ur_w))
+                : interleave_stack_size(
+                          ur_w, static_cast<int>(jcp.ic_block_step));
     } else
         ic_block_step_stack_size = extern_ic_block_step_stack_size;
 
@@ -4230,9 +4276,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -4243,13 +4289,13 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && IMPLICATION(jcp.dilate_h != 0, ext_kh <= jcp.ih);
     VDISPATCH_CONV_IC(ok, "dilation / stride values do not match");
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4329,14 +4375,16 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
@@ -4360,8 +4408,10 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
                     data_type::bf16);
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_DT_CFG);
 
-    jcp.ic_tail = is_data_layout_nxc ? jcp.ic % jcp.ic_block : 0;
-    jcp.oc_tail = is_data_layout_nxc ? jcp.oc % jcp.oc_block : 0;
+    jcp.ic_tail
+            = is_data_layout_nxc ? static_cast<int>(jcp.ic % jcp.ic_block) : 0;
+    jcp.oc_tail
+            = is_data_layout_nxc ? static_cast<int>(jcp.oc % jcp.oc_block) : 0;
 
     if (jcp.is_1stconv) {
         jcp.ic_block_step = 24 / jcp.kw;
@@ -4381,7 +4431,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && jcp.kw == 1 && jcp.ic_block_step > 4;
     // Threshold is based on performance measurements
     const bool apply_permw_nxc = is_data_layout_nxc && ndims == 3
-            && nstl::max(jcp.ic, jcp.oc) <= 32;
+            && nstl::max<dim_t>(jcp.ic, jcp.oc) <= 32;
     jcp.uses_permw_transposition
             = is_permw_applicable && (apply_permw_blocked || apply_permw_nxc);
 
@@ -4437,7 +4487,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
     bool use_spatial_blocking = jcp.is_1stconv && !nt_stores_ok && blocking_ok;
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    int optimal_blk_size = static_cast<int>(is_3d ? jcp.od
+                    : is_2d                       ? jcp.oh
+                                                  : jcp.ow);
     if (use_spatial_blocking) {
         // Default value, works best most of the times
         // TODO: For 3D shapes with intermediate sizes especially the ones not
@@ -4491,7 +4543,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // padding. Because elements are read two at a time, we may need r_pad + 1
     // padding on the right. As such, the shared padding is the max of l_pad and
     // r_pad + 1, rounded as necessary for the transpose data format.
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    const dim_t tr_pad
+            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = jcp.transpose_src
             ? rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
                     * jcp.stride_w
@@ -4517,7 +4570,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     const auto out_row_size
             = static_cast<size_t>(jcp.oc_block) * jcp.tr_ow * jcp.typesize_in;
     const auto full_spat_min_h_block_size
-            = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+            = nstl::max<dim_t>(1, nstl::max<dim_t>(jcp.b_pad, jcp.t_pad));
     const auto full_spat_working_set_size
             = (inp_row_size + out_row_size) * full_spat_min_h_block_size;
     bool use_full_spat_loop = isa_has_bf16(jcp.isa) && jcp.ndims < 5
@@ -4572,7 +4625,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.nb_ic_blocking_max = 1;
     if (is_data_layout_nxc && jcp.uses_permw_transposition
             && (jcp.ow > max_ur_w || jcp.ndims == 5))
-        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+        jcp.nb_ic_blocking_max = static_cast<int>(
+                nstl::min<dim_t>(8, div_up(jcp.nb_ic, jcp.nthr_ic_b)));
     return status::success;
 }
 
@@ -4656,7 +4710,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = max_threads / nthr_g_;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -4682,8 +4736,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         dim_t wei_size
                 = (dim_t)j.oc * j.ic * j.kd * j.kh * j.kw * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
-        float oi_channels_ratio = (float)j.nb_oc / j.nb_ic;
+        float wei_compensation_scale
+                = 0.5f * (float)(dst_size + src_size) / (float)wei_size;
+        float oi_channels_ratio = (float)j.nb_oc / (float)j.nb_ic;
         auto get_src_coef = [oi_channels_ratio, wei_compensation_scale]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
             if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
@@ -4703,16 +4758,24 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         const float dst_coef = get_dst_coef();
         const float wei_coef = get_wei_coef();
 
-        float src_v = src_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_ic, nthr_ic_b) * j.mb
-                * j.ic_block * j.id * j.ih * j.tr_iw / j.nthr_mb_work
-                / j.stride_d / j.stride_h / j.stride_w;
-        float wei_v = wei_coef * div_up(j.ngroups, nthr_g_)
-                * div_up(j.nb_oc, nthr_oc_b) * div_up(j.nb_ic, nthr_ic_b) * j.kh
-                * j.kw * j.kd * j.ic_block * j.oc_block;
-        float dst_v = dst_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_oc, nthr_oc_b) * j.mb
-                * j.oc_block * j.od * j.oh * j.tr_ow / j.nthr_mb_work;
+        float src_v = src_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_ic, nthr_ic_b) * j.mb * j.ic_block * j.id
+                        * j.ih * j.tr_iw)
+                / (float)(j.nthr_mb_work * j.stride_d * j.stride_h
+                        * j.stride_w);
+        float wei_v = wei_coef
+                * (float)(div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_oc, nthr_oc_b)
+                        * div_up(j.nb_ic, nthr_ic_b) * j.kh * j.kw * j.kd
+                        * j.ic_block * j.oc_block);
+        float dst_v = dst_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_oc, nthr_oc_b) * j.mb * j.oc_block * j.od
+                        * j.oh * j.tr_ow)
+                / (float)j.nthr_mb_work;
 
         return src_v + dst_v + wei_v;
     };
@@ -4720,12 +4783,15 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
     float best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
 
     /* find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, j.nthr_mb_work);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, j.nthr_mb_work));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
 
             float mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -4738,7 +4804,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
     }
 
     if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
-        nthr_mb_ = nstl::min(j.nthr_mb_work, nthr);
+        nthr_mb_ = static_cast<int>(nstl::min<dim_t>(j.nthr_mb_work, nthr));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= max_threads);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -855,31 +855,34 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.has_vnni = true;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
     jcp.dst_dt = dst_d.data_type();
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
@@ -1594,35 +1597,38 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(diff_src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(diff_src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(diff_src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
     jcp.dst_dt = cd.diff_src_desc.data_type;
     jcp.nb_iw = 1;
     jcp.iw_block = jcp.iw;
@@ -4238,35 +4244,39 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(diff_weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5)
+            ? static_cast<int>(diff_weights_d.dims()[with_groups + 2])
+            : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -575,15 +575,15 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
-    dim_t iw = jcp.iw;
-    dim_t ow = jcp.ow;
-    int ow_block = static_cast<int>(jcp.ow_block);
-    dim_t nb_ow = jcp.nb_ow;
-    dim_t kw = jcp.kw;
-    dim_t l_pad = jcp.l_pad;
-    int ur_w = jcp.ur_w;
-    int ur_w_tail = jcp.ur_w_tail;
-    dim_t stride_w = jcp.stride_w;
+    const int iw = jcp.iw;
+    const int ow = jcp.ow;
+    const int ow_block = jcp.ow_block;
+    const int nb_ow = jcp.nb_ow;
+    const int kw = jcp.kw;
+    const int l_pad = jcp.l_pad;
+    const int ur_w = jcp.ur_w;
+    const int ur_w_tail = jcp.ur_w_tail;
+    const int stride_w = jcp.stride_w;
 
     auto src_shift = get_src_offset(0, filter_w_to_src(0, ur_w));
     auto dst_shift = get_dst_offset(ur_w, 0);
@@ -656,9 +656,9 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
     mov(reg_ker, ptr[param1 + GET_OFF(filt)]);
     mov(reg_kh, ptr[param1 + GET_OFF(kh_padding)]);
 
-    dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
-    dim_t n_oi = ow / ur_w;
-    dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    const int r_pad = nstl::max(0, jcp.r_pad);
+    int n_oi = ow / ur_w;
+    const int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -718,8 +718,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block
-                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
+        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -894,9 +893,9 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             ? static_cast<int>(types::data_type_size(jcp.bia_dt))
             : 0;
 
-    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1084,14 +1083,14 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                 * jcp.nb_oc_blocking * jcp.ur_w;
         dim_t size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
                 * jcp.nb_oc_blocking * jcp.kw;
-        dim_t nurw = (L1_part - size_wei_chunk)
+        const dim_t nurw = (L1_part - size_wei_chunk)
                 / (size_dst_chunk + size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        jcp.ow_block = jcp.ur_w * nstl::max<dim_t>(2, nurw);
+        jcp.ow_block = jcp.ur_w * static_cast<int>(nstl::max<dim_t>(2, nurw));
     }
     jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
 
-    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
                     jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
@@ -1635,9 +1634,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(dilate_ok, VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -2738,11 +2737,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        const dim_t ext_kw
-                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        r_pad = static_cast<int>(nstl::max<dim_t>(0,
-                calculate_end_padding(jcp.l_pad, jcp.tr_ow, jcp.tr_iw,
-                        jcp.stride_w, ext_kw)));
+        const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        r_pad = nstl::max(0,
+                calculate_end_padding(
+                        jcp.l_pad, jcp.tr_ow, jcp.tr_iw, jcp.stride_w, ext_kw));
     }
     dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
     ur_w = max_ur_w;
@@ -2774,7 +2772,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    dim_t ow = jcp.tr_ow;
+    const int ow = jcp.tr_ow;
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -2782,12 +2780,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        const dim_t ext_kw
-                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        dim_t iw = jcp.tr_iw;
-        r_pad = static_cast<int>(nstl::max<dim_t>(0,
-                calculate_end_padding(
-                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
+        const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        const int iw = jcp.tr_iw;
+        r_pad = nstl::max(0,
+                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
     }
     dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
@@ -2877,7 +2873,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     dim_t ic_block = jcp.ic_block;
     const int ic_tail = jcp.ic_tail;
-    dim_t ow = jcp.tr_ow;
+    const int ow = jcp.tr_ow;
 
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
@@ -2886,12 +2882,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        const dim_t ext_kw
-                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        dim_t iw = jcp.tr_iw;
-        r_pad = static_cast<int>(nstl::max<dim_t>(0,
-                calculate_end_padding(
-                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
+        const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        const int iw = jcp.tr_iw;
+        r_pad = nstl::max(0,
+                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
     }
     dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
@@ -2920,7 +2914,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         xor_(b_ic, b_ic);
         if (jcp.uses_permw_transposition) {
-            convert_src_to_vnni_format(static_cast<int>(ow), l_pad, r_pad, 0);
+            convert_src_to_vnni_format(ow, l_pad, r_pad, 0);
             xor_(b_ic, b_ic);
         }
 
@@ -3011,16 +3005,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 
     dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    dim_t ow = jcp.tr_ow;
+    const int ow = jcp.tr_ow;
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        const dim_t ext_kw
-                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        dim_t iw = jcp.tr_iw;
-        r_pad = static_cast<int>(nstl::max<dim_t>(0,
-                calculate_end_padding(
-                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
+        const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        const int iw = jcp.tr_iw;
+        r_pad = nstl::max(0,
+                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
     }
     dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
@@ -3404,7 +3396,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     const dim_t oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
     const dim_t oh_head_end
             = nstl::min<dim_t>(div_up(t_pad, stride_h), oh_body_end);
@@ -4276,9 +4268,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -4289,13 +4281,13 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && IMPLICATION(jcp.dilate_h != 0, ext_kh <= jcp.ih);
     VDISPATCH_CONV_IC(ok, "dilation / stride values do not match");
 
-    jcp.r_pad = nstl::max<dim_t>(0,
+    jcp.r_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max<dim_t>(0,
+    jcp.b_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max<dim_t>(0,
+    jcp.back_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4543,8 +4535,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // padding. Because elements are read two at a time, we may need r_pad + 1
     // padding on the right. As such, the shared padding is the max of l_pad and
     // r_pad + 1, rounded as necessary for the transpose data format.
-    const dim_t tr_pad
-            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    const int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = jcp.transpose_src
             ? rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
                     * jcp.stride_w

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -107,7 +107,7 @@ jit_avx512_core_bf16_fwd_kernel_vmm_t<
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         const dim_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const dim_t tail_size = oc_block_tail
+        const std::size_t tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -134,11 +134,11 @@ private:
     inline void prepare_dst(int ur_w);
     void apply_postops(int ur_w);
     inline void store_dst(int ur_w);
-    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop(int ur_w, dim_t pad_l, dim_t pad_r);
 
     void generate() override;
 
-    inline dim_t get_dst_offset(dim_t sp_idx, int ocb) {
+    inline dim_t get_dst_offset(dim_t sp_idx, dim_t ocb) {
         const bool is_layout_nxc = is_dst_layout_nxc();
         dim_t sp_str = is_layout_nxc ? static_cast<dim_t>(jcp.ngroups) * jcp.oc
                                      : jcp.oc_block;
@@ -147,20 +147,19 @@ private:
         return jcp.typesize_out * (ocb_str * ocb + sp_str * sp_idx);
     }
 
-    inline dim_t filter_w_to_src(int kw, int ow = 0, int pad_l = 0) {
-        return static_cast<dim_t>(kw) * (jcp.dilate_w + 1) + ow * jcp.stride_w
-                - pad_l;
+    inline dim_t filter_w_to_src(dim_t kw, dim_t ow = 0, dim_t pad_l = 0) {
+        return kw * (jcp.dilate_w + 1) + ow * jcp.stride_w - pad_l;
     }
-    inline dim_t filter_h_to_src(int kh) {
-        return static_cast<dim_t>(kh) * (jcp.dilate_h + 1) * jcp.iw;
+    inline dim_t filter_h_to_src(dim_t kh) {
+        return kh * (jcp.dilate_h + 1) * jcp.iw;
     }
-    inline dim_t filter_d_to_src(int kd) {
-        return static_cast<dim_t>(kd) * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
+    inline dim_t filter_d_to_src(dim_t kd) {
+        return kd * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
     }
 
     inline dim_t get_src_offset(dim_t ic_idx, dim_t isp) {
-        int icb = ic_idx / jcp.ic_block;
-        int ic = ic_idx % jcp.ic_block;
+        dim_t icb = ic_idx / jcp.ic_block;
+        dim_t ic = ic_idx % jcp.ic_block;
         dim_t isp_str = is_src_layout_nxc()
                 ? static_cast<dim_t>(jcp.ngroups) * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
@@ -174,12 +173,12 @@ private:
     }
 
     inline dim_t get_kernel_offset(
-            int ocb, int ic_idx, int kw, int kh = 0, int kd = 0) {
-        int scale = 2; //bf16 vnni is used
-        int rnd_ic_block = utils::rnd_up(jcp.ic_block, scale);
-        int icb = ic_idx / jcp.ic_block;
-        int ic = ic_idx % jcp.ic_block;
-        dim_t ksp_str = static_cast<dim_t>(rnd_ic_block) * jcp.oc_block;
+            dim_t ocb, dim_t ic_idx, dim_t kw, dim_t kh = 0, dim_t kd = 0) {
+        const dim_t scale = 2; //bf16 vnni is used
+        dim_t rnd_ic_block = utils::rnd_up(jcp.ic_block, scale);
+        dim_t icb = ic_idx / jcp.ic_block;
+        dim_t ic = ic_idx % jcp.ic_block;
+        dim_t ksp_str = rnd_ic_block * jcp.oc_block;
         dim_t ksp_idx
                 = static_cast<dim_t>(kd) * jcp.kh * jcp.kw + kh * jcp.kw + kw;
 
@@ -191,15 +190,16 @@ private:
                 * (ocb * ocb_str + icb * icb_str + ksp_idx * ksp_str + ic_off);
     }
 
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -354,11 +354,11 @@ private:
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop(int ur_w, dim_t l_overflow, dim_t r_overflow);
     void generate() override;
 
-    int get_iw_start(int ki, int l_overflow) {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    dim_t get_iw_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -367,10 +367,10 @@ private:
         return res;
     }
 
-    int get_iw_end(int ur_w, int ki, int r_overflow) {
+    dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -378,39 +378,39 @@ private:
         return ur_w - res;
     }
 
-    inline int filter_h_to_dst(int kh) {
+    inline dim_t filter_h_to_dst(dim_t kh) {
         return kh * (jcp.dilate_h + 1) * jcp.ow;
     }
-    inline int filter_d_to_dst(int kd) {
+    inline dim_t filter_d_to_dst(dim_t kd) {
         return kd * (jcp.dilate_d + 1) * jcp.ow * jcp.oh;
     }
 
-    inline size_t get_diff_src_offset(int iw_idx, int n_ic_block) {
+    inline dim_t get_diff_src_offset(dim_t iw_idx, dim_t n_ic_block) {
         const bool is_nxc_layout = is_dsrc_layout_nxc();
-        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
-        size_t icb_str = jcp.ic_block
-                * (is_nxc_layout ? 1 : (size_t)jcp.id * jcp.ih * jcp.iw);
+        dim_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
+        dim_t icb_str
+                = jcp.ic_block * (is_nxc_layout ? 1 : jcp.id * jcp.ih * jcp.iw);
         return jcp.typesize_out * (iw_str * iw_idx + icb_str * n_ic_block);
     }
 
-    inline size_t get_diff_dst_offset(
-            int osp_idx, int oc_within_block_idx, int oc_block_idx = 0) {
+    inline dim_t get_diff_dst_offset(
+            dim_t osp_idx, dim_t oc_within_block_idx, dim_t oc_block_idx = 0) {
         const bool is_nxc_layout = is_ddst_layout_nxc();
-        size_t osp_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
-        size_t ocb_str = jcp.oc_block
-                * (is_nxc_layout ? 1 : (size_t)jcp.od * jcp.oh * jcp.ow);
+        dim_t osp_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
+        dim_t ocb_str
+                = jcp.oc_block * (is_nxc_layout ? 1 : jcp.od * jcp.oh * jcp.ow);
         return jcp.typesize_in
                 * (osp_str * osp_idx + ocb_str * oc_block_idx
                         + oc_within_block_idx);
     }
 
-    inline size_t get_kernel_offset(
-            int icb, int oc_idx, int kw, int kh = 0, int kd = 0) {
+    inline dim_t get_kernel_offset(
+            dim_t icb, dim_t oc_idx, dim_t kw, dim_t kh = 0, dim_t kd = 0) {
         int scale = 2; //bf16 vnni is used
-        int ocb = oc_idx / jcp.oc_block;
-        int oc = oc_idx % jcp.oc_block;
-        size_t ksp_str = jcp.ic_block * jcp.oc_block;
-        size_t ksp_idx = kd * jcp.kh * jcp.kw + kh * jcp.kw + kw;
+        dim_t ocb = oc_idx / jcp.oc_block;
+        dim_t oc = oc_idx % jcp.oc_block;
+        dim_t ksp_str = jcp.ic_block * jcp.oc_block;
+        dim_t ksp_idx = kd * jcp.kh * jcp.kw + kh * jcp.kw + kw;
 
         size_t icb_str = jcp.kd * jcp.kh * jcp.kw * ksp_str;
         size_t ocb_str = jcp.nb_ic * icb_str;
@@ -569,18 +569,18 @@ private:
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
     inline void compute_oh_step_unroll_ow(int ic_block_step);
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_extern(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_interleave(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_vpermw(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_extern(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_interleave(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t src_offset,
+            dim_t kernel_offset, dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_vpermw(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
     inline void compute_oh_step_common(int ic_block_step);
     inline void compute_oh_step_disp();
     inline void compute_loop();
@@ -591,12 +591,12 @@ private:
     void compute_diff_bias_row(bool is_partial = true);
     void maybe_compute_diff_bias();
     void convert_src_to_vnni_format(
-            int ur_w, int pad_l, int pad_r, int src_offset);
+            int ur_w, dim_t pad_l, dim_t pad_r, dim_t src_offset);
     void may_be_set_oc_tail_mask();
     void may_be_reset_oc_tail_mask();
-    inline void compute_ic_block_step_vpermw_expl(int ur_w, int pad_l,
-            int pad_r, int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_vpermw_expl(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t src_offset,
+            dim_t kernel_offset, dim_t ddst_offset, bool is_tail = false);
     inline bool is_src_layout_nxc() const {
         return jcp.uses_permw_transposition
                 && utils::one_of(jcp.src_tag, format_tag::ndhwc,
@@ -613,26 +613,26 @@ private:
     static void balance(const jit_conv_conf_t &j, int &nthr, int &nthr_mb,
             int &nthr_g, int &nthr_oc_b, int &nthr_ic_b);
 
-    void get_w_positions(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw,
+    void get_w_positions(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw,
             int &iw_0, int &iw_1) const {
         auto get_w_position = [&](int idx) {
-            int iw = i_ur + idx;
+            dim_t iw = i_ur + idx;
             if (iw >= ur_w) return -1;
             iw += i_kw;
             if (iw - pad_l < 0 || iw > (ur_w - 1) + (jcp.kw - 1) - pad_r)
                 return -1;
-            return iw - pad_l;
+            return static_cast<int>(iw - pad_l);
         };
         iw_0 = get_w_position(0);
         iw_1 = get_w_position(1);
     }
-    bool check_borders(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw) {
+    bool check_borders(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw) {
         int iw_1, iw_2;
         get_w_positions(ur_w, pad_l, pad_r, i_ur, i_kw, iw_1, iw_2);
 
         return (iw_1 == -1 && iw_2 == -1) ? false : true;
     }
-    bool get_load_mask(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw,
+    bool get_load_mask(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw,
             Xbyak::Opmask &load_mask) {
         int iw_1, iw_2;
         get_w_positions(ur_w, pad_l, pad_r, i_ur, i_kw, iw_1, iw_2);
@@ -650,10 +650,10 @@ private:
         return rt;
     }
 
-    inline dim_t filter_w_to_src(int kw, int ow = 0, int pad_l = 0) const {
-        int stride_w = jcp.transpose_src ? 1 : jcp.stride_w;
-        return static_cast<dim_t>(kw) * (jcp.dilate_w + 1) + ow * stride_w
-                - pad_l;
+    inline dim_t filter_w_to_src(
+            dim_t kw, dim_t ow = 0, dim_t pad_l = 0) const {
+        const dim_t stride_w = jcp.transpose_src ? 1 : jcp.stride_w;
+        return kw * (jcp.dilate_w + 1) + ow * stride_w - pad_l;
     }
     inline dim_t filter_h_to_src(int kh) const {
         return static_cast<dim_t>(kh) * (jcp.dilate_h + 1);
@@ -690,8 +690,8 @@ private:
     }
 
     inline dim_t get_ddst_offset(dim_t w_idx, dim_t hd_idx = 0) {
-        int ow_per_oc = jcp.transpose_dst ? 2 : 1;
-        int ch_mult
+        const dim_t ow_per_oc = jcp.transpose_dst ? 2 : 1;
+        dim_t ch_mult
                 = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
         dim_t hd_off = jcp.tr_ow * ch_mult * hd_idx;
         dim_t w_off
@@ -699,7 +699,7 @@ private:
         return jcp.typesize_in * (w_off + hd_off);
     }
 
-    inline dim_t get_kernel_offset(int ic_idx, dim_t ksp_idx) const {
+    inline dim_t get_kernel_offset(dim_t ic_idx, dim_t ksp_idx) const {
         // Only the ic_idx index inside the block is supported,
         // ic_idx == jcp.ic_block is considered as a shift inside one block
         // and not as moving to the next ic block.
@@ -721,7 +721,7 @@ private:
     inline int interleave_w_reorder_size(int ur_w) const;
     inline int interleave_w_reorder_bytes(int ur_w);
     inline int interleave_stack_size(int ur_w, int ic_block_step);
-    inline int permw_stack_size(int ur_w) const {
+    inline dim_t permw_stack_size(dim_t ur_w) const {
         return (ur_w + jcp.kw - 1) * sizeof_cacheline;
     }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -71,10 +71,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks * jcp.nb_ow;
 
@@ -84,14 +84,14 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
         balance211(work_amount, nthr, ithr, start, end);
         auto par_conv = jit_conv_args_t();
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn) {
-            int dummy {0};
+            dim_t dummy {0};
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
                     nb_groups, n, jcp.mb, dummy, 1);
         } else if (jcp.loop_order == loop_gncw) {
-            int dummy {0};
+            dim_t dummy {0};
             nd_iterator_init(start, gg, nb_groups, n, jcp.mb, occ, oc_chunks,
                     owb, jcp.nb_ow, dummy, 1);
         } else if (jcp.loop_order == loop_nhwcg) {
@@ -101,13 +101,13 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w
@@ -117,7 +117,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb);
 
@@ -135,11 +135,11 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
             (*kernel_)(&par_conv);
 
             if (jcp.loop_order == loop_cwgn) {
-                int dummy {0};
+                dim_t dummy {0};
                 nd_iterator_jump(start, end, occ, oc_chunks, owb, jcp.nb_ow, gg,
                         nb_groups, n, jcp.mb, dummy, 1);
             } else if (jcp.loop_order == loop_gncw) {
-                int dummy {0};
+                dim_t dummy {0};
                 nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, occ,
                         oc_chunks, owb, jcp.nb_ow, dummy, 1);
             } else if (jcp.loop_order == loop_nhwcg) {
@@ -172,10 +172,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks
             * jcp.oh * jcp.nb_ow;
 
@@ -191,7 +191,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
         size_t dst_h_stride = dst_d.blk_off<false, true>(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -207,18 +207,18 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
 
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) oh_e = oh_s + 1; //step instead
 
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w = dst
@@ -228,19 +228,20 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, ih_s, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-            for (int oj = oh_s, ij = ih_s; oj < oh_e;
+            for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                     ++oj, ij += jcp.stride_h) {
-                int dilate_h = jcp.dilate_h + 1;
-                int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                int i_b_overflow = div_up(
-                        max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+                dim_t dilate_h = jcp.dilate_h + 1;
+                dim_t i_t_overflow = div_up(max<dim_t>(0, -ij), dilate_h);
+                dim_t i_b_overflow = div_up(
+                        max<dim_t>(
+                                0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h);
-                int kh_padding
-                        = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+                dim_t kh_padding = nstl::max<dim_t>(
+                        0, jcp.kh - i_t_overflow - i_b_overflow);
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
@@ -298,10 +299,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks
             * jcp.od * jcp.oh * jcp.nb_ow;
 
@@ -319,7 +320,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, gg {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -335,25 +336,26 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
 
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) oh_e = oh_s + 1; //step instead
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
-            int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-            int dilate_d = jcp.dilate_d + 1;
-            int d_t_overflow = div_up(max(0, -id_s), dilate_d);
-            int d_b_overflow = div_up(
-                    max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+            dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+            dim_t dilate_d = jcp.dilate_d + 1;
+            dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
+            dim_t d_b_overflow = div_up(
+                    max<dim_t>(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                     dilate_d);
-            int kd_padding = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+            dim_t kd_padding
+                    = nstl::max<dim_t>(0, jcp.kd - d_t_overflow - d_b_overflow);
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w = dst
@@ -364,21 +366,22 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, id_s, ih_s, iw_s)
                     + d_t_overflow * dilate_d * src_d_stride;
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0)
                     + d_t_overflow * wht_d_stride;
 
-            for (int oj = oh_s, ij = ih_s; oj < oh_e;
+            for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                     ++oj, ij += jcp.stride_h) {
-                int dilate_h = jcp.dilate_h + 1;
-                int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                int i_b_overflow = div_up(
-                        max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+                dim_t dilate_h = jcp.dilate_h + 1;
+                dim_t i_t_overflow = div_up(max<dim_t>(0, -ij), dilate_h);
+                dim_t i_b_overflow = div_up(
+                        max<dim_t>(
+                                0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h);
-                int kh_padding
-                        = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+                dim_t kh_padding = nstl::max<dim_t>(
+                        0, jcp.kh - i_t_overflow - i_b_overflow);
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
@@ -430,12 +433,12 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
     const auto &jcp = pd()->jcp_;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t start {0}, end {0};
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
         // TODO: experiment with g_blocking for perf fine tuning
-        int g_blocking = 1;
-        int nb_groups = jcp.ngroups / g_blocking;
-        int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+        dim_t g_blocking = 1;
+        dim_t nb_groups = jcp.ngroups / g_blocking;
+        dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto par_conv = jit_conv_args_t();
@@ -449,7 +452,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        int n {0}, gg {0}, icc {0}, id_s {0}, ih_s {0};
+        dim_t n {0}, gg {0}, icc {0}, id_s {0}, ih_s {0};
         if (jcp.loop_order == loop_cgn)
             nd_iterator_init(start, icc, ic_chunks, gg, nb_groups, n, jcp.mb,
                     id_s, jcp.id, ih_s, jcp.ih);
@@ -463,28 +466,30 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int icb = icc * jcp.nb_ic_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+            dim_t icb = icc * jcp.nb_ic_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) ih_e = ih_s + 1; //step instead
 
-            int od_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t od_s = 0, kd_len = 0, kd_lo = 0;
             if (is_fast_path_d) {
-                int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                int d_b_overflow
-                        = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                dim_t d_t_overflow
+                        = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                dim_t d_b_overflow
+                        = max<dim_t>(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                 kd_len = jcp.kd - d_t_overflow - d_b_overflow;
                 kd_lo = d_b_overflow;
                 od_s = id_s + jcp.f_pad - d_b_overflow;
             } else if (jcp.dilate_d != 0) { // stride == 1
-                int dilate_d = jcp.dilate_d + 1;
+                dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
-                int d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                dim_t d_t_overflow = div_up(
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                         dilate_d);
-                int d_b_overflow
-                        = div_up(max(0,
+                dim_t d_b_overflow
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.id
                                                  + id_s - jcp.back_pad),
                                 dilate_d);
@@ -492,14 +497,14 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                 kd_lo = d_b_overflow;
                 od_s = id_s + jcp.f_pad - d_b_overflow * dilate_d;
             } else { // dilate == 0
-                int d_t_overflow = max(
+                dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                int d_b_overflow = max(0,
+                dim_t d_b_overflow = max<dim_t>(0,
                         (jcp.kd - jcp.id + id_s - jcp.back_pad) / jcp.stride_d);
-                int overflow_kd_hi = jcp.kd - 1
+                dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(
                                 jcp.id - 1 + jcp.back_pad - id_s, jcp.stride_d);
-                int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_b_overflow;
@@ -509,32 +514,36 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
             assert(kd_len >= 0);
 
             const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-            const int ic_idx = is_dsrc_layout_nxc
+            const dim_t ic_idx = is_dsrc_layout_nxc
                     ? g * jcp.ic + icb * jcp.ic_block
                     : g * jcp.nb_ic + icb;
             auto diff_src_w = diff_src
                     + jcp.typesize_out * diff_src_d.blk_off(n, ic_idx, id_s);
             const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-            const int oc_idx = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
+            const dim_t oc_idx
+                    = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
             auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_idx, od_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, 0, icb, kd_lo);
 
-            for (int ij = ih_s; ij < ih_e; ++ij) {
-                int oj, kh_len, kh_lo;
+            for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                dim_t oj, kh_len, kh_lo;
                 if (is_fast_path_h) { // dilate == 0 && stride == 1
-                    int i_t_overflow = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                    int i_b_overflow = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                    dim_t i_t_overflow
+                            = max<dim_t>(0, jcp.kh - 1 - ij - jcp.t_pad);
+                    dim_t i_b_overflow
+                            = max<dim_t>(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                     kh_len = jcp.kh - i_t_overflow - i_b_overflow;
                     kh_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow;
                 } else if (jcp.dilate_h != 0) { // stride == 1
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int i_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
+                    dim_t i_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
                             dilate_h);
-                    int i_b_overflow
-                            = div_up(max(0,
+                    dim_t i_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.ih + ij - jcp.b_pad),
                                     dilate_h);
@@ -542,13 +551,13 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                     kh_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                 } else { // dilate == 0
-                    int i_t_overflow = max(
+                    dim_t i_t_overflow = max<dim_t>(
                             0, (jcp.kh - 1 - ij - jcp.t_pad) / jcp.stride_h);
-                    int i_b_overflow = max(0,
+                    dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
-                    int overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - i_t_overflow - i_b_overflow;
@@ -598,12 +607,12 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
     const auto &jcp = pd()->jcp_;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t start {0}, end {0};
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
         // TODO: experiment with g_blocking for perf fine tuning
-        int g_blocking = 1;
-        int nb_groups = jcp.ngroups / g_blocking;
-        int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+        dim_t g_blocking = 1;
+        dim_t nb_groups = jcp.ngroups / g_blocking;
+        dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto par_conv = jit_conv_args_t();
@@ -616,7 +625,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+        dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
                     nb_groups, n, jcp.mb, ih_s, jcp.ih);
@@ -630,22 +639,23 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int icb = icc * jcp.nb_ic_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+            dim_t icb = icc * jcp.nb_ic_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) ih_e = ih_s + 1; //step instead
-            int iw_s = iwb * jcp.iw_block;
-            int ow_s = iw_s / jcp.stride_w;
+            dim_t iw_s = iwb * jcp.iw_block;
+            dim_t ow_s = iw_s / jcp.stride_w;
 
             auto diff_src_w = diff_src;
             auto diff_dst_w = diff_dst;
             const bool is_ddst_layout_nxc = utils::one_of(
                     jcp.dst_tag, format_tag::nwc, format_tag::nhwc);
-            const int oc_idx = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
+            const dim_t oc_idx
+                    = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
             const bool is_dsrc_layout_nxc = utils::one_of(
                     jcp.src_tag, format_tag::nwc, format_tag::nhwc);
-            const int ic_idx = is_dsrc_layout_nxc
+            const dim_t ic_idx = is_dsrc_layout_nxc
                     ? g * jcp.ic + icb * jcp.ic_block
                     : g * jcp.nb_ic + icb;
             if (jcp.ndims == 3) {
@@ -659,22 +669,25 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
             }
             auto wht_w = weights + wht_blk_off(weights_d, g, 0, icb);
 
-            for (int ij = ih_s; ij < ih_e; ++ij) {
-                int oj, k_len, k_lo;
+            for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                dim_t oj, k_len, k_lo;
                 if (is_fast_path) { // dilate == 0 && stride == 1
-                    int i_t_overflow = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                    int i_b_overflow = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                    dim_t i_t_overflow
+                            = max<dim_t>(0, jcp.kh - 1 - ij - jcp.t_pad);
+                    dim_t i_b_overflow
+                            = max<dim_t>(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                     k_len = jcp.kh - i_t_overflow - i_b_overflow;
                     k_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow;
                 } else if (jcp.dilate_h != 0) { // stride == 1
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int i_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
+                    dim_t i_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
                             dilate_h);
-                    int i_b_overflow
-                            = div_up(max(0,
+                    dim_t i_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.ih + ij - jcp.b_pad),
                                     dilate_h);
@@ -682,13 +695,13 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
                     k_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                 } else { // dilate == 0
-                    int i_t_overflow = max(
+                    dim_t i_t_overflow = max<dim_t>(
                             0, (jcp.kh - 1 - ij - jcp.t_pad) / jcp.stride_h);
-                    int i_b_overflow = max(0,
+                    dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
-                    int overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     k_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h + 1
                             - i_t_overflow - i_b_overflow;
@@ -842,34 +855,35 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
         ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
                 + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        int work_amount = static_cast<int>(jcp.nthr_mb_work);
         /* reduction dimension */
         balance211(work_amount, self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
+                g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };
 
 size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_src_buf_number(
-        const thread_info_t *ti, int g, int ic) const {
+        const thread_info_t *ti, dim_t g, dim_t ic) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + ic
             : ti->ithr;
 }
 size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_diff_dst_buf_number(
-        const thread_info_t *ti, int g, int oc) const {
+        const thread_info_t *ti, dim_t g, dim_t oc) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_oc * jcp.ngroups + g * jcp.nb_oc + oc
@@ -877,7 +891,7 @@ size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_diff_dst_buf_number(
 }
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
-        src_data_t *tr_src, const src_data_t *src, int row_count) const {
+        src_data_t *tr_src, const src_data_t *src, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     const int pf_depth = 2;
     struct {
@@ -886,14 +900,14 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
     } pf_circ_buf_src[pf_depth];
 
     assert(jcp.ic_block == 16 || jcp.is_1stconv);
-    const int src_stride = jcp.iw * jcp.ic_block;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ic_block;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
     for (int iwork = 0; iwork < row_count + pf_depth - 1; iwork++) {
         pf_circ_buf_src[iwork % pf_depth] = {src, tr_src};
 
         if (iwork >= pf_depth - 1) {
-            int old_idx = (iwork - pf_depth + 1) % pf_depth;
+            dim_t old_idx = (iwork - pf_depth + 1) % pf_depth;
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = pf_circ_buf_src[old_idx].src;
             ctx.tr_src = pf_circ_buf_src[old_idx].tr_src;
@@ -907,27 +921,29 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
 }
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
-        src_data_t *tr_src, const src_data_t *src_base, int spatial_start,
-        dim_t spatial_start_offset, int icb_start, dim_t chb_stride,
-        int row_count) const {
+        src_data_t *tr_src, const src_data_t *src_base, dim_t spatial_start,
+        dim_t spatial_start_offset, dim_t icb_start, dim_t chb_stride,
+        dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int src_stride = jcp.iw * jcp.ngroups * jcp.ic;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
-    int work_rest = row_count;
-    int max_spatial_work = jcp.id * jcp.ih;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    dim_t work_rest = row_count;
+    dim_t max_spatial_work = jcp.id * jcp.ih;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *src = src_base + spatial_start_offset;
-    int icb = 0;
-    const int ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
+    dim_t icb = 0;
+    const dim_t ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = src;
             ctx.tr_src = tr_src;
             assert(icb_start + icb < jcp.nb_ic);
-            ctx.ch_work = (icb_start + icb + 1) == jcp.nb_ic ? ic_tail_work
-                                                             : jcp.ic_block;
+            ctx.ch_work = static_cast<int>((icb_start + icb + 1) == jcp.nb_ic
+                            ? ic_tail_work
+                            : jcp.ic_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_kernel_)(&ctx);
@@ -935,7 +951,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
             tr_src += tr_src_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         icb++;
         src = src_base + icb * chb_stride;
     }
@@ -943,7 +959,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst,
-        int row_count) const {
+        dim_t row_count) const {
 
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     const int pf_depth = 2;
@@ -953,15 +969,15 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
     } pf_circ_buf_dst[pf_depth];
 
     assert(jcp.ic_block == 16 || jcp.is_1stconv);
-    const int diff_dst_stride = jcp.ow * jcp.oc_block;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    const dim_t diff_dst_stride = jcp.ow * jcp.oc_block;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
 
     for (int iwork = 0; iwork < row_count + pf_depth - 1; iwork++) {
         pf_circ_buf_dst[iwork % pf_depth]
                 = {(diff_dst_data_t *)diff_dst, tr_diff_dst};
 
         if (iwork >= pf_depth - 1) {
-            int old_idx = (iwork - pf_depth + 1) % pf_depth;
+            dim_t old_idx = (iwork - pf_depth + 1) % pf_depth;
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = pf_circ_buf_dst[old_idx].diff_dst;
             ctx.tr_src = pf_circ_buf_dst[old_idx].tr_diff_dst;
@@ -976,25 +992,27 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_dst_nxc(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst_base,
-        int spatial_start, dim_t spatial_start_offset, int ocb_start,
-        dim_t chb_stride, int row_count) const {
+        dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+        dim_t chb_stride, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
-    int work_rest = row_count;
-    int max_spatial_work = jcp.od * jcp.oh;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    const dim_t diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    dim_t work_rest = row_count;
+    dim_t max_spatial_work = jcp.od * jcp.oh;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *diff_dst = diff_dst_base + spatial_start_offset;
-    int ocb = 0;
-    const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+    dim_t ocb = 0;
+    const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
     while (work_rest > 0) {
         for (int iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = diff_dst;
             ctx.tr_src = tr_diff_dst;
             assert(ocb_start + ocb < jcp.nb_oc);
-            ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                             : jcp.oc_block;
+            ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                            ? oc_tail_work
+                            : jcp.oc_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_dst_kernel_)(&ctx);
@@ -1002,7 +1020,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_dst_nxc(
             tr_diff_dst += tr_diff_dst_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         ocb++;
         diff_dst = diff_dst_base + ocb * chb_stride;
     }
@@ -1017,10 +1035,10 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_hblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_hblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1040,30 +1058,30 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + oj * tr_row_size;
     };
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
-        const int ih_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        dim_t ih_s = nstl::max<dim_t>(0, -jcp.t_pad + oh_s * jcp.stride_h);
+        const dim_t ih_e = nstl::min<dim_t>(
                 jcp.ih, -jcp.t_pad + (oh_e - 1) * jcp.stride_h + ext_kh);
 
-        auto tr_src_off = [&](int g, int ic, int ih_end, int ij) {
-            const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ih_end, dim_t ij) {
+            const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             // Aligned to buffer end to use guard elements
             return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                     + (jcp.ih - ih_end + ij) * tr_row_size;
@@ -1074,25 +1092,26 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][ih][16][~iw~] <- src[nb_ic][ih][iw][16] */
             if (jcp.transpose_src) {
-                int j {0};
-                const int work_amount
+                dim_t j {0};
+                const dim_t work_amount
                         = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start,
                         tr_end);
 
-                int g {0}, ic_b {0};
+                dim_t g {0}, ic_b {0};
                 nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work,
                         j, ih_e - ih_s);
 
                 if (nthr_oc_b_ > 1)
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int ic_b_ = ic_b + ti->ic_b_start;
-                    int j_s = j + ih_s;
-                    int j_e = j_s + nstl::min(tr_end - tr_start, ih_e - j_s);
-                    const int ic_off_idx = is_src_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t ic_b_ = ic_b + ti->ic_b_start;
+                    dim_t j_s = j + ih_s;
+                    dim_t j_e = j_s
+                            + nstl::min<dim_t>(tr_end - tr_start, ih_e - j_s);
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g_ * jcp.ic + ic_b_ * jcp.ic_block
                             : g_ * jcp.nb_ic + ic_b_;
                     const src_data_t *src
@@ -1112,25 +1131,26 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             }
             if (jcp.transpose_dst) {
-                int j {0};
-                const int work_amount
+                dim_t j {0};
+                const dim_t work_amount
                         = ti->g_work * ti->oc_b_work * (oh_e - oh_s);
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start,
                         tr_end);
 
-                int g {0}, oc_b {0};
+                dim_t g {0}, oc_b {0};
                 nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work,
                         j, oh_e - oh_s);
 
                 if (nthr_ic_b_ > 1)
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int oc_b_ = oc_b + ti->oc_b_start;
-                    int j_s = j + oh_s;
-                    int j_e = j_s + nstl::min(tr_end - tr_start, oh_e - j_s);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t oc_b_ = oc_b + ti->oc_b_start;
+                    dim_t j_s = j + oh_s;
+                    dim_t j_e = j_s
+                            + nstl::min<dim_t>(tr_end - tr_start, oh_e - j_s);
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g_ * jcp.oc + oc_b_ * jcp.oc_block
                             : g_ * jcp.nb_oc + oc_b_;
                     const diff_dst_data_t *diff_dst
@@ -1152,34 +1172,36 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             }
         }
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
         int ic_b_step
                 = jcp.uses_permw_transposition ? jcp.nb_ic_blocking_max : 1;
         int icb_work = ti->ic_b_end - ti->ic_b_start;
         if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
             ic_b_step = utils::div_up(icb_work, 2);
 
-        for_(int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int ohb_e = nstl::min(ohb_s + height_block, oh_e);
-            const int ihb_s = nstl::max(0, -jcp.t_pad + ohb_s * jcp.stride_h);
-            const int ihb_e = nstl::min(
+            const dim_t ohb_e = nstl::min<dim_t>(ohb_s + height_block, oh_e);
+            const dim_t ihb_s
+                    = nstl::max<dim_t>(0, -jcp.t_pad + ohb_s * jcp.stride_h);
+            const dim_t ihb_e = nstl::min<dim_t>(
                     jcp.ih, -jcp.t_pad + (ohb_e - 1) * jcp.stride_h + ext_kh);
             assert(IMPLICATION(jcp.global_transpose,
                     oh_s == ohb_s && oh_e == ohb_e && ih_s == ihb_s
                             && ih_e == ihb_e));
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             if (jcp.transpose_src) {
@@ -1249,10 +1271,10 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
     const auto &jcp = kernel_->jcp;
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_dblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_dblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1272,31 +1294,31 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od) {
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od) {
         assert(IMPLICATION(is_ddst_layout_nxc, jcp.transpose_dst));
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
-        const size_t tr_3d_size = tr_row_size * jcp.oh;
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.oh;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size;
     };
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
-        const int id_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        dim_t id_s = nstl::max<dim_t>(0, -jcp.f_pad + od_s * jcp.stride_d);
+        const dim_t id_e = nstl::min<dim_t>(
                 jcp.id, -jcp.f_pad + (od_e - 1) * jcp.stride_d + ext_kd);
 
-        auto tr_src_off_3d = [&](int g, int ic, int id_end, int id) {
-            const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
-            const size_t tr_3d_size = tr_row_size * jcp.ih;
+        auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id_end, dim_t id) {
+            const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+            const dim_t tr_3d_size = tr_row_size * jcp.ih;
             // Aligned to buffer end to use guard elements
             return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                     + (jcp.id - id_end + id) * tr_3d_size;
@@ -1307,16 +1329,16 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][id][16][~iw~] <- src[nb_ic][id][iw][16] */
             if (jcp.transpose_src) {
-                int d {0};
+                dim_t d {0};
 
-                const int work_amount
+                const dim_t work_amount
                         = ti->g_work * ti->ic_b_work * (id_e - id_s);
 
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start,
                         tr_end);
 
-                int g {0}, ic_b {0};
+                dim_t g {0}, ic_b {0};
 
                 nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work,
                         d, id_e - id_s);
@@ -1324,12 +1346,13 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                 if (nthr_oc_b_ > 1)
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int ic_b_ = ic_b + ti->ic_b_start;
-                    int d_s = d + id_s;
-                    int d_e = d_s + nstl::min(tr_end - tr_start, id_e - d_s);
+                    dim_t g_ = g + ti->g_start;
+                    dim_t ic_b_ = ic_b + ti->ic_b_start;
+                    dim_t d_s = d + id_s;
+                    dim_t d_e = d_s
+                            + nstl::min<dim_t>(tr_end - tr_start, id_e - d_s);
 
-                    const int ic_off_idx = is_src_layout_nxc
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g_ * jcp.ic + ic_b_ * jcp.ic_block
                             : g_ * jcp.nb_ic + ic_b_;
                     const src_data_t *src
@@ -1350,16 +1373,16 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             }
             if (jcp.transpose_dst) {
-                int d {0};
+                dim_t d {0};
 
-                const int work_amount
+                const dim_t work_amount
                         = ti->g_work * ti->oc_b_work * (od_e - od_s);
 
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start,
                         tr_end);
 
-                int g {0}, oc_b {0};
+                dim_t g {0}, oc_b {0};
 
                 nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work,
                         d, od_e - od_s);
@@ -1367,11 +1390,12 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                 if (nthr_ic_b_ > 1)
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int oc_b_ = oc_b + ti->oc_b_start;
-                    int d_s = d + od_s;
-                    int d_e = d_s + nstl::min(tr_end - tr_start, od_e - d_s);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t oc_b_ = oc_b + ti->oc_b_start;
+                    dim_t d_s = d + od_s;
+                    dim_t d_e = d_s
+                            + nstl::min<dim_t>(tr_end - tr_start, od_e - d_s);
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g_ * jcp.oc + oc_b_ * jcp.oc_block
                             : g_ * jcp.nb_oc + oc_b_;
 
@@ -1396,37 +1420,38 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
             }
         }
 
-        int depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
+        dim_t depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
 
-        for_(int odb_s = od_s; odb_s < od_e; odb_s += depth_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end; ++ic_b) {
-            const int odb_e = nstl::min(odb_s + depth_block, od_e);
-            const int idb_s = nstl::max(0, -jcp.f_pad + odb_s * jcp.stride_d);
-            const int idb_e = nstl::min(
+        for_(dim_t odb_s = od_s; odb_s < od_e; odb_s += depth_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end; ++ic_b) {
+            const dim_t odb_e = nstl::min<dim_t>(odb_s + depth_block, od_e);
+            const dim_t idb_s
+                    = nstl::max<dim_t>(0, -jcp.f_pad + odb_s * jcp.stride_d);
+            const dim_t idb_e = nstl::min<dim_t>(
                     jcp.id, -jcp.f_pad + (odb_e - 1) * jcp.stride_d + ext_kd);
-            const int kdb_front_pad
-                    = nstl::max(0, jcp.f_pad - odb_s * jcp.stride_d);
+            const dim_t kdb_front_pad
+                    = nstl::max<dim_t>(0, jcp.f_pad - odb_s * jcp.stride_d);
             // Assumes kd_back_pad = 0 when kernel is dilated
-            const int kdb_back_pad = nstl::max(
+            const dim_t kdb_back_pad = nstl::max<dim_t>(
                     0, odb_s * jcp.stride_d + jcp.kd - jcp.f_pad - jcp.id);
-            const int kdb_pad_off = nstl::min(jcp.kd - 1, kdb_front_pad)
-                    * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
-                    * jcp.typesize_out;
+            const dim_t kdb_pad_off
+                    = nstl::min<dim_t>(jcp.kd - 1, kdb_front_pad) * jcp.kh
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
             assert(IMPLICATION(jcp.global_transpose,
                     od_s == odb_s && od_e == odb_e && id_s == idb_s
                             && id_e == idb_e));
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
             if (jcp.transpose_src) {
                 if (!jcp.global_transpose) {
@@ -1504,7 +1529,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
     const size_t wei_size = static_cast<size_t>(jcp.ngroups) * jcp.nb_oc
             * jcp.oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
             * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1524,45 +1549,45 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_src_off = [&](int g, int ic, int ij) {
+    auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ij) {
         assert(IMPLICATION(is_src_layout_nxc, jcp.transpose_src));
-        const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                 + ij * tr_row_size;
     };
 
-    auto tr_src_off_3d = [&](int g, int ic, int id, int ij) {
+    auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id, dim_t ij) {
         assert(IMPLICATION(is_ddst_layout_nxc, jcp.transpose_dst));
-        const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
-        const size_t tr_3d_size = tr_row_size * jcp.ih;
+        const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.ih;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                 + id * tr_3d_size + ij * tr_row_size;
     };
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + oj * tr_row_size;
     };
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
-        const size_t tr_3d_size = tr_row_size * jcp.oh;
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.oh;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size + oj * tr_row_size;
     };
 
-    auto uker_trans = [&](int img, int g = 0, int ic_b = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.ih * jcp.id;
+    auto uker_trans = [&](dim_t img, dim_t g = 0, dim_t ic_b = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.ih * jcp.id;
         dim_t ic;
-        int icb_start = ic_b;
+        dim_t icb_start = ic_b;
         if (jcp.global_transpose) {
-            const int work_amount = is_src_layout_nxc
+            const dim_t work_amount = is_src_layout_nxc
                     ? ti->ic_b_work * jcp.ih * jcp.id
                     : ti->g_work * ti->ic_b_work * jcp.ih * jcp.id;
 
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, start, end);
             my_work = end - start;
 
@@ -1596,7 +1621,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         const bool need_local_gwork = is_src_layout_nxc && jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork)
                 ic = static_cast<dim_t>(gg) * jcp.ic
                         + static_cast<dim_t>(ic_b) * jcp.ic_block;
@@ -1614,7 +1639,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                         ? src_d.blk_off(0, 0, d, j)
                         : src_d.blk_off(0, 0, j);
                 dim_t ch_shift = src_d.blk_off(0, jcp.ic_block);
-                int sp_start_idx = d * jcp.ih + j;
+                dim_t sp_start_idx = d * jcp.ih + j;
                 trans_src_nxc(tr_src, src, sp_start_idx, sp_start_offset,
                         icb_start, ch_shift, my_work);
             } else
@@ -1622,18 +1647,18 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         }
     };
 
-    auto diff_dst_trans = [&](int img, int g = 0, int oc_b = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.oh * jcp.od;
-        int oc;
-        int ocb_start = oc_b;
+    auto diff_dst_trans = [&](dim_t img, dim_t g = 0, dim_t oc_b = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.oh * jcp.od;
+        dim_t oc;
+        dim_t ocb_start = oc_b;
 
         if (jcp.global_transpose) {
-            const size_t work_amount = is_ddst_layout_nxc
+            const dim_t work_amount = is_ddst_layout_nxc
                     ? ti->oc_b_work * jcp.oh * jcp.od
                     : ti->g_work * ti->oc_b_work * jcp.oh * jcp.od;
 
-            size_t start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, start, end);
             my_work = end - start;
 
@@ -1666,7 +1691,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                 = is_ddst_layout_nxc && jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(gg, oc_b, d, j)]
@@ -1682,7 +1707,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                         ? diff_dst_d.blk_off(0, 0, d, j)
                         : diff_dst_d.blk_off(0, 0, j);
                 dim_t ch_shift = diff_dst_d.blk_off(0, jcp.oc_block);
-                int sp_start_idx = d * jcp.oh + j;
+                dim_t sp_start_idx = d * jcp.oh + j;
                 trans_dst_nxc(tr_diff_dst, diff_dst, sp_start_idx,
                         sp_start_offset, ocb_start, ch_shift, my_work);
             } else
@@ -1716,19 +1741,19 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         int icb_work = ti->ic_b_end - ti->ic_b_start;
         if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
             ic_b_step = utils::div_up(icb_work, 2);
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
             if (jcp.transpose_src) {
                 if (!jcp.global_transpose) {
@@ -1798,8 +1823,8 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
     if (nthr_mb_ == 1) {
         if (is_bf16_out) {
             // reduction is not required, only conversion
-            for_(int g = ti->g_start; g < ti->g_end; g++)
-            for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+            for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+            for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                 const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh * jcp.kw
                         * ((jcp.ndims == 5) ? jcp.kd : 1) * jcp.ic_block
                         * jcp.oc_block;
@@ -1811,12 +1836,12 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
         }
 
         if (is_bf16_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx = g * jcp.oc_without_padding
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx = g * jcp.oc_without_padding
                         + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
                 bfloat16_t *diff_bias
@@ -1832,31 +1857,32 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, nthr_mb_, ti->ithr_mb, start, end);
     if (start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
                     * ((jcp.ndims == 5) ? jcp.kh : 1)
-                    * nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start);
+                    * nstl::min<dim_t>(
+                            end - w, ic_b_kh_work - sub_ic_b_kh_start);
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kX);
 
@@ -1882,22 +1908,22 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
         }
         if (jcp.with_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0
                 && ti->ithr_mb == 0 && ti->img_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
                 float *bias_reduced = is_bf16_bias ? ti->bia_reduction
                                                    : (float *)(ti->diff_bias);
                 int thr_mb_buffer_idx = is_bf16_bias ? thr_mb : thr_mb - 1;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (is_bf16_bias && thr_mb == nthr_mb_ - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx = g * jcp.oc_without_padding
+                    dim_t diff_bias_idx = g * jcp.oc_without_padding
                             + ti->oc_b_start * jcp.oc_block;
                     add_floats_and_cvt_to_bfloat16(
                             (bfloat16_t *)(ti->diff_bias) + diff_bias_idx,
@@ -1926,7 +1952,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::prepare_scratchpad_data(
         // buffers sharing padding
         for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
             src_data_t *ts = &tr_src[ithr * jcp.tr_src_buf_size];
-            for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
+            for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
                 ts[i] = 0;
         }
 
@@ -2007,9 +2033,9 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -502,8 +502,8 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                 dim_t d_b_overflow = max<dim_t>(0,
                         (jcp.kd - jcp.id + id_s - jcp.back_pad) / jcp.stride_d);
                 dim_t overflow_kd_hi = jcp.kd - 1
-                        - modulo(
-                                jcp.id - 1 + jcp.back_pad - id_s, jcp.stride_d);
+                        - modulo(jcp.id - 1 + jcp.back_pad - id_s,
+                                static_cast<dim_t>(jcp.stride_d));
                 dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
@@ -556,7 +556,8 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                     dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
                     dim_t overflow_kh_hi = jcp.kh - 1
-                            - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
+                            - modulo(jcp.ih - 1 + jcp.b_pad - ij,
+                                    static_cast<dim_t>(jcp.stride_h));
                     dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
@@ -700,7 +701,8 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
                     dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
                     dim_t overflow_kh_hi = jcp.kh - 1
-                            - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
+                            - modulo(jcp.ih - 1 + jcp.b_pad - ij,
+                                    static_cast<dim_t>(jcp.stride_h));
                     dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     k_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h + 1

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -254,19 +254,20 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    size_t tr_src_buf_number(const thread_info_t *ti, int g, int ic) const;
-    size_t tr_diff_dst_buf_number(const thread_info_t *ti, int g, int oc) const;
+    size_t tr_src_buf_number(const thread_info_t *ti, dim_t g, dim_t ic) const;
+    size_t tr_diff_dst_buf_number(
+            const thread_info_t *ti, dim_t g, dim_t oc) const;
     void trans_src(
-            src_data_t *tr_src1, const src_data_t *src1, int my_work) const;
+            src_data_t *tr_src1, const src_data_t *src1, dim_t my_work) const;
     void trans_dst(diff_dst_data_t *tr_diff_dst1,
-            const diff_dst_data_t *diff_dst1, int my_work) const;
+            const diff_dst_data_t *diff_dst1, dim_t my_work) const;
     void trans_src_nxc(src_data_t *tr_src, const src_data_t *src_base,
-            int spatial_start, dim_t spatial_start_offset, int icb_start,
-            dim_t chb_stride, int my_work) const;
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t icb_start,
+            dim_t chb_stride, dim_t my_work) const;
     void trans_dst_nxc(diff_dst_data_t *tr_diff_dst,
-            const diff_dst_data_t *diff_dst_base, int spatial_start,
-            dim_t spatial_start_offset, int ocb_start, dim_t chb_stride,
-            int my_work) const;
+            const diff_dst_data_t *diff_dst_base, dim_t spatial_start,
+            dim_t spatial_start_offset, dim_t ocb_start, dim_t chb_stride,
+            dim_t my_work) const;
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the BF16 GEMM/JIT convolution kernels (`gemm_bf16_convolution`, `jit_avx512_core_bf16_1x1_conv_kernel`, `jit_avx512_core_bf16_1x1_convolution`, `jit_avx512_core_bf16_conv_kernel`, `jit_avx512_core_bf16_convolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5661 (AVX512 common) / #5662 (AMX) for review convenience; independently reviewable.