### PR TITLE
cpu: conv: depthwise: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -42,7 +42,7 @@ jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const size_t tail_size = jcp.oc_without_padding
+        const dim_t tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<avx512_core>::vlen / sizeof(float));
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
@@ -88,14 +88,14 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
                     = mask_flag ? zmm_acc | ktail_mask | T_z : zmm_acc;
 
             if (this->jcp.with_bias) {
-                int b_off = ch * ch_blk;
+                const dim_t b_off = ch * ch_blk;
                 uni_vmovups(
                         zmm_acc_msk, vmmword[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
             if (this->jcp.with_sum) {
-                int o_off = ch * ocb_stride + ow * ow_stride;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                 if (jcp.dst_dt == data_type::bf16) {
                     const Zmm zmm_prev_dst_msk = mask_flag
                             ? zmm_prev_dst | ktail_mask | T_z
@@ -116,10 +116,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r,
         bool last_ch_block_flag) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -144,20 +144,21 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
             const bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
             for (int kw = 0; kw < jcp.kw; kw++) {
-                int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const dim_t ker_off
+                        = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
                 const Zmm zmm_ker_reg_msk = mask_flag
                         ? zmm_ker_reg | ktail_mask | T_z
                         : zmm_ker_reg;
                 vpmovzxwd(zmm_ker_reg_msk,
                         ptr[aux_reg_kernel + ker_off * jcp.typesize_in]);
-                int ow_start = get_ow_start(kw, pad_l);
-                int ow_end = get_ow_end(ur_w, kw, pad_r);
-                for (int ow = ow_start; ow < ow_end; ow++) {
+                const dim_t ow_start = get_ow_start(kw, pad_l);
+                const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const Zmm zmm_src_reg_msk = mask_flag
                             ? zmm_src_reg | ktail_mask | T_z
                             : zmm_src_reg;
-                    Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
-                    int inp_off = ch * icb_stride
+                    Zmm zmm_acc = get_acc_reg(static_cast<int>(ch * ur_w + ow));
+                    const dim_t inp_off = ch * icb_stride
                             + (ow * stride_w - pad_l) * iw_stride
                             + kw * dilate_w * iw_stride;
                     /* zero-extend bf16 to packed 32-bit int */
@@ -312,7 +313,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
                 for (int ow = 0; ow < ur_w; ow++) {
-                    int o_off = ch * ocb_stride + ow * ow_stride;
+                    const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                     Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
                     Zmm zmm_dst_msk
                             = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
@@ -353,7 +354,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
                     bool mask_flag
                             = last_ch_block_flag && ch == ur_ch_blocks - 1;
                     for (int ow = 0; ow < ur_w; ow++) {
-                        int o_off = ch * ocb_stride + ow * ow_stride;
+                        const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                         Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
 
                         /* down-convert f32 output to bf16 */
@@ -408,10 +409,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_ch = jcp.oc / jcp.ch_block;
-        const int nb_ch_blocking_tail
-                = jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking);
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_ch = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int nb_ch_blocking_tail = static_cast<int>(
+                jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -427,10 +428,11 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_input, static_cast<uint32_t>(inp_ch_stride));
+                add(reg_output, static_cast<uint32_t>(out_ch_stride));
+                if (jcp.with_bias)
+                    add(reg_bias, static_cast<uint32_t>(bias_stride));
                 sub(reg_ch_blocks, ch_step);
                 cmp(reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -458,46 +460,46 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int n_oi = static_cast<int>(ow / ur_w);
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -505,8 +507,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, static_cast<uint32_t>(inp_shift));
+                    add(reg_output, static_cast<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -515,8 +517,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, static_cast<uint32_t>(inp_shift));
+                add(reg_output, static_cast<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -563,7 +565,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     if (oc_tail != 0) {
         // Note: is_src_layout_nxc() == true, otherwise channels are padded
         // Prepare masks for tailing
-        const int oc_tail_shift
+        const dim_t oc_tail_shift
                 = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
         static constexpr auto zmm_16b_mask = ((1 << 16) - 1);
 
@@ -597,7 +599,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        loop_ow(jcp.nb_ch);
+        loop_ow(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
@@ -632,14 +634,14 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::load_ddst(
 
 inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
-    int kw = jcp.kw;
-    int kh = jcp.kh;
-    int ow = jcp.ow;
-    int oh = jcp.oh;
+    const dim_t kw = jcp.kw;
+    const dim_t kh = jcp.kh;
+    const dim_t ow = jcp.ow;
+    const dim_t oh = jcp.oh;
 
-    int ch_blk = jcp.ch_block;
-    int stride_h = jcp.stride_h;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
@@ -667,7 +669,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 const bool mask_flag
                         = last_ch_block_flag && ch == ur_ch_blocks - 1;
-                int ker_off = ch * kh * kw * ch_blk;
+                const dim_t ker_off = ch * kh * kw * ch_blk;
                 Zmm mm_zmm_ker // mm: maybe masked
                         = mask_flag ? zmm_ker_reg | k_ch_tail_mask | T_z
                                     : zmm_ker_reg;
@@ -693,7 +695,8 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
             }
 
             add(aux1_reg_kernel, ch_blk * stride_w * jcp.typesize_in);
-            sub(aux1_reg_ddst, sp_step * jcp.typesize_in);
+            sub(aux1_reg_ddst,
+                    static_cast<uint32_t>(sp_step * jcp.typesize_in));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
@@ -701,7 +704,8 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         }
 
         add(aux_reg_kernel, kw * ch_blk * stride_h * jcp.typesize_in);
-        sub(aux_reg_ddst, ow * sp_step * jcp.typesize_in);
+        sub(aux_reg_ddst,
+                static_cast<uint32_t>(ow * sp_step * jcp.typesize_in));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -713,10 +717,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
 
 inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
-    int ch_blk = jcp.ch_block;
-    int iw = jcp.iw;
-    int ih = jcp.ih;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t iw = jcp.iw;
+    const dim_t ih = jcp.ih;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
     const size_t ch_block_step = ch_blk * (dsrc_layout_nxc ? 1 : ih * iw);
@@ -730,7 +734,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         for (int w = 0; w < ur_str_w; w++) {
             size_t sp_offset = w * stride_w * sp_step;
             size_t ch_offset = ch * ch_block_step;
-            int dsrc_off = sp_offset + ch_offset;
+            const dim_t dsrc_off = sp_offset + ch_offset;
             auto zmm_dsrc = get_acc_reg(ch * ur_str_w + w);
             Zmm mm_zmm_dsrc // mm: maybe masked
                     = mask_flag ? zmm_dsrc | k_ch_tail_mask : zmm_dsrc;
@@ -776,10 +780,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
         assert(is_ddst_layout_nxc() && is_dsrc_layout_nxc());
 
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_oc = jcp.oc / jcp.ch_block;
-        const int ch_block_tail
-                = jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_oc = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int ch_block_tail = static_cast<int>(
+                jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         const size_t wei_ch_stride
                 = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block;
@@ -800,9 +804,14 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
             {
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
-                add(reg_kernel, wei_ch_stride * jcp.typesize_in);
-                add(reg_dsrc, data_ch_stride * jcp.typesize_out);
-                add(reg_ddst, data_ch_stride * jcp.typesize_in);
+                add(reg_kernel,
+                        static_cast<uint32_t>(wei_ch_stride * jcp.typesize_in));
+                add(reg_dsrc,
+                        static_cast<uint32_t>(
+                                data_ch_stride * jcp.typesize_out));
+                add(reg_ddst,
+                        static_cast<uint32_t>(
+                                data_ch_stride * jcp.typesize_in));
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -842,8 +851,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, jcp.typesize_out * jcp.stride_w * ch_step);
-            add(reg_ddst, jcp.typesize_in * ch_step);
+            add(reg_dsrc,
+                    static_cast<uint32_t>(
+                            jcp.typesize_out * jcp.stride_w * ch_step));
+            add(reg_ddst, static_cast<uint32_t>(jcp.typesize_in * ch_step));
 
             sub(reg_ur_str_w, unroll_w);
             jmp(unroll_w_label);
@@ -874,7 +885,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
             const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
-            cmp(reg_ch_blocks, channel_step);
+            cmp(reg_ch_blocks, static_cast<uint32_t>(channel_step));
             je(masking_done, T_NEAR);
             // Prepare masks for tail
             Reg32 reg_tmp_32 = reg_tmp.cvt32();
@@ -883,7 +894,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
             L(masking_done);
         }
 
-        unroll_width_body(jcp.nb_ch);
+        unroll_width_body(static_cast<int>(jcp.nb_ch));
     } else {
         auto ch_blocks_loop = [&](int ch_blocks) {
             Label skip_loop_label;
@@ -913,7 +924,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter() {
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::load_filter(
         bool is_last_ch) {
     for (int i = 0; i < jcp.kw; ++i) {
-        int off_filter = i * jcp.ch_block;
+        const dim_t off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
         Zmm m_zmm_acc = is_last_ch ? zmm_acc | k_ch_tail_mask | T_z : zmm_acc;
         vmovups(m_zmm_acc,
@@ -936,14 +947,15 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         bool is_last_ch) {
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const int right_border = static_cast<int>(jcp.iw - iw_block);
+    const int r_pad = static_cast<int>(jcp.r_pad);
 
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const int cascade_input = static_cast<int>(nstl::min(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const int input_overlap
+            = static_cast<int>(nstl::max<dim_t>(jcp.kw - l_pad, 0));
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
@@ -971,8 +983,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
             }
         } else {
             for (int c = 0; c < cascade_input; ++c) {
-                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                int input_sp = overlap + c - pad_offset;
+                const dim_t overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                const dim_t input_sp = overlap + c - pad_offset;
                 if (input_sp < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -982,7 +994,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
 
                 size_t input_offset = static_cast<size_t>(
                         input_sp * ch_step * jcp.typesize_in);
-                Zmm zmm_input = get_input_reg(overlap + c);
+                Zmm zmm_input = get_input_reg(static_cast<int>(overlap + c));
                 Zmm m_zmm_input = is_last_ch ? zmm_input | k_ch_tail_mask | T_z
                                              : zmm_input;
                 vpmovzxwd(m_zmm_input, ptr[reg_tmp_input + input_offset]);
@@ -990,7 +1002,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         }
 
         for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+            const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
             /* Don't apply FMAs that fall into the padded region */
             if (io_overlap - l_pad < 0
@@ -1001,7 +1013,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
                     && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
             if (over_steps_bdry) continue;
 
-            Zmm zmm_input = get_input_reg(io_overlap - l_pad);
+            Zmm zmm_input = get_input_reg(static_cast<int>(io_overlap - l_pad));
             Zmm zmm_acc = get_acc_reg(i_kw);
             if (isa_has_bf16(jcp.isa))
                 vdpbf16ps(zmm_acc, zmm_input, zmm_out_reg);
@@ -1014,7 +1026,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_bias_step_unroll(
         const int unroll_w, bool is_last_ch) {
 
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     for (int i = 0; i < unroll_w; ++i) {
         size_t off_output = static_cast<size_t>(i * ch_step * jcp.typesize_in);
         /* bf16 output data requires conversion to f32 */
@@ -1032,7 +1044,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::store_filter(
     /* bf16: all data is stored as f32. Down-convert to bf16 happens at the
      * reduction phase. */
     for (int i = 0; i < jcp.kw; ++i) {
-        int off_filter = i * jcp.ch_block;
+        const dim_t off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
         Zmm m_zmm_acc = is_last_ch ? zmm_acc | k_ch_tail_mask : zmm_acc;
         vmovups(vmmword[reg_tmp_filter + off_filter * jcp.typesize_out],
@@ -1051,9 +1063,12 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
     Label oh_label;
     Label ow_blk_label;
 
-    const int unroll_w = nstl::min(max_unroll_w_, jcp.ow);
-    const int unroll_w_trips = jcp.ow / unroll_w;
-    const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
+    const int unroll_w
+            = static_cast<int>(nstl::min<dim_t>(max_unroll_w_, jcp.ow));
+    const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
+    const int tail_w = jcp.ow > max_unroll_w_
+            ? static_cast<int>(jcp.ow % max_unroll_w_)
+            : 0;
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     const size_t ch_offset = ch_step * jcp.typesize_in;
@@ -1069,7 +1084,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
         L(ow_blk_label);
         {
             compute_bias_step_unroll(unroll_w, is_last_ch);
-            add(reg_tmp_output, unroll_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(unroll_w * ch_offset));
 
             dec(reg_iter_ow_blk);
             cmp(reg_iter_ow_blk, 0);
@@ -1078,7 +1093,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
 
         if (tail_w > 0) {
             compute_bias_step_unroll(tail_w, is_last_ch);
-            add(reg_tmp_output, tail_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(tail_w * ch_offset));
         }
 
         inc(reg_oh);
@@ -1209,14 +1224,14 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter_kh_loop() {
     {
         store_filter();
 
-        add(reg_tmp_filter, filter_offset_kw);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kw));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
     }
 
     /* Comeback pointers */
-    sub(reg_tmp_filter, filter_offset_kh);
+    sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kh));
 }
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::deploy_zero_filter() {
@@ -1256,8 +1271,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
                 unroll_w, l_pad, pad_offset, ow_block, is_last_ch);
         store_filter();
 
-        add(reg_tmp_filter, filter_offset);
-        add(reg_tmp_input, input_offset);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
+        add(reg_tmp_input, static_cast<uint32_t>(input_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
@@ -1268,8 +1283,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
     mov(reg_kh_aux, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_tmp_input, input_offset);
-        sub(reg_tmp_filter, filter_offset);
+        sub(reg_tmp_input, static_cast<uint32_t>(input_offset));
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -1313,7 +1328,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     mov(reg_tmp_input, reg_input_baddr);
     mov(reg_tmp_filter, reg_filter_baddr);
 
-    const int input_bottom_padding_overlap
+    const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1348,11 +1363,11 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_tmp_filter, filter_shift * jcp.stride_h);
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -1360,14 +1375,17 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_tmp_filter, filter_shift * inp_corr);
-                add(reg_tmp_input, input_shift * inp_corr);
+                const dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add(reg_tmp_filter,
+                        static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_tmp_input,
+                        static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
             sub(reg_tmp_filter,
-                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+                    static_cast<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Apply correction: reset value of 'reg_kh' to scenario outside of
@@ -1402,11 +1420,11 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     }
 
     /* Compute middle block */
-    add(reg_tmp_input, input_shift * jcp.stride_h);
+    add(reg_tmp_input, static_cast<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_tmp_output, output_shift);
+    add(reg_tmp_output, static_cast<uint32_t>(output_shift));
     inc(reg_oh);
     cmp(reg_oh, reg_oh_worksize);
     jl(loop_begin_label, T_NEAR);
@@ -1415,12 +1433,12 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
 }
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
-        int &unroll_trips, int &unroll_w, int &unroll_w_tail) {
+        int &unroll_trips, int &unroll_w, int &unroll_w_tail) const {
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (do_unroll_w) {
-        unroll_w = nstl::min(block_size_, jcp.ow);
-        unroll_trips = jcp.ow / unroll_w;
+        unroll_w = static_cast<int>(nstl::min<dim_t>(block_size_, jcp.ow));
+        unroll_trips = static_cast<int>(jcp.ow / unroll_w);
         /* calculate tail */
         unroll_w_tail = jcp.ow % unroll_w;
         /* Perform some rebalancing if tail too small*/
@@ -1436,7 +1454,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
             }
         }
     } else {
-        unroll_w_tail = jcp.ow;
+        unroll_w_tail = static_cast<int>(jcp.ow);
     }
 }
 
@@ -1444,7 +1462,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for compute middle block
     int pad_offset = 0;
-    int l_pad = jcp.l_pad;
+    int l_pad = static_cast<int>(jcp.l_pad);
     int unroll_w_tail = 0;
     int unroll_w = 0;
     int unroll_trips = 0;
@@ -1465,8 +1483,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (l_pad && do_unroll_w) {
         compute_h_loop(unroll_w, l_pad, 0, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
         unroll_trips--;
         pad_offset = l_pad;
         l_pad = 0;
@@ -1481,8 +1499,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     }
     if (unroll_trips > 0) {
         compute_h_loop(unroll_w, l_pad, pad_offset, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
     }
     if (do_ow_blk_loop) {
         dec(reg_iter_ow_blk);
@@ -1492,8 +1510,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     /* compute right padded block */
     if (unroll_w_tail) {
-        compute_h_loop(
-                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+        compute_h_loop(unroll_w_tail, l_pad, pad_offset,
+                static_cast<int>(jcp.ow - unroll_w_tail));
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -460,13 +460,13 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
 
-    const dim_t iw = jcp.iw;
-    const dim_t ow = jcp.ow;
-    const dim_t kw = jcp.kw;
-    const dim_t l_pad = jcp.l_pad;
+    const int iw = jcp.iw;
+    const int ow = jcp.ow;
+    const int kw = jcp.kw;
+    const int l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    const dim_t stride_w = jcp.stride_w;
+    const int stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
@@ -476,20 +476,20 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
     const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
-    int n_oi = static_cast<int>(ow / ur_w);
-    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
-            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
+    int r_pad = nstl::max(0, jcp.r_pad);
+    int n_oi = ow / ur_w;
+    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+            calculate_extended_filter_size(kw, jcp.dilate_w));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
+        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
             add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
@@ -497,7 +497,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
+                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
                 add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -42,7 +42,7 @@ jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const dim_t tail_size = jcp.oc_without_padding
+        const std::size_t tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<avx512_core>::vlen / sizeof(float));
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -88,16 +88,17 @@ private:
     Xbyak::Zmm get_acc_reg(int idx);
 
     int get_ow_start(int ki, int pad_l) const {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
     int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
+                - static_cast<int>(utils::div_up(
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
 
     inline bool is_src_layout_nxc() const {
@@ -242,7 +243,7 @@ private:
         return Xbyak::Zmm(idx + idx_start);
     }
     inline Xbyak::Zmm get_input_reg(int idx) const {
-        const int i_idx = idx_start + jcp.kw + idx % jcp.kw;
+        const int i_idx = static_cast<int>(idx_start + jcp.kw + idx % jcp.kw);
         assert(i_idx <= get_max_regs());
         return Xbyak::Zmm(i_idx);
     }
@@ -313,7 +314,7 @@ private:
     void store_bias(bool is_last_ch);
     void compute_bias();
     void calculate_w_unrolling(
-            int &unroll_trips, int &unroll_w, int &unroll_w_tail);
+            int &unroll_trips, int &unroll_w, int &unroll_w_tail) const;
 
     void generate() override;
 

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -39,7 +39,7 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name()), jcp(ajcp) {
     const auto simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const auto tail_size = jcp.oc_without_padding % simd_w;
+    const dim_t tail_size = jcp.oc_without_padding % simd_w;
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr auto preserve_gpr = true;
@@ -62,11 +62,12 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
             jcp.src_dt, jcp.dst_dt};
     io_ = utils::make_unique<io::jit_io_multi_dt_helper_t<Xbyak::Zmm>>(this,
             jcp.isa, data_types, io::io_conf_t {},
-            io::io_tail_conf_t {simd_w, tail_size, k_oc_tail_mask, 0, reg_tmp});
+            io::io_tail_conf_t {simd_w, static_cast<std::size_t>(tail_size),
+                    k_oc_tail_mask, 0, reg_tmp});
 }
 
-static bool check_if_tail(const bool is_ch_tail, const int c_tail, const int ch,
-        const int ur_ch_blocks, const int simd_w) {
+static bool check_if_tail(const bool is_ch_tail, const dim_t c_tail,
+        const int ch, const int ur_ch_blocks, const int simd_w) {
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && simd_w > c_tail;
 }
 
@@ -78,7 +79,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const int c_tail = jcp.oc % jcp.ch_block;
+    const dim_t c_tail = jcp.oc % jcp.ch_block;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         const bool is_tail_load
@@ -91,14 +92,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
                 const Zmm zmm_acc_msk = is_tail_load
                         ? zmm_acc | k_oc_tail_mask | T_z
                         : zmm_acc;
-                const int b_off = ch * ch_blk;
+                const dim_t b_off = ch * ch_blk;
                 uni_vmovups(zmm_acc_msk, ptr[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
 
             if (jcp.with_sum) {
-                const int o_off = ch * ocb_stride + ow * ow_stride;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                 // using ker_zmm as zmm_tmp as it is safe to do so.
                 auto zmm_tmp = get_ker_reg(0);
                 io_->at(jcp.src_dt)
@@ -112,10 +113,10 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -125,16 +126,16 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
 
-    auto get_input_spatial_index = [=](int oi, int ki) {
+    auto get_input_spatial_index = [=](dim_t oi, dim_t ki) -> dim_t {
         return (ki * dilate_w + oi * stride_w - pad_l);
     };
 
-    auto get_input_offset = [&](int ii, int ci) {
+    auto get_input_offset = [&](dim_t ii, dim_t ci) -> dim_t {
         return (ci * icb_stride + ii * iw_stride) * jcp.typesize_in;
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise) {
         // find bounds of input spatial indices
         bool first = true;
@@ -142,7 +143,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             int oi_start = get_ow_start(ki, pad_l);
             int oi_end = get_ow_end(ur_w, ki, pad_r);
             for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = get_input_spatial_index(oi, ki);
+                const dim_t ii = get_input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -163,42 +164,44 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             mov(aux_reg_input, ptr[aux_reg_input_buffer_ptr]);
             add(aux_reg_input, reg_iw_offset);
         }
-        const int c_tail = jcp.oc % jcp.ch_block;
+        const dim_t c_tail = jcp.oc % jcp.ch_block;
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
             const bool is_tail_load = check_if_tail(
                     is_ch_tail, c_tail, ch, ur_ch_blocks, simd_w);
             if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= 0) continue;
             if (jcp.is_resrc_depthwise) {
                 // now we can load input once and reuse up to jcp.kw times
-                for (int ii = ii_start; ii <= ii_end; ii++) {
-                    Zmm zmm_src = get_src_reg(ii);
-                    const int inp_off = get_input_offset(ii, ch);
+                for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                    Zmm zmm_src = get_src_reg(static_cast<int>(ii));
+                    const dim_t inp_off = get_input_offset(ii, ch);
                     io_->at(jcp.src_dt)
                             ->load(ptr[aux_reg_input + inp_off], zmm_src,
                                     is_tail_load);
                 }
             }
             for (int kw = 0; kw < jcp.kw; kw++) {
-                const int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const dim_t ker_off
+                        = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
 
                 Zmm zmm_ker = get_ker_reg(0);
                 io_->at(jcp.src_dt)
                         ->load(ptr[aux_reg_kernel + ker_off * jcp.typesize_in],
                                 zmm_ker, is_tail_load);
-                int ow_start = get_ow_start(kw, pad_l);
-                int ow_end = get_ow_end(ur_w, kw, pad_r);
-                for (int ow = ow_start; ow < ow_end; ow++) {
+                const dim_t ow_start = get_ow_start(kw, pad_l);
+                const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (dim_t ow = ow_start; ow < ow_end; ow++) {
 
-                    const int ii = get_input_spatial_index(ow, kw);
-                    Zmm zmm_src = jcp.is_resrc_depthwise ? get_src_reg(ii)
-                                                         : get_src_reg(0);
+                    const dim_t ii = get_input_spatial_index(ow, kw);
+                    Zmm zmm_src = jcp.is_resrc_depthwise
+                            ? get_src_reg(static_cast<int>(ii))
+                            : get_src_reg(0);
                     if (!jcp.is_resrc_depthwise) {
-                        const int inp_off = get_input_offset(ii, ch);
+                        const dim_t inp_off = get_input_offset(ii, ch);
                         io_->at(jcp.src_dt)
                                 ->load(ptr[aux_reg_input + inp_off], zmm_src,
                                         is_tail_load);
                     }
-                    Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
+                    Zmm zmm_acc = get_acc_reg(static_cast<int>(ch * ur_w + ow));
                     const Zmm zmm_ker_msk = is_tail_load
                             ? zmm_ker | k_oc_tail_mask | T_z
                             : zmm_ker;
@@ -252,7 +255,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_postops(
             const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
             const auto mask_tail_blocked_layout
                     = jcp.oc_without_padding % jcp.ch_block && !dst_layout_nxc;
-            const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+            const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
             iterate(ur_ch_blocks, ur_w, mask_tail_blocked_layout,
                     [&](const int ch, const int ow,
                             const bool mask_flag_blocked_layout) {
@@ -316,14 +319,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::store_dst(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+    const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         const bool is_tail_load
                 = check_if_tail(is_ch_tail, c_tail, ch, ur_ch_blocks, simd_w);
         if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= 0) continue;
         for (int ow = 0; ow < ur_w; ow++) {
-            const int o_off = ch * ocb_stride + ow * ow_stride;
+            const dim_t o_off = ch * ocb_stride + ow * ow_stride;
             Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
             io_->at(jcp.dst_dt)
                     ->store(zmm_dst, ptr[reg_output + o_off * jcp.typesize_out],
@@ -364,9 +367,9 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
     mov(aux_reg_ch_blocks, reg_ch_blocks);
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int ch_block_tail = jcp.nb_ch
-                - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int ch_block_tail = static_cast<int>(jcp.nb_ch
+                - utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -382,10 +385,11 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking, false);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_input, static_cast<uint32_t>(inp_ch_stride));
+                add(reg_output, static_cast<uint32_t>(out_ch_stride));
+                if (jcp.with_bias)
+                    add(reg_bias, static_cast<uint32_t>(bias_stride));
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -413,46 +417,46 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int n_oi = static_cast<int>(ow / ur_w);
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -460,8 +464,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, static_cast<uint32_t>(inp_shift));
+                    add(reg_output, static_cast<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -470,8 +474,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, static_cast<uint32_t>(inp_shift));
+                add(reg_output, static_cast<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -518,7 +522,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     if (oc_tail != 0) {
         // Prepare masks for tailing
         // Not using io_->prepare_tail_mask() since mask needs shifting
-        const int oc_tail_shift
+        const dim_t oc_tail_shift
                 = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
         static constexpr auto zmm_full_mask = ((1 << 16) - 1);
         Reg32 reg_tail_32 = reg_tail.cvt32();
@@ -527,7 +531,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        ow_loop(jcp.nb_ch);
+        ow_loop(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -39,7 +39,7 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name()), jcp(ajcp) {
     const auto simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const dim_t tail_size = jcp.oc_without_padding % simd_w;
+    const std::size_t tail_size = jcp.oc_without_padding % simd_w;
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr auto preserve_gpr = true;

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -417,13 +417,13 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
 
-    const dim_t iw = jcp.iw;
-    const dim_t ow = jcp.ow;
-    const dim_t kw = jcp.kw;
-    const dim_t l_pad = jcp.l_pad;
+    const int iw = jcp.iw;
+    const int ow = jcp.ow;
+    const int kw = jcp.kw;
+    const int l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    const dim_t stride_w = jcp.stride_w;
+    const int stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
@@ -433,20 +433,20 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
     const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
-    int n_oi = static_cast<int>(ow / ur_w);
-    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
-            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
+    int r_pad = nstl::max(0, jcp.r_pad);
+    int n_oi = ow / ur_w;
+    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+            calculate_extended_filter_size(kw, jcp.dilate_w));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
+        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
             add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
@@ -454,7 +454,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
+                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
                 add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
@@ -85,16 +85,17 @@ private:
     }
 
     int get_ow_start(int ki, int pad_l) const {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
     int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
+                - static_cast<int>(utils::div_up(
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
 
     inline bool is_src_layout_nxc() const {

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -187,25 +187,25 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init(engine_t *engine) {
             VERBOSE_UNSUPPORTED_FEATURE, "dilations are not supported");
 
     jcp = zero<decltype(jcp)>();
-    jcp.ngroups = weights_d.dims()[0];
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[3] : 1;
-    jcp.kh = weights_d.dims()[ndims - 1];
-    jcp.kw = weights_d.dims()[ndims];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = cd.padding[0][is_3d];
-    jcp.l_pad = cd.padding[0][is_3d + 1];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = cd.strides[is_3d];
-    jcp.stride_w = cd.strides[is_3d + 1];
+    jcp.ngroups = static_cast<int>(weights_d.dims()[0]);
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[3]) : 1;
+    jcp.kh = static_cast<int>(weights_d.dims()[ndims - 1]);
+    jcp.kw = static_cast<int>(weights_d.dims()[ndims]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = static_cast<int>(cd.padding[0][is_3d]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][is_3d + 1]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = static_cast<int>(cd.strides[is_3d]);
+    jcp.stride_w = static_cast<int>(cd.strides[is_3d + 1]);
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, jcp.kd);
     jcp.b_pad = calculate_end_padding(

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -45,7 +45,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const size_t tail_size = jcp.oc_without_padding
+        const dim_t tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<isa>::vlen / sizeof(float));
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r14, r15,
                 r12, preserve_gpr, preserve_vmm,
@@ -60,7 +60,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
     }
 }
 
-bool check_if_tail_load(const bool is_ch_tail, const int c_tail, const int ch,
+bool check_if_tail_load(const bool is_ch_tail, const dim_t c_tail, const int ch,
         const int ur_ch_blocks, const int vlen, const int i) {
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && ((i + 1) * vlen > c_tail);
 }
@@ -74,7 +74,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    const int c_tail = jcp.oc % jcp.ch_block;
+    const dim_t c_tail = jcp.oc % jcp.ch_block;
 
     const int repeats = max_repeats();
     for (int i = 0; i < repeats; i++) {
@@ -87,11 +87,12 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                 Vmm vmm_acc
                         = get_acc_reg(i * ur_ch_blocks * ur_w + ch * ur_w + ow);
 
-                const int b_off = ch * ch_blk + i * vlen;
+                const dim_t b_off = ch * ch_blk + i * vlen;
                 if (this->jcp.with_bias) {
                     if (is_tail_load) {
                         load_tail(vmm_acc, reg_bias, b_off * sizeof(float),
-                                (c_tail - i * vlen) * sizeof(float));
+                                static_cast<int>(
+                                        (c_tail - i * vlen) * sizeof(float)));
                     } else {
                         uni_vmovups(vmm_acc,
                                 vmmword[reg_bias + b_off * sizeof(float)]);
@@ -100,7 +101,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                     uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
                 }
 
-                const int o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
                 if (this->jcp.with_sum) {
                     if (is_tail_load) {
                         if (this->jcp.with_bias) {
@@ -108,12 +109,13 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                             auto vmm_tmp = get_ker_reg(0);
                             add_tail_from_mem(vmm_acc, vmm_tmp, reg_output,
                                     o_off * sizeof(float),
-                                    (c_tail - i * vlen) * sizeof(float));
+                                    static_cast<int>((c_tail - i * vlen)
+                                            * sizeof(float)));
                         } else {
                             // nothing to add, just load dst.
                             load_tail(vmm_acc, reg_output,
                                     o_off * sizeof(float),
-                                    c_tail * sizeof(float));
+                                    static_cast<int>(c_tail * sizeof(float)));
                         }
                     } else {
                         // blocked layout has dst padded, so no tail handling.
@@ -129,10 +131,10 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -142,25 +144,25 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
 
-    auto get_input_spatial_index = [=](int oi, int ki) {
+    auto get_input_spatial_index = [=](dim_t oi, dim_t ki) -> dim_t {
         return (ki * dilate_w + oi * stride_w - pad_l);
     };
 
-    auto get_input_offset = [&](int ii, int ci, int rep) {
+    auto get_input_offset = [&](dim_t ii, dim_t ci, dim_t rep) -> dim_t {
         return (ci * icb_stride + ii * iw_stride + rep * vlen)
                 * jcp.typesize_in;
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise) {
         // find bounds of input spatial indices
         bool first = true;
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = get_input_spatial_index(oi, ki);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; oi++) {
+                const dim_t ii = get_input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -181,7 +183,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             mov(aux_reg_input, ptr[aux_reg_input_buffer_ptr]);
             add(aux_reg_input, reg_iw_offset);
         }
-        const int c_tail = jcp.oc % jcp.ch_block;
+        const dim_t c_tail = jcp.oc % jcp.ch_block;
         const int repeats = max_repeats();
         for (int i = 0; i < repeats; i++) {
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
@@ -192,56 +194,61 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
                     continue;
                 if (jcp.is_resrc_depthwise) {
                     // now we can load input once and reuse up to jcp.kw times
-                    for (int ii = ii_start; ii <= ii_end; ii++) {
-                        Vmm vmm_src = get_src_reg(ii);
-                        const int inp_off = get_input_offset(ii, ch, i);
+                    for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                        Vmm vmm_src = get_src_reg(static_cast<int>(ii));
+                        const dim_t inp_off = get_input_offset(ii, ch, i);
                         if (is_tail_load) {
                             load_tail(vmm_src, aux_reg_input, inp_off,
-                                    (c_tail - i * vlen) * jcp.typesize_in);
+                                    static_cast<int>((c_tail - i * vlen)
+                                            * jcp.typesize_in));
                         } else {
                             uni_vmovups(vmm_src, ptr[aux_reg_input + inp_off]);
                         }
                     }
                 }
-                for (int kw = 0; kw < jcp.kw; kw++) {
-                    const int ker_off = ch * jcp.kh * jcp.kw * ch_blk
+                for (dim_t kw = 0; kw < jcp.kw; kw++) {
+                    const dim_t ker_off = ch * jcp.kh * jcp.kw * ch_blk
                             + kw * ch_blk + i * vlen;
 
                     Vmm vmm_ker = get_ker_reg(0);
                     uni_vmovups(vmm_ker,
                             ptr[aux_reg_kernel + ker_off * sizeof(float)]);
 
-                    int ow_start = get_ow_start(kw, pad_l);
-                    int ow_end = get_ow_end(ur_w, kw, pad_r);
-                    for (int ow = ow_start; ow < ow_end; ow++) {
+                    const dim_t ow_start = get_ow_start(kw, pad_l);
+                    const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                    for (dim_t ow = ow_start; ow < ow_end; ow++) {
 
-                        const int ii = get_input_spatial_index(ow, kw);
-                        Vmm vmm_src = jcp.is_resrc_depthwise ? get_src_reg(ii)
-                                                             : get_src_reg(0);
+                        const dim_t ii = get_input_spatial_index(ow, kw);
+                        Vmm vmm_src = jcp.is_resrc_depthwise
+                                ? get_src_reg(static_cast<int>(ii))
+                                : get_src_reg(0);
                         if (!jcp.is_resrc_depthwise) {
-                            const int inp_off = get_input_offset(ii, ch, i);
+                            const dim_t inp_off = get_input_offset(ii, ch, i);
                             if (is_tail_load) {
                                 load_tail(vmm_src, aux_reg_input, inp_off,
-                                        (c_tail - i * vlen) * jcp.typesize_in);
+                                        static_cast<int>((c_tail - i * vlen)
+                                                * jcp.typesize_in));
                             } else {
                                 uni_vmovups(
                                         vmm_src, ptr[aux_reg_input + inp_off]);
                             }
                         }
-                        Vmm vmm_acc = get_acc_reg(
-                                i * ur_ch_blocks * ur_w + ch * ur_w + ow);
+                        Vmm vmm_acc = get_acc_reg(static_cast<int>(
+                                i * ur_ch_blocks * ur_w + ch * ur_w + ow));
                         uni_vfmadd231ps(vmm_acc, vmm_src, vmm_ker);
                     }
                 }
             }
         }
 
-        add(aux_reg_kernel, jcp.kw * ch_blk * sizeof(float));
+        add(aux_reg_kernel,
+                static_cast<uint32_t>(jcp.kw * ch_blk * sizeof(float)));
         if (jcp.is_fused_conv) {
             // Move to next row pointer in the buffer
             add(aux_reg_input_buffer_ptr, sizeof(void *));
         } else {
-            add(aux_reg_input, ih_stride * dilate_h * sizeof(float));
+            add(aux_reg_input,
+                    static_cast<int>(ih_stride * dilate_h * sizeof(float)));
         }
 
         dec(iter_kh);
@@ -285,7 +292,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_postops(
             const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
             const auto mask_tail_blocked_layout
                     = jcp.oc_without_padding % jcp.ch_block && !dst_layout_nxc;
-            const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+            const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
             iterate(repeats, ur_ch_blocks, ur_w, mask_tail_blocked_layout,
                     [&](const int r, const int ch, const int ow,
                             const bool mask_flag_blocked_layout) {
@@ -408,7 +415,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+    const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
 
     const int repeats = max_repeats();
     for (int i = 0; i < repeats; i++) {
@@ -418,12 +425,13 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
             if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= i * vlen)
                 continue;
             for (int ow = 0; ow < ur_w; ow++) {
-                const int o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
                 Vmm vmm_dst
                         = get_acc_reg(i * ur_ch_blocks * ur_w + ch * ur_w + ow);
                 if (is_tail_load) {
                     store_tail(vmm_dst, reg_output, o_off * sizeof(float),
-                            (c_tail - i * vlen) * sizeof(float));
+                            static_cast<int>(
+                                    (c_tail - i * vlen) * sizeof(float)));
                 } else
                     uni_vmovups(vmmword[reg_output + o_off * sizeof(float)],
                             vmm_dst);
@@ -465,9 +473,9 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
     mov(aux_reg_ch_blocks, reg_ch_blocks);
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int ch_block_tail = jcp.nb_ch
-                - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int ch_block_tail = static_cast<int>(jcp.nb_ch
+                - utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -483,10 +491,11 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking, false);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_input, static_cast<uint32_t>(inp_ch_stride));
+                add(reg_output, static_cast<uint32_t>(out_ch_stride));
+                if (jcp.with_bias)
+                    add(reg_bias, static_cast<uint32_t>(bias_stride));
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -515,26 +524,26 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    int iw = static_cast<int>(jcp.iw);
+    int ow = static_cast<int>(jcp.ow);
+    int kw = static_cast<int>(jcp.kw);
+    int l_pad = static_cast<int>(jcp.l_pad);
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    int stride_w = static_cast<int>(jcp.stride_w);
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
@@ -546,7 +555,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
         if (n_oi == 0) {
             compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
@@ -554,7 +563,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
             if (l_pad > 0) {
                 compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -562,8 +571,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, static_cast<uint32_t>(inp_shift));
+                    add(reg_output, static_cast<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -572,8 +581,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, static_cast<uint32_t>(inp_shift));
+                add(reg_output, static_cast<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -620,7 +629,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
         const auto oc_tail = jcp.oc_without_padding % jcp.ch_block;
         if (oc_tail != 0) {
             // Prepare masks for tailing
-            const int oc_tail_shift
+            const dim_t oc_tail_shift
                     = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
             static constexpr auto zmm_full_mask = ((1 << 16) - 1);
             Reg32 reg_tail_32 = reg_tail.cvt32();
@@ -630,7 +639,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        ow_loop(jcp.nb_ch);
+        ow_loop(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
@@ -666,7 +675,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_vmm(
 template <>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::load_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
-    int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     load_bytes(vmm, addr, bytes);
 }
 template <>
@@ -686,7 +696,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_vmm(
 template <>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::store_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
-    int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     store_bytes(vmm, addr, bytes);
 }
 template <>
@@ -713,14 +724,14 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_ddst(
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
-    int kw = jcp.kw;
-    int kh = jcp.kh;
-    int ow = jcp.ow;
-    int oh = jcp.oh;
+    const dim_t kw = jcp.kw;
+    const dim_t kh = jcp.kh;
+    const dim_t ow = jcp.ow;
+    const dim_t oh = jcp.oh;
 
-    int ch_blk = jcp.ch_block;
-    int stride_h = jcp.stride_h;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
@@ -756,10 +767,12 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                     if (last_block && isa == sse41 && tail_simd_overlap(r))
                         break;
 
-                    int ker_off = ch * kh * kw * ch_blk + r * simd_w_;
+                    const dim_t ker_off = ch * kh * kw * ch_blk + r * simd_w_;
                     Vmm vmm_ker = get_ker_reg(0);
                     load_vmm(vmm_ker,
-                            ptr[aux1_reg_kernel + ker_off * sizeof(float)],
+                            ptr[aux1_reg_kernel
+                                    + static_cast<int>(
+                                            ker_off * sizeof(float))],
                             masked_load);
 
                     for (int w = 0; w < ur_str_w; w++) {
@@ -780,16 +793,18 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                 }
             }
 
-            add(aux1_reg_kernel, ch_blk * stride_w * sizeof(float));
-            sub(aux1_reg_ddst, sp_step * sizeof(float));
+            add(aux1_reg_kernel,
+                    static_cast<int>(ch_blk * stride_w * sizeof(float)));
+            sub(aux1_reg_ddst, static_cast<uint32_t>(sp_step * sizeof(float)));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
             jg(kw_label, T_NEAR);
         }
 
-        add(aux_reg_kernel, kw * ch_blk * stride_h * sizeof(float));
-        sub(aux_reg_ddst, ow * sp_step * sizeof(float));
+        add(aux_reg_kernel,
+                static_cast<int>(kw * ch_blk * stride_h * sizeof(float)));
+        sub(aux_reg_ddst, static_cast<uint32_t>(ow * sp_step * sizeof(float)));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -802,10 +817,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
-    int ch_block = jcp.ch_block;
-    int iw = jcp.iw;
-    int ih = jcp.ih;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_block = jcp.ch_block;
+    const dim_t iw = jcp.iw;
+    const dim_t ih = jcp.ih;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
     const size_t ch_block_step = ch_block * (dsrc_layout_nxc ? 1 : ih * iw);
@@ -854,10 +869,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
         assert(is_ddst_layout_nxc());
 
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_oc = jcp.oc / jcp.ch_block;
-        const int ch_block_tail
-                = jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_oc = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int ch_block_tail = static_cast<int>(
+                jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh
                 * jcp.kw * jcp.ch_block * sizeof(float);
@@ -879,9 +894,9 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
             {
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
-                add(reg_kernel, wei_ch_stride);
-                add(reg_dsrc, data_ch_stride);
-                add(reg_ddst, data_ch_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_dsrc, static_cast<uint32_t>(data_ch_stride));
+                add(reg_ddst, static_cast<uint32_t>(data_ch_stride));
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -923,8 +938,9 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, unroll_w * jcp.stride_w * ch_step);
-            add(reg_ddst, unroll_w * ch_step);
+            add(reg_dsrc,
+                    static_cast<uint32_t>(unroll_w * jcp.stride_w * ch_step));
+            add(reg_ddst, static_cast<uint32_t>(unroll_w * ch_step));
 
             sub(reg_ur_str_w, unroll_w);
             jmp(unroll_w_label);
@@ -952,7 +968,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
     if (is_dsrc_layout_nxc()) {
         if (isa == avx512_core && (jcp.ch_tail > 0)) {
             Label masking_done;
-            const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
+            const dim_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
             cmp(reg_ch_blocks, channel_step);
@@ -964,7 +980,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
             L(masking_done);
         }
 
-        unroll_width_body(jcp.nb_ch);
+        unroll_width_body(static_cast<int>(jcp.nb_ch));
     } else {
 
         auto ch_blocks_loop = [&](int ch_blocks) {
@@ -1002,7 +1018,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_xmm(
 template <>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::load_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
-    int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     load_bytes(vmm, addr, bytes);
 }
 template <>
@@ -1023,7 +1040,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_xmm(
 template <>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::store_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
-    int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     store_bytes(vmm, addr, bytes);
 }
 template <>
@@ -1065,8 +1083,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter() {
     for (int ch = 0; ch < jcp.nb_ch_blocking; ++ch) {
         for (int r = 0; r < reg_repeats_; ++r) {
             for (int i = 0; i < jcp.kw; ++i) {
-                Vmm vmm_acc
-                        = get_acc_reg(r * jcp.kw + i * jcp.nb_ch_blocking + ch);
+                Vmm vmm_acc = get_acc_reg(static_cast<int>(
+                        r * jcp.kw + i * jcp.nb_ch_blocking + ch));
                 uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
             }
         }
@@ -1080,7 +1098,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::load_filter(
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
-        const int reg_set = r * jcp.kw;
+        const int reg_set = static_cast<int>(r * jcp.kw);
         for (int i = 0; i < jcp.kw; ++i) {
             size_t off_filter = static_cast<size_t>(
                     (i * jcp.ch_block + r * simd_w_) * sizeof(float));
@@ -1153,23 +1171,24 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
 
     assert(one_of(isa, avx2, avx512_core));
 
-    const size_t ch_step = jcp.ngroups;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const dim_t ch_step = jcp.ngroups;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const dim_t right_border = jcp.iw - iw_block;
+    const dim_t r_pad = jcp.r_pad;
+    const int cascade_input
+            = static_cast<int>(nstl::min<dim_t>(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const dim_t input_overlap = nstl::max<dim_t>(jcp.kw - l_pad, 0);
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
     for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-        int output_sp_offset = i_ur * ch_step;
+        const dim_t output_sp_offset = i_ur * ch_step;
         if (i_ur == 0) {
             for (int c = 0; c < input_overlap; ++c) {
-                int input_sp = c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                const dim_t input_sp = c - pad_offset;
+                const dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
 
                 const bool over_steps_bdry = true && is_last_block
@@ -1180,17 +1199,17 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                     bool masked_load = is_last_ch && ch == nb_ch_blocking - 1;
                     size_t input_offset = static_cast<size_t>(
                             (input_sp_offset + ch * simd_w_) * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            (c % jcp.kw) * jcp.nb_ch_blocking + ch);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            (c % jcp.kw) * jcp.nb_ch_blocking + ch));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
         } else {
             for (int c = 0; c < cascade_input; ++c) {
-                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                int input_sp = overlap + c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                const dim_t overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                const dim_t input_sp = overlap + c - pad_offset;
+                const dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -1202,15 +1221,16 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                     bool masked_load = is_last_ch && ch == nb_ch_blocking - 1;
                     size_t input_offset = static_cast<size_t>(
                             (input_sp_offset + ch * simd_w_) * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            ((overlap + c) % jcp.kw) * jcp.nb_ch_blocking + ch);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            ((overlap + c) % jcp.kw) * jcp.nb_ch_blocking
+                            + ch));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
         }
         for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+            const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
             /* Don't apply FMAs that fall into the padded region */
             if (io_overlap - l_pad < 0
@@ -1226,9 +1246,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                 size_t output_offset = static_cast<size_t>(
                         (output_sp_offset + ch * simd_w_) * sizeof(float));
 
-                Vmm vmm_input = get_input_reg(
+                Vmm vmm_input = get_input_reg(static_cast<int>(
                         ((io_overlap - l_pad) % jcp.kw) * jcp.nb_ch_blocking
-                        + ch);
+                        + ch));
                 Vmm vmm_acc = get_acc_reg(i_kw * jcp.nb_ch_blocking + ch);
                 if (masked_load) {
                     Vmm vmm_output = get_output_reg(0);
@@ -1250,14 +1270,15 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         bool is_last_ch) {
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : simd_w_;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : simd_w_;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const dim_t right_border = jcp.iw - iw_block;
+    const dim_t r_pad = jcp.r_pad;
+    const int cascade_input
+            = static_cast<int>(nstl::min<dim_t>(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const dim_t input_overlap = nstl::max<dim_t>(jcp.kw - l_pad, 0);
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
     const bool nxc_sse41_offset = is_layout_nxc() && isa == sse41;
 
@@ -1267,7 +1288,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         bool masked_load
                 = IMPLICATION(isa == sse41, tail_in_first_simd) && is_last_ch;
         for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-            int output_sp_offset = nxc_sse41_offset
+            const dim_t output_sp_offset = nxc_sse41_offset
                     ? i_ur * ch_step + r * simd_w_
                     : (i_ur * reg_repeats_ + r) * ch_step;
             size_t output_offset
@@ -1277,8 +1298,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                     masked_load);
             if (i_ur == 0) {
                 for (int c = 0; c < input_overlap; ++c) {
-                    int input_sp = c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
+                    const dim_t input_sp = c - pad_offset;
+                    const dim_t input_sp_offset = nxc_sse41_offset
                             ? input_sp * ch_step + r * simd_w_
                             : (input_sp * reg_repeats_ + r) * ch_step;
                     if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
@@ -1296,9 +1317,10 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                 }
             } else {
                 for (int c = 0; c < cascade_input; ++c) {
-                    int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                    int input_sp = overlap + c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
+                    const dim_t overlap
+                            = (i_ur - 1) * jcp.stride_w + input_overlap;
+                    const dim_t input_sp = overlap + c - pad_offset;
+                    const dim_t input_sp_offset = nxc_sse41_offset
                             ? input_sp * ch_step + r * simd_w_
                             : (input_sp * reg_repeats_ + r) * ch_step;
                     if (input_sp_offset < 0
@@ -1312,14 +1334,14 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
 
                     size_t input_offset = static_cast<size_t>(
                             input_sp_offset * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            ((overlap + c) % jcp.kw) * reg_repeats_ + r);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            ((overlap + c) % jcp.kw) * reg_repeats_ + r));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
             for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-                int io_overlap = i_kw + (i_ur * jcp.stride_w);
+                const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
                 /* Don't apply FMAs that fall into the padded region */
                 if (io_overlap - l_pad < 0
@@ -1330,9 +1352,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                         && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
                 if (over_steps_bdry) continue;
 
-                Vmm vmm_input = get_input_reg(
-                        ((io_overlap - l_pad) % jcp.kw) * reg_repeats_ + r);
-                Vmm vmm_acc = get_acc_reg(r * jcp.kw + i_kw);
+                Vmm vmm_input = get_input_reg(static_cast<int>(
+                        ((io_overlap - l_pad) % jcp.kw) * reg_repeats_ + r));
+                Vmm vmm_acc = get_acc_reg(static_cast<int>(r * jcp.kw + i_kw));
                 Vmm vmm_aux = isa == sse41 ? get_aux_reg() : vmm_input;
                 if (isa == sse41) uni_vmovups(vmm_aux, vmm_input);
                 uni_vfmadd231ps(vmm_acc, vmm_aux, vmm_output);
@@ -1362,7 +1384,8 @@ template <>
 inline void
 jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
+    const int ch_step
+            = static_cast<int>(is_ddst_layout_nxc() ? jcp.ngroups : simd_w_);
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
@@ -1384,7 +1407,7 @@ template <cpu_isa_t isa>
 inline void
 jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
+    const dim_t ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
     for (int i = 0; i < unroll_w; ++i) {
         for (int ch = 0; ch < nb_ch_blocking; ++ch) {
             Vmm vmm_bias = get_bias_reg(ch);
@@ -1407,7 +1430,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::store_filter(
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
-        const int reg_set = r * jcp.kw;
+        const int reg_set = static_cast<int>(r * jcp.kw);
         for (int i = 0; i < jcp.kw; ++i) {
             size_t off_filter = static_cast<size_t>(
                     (i * jcp.ch_block + r * simd_w_) * sizeof(float));
@@ -1469,9 +1492,12 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
     Label oh_label;
     Label ow_blk_label;
 
-    const int unroll_w = nstl::min(max_unroll_w_, jcp.ow);
-    const int unroll_w_trips = jcp.ow / unroll_w;
-    const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
+    const int unroll_w
+            = static_cast<int>(nstl::min<dim_t>(max_unroll_w_, jcp.ow));
+    const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
+    const int tail_w = jcp.ow > max_unroll_w_
+            ? static_cast<int>(jcp.ow % max_unroll_w_)
+            : 0;
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     const size_t ch_offset = ch_step * sizeof(float);
@@ -1487,7 +1513,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
         L(ow_blk_label);
         {
             compute_bias_step_unroll(unroll_w, nb_ch_blocking, is_last_ch);
-            add(reg_tmp_output, unroll_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(unroll_w * ch_offset));
 
             dec(reg_iter_ow_blk);
             cmp(reg_iter_ow_blk, 0);
@@ -1496,7 +1522,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
 
         if (tail_w > 0) {
             compute_bias_step_unroll(tail_w, nb_ch_blocking, is_last_ch);
-            add(reg_tmp_output, tail_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(tail_w * ch_offset));
         }
 
         inc(reg_oh);
@@ -1646,14 +1672,14 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter_kh_loop(
     {
         store_filter(nb_ch_blocking);
 
-        add(reg_tmp_filter, filter_offset_kw);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kw));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
     }
 
     /* Comeback pointers */
-    sub(reg_tmp_filter, filter_offset_kh);
+    sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kh));
 }
 
 template <cpu_isa_t isa>
@@ -1729,8 +1755,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
                 nb_ch_blocking, is_last_ch);
         store_filter(nb_ch_blocking, is_last_ch);
 
-        add(reg_tmp_filter, filter_offset);
-        add(reg_tmp_input, input_offset);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
+        add(reg_tmp_input, static_cast<uint32_t>(input_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
@@ -1741,8 +1767,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
     mov(reg_kh_aux, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_tmp_input, input_offset);
-        sub(reg_tmp_filter, filter_offset);
+        sub(reg_tmp_input, static_cast<uint32_t>(input_offset));
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -1800,7 +1826,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     mov(reg_tmp_input, reg_input_baddr);
     mov(reg_tmp_filter, reg_filter_baddr);
 
-    const int input_bottom_padding_overlap
+    const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1836,11 +1862,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_tmp_filter, filter_shift * jcp.stride_h);
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -1848,14 +1874,17 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_tmp_filter, filter_shift * inp_corr);
-                add(reg_tmp_input, input_shift * inp_corr);
+                const dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add(reg_tmp_filter,
+                        static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_tmp_input,
+                        static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
             sub(reg_tmp_filter,
-                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+                    static_cast<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Apply correction */
@@ -1889,11 +1918,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     }
 
     /* Compute middle block */
-    add(reg_tmp_input, input_shift * jcp.stride_h);
+    add(reg_tmp_input, static_cast<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_tmp_output, output_shift);
+    add(reg_tmp_output, static_cast<uint32_t>(output_shift));
     inc(reg_oh);
     cmp(reg_oh, reg_oh_worksize);
     jl(loop_begin_label, T_NEAR);
@@ -1907,10 +1936,10 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (do_unroll_w) {
-        unroll_w = nstl::min(block_size_, jcp.ow);
-        unroll_trips = jcp.ow / unroll_w;
+        unroll_w = static_cast<int>(nstl::min<dim_t>(block_size_, jcp.ow));
+        unroll_trips = static_cast<int>(jcp.ow / unroll_w);
         /* calculate tail */
-        unroll_w_tail = jcp.ow % unroll_w;
+        unroll_w_tail = static_cast<int>(jcp.ow % unroll_w);
         /* Perform some rebalancing if tail too small*/
         if ((unroll_w_tail == 0 && jcp.r_pad != 0)
                 || (jcp.r_pad > 0 && jcp.r_pad >= unroll_w_tail)) {
@@ -1924,7 +1953,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
             }
         }
     } else {
-        unroll_w_tail = jcp.ow;
+        unroll_w_tail = static_cast<int>(jcp.ow);
     }
 }
 
@@ -1934,7 +1963,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for computing 'ow middle' block
     int pad_offset = 0;
-    int l_pad = jcp.l_pad;
+    int l_pad = static_cast<int>(jcp.l_pad);
 
     int unroll_w_tail = 0;
     int unroll_w = 0;
@@ -1955,8 +1984,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (l_pad && do_unroll_w) {
         compute_h_loop(unroll_w, l_pad, 0, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
         unroll_trips--;
         pad_offset = l_pad;
         l_pad = 0;
@@ -1971,8 +2000,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     }
     if (unroll_trips > 0) {
         compute_h_loop(unroll_w, l_pad, pad_offset, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
     }
     if (do_ow_blk_loop) {
         dec(reg_iter_ow_blk);
@@ -1982,8 +2011,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     /* compute right padded block */
     if (unroll_w_tail) {
-        compute_h_loop(
-                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+        compute_h_loop(unroll_w_tail, l_pad, pad_offset,
+                static_cast<int>(jcp.ow - unroll_w_tail));
     }
 }
 

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -45,7 +45,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const dim_t tail_size = jcp.oc_without_padding
+        const std::size_t tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<isa>::vlen / sizeof(float));
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r14, r15,
                 r12, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -97,15 +97,16 @@ private:
     void store_tail(
             Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size);
 
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -218,14 +219,17 @@ private:
      * is no larger than 3*/
     inline Vmm get_bias_reg(int idx = 0) { return Vmm(idx); }
     inline Vmm get_output_reg(int idx) {
-        int vmm_idx = jcp.is_fast_depthwise
-                ? idx + 2 * jcp.kw * jcp.nb_ch_blocking
+        // `jcp.kw` is a genuine (dim_t) kernel-width dimension, but is
+        // assumed no larger than 3 here (see comment above), so the
+        // resulting register index is bounded and narrowed once here.
+        const int vmm_idx = jcp.is_fast_depthwise
+                ? idx + static_cast<int>(2 * jcp.kw * jcp.nb_ch_blocking)
                 : idx + req_aux_vmm;
         return Vmm(vmm_idx);
     }
     inline Vmm get_input_reg(int idx) {
-        int vmm_idx = jcp.is_fast_depthwise
-                ? idx + jcp.kw * jcp.nb_ch_blocking
+        const int vmm_idx = jcp.is_fast_depthwise
+                ? idx + static_cast<int>(jcp.kw * jcp.nb_ch_blocking)
                 : idx + 4 * reg_repeats_ + req_aux_vmm;
         return Vmm(vmm_idx);
     }

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -134,8 +134,8 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -146,8 +146,10 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
 
     jcp.loop_order = loop_ngcw;
 
@@ -155,25 +157,28 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
             : utils::one_of(isa, avx512_core, avx512_core_fp16) ? 6
             : isa == avx2                                       ? 4
                                                                 : 3;
-    jcp.ur_w = nstl::min(jcp.ur_w, jcp.ow);
+    jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ur_w, jcp.ow));
 
     jcp.ch_block = simd_w;
     jcp.nb_ch = div_up(jcp.oc, jcp.ch_block);
     jcp.nb_ch_blocking = is_superset(isa, avx512_core) ? 4
             : isa == avx2                              ? 3
                                                        : 2;
-    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+    if (jcp.nb_ch < jcp.nb_ch_blocking)
+        jcp.nb_ch_blocking = static_cast<int>(jcp.nb_ch);
 
     if (is_data_layout_nxc) {
         jcp.loop_order = loop_nhwcg;
-        const int resrc_depthwise_ur_w = (31 - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        const int resrc_depthwise_ur_w
+                = static_cast<int>((31 - jcp.kw + jcp.stride_w)
+                        / (jcp.nb_ch_blocking + jcp.stride_w));
         jcp.is_resrc_depthwise = (!is_bf16 && !is_f16)
                 && is_superset(isa, avx512_core) && jcp.stride_w < jcp.kw
                 && jcp.kw <= 5 && jcp.dilate_w == 0
                 && resrc_depthwise_ur_w >= 2;
         if (jcp.is_resrc_depthwise) {
-            jcp.ur_w = nstl::min(jcp.ow, resrc_depthwise_ur_w);
+            jcp.ur_w = static_cast<int>(
+                    nstl::min<dim_t>(jcp.ow, resrc_depthwise_ur_w));
         }
         bool cache_aliasing
                 = (jcp.ngroups * jcp.iw * jcp.typesize_in) % 1024 == 0;
@@ -211,9 +216,9 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -334,8 +339,8 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -408,8 +413,10 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
             && jcp.ngroups <= weights_d.padded_dims()[0];
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BAD_PARAM, "");
 
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     jcp.ur_w = is_bf16           ? (isa_has_bf16(jcp.isa) ? 6 : 4)
             : isa == avx512_core ? 6
@@ -418,10 +425,11 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.loop_order = is_data_layout_nxc ? loop_nhwcg : loop_ngcw;
 
-    jcp.ch_tail = jcp.ngroups % jcp.ch_block;
+    jcp.ch_tail = static_cast<int>(jcp.ngroups % jcp.ch_block);
     jcp.nb_ch = div_up(jcp.ic, jcp.ch_block);
     jcp.nb_ch_blocking = isa == avx512_core ? 4 : isa == avx2 ? 3 : 2;
-    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+    if (jcp.nb_ch < jcp.nb_ch_blocking)
+        jcp.nb_ch_blocking = static_cast<int>(jcp.nb_ch);
 
     const size_t max_ch_off
             = static_cast<size_t>(jcp.nb_ch_blocking - 1) * jcp.ch_block;
@@ -517,12 +525,12 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    jcp.r_pad = nstl::max(0,
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
 
@@ -578,7 +586,7 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     }
 
     jcp.ch_block = isa == avx512_core ? 16 : 8;
-    jcp.ch_tail = jcp.oc_without_padding % jcp.ch_block;
+    jcp.ch_tail = static_cast<int>(jcp.oc_without_padding % jcp.ch_block);
 
     // note: bf16 to be supported in the next commit
     bool ok_to_pad_channels
@@ -610,15 +618,17 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     constexpr int max_reg_idx = isa == avx512_core ? 31 : 15;
     // Note: anything larger than 4 didn't show significant speedup
     const int max_isa_unroll = jcp.is_fast_depthwise ? 4 : 1;
-    int max_ch_unroll = nstl::min(max_isa_unroll, max_reg_idx / (2 * jcp.kw));
-    jcp.nb_ch_blocking = nstl::min(jcp.nb_ch, max_ch_unroll);
+    int max_ch_unroll = static_cast<int>(
+            nstl::min<dim_t>(max_isa_unroll, max_reg_idx / (2 * jcp.kw)));
+    jcp.nb_ch_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.nb_ch, max_ch_unroll));
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_hpad = (jcp.kh - 1 + 1) / 2;
-    const int max_wpad = (jcp.kw - 1 + 1) / 2;
-    const int min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
+    const dim_t max_hpad = (jcp.kh - 1 + 1) / 2;
+    const dim_t max_wpad = (jcp.kw - 1 + 1) / 2;
+    const dim_t min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
     const bool boundaries_ok = true && jcp.t_pad <= max_hpad
             && jcp.b_pad <= max_hpad && jcp.l_pad <= max_wpad
             && jcp.r_pad <= max_wpad
@@ -633,7 +643,8 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     /* BF16: accumulation of output happens in f32, down-conversion to bf16
      * happens during the reduction phase. */
     jcp.typesize_out = sizeof(float);
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
     jcp.bia_dt = jcp.with_bias ? cd.diff_bias_desc.data_type : data_type::undef;
 
     jcp.harness = is_data_layout_nxc ? harness_nxc : harness_mb_reduction;
@@ -707,8 +718,9 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::balance(
          * per-thread load when the number of threads is high (e.g. > 16).
          */
         jcp.oh_blk_size = 15;
-        jcp.nthr_g = nstl::min(jcp.nb_ch, nthreads);
-        jcp.nthr_mb = nstl::min(nstl::max(1, nthreads / jcp.nthr_g), jcp.mb);
+        jcp.nthr_g = static_cast<int>(nstl::min<dim_t>(jcp.nb_ch, nthreads));
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(
+                nstl::max<dim_t>(1, nthreads / jcp.nthr_g), jcp.mb));
         jcp.nthr = jcp.nthr_g * jcp.nthr_mb;
     } else if (jcp.harness == harness_nxc) {
         /* Allocate threads and partition space with regards to 'nb_ch', 'mb'
@@ -743,15 +755,16 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
     const int env_max_nthr_oh = nthreads; // DNNL_MAX_NTHR_OH
     const int env_min_oh_block = 1; // DNNL_MIN_OH_BLOCK
 
-    const int ch_outer_blocks = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
-    int max_g = nstl::min(env_max_nthr_g, nstl::min(ch_outer_blocks, nthreads));
+    const dim_t ch_outer_blocks = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    int max_g = static_cast<int>(nstl::min<dim_t>(
+            env_max_nthr_g, nstl::min<dim_t>(ch_outer_blocks, nthreads)));
     for (int g = max_g; g >= 1; --g) {
         int cur_nthr_g = g;
         auto div_nthr_g = nthreads / cur_nthr_g;
 
         int available_nthr_mb = div_nthr_g;
-        int max_mb = nstl::min(
-                env_max_nthr_mb, nstl::min(jcp.mb, available_nthr_mb));
+        int max_mb = static_cast<int>(nstl::min<dim_t>(
+                env_max_nthr_mb, nstl::min<dim_t>(jcp.mb, available_nthr_mb)));
         for (int mb = max_mb; mb >= 1; --mb) {
             int cur_nthr_mb = mb;
             auto div_nthr_mb = available_nthr_mb / cur_nthr_mb;
@@ -759,27 +772,30 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
             // used to skip cases where efficiency can only worsen
             bool prev_under_blocked = false;
 
-            int available_nthr_oh = nstl::min(
-                    jcp.oh, nstl::min(env_max_nthr_oh, div_nthr_mb));
-            int max_oh_block = jcp.oh;
+            int available_nthr_oh = static_cast<int>(nstl::min<dim_t>(
+                    jcp.oh, nstl::min(env_max_nthr_oh, div_nthr_mb)));
+            int max_oh_block = static_cast<int>(jcp.oh);
             // Note: maybe it's worth exploring a heuristic to determine
             // optimal_min(oh_block)
-            int min_oh_block
-                    = nstl::max(1, nstl::min(jcp.oh, env_min_oh_block));
+            int min_oh_block = static_cast<int>(nstl::max<dim_t>(
+                    1, nstl::min<dim_t>(jcp.oh, env_min_oh_block)));
             for (int oh_block = max_oh_block; oh_block >= min_oh_block;
                     --oh_block) {
 
                 // Calculate most efficient approximation for thread use and/or
                 // blocking:
-                int approx_g_block = utils::div_up(ch_outer_blocks, cur_nthr_g);
-                int approx_mb_block = utils::div_up(jcp.mb, cur_nthr_mb);
-                int approx_oh_block = utils::div_up(jcp.oh, oh_block);
+                int approx_g_block = static_cast<int>(
+                        utils::div_up(ch_outer_blocks, cur_nthr_g));
+                int approx_mb_block
+                        = static_cast<int>(utils::div_up(jcp.mb, cur_nthr_mb));
+                int approx_oh_block
+                        = static_cast<int>(utils::div_up(jcp.oh, oh_block));
 
                 int cur_nthr_oh = nstl::min(available_nthr_oh, approx_oh_block);
 
                 // calculate thread use efficiency
                 int total_nthr = cur_nthr_g * cur_nthr_mb * cur_nthr_oh;
-                float thr_eff = ((float)total_nthr) / nthreads;
+                float thr_eff = ((float)total_nthr) / (float)nthreads;
                 assert(total_nthr <= nthreads);
 
                 // efficiency can only worsen, skip
@@ -790,17 +806,17 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
                 // calculate imbalance
                 float imbalance_g = ((float)std::abs(approx_g_block * cur_nthr_g
                                             - ch_outer_blocks))
-                        / ch_outer_blocks;
+                        / (float)ch_outer_blocks;
                 float imbalance_mb
                         = ((float)std::abs(
                                   approx_mb_block * cur_nthr_mb - jcp.mb))
-                        / jcp.mb;
+                        / (float)jcp.mb;
                 float imbalance_oh
                         = ((float)std::abs(oh_block * cur_nthr_oh - jcp.oh))
-                        / jcp.oh;
-                float total_imbalance = imbalance_g * (jcp.mb * jcp.oh)
-                        + imbalance_mb * (ch_outer_blocks * jcp.oh)
-                        + imbalance_oh * (ch_outer_blocks * jcp.mb);
+                        / (float)jcp.oh;
+                float total_imbalance = imbalance_g * (float)(jcp.mb * jcp.oh)
+                        + imbalance_mb * (float)(ch_outer_blocks * jcp.oh)
+                        + imbalance_oh * (float)(ch_outer_blocks * jcp.mb);
 
                 /* 1) When 'prioritize_threading == true'
                  * First Condition: pick the blocking strategy that uses the

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -134,8 +134,8 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -216,7 +216,7 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
-    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
                     jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
@@ -339,8 +339,8 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -525,12 +525,12 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    jcp.r_pad = nstl::max<dim_t>(0,
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.r_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max<dim_t>(0,
+    jcp.b_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
 

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -110,29 +110,29 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
             "skipping non-grouped convolution in depthwise convolution "
             "implementation");
 
-    jcp.ngroups = weights_d.dims()[0];
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = static_cast<int>(weights_d.dims()[0]);
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1];
+    jcp.oc = static_cast<int>(dst_d.dims()[1]);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1];
+    jcp.ic = static_cast<int>(src_d.dims()[1]);
 
-    jcp.ih = src_d.dims()[2];
-    jcp.iw = src_d.dims()[3];
-    jcp.oh = dst_d.dims()[2];
-    jcp.ow = dst_d.dims()[3];
+    jcp.ih = static_cast<int>(src_d.dims()[2]);
+    jcp.iw = static_cast<int>(src_d.dims()[3]);
+    jcp.oh = static_cast<int>(dst_d.dims()[2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[3]);
 
-    jcp.kh = weights_d.dims()[3];
-    jcp.kw = weights_d.dims()[4];
+    jcp.kh = static_cast<int>(weights_d.dims()[3]);
+    jcp.kw = static_cast<int>(weights_d.dims()[4]);
 
-    jcp.t_pad = cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][1];
+    jcp.t_pad = static_cast<int>(cd.padding[0][0]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][1]);
 
-    jcp.stride_h = cd.strides[0];
-    jcp.stride_w = cd.strides[1];
+    jcp.stride_h = static_cast<int>(cd.strides[0]);
+    jcp.stride_w = static_cast<int>(cd.strides[1]);
 
-    jcp.dilate_h = cd.dilates[0];
-    jcp.dilate_w = cd.dilates[1];
+    jcp.dilate_h = static_cast<int>(cd.dilates[0]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[1]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -315,29 +315,29 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
             "non-grouped convolution in depthwise implementation");
 
     const int ndims = diff_src_d.ndims();
-    jcp.ngroups = weights_d.dims()[0];
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = static_cast<int>(weights_d.dims()[0]);
+    jcp.mb = static_cast<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1];
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]);
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1];
+    jcp.ic = static_cast<int>(diff_src_d.dims()[1]);
 
-    jcp.ih = diff_src_d.dims()[2];
-    jcp.iw = diff_src_d.dims()[3];
-    jcp.oh = diff_dst_d.dims()[2];
-    jcp.ow = diff_dst_d.dims()[3];
+    jcp.ih = static_cast<int>(diff_src_d.dims()[2]);
+    jcp.iw = static_cast<int>(diff_src_d.dims()[3]);
+    jcp.oh = static_cast<int>(diff_dst_d.dims()[2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[3]);
 
-    jcp.kh = weights_d.dims()[3];
-    jcp.kw = weights_d.dims()[4];
+    jcp.kh = static_cast<int>(weights_d.dims()[3]);
+    jcp.kw = static_cast<int>(weights_d.dims()[4]);
 
-    jcp.t_pad = cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][1];
+    jcp.t_pad = static_cast<int>(cd.padding[0][0]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][1]);
 
-    jcp.stride_h = cd.strides[0];
-    jcp.stride_w = cd.strides[1];
+    jcp.stride_h = static_cast<int>(cd.strides[0]);
+    jcp.stride_w = static_cast<int>(cd.strides[1]);
 
-    jcp.dilate_h = cd.dilates[0];
-    jcp.dilate_w = cd.dilates[1];
+    jcp.dilate_h = static_cast<int>(cd.dilates[0]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[1]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -492,10 +492,10 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(!(!mayiuse(isa) || (is_bf16 && !mayiuse(avx512_core))),
             VERBOSE_UNSUPPORTED_ISA);
 
-    jcp.ngroups = diff_weights_d.dims()[0];
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
-    jcp.oc_without_padding = diff_dst_d.dims()[1];
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = static_cast<int>(diff_weights_d.dims()[0]);
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
+    jcp.oc_without_padding = static_cast<int>(diff_dst_d.dims()[1]);
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
     const bool with_groups = diff_weights_d.ndims() == src_d.ndims() + 1;
 
@@ -504,24 +504,24 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(jcp.is_depthwise, VERBOSE_UNSUPPORTED_FEATURE,
             "non-grouped convolution in depthwise implementation");
 
-    jcp.mb = src_d.dims()[0];
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.ih = src_d.dims()[2];
-    jcp.iw = src_d.dims()[3];
-    jcp.oh = diff_dst_d.dims()[2];
-    jcp.ow = diff_dst_d.dims()[3];
+    jcp.ih = static_cast<int>(src_d.dims()[2]);
+    jcp.iw = static_cast<int>(src_d.dims()[3]);
+    jcp.oh = static_cast<int>(diff_dst_d.dims()[2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[3]);
 
-    jcp.kh = diff_weights_d.dims()[3];
-    jcp.kw = diff_weights_d.dims()[4];
+    jcp.kh = static_cast<int>(diff_weights_d.dims()[3]);
+    jcp.kw = static_cast<int>(diff_weights_d.dims()[4]);
 
-    jcp.stride_h = cd.strides[0];
-    jcp.stride_w = cd.strides[1];
+    jcp.stride_h = static_cast<int>(cd.strides[0]);
+    jcp.stride_w = static_cast<int>(cd.strides[1]);
 
-    jcp.t_pad = cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][1];
+    jcp.t_pad = static_cast<int>(cd.padding[0][0]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][1]);
 
-    jcp.dilate_h = cd.dilates[0];
-    jcp.dilate_w = cd.dilates[1];
+    jcp.dilate_h = static_cast<int>(cd.dilates[0]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[1]);
 
     jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
 

--- a/src/cpu/x64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.cpp
@@ -77,24 +77,24 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             bias = const_cast<float *>(bias_in);
     }
 
-    const int dil_h = jcp.dilate_h + 1;
-    const int str_h = jcp.stride_h;
+    const dim_t dil_h = jcp.dilate_h + 1;
+    const dim_t str_h = jcp.stride_h;
     const int ch_step = jcp.nb_ch_blocking;
-    const int ow = 0;
-    const int iw = 0;
-    const int kw = 0;
-    const int chb_work = utils::div_up(jcp.nb_ch, ch_step);
+    const dim_t ow = 0;
+    const dim_t iw = 0;
+    const dim_t kw = 0;
+    const dim_t chb_work = utils::div_up(jcp.nb_ch, ch_step);
     const auto is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
     const auto is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
 
-    const int work_amount = jcp.mb * chb_work * jcp.oh;
+    const dim_t work_amount = jcp.mb * chb_work * jcp.oh;
     const auto nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int n {0}, chb {0}, oh {0};
+        dim_t n {0}, chb {0}, oh {0};
         if (jcp.loop_order == loop_ngcw)
             utils::nd_iterator_init(
                     start, n, jcp.mb, chb, chb_work, oh, jcp.oh);
@@ -107,26 +107,24 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
         auto iwork = start;
         while (iwork < end) {
 
-            int ch = chb * ch_step;
+            const dim_t ch = chb * ch_step;
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp.t_pad - oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp.ih,
-                              (int)(oh * str_h + (jcp.kh - 1) * dil_h
-                                      - jcp.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp.t_pad - oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp.ih,
+                              oh * str_h + (jcp.kh - 1) * dil_h - jcp.t_pad + 1)
                     - jcp.ih;
 
-            const int ih
-                    = nstl::max((int)(oh * str_h - jcp.t_pad
-                                        + div_up(i_t_overflow, dil_h) * dil_h),
-                            0);
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
+            const dim_t ih = nstl::max<dim_t>(0,
+                    oh * str_h - jcp.t_pad
+                            + div_up(i_t_overflow, dil_h) * dil_h);
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            const auto ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
-            const auto oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
+            const dim_t ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
+            const dim_t oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
 
             auto par_conv = jit_conv_args_t();
             par_conv.src = jcp.is_fused_conv
@@ -137,12 +135,13 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0, kh, kw)];
             if (bias) par_conv.bias = &bias[bias_d.blk_off(ch * jcp.ch_block)];
 
-            par_conv.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
             assert(IMPLICATION(
                     jcp.loop_order == loop_nhwcg, is_src_layout_nxc));
             // For is_src_layout_nxc maximize jit work along contiguous dim.
-            const int work_rem = end - iwork;
+            const dim_t work_rem = end - iwork;
             par_conv.load_work = utils::this_block_size(ch * jcp.ch_block,
                     jcp.oc_without_padding,
                     (is_src_layout_nxc ? work_rem * ch_step : ch_step)
@@ -191,38 +190,39 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
 
     const auto &jcp = pd()->jcp_;
 
-    auto kernel_params
-            = [=](int ur_str_w, int iw, int oh, int ih, int i_t_overflow,
-                      int i_b_overflow, int stride_off_h, int ch, int n,
-                      int work_remaining) {
+    auto kernel_params = [=](dim_t ur_str_w, dim_t iw, dim_t oh, dim_t ih,
+                                 dim_t i_t_overflow, dim_t i_b_overflow,
+                                 dim_t stride_off_h, dim_t ch, dim_t n,
+                                 dim_t work_remaining) {
         auto par_conv = jit_conv_args_t();
         const bool is_dsrc_layout_nxc
                 = utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc);
         const bool is_ddst_layout_nxc
                 = utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc);
-        const int nb_ch_blocking = jcp.nb_ch_blocking;
+        const dim_t nb_ch_blocking = jcp.nb_ch_blocking;
 
-        const int i_l_overflow = nstl::max(0, (jcp.kw - 1 - iw - jcp.l_pad));
-        const int i_r_overflow
-                = nstl::max(0, (jcp.kw - 1 - (jcp.iw - 1 - iw) - jcp.r_pad));
+        const dim_t i_l_overflow
+                = nstl::max<dim_t>(0, jcp.kw - 1 - iw - jcp.l_pad);
+        const dim_t i_r_overflow = nstl::max<dim_t>(
+                0, jcp.kw - 1 - (jcp.iw - 1 - iw) - jcp.r_pad);
 
-        int ow = iw + jcp.l_pad - i_r_overflow;
-        int stride_off_w = ow % jcp.stride_w;
+        dim_t ow = iw + jcp.l_pad - i_r_overflow;
+        const dim_t stride_off_w = ow % jcp.stride_w;
         ow /= jcp.stride_w;
 
-        const int ic_offset = is_dsrc_layout_nxc ? ch * jcp.ch_block : ch;
+        const dim_t ic_offset = is_dsrc_layout_nxc ? ch * jcp.ch_block : ch;
         par_conv.src = &diff_src[diff_src_d.blk_off(n, ic_offset, ih, iw)];
-        const int oc_offset = is_ddst_layout_nxc ? ch * jcp.ch_block : ch;
+        const dim_t oc_offset = is_ddst_layout_nxc ? ch * jcp.ch_block : ch;
         par_conv.dst = &diff_dst[diff_dst_d.blk_off(n, oc_offset, oh, ow)];
         par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0,
                 i_b_overflow + stride_off_h, i_r_overflow + stride_off_w)];
 
-        par_conv.kh_padding = nstl::max(
+        par_conv.kh_padding = nstl::max<dim_t>(
                 0, jcp.kh - i_t_overflow - i_b_overflow - stride_off_h);
-        par_conv.kw_padding = nstl::max(
+        par_conv.kw_padding = nstl::max<dim_t>(
                 0, jcp.kw - i_l_overflow - i_r_overflow - stride_off_w);
 
-        par_conv.ur_str_w = ur_str_w;
+        par_conv.ur_str_w = static_cast<int>(ur_str_w);
 
         const size_t ch_work = (is_ddst_layout_nxc ? work_remaining : 1)
                 * nb_ch_blocking * jcp.ch_block;
@@ -234,10 +234,10 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
         return par_conv;
     };
 
-    const int aux_w
-            = nstl::min(jcp.iw, jcp.iw - jcp.kw + jcp.r_pad + jcp.stride_w);
-    const int chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
-    const dim_t work_amount = static_cast<dim_t>(jcp.mb) * chb_work * jcp.ih;
+    const dim_t aux_w = nstl::min<dim_t>(
+            jcp.iw, jcp.iw - jcp.kw + jcp.r_pad + jcp.stride_w);
+    const dim_t chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    const dim_t work_amount = jcp.mb * chb_work * jcp.ih;
     const auto nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
@@ -255,23 +255,24 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
 
         auto iwork = start;
         while (iwork < end) {
-            int ch = chb * jcp.nb_ch_blocking;
+            const dim_t ch = chb * jcp.nb_ch_blocking;
 
-            const int work_rem = end - iwork;
+            const dim_t work_rem = end - iwork;
             const dim_t i_t_overflow
                     = nstl::max(dim_t(0), jcp.kh - 1 - ih - jcp.t_pad);
             const dim_t i_b_overflow = nstl::max(
                     dim_t(0), jcp.kh - 1 - (jcp.ih - 1 - ih) - jcp.b_pad);
 
-            int oh = ih + jcp.t_pad - i_b_overflow;
-            int stride_off_h = oh % jcp.stride_h;
+            dim_t oh = ih + jcp.t_pad - i_b_overflow;
+            const dim_t stride_off_h = oh % jcp.stride_h;
             oh /= jcp.stride_h;
 
-            for (int i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
+            for (dim_t i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
                 // left border
-                int iw = i_str_w;
-                int l_border = nstl::min(jcp.kw - 1 - jcp.l_pad, jcp.iw);
-                int ur_str_w = 1;
+                dim_t iw = i_str_w;
+                const dim_t l_border
+                        = nstl::min<dim_t>(jcp.kw - 1 - jcp.l_pad, jcp.iw);
+                dim_t ur_str_w = 1;
                 for (; iw < l_border; iw += jcp.stride_w) {
                     jit_conv_args_t par_conv = kernel_params(ur_str_w, iw, oh,
                             ih, i_t_overflow, i_b_overflow, stride_off_h, ch, n,
@@ -374,24 +375,24 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
             ? diff_bias_f32_to_bf16_accum
             : CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_BIAS);
 
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         auto conv_params = jit_dw_conv_args_t();
-        const int h_block_size = jcp.oh_blk_size;
+        const dim_t h_block_size = jcp.oh_blk_size;
 
-        const int ch_outer_blocks
+        const dim_t ch_outer_blocks
                 = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
         const int ithr_g = ithr % jcp.nthr_g;
-        int g_start {0}, g_end {0};
+        dim_t g_start {0}, g_end {0};
         balance211(ch_outer_blocks, jcp.nthr_g, ithr_g, g_start, g_end);
 
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
-        int mb_start {0}, mb_end {0};
+        dim_t mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         const int ithr_oh = (ithr / (jcp.nthr_mb * jcp.nthr_g)) % jcp.nthr_oh;
-        const int nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
-        int nb_oh_start {0}, nb_oh_end {0};
+        const dim_t nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
+        dim_t nb_oh_start {0}, nb_oh_end {0};
         balance211(nb_oh, jcp.nthr_oh, ithr_oh, nb_oh_start, nb_oh_end);
 
         const size_t wei_size
@@ -416,23 +417,24 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 ? diff_bias_reduction_buffer + (ithr_block - 1) * bias_size
                 : nullptr;
         const int g_step = jcp.nb_ch_blocking;
-        for (int g_ = g_start; g_ < g_end; ++g_) {
-            const int g = g_ * jcp.nb_ch_blocking;
+        for (dim_t g_ = g_start; g_ < g_end; ++g_) {
+            const dim_t g = g_ * jcp.nb_ch_blocking;
             unsigned char last_g_flag
                     = (g + g_step) >= jcp.nb_ch ? FLAG_OC_LAST : 0;
             unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
             unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
-            for (int mb = mb_start; mb < mb_end; mb++) {
-                for (int nb_oh = nb_oh_start; nb_oh < nb_oh_end; ++nb_oh) {
-                    const int oh_s = nb_oh * h_block_size;
-                    const int h_work = nstl::min(h_block_size, jcp.oh - oh_s);
-                    const int oh_e = oh_s + h_work;
-                    const int ih = -jcp.t_pad + oh_s * jcp.stride_h;
-                    const int kh_top_overflow = nstl::max(0, -ih);
-                    const int kh_bottom_overflow
-                            = nstl::max(0, ih - jcp.ih + jcp.kh);
-                    const int kh_padding_offset
-                            = nstl::min(jcp.kh - 1, kh_top_overflow);
+            for (dim_t mb = mb_start; mb < mb_end; mb++) {
+                for (dim_t nb_oh = nb_oh_start; nb_oh < nb_oh_end; ++nb_oh) {
+                    const dim_t oh_s = nb_oh * h_block_size;
+                    const dim_t h_work
+                            = nstl::min<dim_t>(h_block_size, jcp.oh - oh_s);
+                    const dim_t oh_e = oh_s + h_work;
+                    const dim_t ih = -jcp.t_pad + oh_s * jcp.stride_h;
+                    const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih);
+                    const dim_t kh_bottom_overflow
+                            = nstl::max<dim_t>(0, ih - jcp.ih + jcp.kh);
+                    const dim_t kh_padding_offset
+                            = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow);
                     conv_params.kh_count
                             = jcp.kh - kh_top_overflow - kh_bottom_overflow;
                     conv_params.filter_pad_off
@@ -499,21 +501,21 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
     const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
     const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
 
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
 
     auto set_kernel_params
-            = [=](jit_dw_conv_args_t *conv_params, const int batch,
-                      const int group, const int oh_start, const int work_size,
-                      const unsigned char exec_flag, const size_t kh_padding,
-                      const size_t filter_off) {
-        const int tpad_underflow_off = jcp.t_pad - filter_off;
+            = [=](jit_dw_conv_args_t *conv_params, const dim_t batch,
+                      const dim_t group, const dim_t oh_start,
+                      const dim_t work_size, const unsigned char exec_flag,
+                      const size_t kh_padding, const size_t filter_off) {
+        const dim_t tpad_underflow_off = jcp.t_pad - filter_off;
 
         conv_params->exec_flags = exec_flag;
         conv_params->kh_count = jcp.kh - kh_padding;
 
-        const int oh_s = oh_start;
-        const int oh_e = oh_start + work_size;
-        const int ih_s = oh_s * jcp.stride_h;
+        const dim_t oh_s = oh_start;
+        const dim_t oh_e = oh_start + work_size;
+        const dim_t ih_s = oh_s * jcp.stride_h;
 
         conv_params->filter_pad_off
                 = filter_off * jcp.kw * ch_block * jcp.typesize_out;
@@ -537,18 +539,18 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         assert(nthr == jcp.nthr);
 
         auto conv_params = jit_dw_conv_args_t();
-        const int h_block_size = jcp.oh_blk_size;
-        const int nb_ch = jcp.nb_ch;
+        const dim_t h_block_size = jcp.oh_blk_size;
+        const dim_t nb_ch = jcp.nb_ch;
 
         /* assign iteration space to thread */
         const int ithr_g = ithr % jcp.nthr_g;
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
 
         /* split dimensions */
-        int g_start {0}, g_end {0};
+        dim_t g_start {0}, g_end {0};
         balance211(nb_ch, jcp.nthr_g, ithr_g, g_start, g_end);
 
-        int mb_start {0}, mb_end {0};
+        dim_t mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         auto i_mb = diff_weights_type == bf16 ? ithr_mb : ithr_mb - 1;
@@ -560,7 +562,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 ? diff_bias
                 : diff_bia_reduction_buf + (ithr_mb - 1) * bias_size;
 
-        for (int g = g_start; g < g_end; ++g) {
+        for (dim_t g = g_start; g < g_end; ++g) {
             unsigned char last_g_flag = g == nb_ch - 1 ? FLAG_OC_LAST : 0;
             unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
             unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
@@ -570,14 +572,16 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
             if (jcp.with_bias) conv_params.bias = &diff_bia[g * ch_block];
 
-            for (int mb = mb_start; mb < mb_end; ++mb) {
-                int oh = 0;
+            for (dim_t mb = mb_start; mb < mb_end; ++mb) {
+                dim_t oh = 0;
                 while (oh < jcp.oh) {
-                    const int h_work = nstl::min(h_block_size, jcp.oh - oh);
-                    auto kh_t_padding = nstl::max(0, jcp.t_pad - oh);
-                    auto kh_b_padding
+                    const dim_t h_work
+                            = nstl::min<dim_t>(h_block_size, jcp.oh - oh);
+                    const dim_t kh_t_padding
+                            = nstl::max<dim_t>(0, jcp.t_pad - oh);
+                    const dim_t kh_b_padding
                             = (oh * jcp.stride_h + jcp.kh > jcp.ih + jcp.t_pad)
-                            ? nstl::max(jcp.b_pad - (h_work - 1), 0)
+                            ? nstl::max<dim_t>(jcp.b_pad - (h_work - 1), 0)
                             : 0;
 
                     set_kernel_params(&conv_params, mb, g, oh, h_work,
@@ -622,26 +626,26 @@ void jit_uni_dw_convolution_bwd_weights_t<avx512_core, bf16>::execute_reduction(
     const size_t wei_size
             = utils::rnd_up(jcp.ngroups, jcp.ch_block) * jcp.kh * jcp.kw;
     const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
 
     /* Apply single-threaded 'mb' reduction */
     if (jcp.with_bias && jcp.nthr_mb > 1) {
         for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
             size_t b_accum_offset = (thr_mb - 1) * bias_size;
-            const int bias_ch_tail = jcp.ch_tail;
-            const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+            const dim_t bias_ch_tail = jcp.ch_tail;
+            const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
 
-            for (int g = 0; g < nb_ch; ++g) {
+            for (dim_t g = 0; g < nb_ch; ++g) {
                 /* Reduction on Bias */
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     size_t bias_offset = g * ch_block + g_block;
                     diff_bias[bias_offset]
                             += diff_bia_reduction_buf[b_accum_offset
                                     + bias_offset];
                 }
             }
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 size_t bias_offset = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
                         += diff_bia_reduction_buf[b_accum_offset + bias_offset];
@@ -685,19 +689,19 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
 
     /* Apply single-threaded 'mb' reduction */
     for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t wei_size
                 = static_cast<size_t>(jcp.ngroups * jcp.kh * jcp.kw);
         const size_t mb_accum_offset = (thr_mb - 1) * wei_size;
         const size_t bias_size = jcp.ngroups;
         const size_t b_accum_offset = (thr_mb - 1) * bias_size;
 
-        const int bias_ch_tail = jcp.ch_tail;
-        const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-        for (int g = 0; g < nb_ch; ++g) {
+        const dim_t bias_ch_tail = jcp.ch_tail;
+        const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+        for (dim_t g = 0; g < nb_ch; ++g) {
             if (jcp.with_bias) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -705,11 +709,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
                                     + bias_offset];
                 }
             }
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = (g * jcp.kh + kh) * jcp.kw + kw;
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t wei_offset = static_cast<size_t>(
                             wei_sp_offset * ch_block + g_block);
                     diff_weights[wei_offset]
@@ -720,7 +724,7 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
         }
         // handle reduction for channel tail
         if (jcp.with_bias) {
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -729,11 +733,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
             }
         }
         if (bias_ch_tail > 0) {
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = static_cast<size_t>(
                         ((nb_ch * jcp.kh + kh) * jcp.kw + kw) * ch_block);
-                for (int g = 0; g < bias_ch_tail; ++g) {
+                for (dim_t g = 0; g < bias_ch_tail; ++g) {
                     const size_t wei_offset = wei_sp_offset + g;
                     diff_weights[wei_offset]
                             += diff_wei_reduction_buffer[mb_accum_offset
@@ -767,7 +771,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
     /* Apply single-threaded 'mb' reduction */
     for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t wei_size
                 = static_cast<size_t>(jcp.ngroups * jcp.kh * jcp.kw);
         const size_t mb_accum_offset = (thr_mb - 1) * wei_size;
@@ -775,11 +779,11 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         const size_t b_accum_offset = (thr_mb - 1) * bias_size;
 
         if (jcp.with_bias) { // Reduction on Bias:
-            const int bias_ch_tail = jcp.ch_tail;
-            const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-            for (int g = 0; g < nb_ch; ++g) {
+            const dim_t bias_ch_tail = jcp.ch_tail;
+            const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+            for (dim_t g = 0; g < nb_ch; ++g) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -788,7 +792,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 }
             }
             // handle reduction for channel tail
-            for (int g = 0; g < bias_ch_tail; g++) {
+            for (dim_t g = 0; g < bias_ch_tail; g++) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -857,17 +861,17 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                     reduction_size);
 
             const bool compute_bias = jcp.with_bias;
-            const int ch_block = jcp.ch_block;
+            const dim_t ch_block = jcp.ch_block;
             const size_t bias_size = jcp.ngroups;
             const size_t bias_accum_offset = ithr_offset * bias_size;
             if (compute_bias) {
                 const size_t nb_ch_offset = NB_CH * ch_block;
-                const int bias_ch_tail = jcp.ch_tail;
+                const dim_t bias_ch_tail = jcp.ch_tail;
                 const bool compute_ch_tail
                         = (NB_CH == jcp.nb_ch - 1) && bias_ch_tail > 0;
                 if (!compute_ch_tail) {
                     PRAGMA_OMP_SIMD()
-                    for (int g_block = 0; g_block < ch_block; ++g_block) {
+                    for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                         const size_t bias_offset
                                 = static_cast<size_t>(nb_ch_offset + g_block);
                         diff_bias[bias_offset]
@@ -876,7 +880,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                     }
                 } else {
                     // handle reduction for channel tail
-                    for (int g = 0; g < bias_ch_tail; g++) {
+                    for (dim_t g = 0; g < bias_ch_tail; g++) {
                         const size_t bias_offset
                                 = static_cast<size_t>(nb_ch_offset + g);
                         diff_bias[bias_offset]
@@ -929,17 +933,17 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
                 utils::rnd_up(jcp.ngroups, jcp.ch_block) * jcp.kh * jcp.kw);
         const size_t reduction_offset = ithr_offset * wei_size;
 
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t bias_size = jcp.ngroups;
         size_t b_accum_offset = ithr_offset * bias_size;
 
         const bool compute_bias = jcp.with_bias;
-        const int bias_ch_tail = jcp.ch_tail;
-        const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-        for (int g = 0; g < nb_ch; ++g) {
+        const dim_t bias_ch_tail = jcp.ch_tail;
+        const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+        for (dim_t g = 0; g < nb_ch; ++g) {
             if (compute_bias) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -947,12 +951,12 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
                                     + bias_offset];
                 }
             }
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset
                         = static_cast<size_t>((g * jcp.kh + kh) * jcp.kw + kw);
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t wei_offset = static_cast<size_t>(
                             wei_sp_offset * ch_block + g_block);
                     diff_weights[wei_offset]
@@ -963,7 +967,7 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
         }
         // handle reduction for channel tail
         if (compute_bias) {
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -972,11 +976,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
             }
         }
         if (bias_ch_tail > 0) {
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = static_cast<size_t>(
                         (nb_ch * jcp.kh + kh) * jcp.kw + kw);
-                for (int g = 0; g < bias_ch_tail; ++g) {
+                for (dim_t g = 0; g < bias_ch_tail; ++g) {
                     const size_t wei_offset
                             = static_cast<size_t>(wei_sp_offset * ch_block + g);
                     diff_weights[wei_offset]

--- a/src/cpu/x64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.cpp
@@ -380,14 +380,14 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         auto conv_params = jit_dw_conv_args_t();
         const dim_t h_block_size = jcp.oh_blk_size;
 
-        const dim_t ch_outer_blocks
+        const int ch_outer_blocks
                 = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
         const int ithr_g = ithr % jcp.nthr_g;
-        dim_t g_start {0}, g_end {0};
+        int g_start {0}, g_end {0};
         balance211(ch_outer_blocks, jcp.nthr_g, ithr_g, g_start, g_end);
 
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
-        dim_t mb_start {0}, mb_end {0};
+        int mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         const int ithr_oh = (ithr / (jcp.nthr_mb * jcp.nthr_g)) % jcp.nthr_oh;
@@ -540,17 +540,17 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
         auto conv_params = jit_dw_conv_args_t();
         const dim_t h_block_size = jcp.oh_blk_size;
-        const dim_t nb_ch = jcp.nb_ch;
+        const int nb_ch = jcp.nb_ch;
 
         /* assign iteration space to thread */
         const int ithr_g = ithr % jcp.nthr_g;
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
 
         /* split dimensions */
-        dim_t g_start {0}, g_end {0};
+        int g_start {0}, g_end {0};
         balance211(nb_ch, jcp.nthr_g, ithr_g, g_start, g_end);
 
-        dim_t mb_start {0}, mb_end {0};
+        int mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         auto i_mb = diff_weights_type == bf16 ? ithr_mb : ithr_mb - 1;


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the depthwise JIT convolution kernels (`jit_avx512_core_bf16_dw_conv_kernel`, `jit_avx512_core_f16_dw_conv_kernel`, `jit_uni_dw_conv_kernel_f32`, `jit_uni_dw_conv_kernel_utils`, `jit_uni_dw_convolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5663 for review convenience; independently reviewable.