### PR TITLE
cpu: conv: AVX512 x8s8s32x: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -58,8 +58,8 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr unsigned helper_vmm_idx = 31;
-        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const size_t tail_size = oc_block_tail
+        const dim_t oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const dim_t tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
@@ -84,7 +84,7 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
-        int load_loop_blk) {
+        dim_t load_loop_blk) {
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
 
@@ -100,9 +100,9 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             reduce_loop(load_loop_blk, jcp.ur, false);
             if (i < num_substeps - 1) {
                 add(aux1_reg_bcast_data, jcp.bcast_loop_bcast_substep);
@@ -112,7 +112,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
                         jcp.bcast_loop_bcast_step
                                 - (num_substeps - 1)
                                         * jcp.bcast_loop_bcast_substep);
-                int output_offset = jcp.bcast_loop_output_step
+                dim_t output_offset = jcp.bcast_loop_output_step
                         - (num_substeps - 1) * jcp.bcast_loop_output_substep;
 
                 add(aux_reg_output_data, output_offset);
@@ -154,29 +154,29 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::cvt2ps(
 }
 
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur,
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
         const bool last_oc_block_flag, const bool force_masking, const F &f) {
-    for (int i_load = 0; i_load < load_loop_blk; i_load++) {
+    for (dim_t i_load = 0; i_load < load_loop_blk; i_load++) {
         const bool mask_flag = force_masking
                 || (last_oc_block_flag && i_load + 1 == load_loop_blk);
-        for (int i_ur = 0; i_ur < ur; i_ur++)
+        for (dim_t i_ur = 0; i_ur < ur; i_ur++)
             f(mask_flag, i_load, i_ur);
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur,
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
         const bool last_oc_block_flag, const F &f) {
     iterate(load_loop_blk, ur, last_oc_block_flag, false, f);
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const F &f) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur, const F &f) {
     iterate(load_loop_blk, ur, false, false, f);
 }
 
 template <typename Vmm>
 Address jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::output_ptr(
-        const int i_load, const int i_ur) {
-    const size_t ur_stride = jcp.with_dw_conv
+        dim_t i_load, dim_t i_ur) {
+    const dim_t ur_stride = jcp.with_dw_conv
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * jcp.ngroups * i_ur;
 
@@ -186,26 +186,26 @@ Address jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::output_ptr(
 
 template <typename Vmm>
 int jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum_idx(
-        const int load_loop_blk, int i_load, int i_ur) const {
-    return (i_ur * load_loop_blk + i_load);
+        dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const {
+    return static_cast<int>(i_ur * load_loop_blk + i_load);
 }
 
 template <typename Vmm>
 Vmm jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum(
-        const int load_loop_blk, int i_load, int i_ur) const {
+        dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const {
     return Vmm(vreg_accum_idx(load_loop_blk, i_load, i_ur));
 }
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_sum(
-        const int load_loop_blk, const int ur, const bool mask_flag_in,
+        dim_t load_loop_blk, dim_t ur, const bool mask_flag_in,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_sum) {
         const float sum_scale = *p_sum_scale;
         const int32_t sum_zp = *p_sum_zp;
         const auto sum_injector_lam
                 = [this, sum_scale, sum_zp, load_loop_blk](const bool mask_flag,
-                          const int i_load, const int i_ur) {
+                          const dim_t i_load, const dim_t i_ur) {
             const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
             cvt2ps(jcp.sum_dt, vmm_prev_dst, output_ptr(i_load, i_ur),
                     mask_flag);
@@ -229,7 +229,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_sum(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
-        const int load_loop_blk, const int ur, const bool mask_flag_in,
+        dim_t load_loop_blk, dim_t ur, const bool mask_flag_in,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
 
@@ -243,11 +243,11 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
             const bool oc_blk_is_smaller_than_vmm
                     = jcp.oc_block < isa_simd_width_;
             iterate(load_loop_blk, ur, mask_tail, oc_blk_is_smaller_than_vmm,
-                    [&](const bool mask_flag, const int i_load,
-                            const int i_ur) {
-                const int ur_stride
+                    [&](const bool mask_flag, const dim_t i_load,
+                            const dim_t i_ur) {
+                const dim_t ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
-                const size_t aux_output_l_off = jcp.typesize_out
+                const dim_t aux_output_l_off = jcp.typesize_out
                         * (ur_stride + i_load * jcp.load_block);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -284,7 +284,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
 
         } else {
             iterate(load_loop_blk, ur,
-                    [&](const bool, const int i_load, const int i_ur) {
+                    [&](const bool, const dim_t i_load, const dim_t i_ur) {
                 vmm_idxs.emplace(vreg_accum_idx(load_loop_blk, i_load, i_ur));
             });
             postops_injector_->compute_vector_range(vmm_idxs);
@@ -294,45 +294,45 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
-        int load_loop_blk, int ur, bool wraparound) {
-    auto vreg_load = [ur, load_loop_blk](int i_load) {
-        return Vmm(ur * load_loop_blk + i_load);
+        dim_t load_loop_blk, dim_t ur, bool wraparound) {
+    auto vreg_load = [ur, load_loop_blk](dim_t i_load) {
+        return Vmm(static_cast<int>(ur * load_loop_blk + i_load));
     };
 
-    auto bias_ptr = [this](int i_load) {
+    auto bias_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_bias_data, jcp.typesize_bia * jcp.oc_block * i_load);
     };
 
-    auto comp_ptr = [this](int i_load) {
+    auto comp_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_comp_data, sizeof(int32_t) * jcp.oc_block * i_load);
     };
 
-    auto bcast_ptr = [this](int i_reduce, int i_ur, bool bcast) {
+    auto bcast_ptr = [this](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
         assert(jcp.reduce_loop_unroll == jcp.reduce_block);
 
-        int offt = (jcp.ic_without_padding * i_ur * jcp.ngroups + i_reduce);
+        dim_t offt = jcp.ic_without_padding * i_ur * jcp.ngroups + i_reduce;
 
         return EVEX_compress_addr(
                 aux_reg_bcast_data, jcp.typesize_in * offt, bcast);
     };
 
-    auto load_ptr = [this](int i_reduce, int i_load) {
-        int u0 = i_reduce % jcp.reduce_loop_unroll;
-        int u1 = i_reduce / jcp.reduce_loop_unroll;
+    auto load_ptr = [this](dim_t i_reduce, dim_t i_load) {
+        const dim_t u0 = i_reduce % jcp.reduce_loop_unroll;
+        const dim_t u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        dim_t offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
 
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
     };
 
     auto init = [this, load_loop_blk, ur]() {
-        for (int i_load = 0; i_load < load_loop_blk; ++i_load)
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+        for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                 vpxord(r, r, r);
             }
@@ -374,7 +374,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             mov(reg_src_zero_point,
                     EVEX_compress_addr(rsp, reg_src_zero_point_off));
         }
-        for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+        for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
             const bool mask_flag = mask_flag_in && i_load == load_loop_blk - 1;
             auto vmm_bias = vmm_tmp;
             auto vmm_comp = vmm_bcast;
@@ -390,7 +390,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             }
             if (jcp.src_zero_point) {
                 // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-                const int zp_offset = sizeof(int32_t) * i_load * jcp.load_block;
+                const dim_t zp_offset
+                        = sizeof(int32_t) * i_load * jcp.load_block;
                 vmovups(vmm_zp,
                         EVEX_compress_addr(reg_zp_compensation, zp_offset));
                 vpmulld(vmm_zp, vmm_zp,
@@ -401,7 +402,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                         = mask_flag ? vmm_zp | k_load_dim_mask | T_z : vmm_zp;
                 vcvtdq2ps(vmm_, vmm_);
             }
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 auto vmm = vreg_accum(load_loop_blk, i_load, i_ur);
                 vcvtdq2ps(vmm, vmm);
                 if (jcp.signed_input) vaddps(vmm, vmm, vmm_comp);
@@ -436,7 +437,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                     mov(reg_wei_scales,
                             EVEX_compress_addr(rsp, reg_wei_scales_off));
 
-                    int scale_offset = jcp.is_oc_scale
+                    const dim_t scale_offset = jcp.is_oc_scale
                             * (sizeof(float) * jcp.oc_block * i_load);
                     vmulps(vmm_k, vmm,
                             EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -461,10 +462,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             mov(reg_dst_scales, EVEX_compress_addr(rsp, reg_dst_scales_off));
 
             /* Apply dst scale to accumulator */
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 const bool mask_flag
                         = mask_flag_in && i_load == load_loop_blk - 1;
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     const auto vmm = vreg_accum(load_loop_blk, i_load, i_ur);
                     const Vmm vmm_k
                             = mask_flag ? vmm | k_load_dim_mask | T_z : vmm;
@@ -481,8 +482,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             vcvtdq2ps(vmm_zp, EVEX_compress_addr(reg_dst_zero_point, 0, true));
 
             /* Add dst zero_point to accumulator */
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     vaddps(r, r, vmm_zp);
                 }
@@ -493,8 +494,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         if (one_of(jcp.dst_dt, u8, s8, s32)) {
             init_saturate_f32(vmm_zero, vmm_saturation,
                     reg_ptr_saturation_ubound, f32, jcp.dst_dt);
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     saturate_cvt_f32(r, vmm_zero, vmm_saturation, jcp.dst_dt);
                 }
@@ -508,8 +509,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {
             // Optimization: use single store instruction for pair
             // of the nearest vectors along LOAD dimension
-            for (int i_ur = 0; i_ur < ur; i_ur++) {
-                int i_load = 0;
+            for (dim_t i_ur = 0; i_ur < ur; i_ur++) {
+                dim_t i_load = 0;
                 for (; i_load < rnd_dn(load_loop_blk, 2); i_load += 2) {
                     auto vmm_dst = vreg_accum(load_loop_blk, i_load, i_ur);
                     auto vmm_dst_next
@@ -530,10 +531,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                 }
             }
         } else {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 const bool mask_flag
                         = mask_flag_in && i_load == load_loop_blk - 1;
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     const Vmm r_vmm = mask_flag ? r | k_load_dim_mask : r;
 
@@ -576,28 +577,28 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
     };
 
     auto fma_block = [&](bool last_block) {
-        int reduce_step = 4;
-        int ic_tail_size = jcp.ic_without_padding % reduce_step;
-        int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
+        const dim_t reduce_step = 4;
+        const dim_t ic_tail_size = jcp.ic_without_padding % reduce_step;
+        const dim_t loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
                 ? rnd_up(jcp.ic_without_padding % jcp.ic_block, reduce_step)
                 : jcp.reduce_loop_unroll;
-        for (int i_reduce = 0; i_reduce < loop_unroll;
+        for (dim_t i_reduce = 0; i_reduce < loop_unroll;
                 i_reduce += reduce_step) {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load)
                 vmovups(vreg_load(i_load), load_ptr(i_reduce, i_load));
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 if (last_block && ic_tail_size != 0
                         && i_reduce == loop_unroll - reduce_step) {
                     Xmm xmm_bcast = Xmm(vmm_bcast.getIdx());
                     load_bytes(xmm_bcast, aux_reg_bcast_data,
                             jcp.ic_without_padding * i_ur + i_reduce,
-                            ic_tail_size);
+                            static_cast<int>(ic_tail_size));
                     vpbroadcastd(vmm_bcast, xmm_bcast);
                 } else {
                     vpbroadcastd(vmm_bcast, bcast_ptr(i_reduce, i_ur, false));
                 }
                 if (jcp.signed_input) vpsubb(vmm_bcast, vmm_bcast, vmm_shift);
-                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                     compute(vreg_accum(load_loop_blk, i_load, i_ur),
                             vreg_load(i_load), vmm_bcast);
                 }
@@ -665,7 +666,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
 
     preamble();
 
-    const int simd_w = jcp.ic_block;
+    const int simd_w = static_cast<int>(jcp.ic_block);
     xor_(reg_scratch, reg_scratch);
     Reg16 _t = reg_scratch.cvt16();
     mov(_t, 0x1);
@@ -724,11 +725,11 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         kmovb(k_load_dim_tail_mask, reg_tail_32);
     }
 
-    const int load_dim_tail
-            = (one_of(jcp.prop_kind, forward_training, forward_inference)
-                              ? jcp.oc_without_padding
-                              : jcp.load_dim)
-            % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(
+            (one_of(jcp.prop_kind, forward_training, forward_inference)
+                            ? jcp.oc_without_padding
+                            : jcp.load_dim)
+            % jcp.load_block);
     const bool use_extended_mask
             = jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa);
     if (load_dim_tail) {
@@ -782,14 +783,16 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         if (jcp.signed_input) {
             mov(reg_comp_data, EVEX_compress_addr(rsp, reg_comp_data_off));
             add(reg_comp_data,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(EVEX_compress_addr(rsp, reg_comp_data_off), reg_comp_data);
         }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation,
                     EVEX_compress_addr(rsp, reg_zp_compensation_off));
             add(reg_zp_compensation,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(EVEX_compress_addr(rsp, reg_zp_compensation_off),
                     reg_zp_compensation);
         }
@@ -797,8 +800,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         if (jcp.with_wei_scales) {
             mov(reg_wei_scales, EVEX_compress_addr(rsp, reg_wei_scales_off));
             add(reg_wei_scales,
-                    jcp.is_oc_scale * load_loop_blk * jcp.load_block
-                            * sizeof(float));
+                    static_cast<uint32_t>(jcp.is_oc_scale * load_loop_blk
+                            * jcp.load_block * sizeof(float)));
             mov(EVEX_compress_addr(rsp, reg_wei_scales_off), reg_wei_scales);
         }
         mov(reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
@@ -1066,10 +1069,13 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 1024;
@@ -1105,9 +1111,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             && (jcp.oh <= size_treshold && jcp.ow <= size_treshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs; // mobilenet_v2 performance improvement
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
-        const int spatial = jcp.od * jcp.oh;
+        const dim_t spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
         for (int ur_w = max_regs; ur_w >= min_regs; ur_w--) {
             if ((spatial >= size_treshold && spatial % ur_w == 0)
@@ -1117,10 +1123,10 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            int os_tail = static_cast<int>(jcp.os % max_regs);
             for (int i = max_regs; i >= min_regs; i--) {
-                int i_tail = jcp.os % i;
+                int i_tail = static_cast<int>(jcp.os % i);
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -1129,7 +1135,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
     }
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
     jcp.reduce_dim = jcp.ic;
     jcp.reduce_block = jcp.ic_block;
@@ -1160,8 +1167,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    int nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    int nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -1173,7 +1180,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     bool cmp_reduce = reduce_blocking <= jcp.reduce_dim;
     if (cmp_reduce) jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
-    load_blocking = jcp.load_dim;
+    load_blocking = static_cast<int>(jcp.load_dim);
 
     jcp.load_grp_count = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
     jcp.load_grp_count = best_divider(
@@ -1184,25 +1191,30 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
         jcp.load_grp_count = nstl::max(jcp.load_grp_count, 4);
     } else if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.mb <= jcp.nthr
             && jcp.load_dim > 512 && jcp.load_dim / jcp.reduce_dim >= 4) {
-        jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2); //
-        load_blocking = jcp.load_block;
+        jcp.load_grp_count
+                = static_cast<int>(nstl::max<dim_t>(jcp.load_grp_count, 2)); //
+        load_blocking = static_cast<int>(jcp.load_block);
     }
 
-    bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                             div_up(jcp.nthr, jcp.load_grp_count))
-            * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+    bcast_blocking
+            = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                       div_up(jcp.nthr, jcp.load_grp_count))
+                    * jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
     bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-    int space_for_bcast = (L2_capacity - /* kernel_size - */
+    const dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
             2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
             - 3 * 1024);
-    if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
+    dim_t space_for_bcast_adjusted = space_for_bcast;
+    if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity)
+        space_for_bcast_adjusted /= 2;
 
-    int bcast_in_cache
-            = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-    bcast_blocking = nstl::min(
-            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+    const dim_t bcast_in_cache = nstl::max<dim_t>(
+            jcp.bcast_block, space_for_bcast_adjusted / reduce_blocking);
+    bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
     load_blocking_max = load_blocking;
     bcast_blocking_max = bcast_blocking * 3 / 2;
@@ -1247,7 +1259,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     if (jcp.mb == 1 && jcp.nb_load % 4 == 0 && jcp.ic / jcp.oc >= 4
             && jcp.ic * jcp.oc <= L2_size && jcp.nthr <= ncores_per_socket) {
         jcp.nb_load_chunk = 4;
-        jcp.load_grp_count = nstl::max(jcp.nb_load / 4, jcp.load_grp_count);
+        jcp.load_grp_count = static_cast<int>(
+                nstl::max<dim_t>(jcp.nb_load / 4, jcp.load_grp_count));
     }
 
     /* adjust the thread decomposition
@@ -1260,7 +1273,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
     if (jcp.typesize_in * bcast_size < 8192 && jcp.ngroups < jcp.nthr
             && jcp.nb_bcast * jcp.nb_load < jcp.nthr) {
-        int nthr = nstl::max(jcp.nb_load, jcp.nb_bcast);
+        const int nthr
+                = static_cast<int>(nstl::max<dim_t>(jcp.nb_load, jcp.nb_bcast));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -59,7 +59,7 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_vmm = false;
         static constexpr unsigned helper_vmm_idx = 31;
         const dim_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const dim_t tail_size = oc_block_tail
+        const std::size_t tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -907,34 +907,36 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
 
     const bool is_1d = ndims == 3;
     const bool is_3d = ndims == 5;
 
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = is_1d ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = is_1d ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = is_1d
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = is_1d ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = is_1d ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
     jcp.signed_input = (src_d.data_type() == data_type::s8);
@@ -1161,7 +1163,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             = jcp.ur * jcp.ngroups * jcp.ic_without_padding * jcp.typesize_in;
     jcp.bcast_loop_bcast_substep = -1; // unused
 
-    jcp.load_loop_load_step = jcp.reduce_dim * jcp.load_block * jcp.typesize_in;
+    jcp.load_loop_load_step = static_cast<int>(
+            jcp.reduce_dim * jcp.load_block * jcp.typesize_in);
 
     jcp.load_loop_iter_step = jcp.load_block;
 
@@ -1246,9 +1249,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     jcp.nb_reduce_blocking = reduce_blocking / jcp.reduce_block;
     jcp.nb_reduce_blocking_max = reduce_blocking_max / jcp.reduce_block;
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     // miniumum size of load dim chunk for work distribution within threads
     jcp.nb_load_chunk = 1;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -134,18 +134,16 @@ private:
     }
     inline Vmm_down_t vmm_store() { return Vmm_down_t(ymm_store.getIdx()); }
 
-    void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, bool wraparound);
+    void bcast_loop(dim_t load_loop_blk);
+    void reduce_loop(dim_t load_loop_blk, dim_t ur, bool wraparound);
 
-    Xbyak::Address output_ptr(const int i_load, const int i_ur);
-    int vreg_accum_idx(const int load_loop_blk, int i_load, int i_ur) const;
-    Vmm vreg_accum(const int load_loop_blk, int i_load, int i_ur) const;
-    void apply_sum(const int load_loop_blk, const int ur,
-            const bool mask_flag_in, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
-    void apply_postops(const int load_loop_blk, const int ur,
-            const bool mask_flag_in, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
+    Xbyak::Address output_ptr(dim_t i_load, dim_t i_ur);
+    int vreg_accum_idx(dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const;
+    Vmm vreg_accum(dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const;
+    void apply_sum(dim_t load_loop_blk, dim_t ur, const bool mask_flag_in,
+            const float *p_sum_scale, const int32_t *p_sum_zp);
+    void apply_postops(dim_t load_loop_blk, dim_t ur, const bool mask_flag_in,
+            const float *p_sum_scale, const int32_t *p_sum_zp);
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag);
@@ -155,7 +153,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel_t {
     jit_avx512_core_x8s8s32x_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.ic_block;
+        const dim_t ch_block = ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -49,7 +49,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const void *src_scales
@@ -110,14 +111,14 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const bool is_2d = pd()->ndims() == 4;
     const bool is_3d = pd()->ndims() == 5;
 
-    const int stride_d = pd()->KSD();
-    const int stride_h = pd()->KSH();
-    const int stride_w = pd()->KSW();
+    const dim_t stride_d = pd()->KSD();
+    const dim_t stride_h = pd()->KSH();
+    const dim_t stride_w = pd()->KSW();
 
     auto offset = weights_d.size() - weights_d.additional_buffer_size();
     char *w = const_cast<char *>(weights);
@@ -139,16 +140,17 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -183,26 +185,26 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
     char *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<char *> addrs;
     // End
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
-        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+        bcast_step = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
-        const int depth_orthogonal_area = jcp.ow * jcp.oh;
+        const dim_t os = osb * os_block;
+        const dim_t depth_orthogonal_area = jcp.ow * jcp.oh;
         od = os / depth_orthogonal_area;
         oh = (os % depth_orthogonal_area) / jcp.ow;
         ow = (os % depth_orthogonal_area) % jcp.ow;
@@ -216,7 +218,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         p.load_dim = this_block_size(ocb * jcp.oc_block, ocb_end * jcp.oc_block,
                 load_step * jcp.oc_block);
@@ -229,17 +231,17 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
     auto init_reduce = [&]() {
         p.reduce_dim = this_block_size(
-                0, jcp.ic_without_padding, jcp.ic_without_padding);
+                dim_t {0}, jcp.ic_without_padding, jcp.ic_without_padding);
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int n, int g, int od, int oh,
-                           int ow, int id, int ih, int iw) {
-        const int icb = 0; // Start from the first IC block
-        const int _ocb = g * nb_oc + ocb;
-        const int _icb = g * nb_ic + icb;
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t n, dim_t g, dim_t od,
+                           dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
+        constexpr dim_t icb = 0; // Start from the first IC block
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g * nb_ic + icb;
 
-        const size_t dst_off = is_3d
+        const dim_t dst_off = is_3d
                 ? dst_d.blk_off(n, _ocb * jcp.oc_block, od, oh, ow)
                 : is_2d ? dst_d.blk_off(n, _ocb * jcp.oc_block, oh, ow)
                         : dst_d.blk_off(n, _ocb * jcp.oc_block, ow);
@@ -288,18 +290,19 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_rlb) {
             init_reduce();
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                    dim_t n, g, od, oh, ow, id, ih, iw;
+                    dim_t bcast_step;
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -308,13 +311,14 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                    dim_t n, g, od, oh, ow, id, ih, iw;
+                    dim_t bcast_step;
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
                     init_reduce();
@@ -325,14 +329,15 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             }
         } else if (jcp.loop_order == loop_rbl) {
             init_reduce();
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                     ocb += load_step;
@@ -340,14 +345,15 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                 iwork += bcast_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     init_reduce();
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -360,30 +366,31 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
-        int oh_1x1_begin = nstl::max(oh_1x1, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
+        dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1_begin++) % jcp_dw->kh) * row_offset;
 
         const auto ocb_end = ocb_start + load_step;
-        const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
+        const dim_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         auto par_conv_dw = jit_conv_args_t();
 
-        par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
-        par_conv_dw.b_overflow = nstl::min(
-                jcp_dw->kh, nstl::max(0, oh_1x1 - jcp.oh + jcp_dw->kh));
-        par_conv_dw.kh_padding = nstl::max<int>(0,
+        par_conv_dw.t_overflow
+                = nstl::max<dim_t>(0, nstl::min<dim_t>(jcp_dw->kh, -oh_1x1));
+        par_conv_dw.b_overflow = nstl::max<dim_t>(
+                0, nstl::min<dim_t>(jcp_dw->kh, oh_1x1 - jcp.oh + jcp_dw->kh));
+        par_conv_dw.kh_padding = nstl::max<dim_t>(0,
                 jcp_dw->kh - par_conv_dw.t_overflow - par_conv_dw.b_overflow);
 
-        const size_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
+        const dim_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
                 + dw_oh * jcp_dw->ow * jcp_dw->ngroups;
 
         const auto wht_h_stride = dw_weights_d.blk_off(0, 0, 0, 1);
         const auto wei_stride = (!jcp_dw->signed_input) * par_conv_dw.t_overflow
                 * wht_h_stride;
-        for (int ocb = ocb_start; ocb < ocb_end;
+        for (dim_t ocb = ocb_start; ocb < ocb_end;
                 ocb += jcp_dw->nb_ch_blocking) {
 
             par_conv_dw.src = addrs.data();
@@ -395,7 +402,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                     = weights_dw + dw_weights_d.blk_off(ocb, 0) + wei_stride;
             par_conv_dw.bias
                     = &bias_dw[ocb * jcp_dw->ch_block * dw_bia_dt_size];
-            par_conv_dw.ur_w = (size_t)(jcp_dw->ow);
+            par_conv_dw.ur_w = jcp_dw->ow;
             par_conv_dw.owb = jcp_dw->ow;
             par_conv_dw.oc_blocks = ocb;
             par_conv_dw.compensation = compensation_dw
@@ -414,7 +421,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
             (*kernel_dw_)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += src_ch_stride;
         }
     };
@@ -423,39 +430,41 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         auto jcp_dw = pd()->jcp_dw_;
         auto dw_conv_buffer = dw_scratchpad.get<char>(key_fusion_inout_buffer);
 
-        const auto dw_conv_buffer_size_
-                = (size_t)jcp_dw->kh * jcp.ow * nb_buffer * jcp.oc_block;
+        const dim_t dw_conv_buffer_size_
+                = jcp_dw->kh * jcp.ow * nb_buffer * jcp.oc_block;
         pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size_;
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+                bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -471,10 +480,10 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                jcp.load_grp_count);
+                static_cast<dim_t>(jcp.load_grp_count));
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -111,7 +111,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const bool is_2d = pd()->ndims() == 4;
     const bool is_3d = pd()->ndims() == 5;
@@ -140,7 +140,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_ic = jcp.nb_reduce;
     // override some constants for fused dw_conv
     const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
@@ -436,10 +436,9 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end,
-                static_cast<dim_t>(jcp.load_grp_count));
+                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
 
         while (ocb_start < ocb_end) {
             dim_t load_step;
@@ -480,10 +479,10 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                static_cast<dim_t>(jcp.load_grp_count));
+                jcp.load_grp_count);
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -265,8 +265,8 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw_->nb_ch_blocking != 0)
                 --jcp_dw_->nb_ch_blocking;
 
-            jcp_dw_->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw_->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
             jcp_1x1.bcast_loop_output_step = jcp_1x1.ur
                     * (jcp_1x1.nb_load_blocking * jcp_1x1.oc_block)
                     * jcp_1x1.typesize_out;
@@ -274,7 +274,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);
 
-            size_t dw_conv_buffer_size_ = (size_t)nthr * jcp_dw_->kh
+            dim_t dw_conv_buffer_size_ = static_cast<dim_t>(nthr) * jcp_dw_->kh
                     * jcp_dw_->iw * jcp_dw_->dw_conv_buffer_oc;
             assert(dw_conv_buffer_size_);
             dw_scratchpad.book(memory_tracking::names::key_fusion_inout_buffer,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -66,10 +66,10 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t block_tail
+        const dim_t block_tail
                 = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const size_t tail_size = block_tail
+        const dim_t tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;
@@ -94,8 +94,9 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::prepare_output(int ur_w) {
-    int nb_oc_block
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::prepare_output(
+        dim_t ur_w) {
+    const dim_t nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
     for (int k = 0; k < nb_oc_block; k++)
         for (int j = 0; j < ur_w; j++) {
@@ -144,36 +145,36 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::cvt2ps(data_type_t type_in,
 }
 
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w,
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w,
         const bool last_oc_block_flag, const bool force_masking, const F &f) {
-    for (int k = 0; k < nb_oc_block; k++) {
+    for (dim_t k = 0; k < nb_oc_block; k++) {
         const bool mask_flag
                 = force_masking || (last_oc_block_flag && k + 1 == nb_oc_block);
-        for (int j = 0; j < ur_w; j++)
+        for (dim_t j = 0; j < ur_w; j++)
             f(mask_flag, k, j);
     }
 }
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w,
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w,
         const bool last_oc_block_flag, const F &f) {
     iterate(nb_oc_block, ur_w, last_oc_block_flag, false, f);
 }
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w, const F &f) {
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w, const F &f) {
     iterate(nb_oc_block, ur_w, false, false, f);
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(dim_t ur_w,
+        bool last_oc_block_flag, const dim_t nb_oc_block, const dim_t oc_block,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_sum) {
         const float sum_scale = *p_sum_scale;
         const int32_t sum_zp = *p_sum_zp;
         const auto sum_injector_lam
                 = [this, oc_block, sum_scale, sum_zp](
-                          const bool mask_flag, const int k, const int j) {
-            int aux_output_offset = jcp.typesize_out
+                          const bool mask_flag, const dim_t k, const dim_t j) {
+            dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
             auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
             Vmm vmm = vmm_out(j, k);
@@ -202,8 +203,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(int ur_w,
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(dim_t ur_w,
+        bool last_oc_block_flag, const dim_t nb_oc_block, const dim_t oc_block,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         apply_sum(ur_w, last_oc_block_flag, nb_oc_block, oc_block, p_sum_scale,
@@ -215,8 +216,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
             const bool oc_blk_is_smaller_than_vmm = oc_block < isa_simd_width_;
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
                     oc_blk_is_smaller_than_vmm,
-                    [&](const bool mask_flag, const int k, const int j) {
-                const size_t aux_output_l_off = jcp.typesize_out
+                    [&](const bool mask_flag, const dim_t k, const dim_t j) {
+                const dim_t aux_output_l_off = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 const auto vmm_idx = vmm_out_idx(j, k);
@@ -231,7 +232,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
             postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
         } else {
             iterate(nb_oc_block, ur_w,
-                    [&](const bool, const int k, const int j) {
+                    [&](const bool, const dim_t k, const dim_t j) {
                 vmm_idxs.emplace(vmm_out_idx(j, k));
             });
             postops_injector_->compute_vector_range(vmm_idxs);
@@ -241,10 +242,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
-        int ur_w, bool last_oc_block_flag) {
-    int nb_oc_block
+        dim_t ur_w, bool last_oc_block_flag) {
+    const dim_t nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-    int oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
+    const dim_t oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
     if (jcp.signed_input)
@@ -265,23 +266,23 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         p_sum_zp = &p_entry.sum.zero_point;
     }
 
-    for (int k = 0; k < nb_oc_block; k++) {
+    for (dim_t k = 0; k < nb_oc_block; k++) {
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * k * oc_block;
+            const dim_t bias_offset = jcp.typesize_bia * k * oc_block;
             auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
 
             cvt2ps(jcp.bia_dt, vmm_bias, bias_addr, mask_flag);
         }
         if (jcp.signed_input) {
-            int comp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * k * oc_block;
             Vmm vmm_comp_ = vmm_mask(vmm_comp, mask_flag);
             vmovups(vmm_comp_,
                     EVEX_compress_addr(reg_compensation, comp_offset));
         }
         if (jcp.src_zero_point) {
             // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-            int zp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * k * oc_block;
             Vmm vmm_zp_ = vmm_mask(vmm_zp, mask_flag);
             vmovups(vmm_zp_,
                     EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -290,7 +291,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
                             reg_src_zero_point, 0, jcp.zp_src_is_common));
         }
         /* add to zmm_accum: compensation, zero_point, bias and permute */
-        for (int j = 0; j < ur_w; j++) {
+        for (dim_t j = 0; j < ur_w; j++) {
             Vmm vmm = vmm_out(j, k);
             if (jcp.is_fast_depthwise)
                 vpermd(zmm_out(j, k), zmm_permute, zmm_out(j, k));
@@ -326,7 +327,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             if (jcp.with_wei_scales) {
                 mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
 
-                int scale_offset
+                const dim_t scale_offset
                         = jcp.is_oc_scale * (sizeof(float) * k * oc_block);
                 vmulps(vmm_k, vmm,
                         EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -352,9 +353,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         mov(reg_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
 
         /* Apply dst scale to accumulator */
-        for (int k = 0; k < nb_oc_block; k++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
             const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-            for (int j = 0; j < ur_w; j++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 const Vmm vmm_k = vmm_mask(vmm, mask_flag);
                 vmulps(vmm_k, vmm,
@@ -369,8 +370,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         vcvtdq2ps(vmm_zp, EVEX_compress_addr(reg_dst_zero_point, 0, true));
 
         /* Add dst zero_point to accumulator */
-        for (int k = 0; k < nb_oc_block; k++) {
-            for (int j = 0; j < ur_w; j++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 vaddps(vmm, vmm, vmm_zp);
             }
@@ -381,8 +382,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (one_of(jcp.dst_dt, u8, s8, s32)) {
         init_saturate_f32(
                 vmm_zero, vmm_saturation, aux_reg_saturation, f32, jcp.dst_dt);
-        for (int k = 0; k < nb_oc_block; k++) {
-            for (int j = 0; j < ur_w; j++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 saturate_cvt_f32(vmm, vmm_zero, vmm_saturation, jcp.dst_dt);
             }
@@ -396,13 +397,13 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {
         // Optimization: use single store instruction for pair of the
         // nearest vectors along OC dimension
-        for (int j = 0; j < ur_w; j++) {
-            int k = 0;
+        for (dim_t j = 0; j < ur_w; j++) {
+            dim_t k = 0;
             for (; k < rnd_dn(nb_oc_block, 2); k += 2) {
                 Vmm vmm = vmm_out(j, k);
                 Vmm vmm_next = vmm_out(j, k + 1);
 
-                int aux_output_offset = jcp.typesize_out
+                dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -417,7 +418,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             if (nb_oc_block % 2 != 0) {
                 Vmm vmm = vmm_out(j, k);
                 auto vmm_down = Vmm_down_t(vmm.getIdx());
-                int aux_output_offset = jcp.typesize_out
+                dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -429,10 +430,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             }
         }
     } else {
-        for (int k = 0; k < nb_oc_block; k++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
             const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-            for (int j = 0; j < ur_w; j++) {
-                int aux_output_offset = jcp.typesize_out
+            for (dim_t j = 0; j < ur_w; j++) {
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -457,14 +458,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker_dw(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     assert(!"invalid group blocking for depthwise convolution");
 }
 
 template <>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
 
     const bool compute_kernel = IMPLICATION(h_padded, jcp.signed_input);
 
@@ -473,11 +476,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    auto input_spatial_index = [this, pad_l](int oi, int ki) {
+    auto input_spatial_index = [this, pad_l](dim_t oi, dim_t ki) -> dim_t {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](dim_t ii, dim_t ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);
@@ -486,11 +489,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
     };
 
     auto input_offset3 = [this, input_offset2, input_spatial_index](
-                                 int oi, int ci, int ki) {
+                                 dim_t oi, dim_t ci, dim_t ki) {
         return jcp.typesize_in * input_offset2(input_spatial_index(oi, ki), ci);
     };
 
-    auto kernel_offset = [this](int ci, int ki) {
+    auto kernel_offset = [this](dim_t ci, dim_t ki) -> dim_t {
         return jcp.typesize_in * ((ci * jcp.kh * jcp.kw + ki) * jcp.ch_block);
     };
 
@@ -504,16 +507,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         }
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise && !h_padded) {
         // find bounds of input spatial indices
         bool first = true;
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = input_spatial_index(oi, ki);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; oi++) {
+                const dim_t ii = input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -523,13 +526,13 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 
     if (jcp.signed_input) vmovups(zmm_shifted_zero, vmm_shift);
 
-    for (int ci = 0; ci < jcp.nb_ch_blocking; ci++) {
+    for (dim_t ci = 0; ci < jcp.nb_ch_blocking; ci++) {
         const bool mask_flag = last_ic_block_flag != ic_block_t::no_last_block
                 && ci == jcp.nb_ch_blocking - 1;
         if (jcp.is_resrc_depthwise && !h_padded) {
             // now we can load input once and reuse up to jcp.kw times
-            for (int ii = ii_start; ii <= ii_end; ii++) {
-                int aux_input_offset = input_offset2(ii, ci);
+            for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                dim_t aux_input_offset = input_offset2(ii, ci);
                 const Zmm zmm_inp_tmp = zmm_inp(ii, jcp.nb_ch_blocking);
                 const Zmm zmm_inp_msk = mask_flag
                         ? zmm_inp_tmp | ktail_mask | T_z
@@ -546,10 +549,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
                     vpaddb(zmm_inp_tmp, zmm_inp_tmp, vmm_shift);
             }
         }
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int aux_kernel_offset = kernel_offset(ci, ki);
-            const int oi_start = get_ow_start(ki, pad_l);
-            const int oi_end = get_ow_end(ur_w, ki, pad_r);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            dim_t aux_kernel_offset = kernel_offset(ci, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
             if (compute_kernel) {
                 if (jcp.is_fast_depthwise) {
                     vbroadcasti32x4(zmm_wei,
@@ -562,20 +565,20 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 
                 if (h_padded) {
                     assert(jcp.signed_input);
-                    for (int oi = 0; oi < ur_w; oi++)
+                    for (dim_t oi = 0; oi < ur_w; oi++)
                         compute(zmm_out(oi, ci), zmm_wei, zmm_shifted_zero);
                 } else {
                     const Zmm r_zmm_src
                             = mask_flag ? zmm_src | ktail_mask : zmm_src;
-                    int start_ = jcp.signed_input ? 0 : oi_start;
-                    int end_ = jcp.signed_input ? ur_w : oi_end;
-                    for (int oi = start_; oi < end_; oi++) {
+                    const dim_t start_ = jcp.signed_input ? 0 : oi_start;
+                    const dim_t end_ = jcp.signed_input ? ur_w : oi_end;
+                    for (dim_t oi = start_; oi < end_; oi++) {
                         if (oi >= oi_start && oi < oi_end) {
                             if (jcp.is_resrc_depthwise) {
-                                int ii = input_spatial_index(oi, ki);
+                                const dim_t ii = input_spatial_index(oi, ki);
                                 zmm_src = zmm_inp(ii, jcp.nb_ch_blocking);
                             } else {
-                                int aux_input_offset
+                                dim_t aux_input_offset
                                         = input_offset3(oi, ci, ki);
                                 if (jcp.is_fast_depthwise) {
                                     assert(!mask_flag);
@@ -608,8 +611,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
                     if (jcp.is_fast_depthwise)
                         vpermd(zmm_wei, zmm_permute, zmm_wei);
                 } // else: already loaded weights from previous block
-                int zp_offset = 0;
-                for (int oi = 0; oi < ur_w; oi++) {
+                dim_t zp_offset = 0;
+                for (dim_t oi = 0; oi < ur_w; oi++) {
                     if (oi < oi_start || oi >= oi_end || h_padded) {
                         vpmulld(vmm_zp_tmp, zmm_wei,
                                 EVEX_compress_addr(reg_src_zero_point,
@@ -624,8 +627,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
@@ -638,22 +642,23 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int ch_block_all = jcp.ch_block * ic_block * oc_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t ch_block_all = jcp.ch_block * ic_block * oc_block;
 
-    int nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
 
-    auto input_offset = [this, stride_w, pad_l](int oi, int ic, int ki) {
+    auto input_offset
+            = [this, stride_w, pad_l](dim_t oi, dim_t ic, dim_t ki) -> dim_t {
         return jcp.typesize_in
                 * ((ki * (jcp.dilate_w + 1) + oi * stride_w - pad_l)
                                 * jcp.ic_without_padding * jcp.ngroups
                         + ic_sub_step * ic);
     };
-    auto kernel_offset
-            = [this, ch_block_all, oc_block](int ii, int ic, int ki) {
+    auto kernel_offset = [this, ch_block_all, oc_block](
+                                 dim_t ii, dim_t ic, dim_t ki) -> dim_t {
         return jcp.typesize_in
                 * ((ii * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
@@ -669,19 +674,19 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
         }
     };
 
-    for (int ki = 0; ki < kw; ki++) {
-        int jj_start = get_ow_start(ki, pad_l);
-        int jj_end = get_ow_end(ur_w, ki, pad_r);
-        int ic_tail_size = jcp.ic_without_padding % ic_sub_step;
-        int _start = jcp.signed_input ? 0 : jj_start;
-        int _end = jcp.signed_input ? ur_w : jj_end;
+    for (dim_t ki = 0; ki < kw; ki++) {
+        const dim_t jj_start = get_ow_start(ki, pad_l);
+        const dim_t jj_end = get_ow_end(ur_w, ki, pad_r);
+        const dim_t ic_tail_size = jcp.ic_without_padding % ic_sub_step;
+        const dim_t _start = jcp.signed_input ? 0 : jj_start;
+        const dim_t _end = jcp.signed_input ? ur_w : jj_end;
         /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
-        int icb = (last_ic_block_flag != ic_block_t::no_last_block)
-                ? div_up((jcp.ic_without_padding % ic_block), ic_sub_step)
+        const dim_t icb = (last_ic_block_flag != ic_block_t::no_last_block)
+                ? div_up(jcp.ic_without_padding % ic_block, ic_sub_step)
                 : ic_block / ic_sub_step;
         if (compute_kernel) {
-            for (int ic = 0; ic < icb; ic++) {
+            for (dim_t ic = 0; ic < icb; ic++) {
                 if (h_padded) {
                     // fill padded area with shifted value in first iteration
                     if (ic == 0) {
@@ -689,15 +694,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                         vmovups(inp, vmm_shift); // bcast(128)
                     }
                 } else {
-                    for (int jj = _start; jj < _end; jj++) {
-                        int aux_input_offset = input_offset(jj, ic, ki);
+                    for (dim_t jj = _start; jj < _end; jj++) {
+                        dim_t aux_input_offset = input_offset(jj, ic, ki);
                         if (jj >= jj_start && jj < jj_end) {
                             if (last_ic_block_flag == ic_block_t::last_sp_block
                                     && ic_tail_size != 0 && ic == icb - 1) {
                                 Xmm xmm_tmp = Xmm(
                                         vmm_inp(jj, nb_oc_block).getIdx());
                                 load_bytes(xmm_tmp, aux_reg_inp,
-                                        aux_input_offset, ic_tail_size);
+                                        aux_input_offset,
+                                        static_cast<int>(ic_tail_size));
                                 vpbroadcastd(vmm_inp(jj, nb_oc_block), xmm_tmp);
                             } else {
                                 vpbroadcastd(vmm_inp(jj, nb_oc_block),
@@ -717,11 +723,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                         }
                     }
                 }
-                for (int ii = 0; ii < nb_oc_block; ii++) {
-                    int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                for (dim_t ii = 0; ii < nb_oc_block; ii++) {
+                    dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                     vmovups(vmm_wei,
                             EVEX_compress_addr(aux_reg_ker, aux_kernel_offset));
-                    for (int jj = _start; jj < _end; jj++) {
+                    for (dim_t jj = _start; jj < _end; jj++) {
                         Vmm inp = h_padded ? vmm_inp(0, nb_oc_block)
                                            : vmm_inp(jj, nb_oc_block);
                         compute(vmm_out(jj, ii), vmm_wei, inp);
@@ -733,12 +739,12 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
             /* calculate src_zero_point padding as:
              *      (is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0) */
             Vmm vmm_tmp = vmm_inp(0, nb_oc_block);
-            for (int jj = 0; jj < ur_w; jj++) {
+            for (dim_t jj = 0; jj < ur_w; jj++) {
                 if (jj < jj_start || jj >= jj_end || h_padded) {
-                    for (int ii = 0; ii < nb_oc_block; ii++) {
+                    for (dim_t ii = 0; ii < nb_oc_block; ii++) {
                         vpxord(vmm_zp_tmp, vmm_zp_tmp, vmm_zp_tmp);
-                        for (int ic = 0; ic < icb; ic++) {
-                            int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                        for (dim_t ic = 0; ic < icb; ic++) {
+                            dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                             if (jcp.has_vnni) {
                                 vpdpbusd(vmm_zp_tmp, vmm_zp_one,
                                         EVEX_compress_addr(aux_reg_ker,
@@ -751,7 +757,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                                 vpaddd(vmm_zp_tmp, vmm_zp_tmp, vmm_tmp);
                             }
                         }
-                        int zp_offset = 0;
+                        const dim_t zp_offset = 0;
                         vpmulld(vmm_zp_tmp, vmm_zp_tmp,
                                 EVEX_compress_addr(reg_src_zero_point,
                                         zp_offset, jcp.zp_src_is_common));
@@ -767,16 +773,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::kh_loop(
-        int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag) {
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
             t_overflow_label, no_t_overflow_label, b_overflow_label,
             no_b_overflow_label, back_overflow_label, no_back_overflow_label,
             d_h_back_overflow_label;
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
-    int shift_input_ptr
+    dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    dim_t shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
+    dim_t shift_input_ptr
             = jcp.typesize_in * jcp.iw * jcp.ic_without_padding * jcp.ngroups;
 
     if (jcp.ndims == 5) {
@@ -917,7 +923,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::kh_loop(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool is_last_sp_block) {
 
     if (jcp.src_zero_point && !jcp.is_depthwise) {
         xor_(reg_scratch, reg_scratch);
@@ -959,9 +965,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        int inp_step = jcp.ic_block;
-        const size_t ker_step = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
-                * jcp.ic_block;
+        const dim_t inp_step = jcp.ic_block;
+        const dim_t ker_step = static_cast<dim_t>(jcp.kd) * jcp.kh * jcp.kw
+                * jcp.oc_block * jcp.ic_block;
         add(reg_inp, jcp.typesize_in * inp_step);
         safe_add(reg_ker, jcp.typesize_in * ker_step, reg_ker_long_offt);
 
@@ -999,16 +1005,19 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
     Label permute_index_table;
-    int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
-                                        : jcp.ic_without_padding * jcp.ngroups;
-    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
-    const int n_urw_l_pad = nstl::min(
-            div_up(nstl::max(0, jcp.l_pad), urw_inp_stride), jcp.ow / jcp.ur_w);
-    const int inp_shift_pad = nstl::max(0,
+    const dim_t in_ic_shift = jcp.is_fused_conv
+            ? jcp.dw_conv_buffer_oc
+            : jcp.ic_without_padding * jcp.ngroups;
+    const dim_t urw_inp_stride = jcp.ur_w * jcp.stride_w;
+    const dim_t n_urw_l_pad = nstl::min<dim_t>(
+            div_up(nstl::max<dim_t>(0, jcp.l_pad), urw_inp_stride),
+            jcp.ow / jcp.ur_w);
+    const dim_t inp_shift_pad = nstl::max<dim_t>(0,
             jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
                     * in_ic_shift);
-    int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
-    int out_shift = jcp.typesize_out
+    const dim_t inp_shift
+            = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
+    const dim_t out_shift = jcp.typesize_out
             * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
     preamble();
 
@@ -1061,10 +1070,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         kmovb(ktail_mask, reg_tail_32);
     }
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
-        int tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
-        int mask = (1 << tail_size) - 1;
+        const int mask = (1 << static_cast<int>(tail_size)) - 1;
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
         Reg32 regw_tmp = reg_oi.cvt32();
         mov(regw_tmp, mask);
@@ -1096,19 +1105,21 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         mov(reg_scratch, permute_index_table);
         vmovdqu32(zmm_permute, ptr[reg_scratch]);
     }
-    const int extended_filter_size
-            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int extended_filter_size = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     const int ow_with_no_rpad = 1
-            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
-                      - extended_filter_size)
-                    / jcp.stride_w;
-    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
-    const int max_safe_iw = nstl::max(
-            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding));
+            + static_cast<int>(
+                    (jcp.iw + jcp.l_pad + nstl::min<dim_t>(0, jcp.r_pad)
+                            - extended_filter_size)
+                    / jcp.stride_w);
+    const int n_urw_per_ow_block = static_cast<int>(jcp.ow_block / jcp.ur_w);
+    const int max_safe_iw = static_cast<int>(nstl::max<dim_t>(
+            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding)));
     const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
-            ? jcp.ow
-            : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
+            ? static_cast<int>(jcp.ow)
+            : static_cast<int>((max_safe_iw + jcp.l_pad - extended_filter_size)
+                      / jcp.stride_w);
     Label middle_block_label, done_compute;
     std::vector<Label> ow_block_jmp_table;
 
@@ -1161,15 +1172,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         int cur_ow = 0;
 
         // l_pad region:
-        n_l_pad_labels = div_up(n_urw_l_pad, n_urw_per_ow_block);
+        n_l_pad_labels
+                = static_cast<int>(div_up(n_urw_l_pad, n_urw_per_ow_block));
         n_labels = n_l_pad_labels;
         cur_ow += n_urw_l_pad * jcp.ur_w;
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
             n_urw_middle_block_loop
                     = nstl::max(0,
@@ -1183,11 +1195,12 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         // r_pad or ic_block_t::last_sp_block
         if (cur_ow + jcp.ur_w <= jcp.ow) {
             if (r_pad_fall_through_n_urw == 0) ++n_labels;
-            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
-            n_labels += nstl::max(0,
+            const int n_urw_r_pad_region
+                    = static_cast<int>((jcp.ow - cur_ow) / jcp.ur_w);
+            n_labels += static_cast<int>(nstl::max<dim_t>(0,
                     div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
                             n_urw_per_ow_block)
-                            - 1);
+                            - 1));
         }
 
         if (jcp.ur_w_tail != 0) {
@@ -1211,9 +1224,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             L(middle_or_rpad_check);
             // harness passes shifted src pointer that does not take
             // left-padding into account. So, we must re-shift here.
-            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
-                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
-                    * in_ic_shift;
+            const int inp_shift_pad_middle_block = static_cast<int>(-1
+                    * jcp.typesize_in
+                    * nstl::min<dim_t>(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift);
             add(reg_inp, inp_shift_pad_middle_block);
         }
         if (r_pad_fall_through_n_urw != 0) {
@@ -1256,7 +1270,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
     int label_cntr = 0;
     int cur_l_pad = 0;
     if (jcp.l_pad > 0) {
-        for (cur_l_pad = jcp.l_pad;
+        for (cur_l_pad = static_cast<int>(jcp.l_pad);
                 cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
                 cur_l_pad -= urw_inp_stride) {
             if (jcp.nb_ow > 1 && cur_n_oi == 0) {
@@ -1272,9 +1286,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = nstl::max(0,
+            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                            jcp.stride_w, extended_filter_size));
+                            jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_out, out_shift);
             dec(reg_oi);
@@ -1294,9 +1308,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
             int n_oi_middle_block_loop
                     = nstl::max(0,
@@ -1337,8 +1351,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
                 L(ow_block_jmp_table[label_cntr++]);
             }
             cur_ow += jcp.ur_w;
-            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                    jcp.stride_w, extended_filter_size);
+            int cur_r_pad = static_cast<int>(calculate_end_padding(jcp.l_pad,
+                    cur_ow, jcp.iw, jcp.stride_w, extended_filter_size));
             assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
             icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_inp, inp_shift);
@@ -1454,9 +1468,9 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1513,7 +1527,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                 VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
     }
 
-    jcp.simd_w = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+    jcp.simd_w
+            = static_cast<int>(jcp.is_depthwise ? jcp.ch_block : jcp.ic_block);
 
     const auto &zp = attr.zero_points_;
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
@@ -1666,10 +1681,13 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1686,7 +1704,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // factor smaller than the left padding (special requirement for SSD:fc6),
     // then search for a smaller OC blocking that satisfies both constraints.
     auto is_oc_blocking_ok = [&](int block) {
-        int ur_w = nstl::min(jcp.ow, jcp.max_regs_ur / (block + 1));
+        int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jcp.ow, jcp.max_regs_ur / (block + 1)));
         return jcp.nb_oc % block == 0 && jcp.l_pad <= ur_w
                 && jcp.ow % ur_w != 1;
     };
@@ -1701,8 +1720,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.stride_w == 1 && jcp.ic % 64 == 0
             && jcp.nthr <= ncores_per_socket)
         max_threading_nb_oc_chunk = 2;
-    jcp.nb_oc_blocking_thr_chunk
-            = nstl::min(max_threading_nb_oc_chunk, jcp.nb_oc);
+    jcp.nb_oc_blocking_thr_chunk = static_cast<int>(
+            nstl::min<dim_t>(max_threading_nb_oc_chunk, jcp.nb_oc));
     for (; jcp.nb_oc_blocking_thr_chunk > 1; jcp.nb_oc_blocking_thr_chunk--) {
         if (is_oc_blocking_ok(jcp.nb_oc_blocking_thr_chunk)) break;
     }
@@ -1718,7 +1737,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && !(jcp.kh == 1 && jcp.kw == 3)
             && !(jcp.kh >= 7 && jcp.oc % 64 == 0)) {
         const int max_nb_oc_blocking = 2;
-        jcp.nb_oc_blocking = nstl::min(max_nb_oc_blocking, jcp.nb_oc);
+        jcp.nb_oc_blocking = static_cast<int>(
+                nstl::min<dim_t>(max_nb_oc_blocking, jcp.nb_oc));
         for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
             if (jcp.nb_oc_blocking_thr_chunk % jcp.nb_oc_blocking == 0
                     && is_oc_blocking_ok(jcp.nb_oc_blocking))
@@ -1726,30 +1746,30 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     }
 
     if (jcp.is_resrc_depthwise)
-        jcp.ur_w = (jcp.max_regs_ur - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        jcp.ur_w = static_cast<int>((jcp.max_regs_ur - jcp.kw + jcp.stride_w)
+                / (jcp.nb_ch_blocking + jcp.stride_w));
     else
-        jcp.ur_w = jcp.max_regs_ur
+        jcp.ur_w = static_cast<int>(jcp.max_regs_ur
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
-                                    : jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
-    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+                                    : jcp.nb_oc_blocking + 1));
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
+    jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
 
-    auto get_thr_eff = [&](int nb_ow, int nthr) {
-        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+    auto get_thr_eff = [&](dim_t nb_ow, int nthr) {
+        const dim_t base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
                 * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-        auto work_amount = base_work_amount * nb_ow;
-        return float(work_amount) / rnd_up(work_amount, nthr);
+        const dim_t work_amount = base_work_amount * nb_ow;
+        return float(work_amount) / (float)rnd_up(work_amount, nthr);
     };
 
-    auto get_ow_block = [&](int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+    auto get_ow_block = [&](dim_t ur_w, int nthr) {
+        dim_t res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
-        int max_nb_ow = div_up(jcp.ow, ur_w);
-        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
+        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1782,13 +1802,13 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < 0.9f && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        int ow_block = static_cast<int>(jcp.ow_block);
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr > end_nthr; nthr--) {
-            ow_block = get_ow_block(jcp.ur_w, nthr);
-            eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);
+            ow_block = static_cast<int>(get_ow_block(jcp.ur_w, nthr));
+            eff = get_thr_eff(static_cast<int>(div_up(jcp.ow, ow_block)), nthr);
             if (eff > 1.1f * best_thr_eff) {
                 best_thr_eff = eff;
                 jcp.ow_block = ow_block;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1179,7 +1179,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
+        int cur_r_pad = static_cast<int>(nstl::max(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
                         jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
@@ -1286,7 +1286,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
+            int cur_r_pad = static_cast<int>(nstl::max(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
                             jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
@@ -1308,7 +1308,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
+        int cur_r_pad = static_cast<int>(nstl::max(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
                         jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
@@ -1468,9 +1468,9 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1762,14 +1762,14 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         return float(work_amount) / (float)rnd_up(work_amount, nthr);
     };
 
-    auto get_ow_block = [&](dim_t ur_w, int nthr) {
-        dim_t res_ow_block = jcp.ow;
+    auto get_ow_block = [&](int ur_w, int nthr) {
+        int res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
-        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
-        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            const dim_t ow_block = nstl::min<dim_t>(
-                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const int max_nb_ow = div_up(jcp.ow, ur_w);
+        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const int ow_block
+                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1802,13 +1802,13 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < 0.9f && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = static_cast<int>(jcp.ow_block);
+        int ow_block = jcp.ow_block;
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
         int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr > end_nthr; nthr--) {
-            ow_block = static_cast<int>(get_ow_block(jcp.ur_w, nthr));
-            eff = get_thr_eff(static_cast<int>(div_up(jcp.ow, ow_block)), nthr);
+            ow_block = get_ow_block(jcp.ur_w, nthr);
+            eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);
             if (eff > 1.1f * best_thr_eff) {
                 best_thr_eff = eff;
                 jcp.ow_block = ow_block;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1440,33 +1440,35 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nthr = nthreads;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = is_1d ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = is_1d ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = is_1d
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = is_1d ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = is_1d ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     jcp.ur_h = 1; /* no code-unrolling by h so far */
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = is_1d ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -69,7 +69,7 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
         const dim_t block_tail
                 = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const dim_t tail_size = block_tail
+        const std::size_t tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -151,54 +151,55 @@ private:
     Xbyak::Zmm zmm_shifted_zero;
     Xbyak::Zmm zmm_permute;
 
-    int vmm_out_idx(int i_ur, int i_oc) {
-        const int nb_x_blocking
+    int vmm_out_idx(dim_t i_ur, dim_t i_oc) {
+        const dim_t nb_x_blocking
                 = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-        const int idx = i_ur * nb_x_blocking + i_oc;
+        const dim_t idx = i_ur * nb_x_blocking + i_oc;
         assert(idx < (jcp.is_depthwise              ? ker_dw_reg_base_idx
                                : jcp.src_zero_point ? ker_zp_reg_base_idx
                                                     : ker_reg_base_idx));
-        return idx;
+        return static_cast<int>(idx);
     }
 
-    Vmm vmm_out(int i_ur, int i_oc) { return Vmm(vmm_out_idx(i_ur, i_oc)); }
-    Xbyak::Zmm zmm_out(int i_ur, int i_oc) {
-        int idx = vmm_out(i_ur, i_oc).getIdx();
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) { return Vmm(vmm_out_idx(i_ur, i_oc)); }
+    Xbyak::Zmm zmm_out(dim_t i_ur, dim_t i_oc) {
+        const int idx = vmm_out(i_ur, i_oc).getIdx();
         assert(idx
                 < (jcp.is_depthwise ? ker_dw_reg_base_idx : ker_reg_base_idx));
         return Xbyak::Zmm(idx);
     }
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    Xbyak::Zmm zmm_inp(int i_ic, int nb_x_blocking) {
-        const int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Xbyak::Zmm zmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         const int max_idx = jcp.src_zero_point ? ker_zp_reg_base_idx
                                                : ker_dw_reg_base_idx;
         assert(idx < max_idx);
         MAYBE_UNUSED(max_idx);
 
-        return Xbyak::Zmm(idx);
+        return Xbyak::Zmm(static_cast<int>(idx));
     }
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
 
     // bf16 utils
-    int get_src_down_idx(int nb_x_blocking) {
-        int idx = nb_x_blocking * jcp.ur_w;
+    int get_src_down_idx(dim_t nb_x_blocking) {
+        const dim_t idx = nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return idx;
+        return static_cast<int>(idx);
     }
     inline Vmm maybe_mask_vmm(Vmm vmm, bool mask_flag) {
         return mask_flag ? vmm | ktail_mask_extended : vmm;
@@ -218,20 +219,22 @@ private:
                 maybe_mask_vmm_down(vmm_down, mask_flag || jcp.simd_w == 4));
     }
 
-    void prepare_output(int ur_w);
-    void apply_sum(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block, const float *p_sum_scale,
+    void prepare_output(dim_t ur_w);
+    void apply_sum(dim_t ur_w, bool last_oc_block_flag, const dim_t nb_oc_block,
+            const dim_t oc_block, const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void apply_postops(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
-    void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker_dw(int ur_w, int pad_l, int pad_r,
+    void apply_postops(dim_t ur_w, bool last_oc_block_flag,
+            const dim_t nb_oc_block, const dim_t oc_block,
+            const float *p_sum_scale, const int32_t *p_sum_zp);
+    void store_output(dim_t ur_w, bool last_oc_block_flag);
+    void compute_ker_dw(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void compute_ker(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded = false);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool is_last_spatial_block);
+    void kh_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag);
+    void icb_loop(
+            dim_t ur_w, dim_t pad_l, dim_t pad_r, bool is_last_spatial_block);
     void generate() override;
     void cvt2ps(data_type_t type_in, Vmm ymm_in, const Xbyak::Operand &op,
             bool mask_flag);
@@ -243,7 +246,8 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel_t {
     jit_avx512_core_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -75,8 +75,8 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
 
     size_t extra_data_offset
             = weights_d.size() - weights_d.additional_buffer_size();
-    size_t ch_offset = jcp.is_depthwise ? jcp.nb_ch * jcp.ch_block
-                                        : jcp.ngroups * jcp.oc;
+    const dim_t ch_offset = jcp.is_depthwise ? jcp.nb_ch * jcp.ch_block
+                                             : jcp.ngroups * jcp.oc;
     auto w = const_cast<char *>(weights);
     int32_t *compensation = (jcp.signed_input)
             ? reinterpret_cast<int32_t *>(&w[extra_data_offset])
@@ -86,13 +86,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
                     + (jcp.signed_input ? ch_offset : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
+    const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -108,7 +108,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -129,13 +129,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int gb = gg * jcp.nb_ch_blocking;
-            int g = gb * group_block;
-            int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.nb_ic * jcp.ic_block;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t gb = gg * jcp.nb_ch_blocking;
+            dim_t g = gb * group_block;
+            dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             p.bias = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                           : nullptr;
@@ -234,12 +234,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -259,7 +260,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
         size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -276,20 +277,21 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
+            for (dim_t occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -301,17 +303,17 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
                 auto src_w = src + src_d.blk_off(n, g_ic, ih_s, iw_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(max(0,
+                    dim_t dilate_h = jcp.dilate_h + 1;
+                    dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ij), dilate_h));
+                    dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
@@ -416,8 +418,8 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.nb_ch * jcp.ch_block : 0)
             : nullptr;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [= COMPAT_THIS_CAPTURE](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
@@ -426,12 +428,12 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
-        int g = gb * group_block;
+        dim_t gb = gg * jcp.nb_ch_blocking;
+        dim_t g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
-        int iw_s = ow_s * jcp.stride_w;
+        dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        dim_t ow_s = owb * jcp.ow_block;
+        dim_t iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;
         int32_t *compensation_w = jcp.signed_input ? compensation + g : nullptr;
@@ -455,12 +457,15 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
                 ? static_cast<const float *>(wei_scales) + jcp.is_oc_scale * g
                 : nullptr;
 
-        int dilate_h = jcp.dilate_h + 1;
-        int i_t_overflow = nstl::min(jcp.kh, div_up(max(0, -ih_s), dilate_h));
-        int i_b_overflow = nstl::min(jcp.kh,
-                div_up(max(0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+        dim_t dilate_h = jcp.dilate_h + 1;
+        dim_t i_t_overflow = nstl::min<dim_t>(
+                jcp.kh, div_up(max<dim_t>(0, -ih_s), dilate_h));
+        dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                div_up(max<dim_t>(
+                               0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h));
-        int kh_padding = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+        dim_t kh_padding
+                = nstl::max<dim_t>(0, jcp.kh - i_t_overflow - i_b_overflow);
 
         size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
                 ? 0
@@ -535,13 +540,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -563,7 +568,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -580,32 +585,33 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
+            for (dim_t occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-                int dilate_d = jcp.dilate_d + 1;
-                int d_f_overflow
-                        = nstl::min(jcp.kd, div_up(max(0, -id_s), dilate_d));
-                int d_back_overflow = nstl::min(jcp.kd,
-                        div_up(max(0,
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                dim_t dilate_d = jcp.dilate_d + 1;
+                dim_t d_f_overflow = nstl::min<dim_t>(
+                        jcp.kd, div_up(max<dim_t>(0, -id_s), dilate_d));
+                dim_t d_back_overflow = nstl::min<dim_t>(jcp.kd,
+                        div_up(max<dim_t>(0,
                                        id_s - jcp.id + (jcp.kd - 1) * dilate_d
                                                + 1),
                                 dilate_d));
 
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+                dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_f_overflow - d_back_overflow);
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -623,17 +629,17 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
                                           : d_f_overflow)
                                 * wht_d_stride;
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(max(0,
+                    dim_t dilate_h = jcp.dilate_h + 1;
+                    dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ij), dilate_h));
+                    dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
     , postops_injector_(nullptr) {
 
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        const std::size_t tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
 
@@ -59,8 +59,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(Xbyak::Xmm(31).getIdx()), this->r14,
-                this->r15, this->r13, preserve_gpr, preserve_vmm,
+                Xbyak::Xmm(31).getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(dst_md), tail_size, ktail_mask,
                 use_exact_tail_scalar_bcast};
@@ -258,9 +258,9 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -301,10 +301,13 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -313,18 +316,18 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     /* kernel blocking params */
     const int regs = jcp.has_vnni ? 30 : 28;
     jcp.nb_ch_blocking = 1;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
                 && jcp.l_pad <= regs / (jcp.nb_oc_blocking + 1))
             break;
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    int l_overflow = max(
-            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
+    int l_overflow = static_cast<int>(max<dim_t>(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w));
 
     if (jcp.ow < jcp.ur_w) {
-        jcp.ur_w = jcp.ow;
+        jcp.ur_w = static_cast<int>(jcp.ow);
         jcp.ur_w_tail = 0;
     } else {
         for (; jcp.ur_w >= 1; jcp.ur_w--) {
@@ -337,10 +340,10 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
                are computed in a single call of compute loop */
             bool left_boundary_covered = jcp.ur_w >= l_overflow * jcp.stride_w;
             jcp.ur_w_tail = jcp.ow % jcp.ur_w;
-            int r_overflow_no_tail = max(0,
-                    ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad)
-                            - jcp.ur_w_tail)
-                            / jcp.stride_w);
+            int r_overflow_no_tail = static_cast<int>(max<dim_t>(0,
+                    ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                            - max<dim_t>(0, jcp.r_pad) - jcp.ur_w_tail)
+                            / jcp.stride_w));
             bool right_boundary_covered
                     = jcp.ur_w >= r_overflow_no_tail * jcp.stride_w;
 
@@ -494,7 +497,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
 
     const auto load_zp_src_pad_comp
             = [&](const Vmm &zp_pad_comp_vmm, const Xbyak::Address &comp_addr,
-                      const int ocb) {
+                      const dim_t ocb) {
         const bool is_last_ocb = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
         const bool is_tail = is_last_ocb && get_tail_size() > 0;
         if (is_tail)
@@ -503,16 +506,16 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
             vmovups(zp_pad_comp_vmm, comp_addr);
     };
 
-    const auto get_zp_src_comp_pad_off = [&](int it_kw, int ocb) {
+    const auto get_zp_src_comp_pad_off = [&](dim_t it_kw, dim_t ocb) {
         const auto kw_offset = it_kw * jcp.oc_without_padding * jcp.ngroups;
         const auto oc_offset = ocb * jcp.oc_block;
 
         return (kw_offset + oc_offset) * sizeof(int32_t);
     };
 
-    for (int it_kw = 0; it_kw < jcp.kw; ++it_kw) {
-        const int ow_start = get_ow_start(it_kw, l_overflow);
-        const int ow_end = get_ow_end(ur_w, it_kw, r_overflow);
+    for (dim_t it_kw = 0; it_kw < jcp.kw; ++it_kw) {
+        const dim_t ow_start = get_ow_start(it_kw, l_overflow);
+        const dim_t ow_end = get_ow_end(ur_w, it_kw, r_overflow);
 
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
             Vmm zp_src_comp_pad_vmm; // will be assigned later
@@ -521,7 +524,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
             const auto zp_src_comp_pad_off
                     = get_zp_src_comp_pad_off(it_kw, ocb);
 
-            for (int it_ow = 0; it_ow < ur_w; ++it_ow) {
+            for (dim_t it_ow = 0; it_ow < ur_w; ++it_ow) {
 
                 const bool inside_padded_area = h_padded
                         || !(it_ow >= ow_start && it_ow < ow_end
@@ -550,7 +553,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
     if (jcp.ndims > 3) {
         if (!base_comp_addr_loaded) load_base_zp_src_pad_comp_addr();
 
-        const auto kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
+        const dim_t kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
                 * sizeof(int32_t);
 
         add(reg_zp_src_pad_comp, kh_offset);
@@ -569,33 +572,34 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
     const bool signed_input_or_src_zp
             = (jcp.signed_input || jcp.src_zero_point);
 
-    const int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    const int ur_w_stride = signed_input_or_src_zp ? 1 : jcp.stride_w;
+    const dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    const int ur_w_stride
+            = signed_input_or_src_zp ? 1 : static_cast<int>(jcp.stride_w);
 
-    auto src_offset = [this](int oj, int icb, int ki) {
+    auto src_offset = [this](dim_t oj, dim_t icb, dim_t ki) {
         return jcp.typesize_in
                 * (((oj + jcp.l_pad - ki * (jcp.dilate_w + 1)) / jcp.stride_w)
                                 * jcp.ngroups * jcp.ic_without_padding
                         + icb * 4);
     };
 
-    auto kernel_offset = [this, ch_block_all](int ocb, int icb, int ki) {
+    auto kernel_offset = [this, ch_block_all](dim_t ocb, dim_t icb, dim_t ki) {
         return jcp.typesize_in
                 * ((ocb * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
                         + icb * jcp.oc_block * ic_sub_step);
     };
 
-    for (int ki = 0; ki < jcp.kw; ki++) {
-        int jj_start = get_ow_start(ki, l_overflow);
-        int jj_end = get_ow_end(ur_w, ki, r_overflow);
+    for (dim_t ki = 0; ki < jcp.kw; ki++) {
+        dim_t jj_start = get_ow_start(ki, l_overflow);
+        dim_t jj_end = get_ow_end(ur_w, ki, r_overflow);
 
-        int _start = (signed_input_or_src_zp) ? 0 : jj_start;
-        int _end = (signed_input_or_src_zp) ? ur_w : jj_end;
+        dim_t _start = (signed_input_or_src_zp) ? 0 : jj_start;
+        dim_t _end = (signed_input_or_src_zp) ? ur_w : jj_end;
 
-        int tail_size = jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
-                                         : jcp.ic_without_padding % 4;
-        int n_ic_blocks = jcp.is_depthwise
+        dim_t tail_size = jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
+                                           : jcp.ic_without_padding % 4;
+        dim_t n_ic_blocks = jcp.is_depthwise
                 ? 1
                 : (last_ic_block_flag & ~ker_block_t::no_last_block
                                   ? div_up(jcp.ic_without_padding
@@ -603,7 +607,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                             4)
                                   : jcp.ic_block / 4);
 
-        for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
+        for (dim_t icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded == true) {
                 if (jcp.signed_input) {
                     /* fill padded area with shifted values */
@@ -613,9 +617,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                 }
             } else {
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
-                    int aux_src_off = src_offset(jj, icb1, ki);
+                    dim_t aux_src_off = src_offset(jj, icb1, ki);
 
                     if (jj >= jj_start && jj < jj_end
                             && ((jj + jcp.l_pad - ki) % jcp.stride_w == 0)) {
@@ -633,9 +637,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                 && tail_size != 0 && icb1 == n_ic_blocks - 1) {
                             const Xmm xmm_tmp = Xmm(
                                     vmm_inp(jj, jcp.nb_oc_blocking).getIdx());
-                            for (int r = 0; r < tail_size; ++r)
+                            for (dim_t r = 0; r < tail_size; ++r)
                                 vpinsrb(xmm_tmp, xmm_tmp,
-                                        ptr[aux_reg_src + aux_src_off + r], r);
+                                        ptr[aux_reg_src + aux_src_off + r],
+                                        static_cast<uint8_t>(r));
                             vpbroadcastd(
                                     vmm_inp(jj, jcp.nb_oc_blocking), xmm_tmp);
                         } else {
@@ -657,7 +662,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                 }
             }
             for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-                int aux_filt_off = kernel_offset(ocb, icb1, ki);
+                dim_t aux_filt_off = kernel_offset(ocb, icb1, ki);
 
                 if (_end - _start > 0) {
                     if (jcp.is_depthwise)
@@ -667,7 +672,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(aux_reg_filt, aux_filt_off));
                 }
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
                     const bool jj_between_start_end
                             = jj >= jj_start && jj < jj_end;
                     const bool ki_applies_to_stride
@@ -696,15 +701,15 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     const bool signed_input_or_src_zp
             = (jcp.signed_input || jcp.src_zero_point);
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_src_ih = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw
+    dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    dim_t shift_src_ih = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw
             * jcp.ngroups * jcp.ic_without_padding;
-    int shift_src_id = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
+    dim_t shift_src_id = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
             * jcp.ngroups * jcp.ic_without_padding;
-    const int stride_h = signed_input_or_src_zp ? 1 : jcp.stride_h;
-    int shift_filt_kh = jcp.typesize_in * jcp.kw * ch_block_all * stride_h;
-    const int stride_d = signed_input_or_src_zp ? 1 : jcp.stride_d;
-    int shift_filt_kd
+    const dim_t stride_h = signed_input_or_src_zp ? 1 : jcp.stride_h;
+    dim_t shift_filt_kh = jcp.typesize_in * jcp.kw * ch_block_all * stride_h;
+    const dim_t stride_d = signed_input_or_src_zp ? 1 : jcp.stride_d;
+    dim_t shift_filt_kd
             = jcp.typesize_in * jcp.kw * ch_block_all * jcp.kh * stride_d;
 
     Label kd_loop_label, kh_loop_label, skip_kh_loop, skip_kd_loop;
@@ -744,9 +749,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
         if ((signed_input_or_src_zp) || (jcp.dilate_d >= jcp.id)
                 || (jcp.kd < jcp.stride_d)
                 || ((!signed_input_or_src_zp)
-                        && ((min(jcp.f_pad, jcp.back_pad) < 0)
+                        && ((min<dim_t>(jcp.f_pad, jcp.back_pad) < 0)
                                 || ((jcp.kd - 1) * (jcp.dilate_d + 1)
-                                        < nstl::max(
+                                        < nstl::max<dim_t>(
                                                 jcp.f_pad, jcp.back_pad))))) {
             cmp(reg_ki, 0);
             je(skip_kd_loop, T_NEAR);
@@ -782,9 +787,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     if ((signed_input_or_src_zp) || (jcp.dilate_h >= jcp.ih)
             || (jcp.kh < jcp.stride_h)
             || ((!signed_input_or_src_zp)
-                    && ((min(jcp.t_pad, jcp.b_pad) < 0)
+                    && ((min<dim_t>(jcp.t_pad, jcp.b_pad) < 0)
                             || ((jcp.kh - 1) * (jcp.dilate_h + 1)
-                                    < nstl::max(jcp.t_pad, jcp.b_pad))))) {
+                                    < nstl::max<dim_t>(
+                                            jcp.t_pad, jcp.b_pad))))) {
         cmp(reg_kh, 0);
         je(skip_kh_loop, T_NEAR);
     }
@@ -885,14 +891,14 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     }
 }
 template <typename Vmm>
-int jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_tail_size()
+dim_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_tail_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
                             : jcp.oc_without_padding % jcp.oc_block;
 }
 
 template <typename Vmm>
-int jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_blocking_size()
+dim_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_blocking_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 }
@@ -948,7 +954,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
 
         const bool is_tail = get_tail_size() > 0;
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-            const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
             const bool is_last_ocb
                     = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
             const auto vmm = is_last_ocb && is_tail
@@ -970,12 +976,12 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
 
         const Vmm vmm_bias = vmm_tmp;
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+            const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
             auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
             cvt2ps(jcp.bia_dt, vmm_bias, bias_addr, mask_flag);
         }
         if (jcp.signed_input) {
-            int comp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
             auto comp_addr = EVEX_compress_addr(reg_compensation, comp_offset);
             cvt2ps(data_type::s32, vmm_comp, comp_addr, mask_flag);
         }
@@ -1010,7 +1016,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
             if (jcp.with_wei_scales) {
                 mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
 
-                int scale_offset = jcp.is_oc_scale
+                const dim_t scale_offset = jcp.is_oc_scale
                         * (sizeof(float) * ocb * jcp.oc_block);
                 vmulps(mask_vmm, vmm,
                         EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -1043,7 +1049,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
                     const bool mask_flag
                             = last_oc_block == 1 && k == jcp.nb_oc_blocking - 1;
                     for (int j = 0; j < ur_w; j++) {
-                        int aux_output_offset = jcp.typesize_out
+                        dim_t aux_output_offset = jcp.typesize_out
                                 * (k * jcp.oc_block
                                         + j * jcp.oc_without_padding
                                                 * jcp.ngroups);
@@ -1072,7 +1078,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
                         = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
                 for (int ur = 0; ur < ur_w; ur++) {
                     const int vmm_idx = vmm_out(ur, ocb).getIdx();
-                    const size_t aux_output_offset = jcp.typesize_out
+                    const dim_t aux_output_offset = jcp.typesize_out
                             * (ocb * jcp.oc_block
                                     + ur * jcp.oc_without_padding
                                             * jcp.ngroups);
@@ -1163,7 +1169,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
     for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
         for (int ur = 0; ur < ur_w; ur++) {
-            int aux_dst_off = jcp.typesize_out
+            dim_t aux_dst_off = jcp.typesize_out
                     * (ur * jcp.ngroups * jcp.oc_without_padding
                             + ocb * jcp.oc_block);
             auto addr = EVEX_compress_addr(reg_dst, aux_dst_off);
@@ -1185,9 +1191,9 @@ template <typename Vmm>
 void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::icb_loop(
         int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
 
-    int shift_src_icb = jcp.typesize_in * jcp.ic_block;
-    const size_t shift_filt_icb = (size_t)jcp.typesize_in * jcp.kd * jcp.kh
-            * jcp.kw * jcp.ic_block * jcp.oc_block;
+    dim_t shift_src_icb = jcp.typesize_in * jcp.ic_block;
+    const dim_t shift_filt_icb = jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw
+            * jcp.ic_block * jcp.oc_block;
 
     prepare_output(ur_w);
 
@@ -1262,20 +1268,20 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::icb_loop(
 template <typename Vmm>
 ur_w_blks_params_t
 jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
-    const int n_ur_blocks = jcp.ow / jcp.ur_w;
+    const dim_t n_ur_blocks = jcp.ow / jcp.ur_w;
 
     ur_w_blks_params_t ur_w_blks_params;
-    int num_blks_to_process_sp_carefully = 0;
-    int idx_last_non_zero_l_overflow_blk = -1;
-    int idx_first_non_zero_r_overflow_blk = n_ur_blocks;
+    dim_t num_blks_to_process_sp_carefully = 0;
+    dim_t idx_last_non_zero_l_overflow_blk = -1;
+    dim_t idx_first_non_zero_r_overflow_blk = n_ur_blocks;
 
     static constexpr int src_pixels_loaded_for_bcast = 4;
     const auto ic_mod = jcp.ic_without_padding % src_pixels_loaded_for_bcast;
-    for (int blk_idx = 0; blk_idx < n_ur_blocks; blk_idx++) {
-        const int first_blk_dst_elem = blk_idx * jcp.ur_w;
-        const int last_dst_blk_elem = first_blk_dst_elem + jcp.ur_w - 1;
+    for (dim_t blk_idx = 0; blk_idx < n_ur_blocks; blk_idx++) {
+        const dim_t first_blk_dst_elem = blk_idx * jcp.ur_w;
+        const dim_t last_dst_blk_elem = first_blk_dst_elem + jcp.ur_w - 1;
 
-        const int last_blk_src_idx = nstl::min(
+        const dim_t last_blk_src_idx = nstl::min<dim_t>(
                 jcp.iw - 1, (last_dst_blk_elem + jcp.l_pad) / jcp.stride_w);
         const bool is_out_of_src_pixels_scope
                 = ((jcp.iw - 1 - last_blk_src_idx) * jcp.ic_without_padding
@@ -1284,30 +1290,29 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
 
         const bool process_sp_carefully
                 = (ic_mod != 0) && is_out_of_src_pixels_scope;
-        const int curr_l_overflow = nstl::max(0,
+        const dim_t curr_l_overflow = nstl::max<dim_t>(0,
                 ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad
                         - first_blk_dst_elem)
                         / jcp.stride_w);
-        const int curr_r_overflow = nstl::max(0,
+        const dim_t curr_r_overflow = nstl::max<dim_t>(0,
                 (last_dst_blk_elem + jcp.l_pad) / jcp.stride_w - (jcp.iw - 1));
 
         ur_w_blks_params.blks_params.emplace_back(
                 curr_l_overflow, curr_r_overflow, process_sp_carefully);
 
-        num_blks_to_process_sp_carefully
-                += static_cast<int>(process_sp_carefully);
+        num_blks_to_process_sp_carefully += process_sp_carefully;
         if (curr_l_overflow > 0) idx_last_non_zero_l_overflow_blk = blk_idx;
         if (curr_r_overflow > 0 && idx_first_non_zero_r_overflow_blk > blk_idx)
             idx_first_non_zero_r_overflow_blk = blk_idx;
     }
     idx_first_non_zero_r_overflow_blk
-            = nstl::max(idx_first_non_zero_r_overflow_blk,
+            = nstl::max<dim_t>(idx_first_non_zero_r_overflow_blk,
                     idx_last_non_zero_l_overflow_blk + 1);
     // limit num_r_overflow_blks and num_blks_to_process_last_sp_carefully so that:
-    // n_ur_blocks >= num_l_overflow_blks + max(num_r_overflow_blks, num_blks_to_process_last_sp_carefully)
+    // n_ur_blocks >= num_l_overflow_blks + max<dim_t>(num_r_overflow_blks, num_blks_to_process_last_sp_carefully)
     ur_w_blks_params.num_pre_blks
-            = nstl::max(0, idx_last_non_zero_l_overflow_blk + 1);
-    const int num_r_overflow_blks = idx_first_non_zero_r_overflow_blk
+            = nstl::max<dim_t>(0, idx_last_non_zero_l_overflow_blk + 1);
+    const dim_t num_r_overflow_blks = idx_first_non_zero_r_overflow_blk
                     <= idx_last_non_zero_l_overflow_blk
             ? n_ur_blocks - ur_w_blks_params.num_pre_blks
             : n_ur_blocks - idx_first_non_zero_r_overflow_blk;
@@ -1316,8 +1321,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
                     < n_ur_blocks
             ? num_blks_to_process_sp_carefully
             : n_ur_blocks - ur_w_blks_params.num_pre_blks;
-    ur_w_blks_params.num_post_blks
-            = nstl::max(num_r_overflow_blks, num_blks_to_process_sp_carefully);
+    ur_w_blks_params.num_post_blks = nstl::max<dim_t>(
+            num_r_overflow_blks, num_blks_to_process_sp_carefully);
 
     return ur_w_blks_params;
 }
@@ -1335,10 +1340,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
     vpbroadcastw(vmm_one, _t);
 
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
-        int tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
-        int mask = (1 << tail_size) - 1;
+        const uint32_t mask = (uint32_t(1) << tail_size) - 1;
         Reg32 regw_tmp = reg_nur_w.cvt32();
         Label skip_tail_mask;
         if (jcp.is_depthwise) {
@@ -1355,26 +1360,26 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
     mov(reg_filt, ptr[param1 + GET_OFF(filt)]);
     mov(reg_dst, ptr[param1 + GET_OFF(dst)]);
 
-    int dst_shift = jcp.typesize_out * jcp.ur_w * jcp.ngroups
+    dim_t dst_shift = jcp.typesize_out * jcp.ur_w * jcp.ngroups
             * jcp.oc_without_padding;
-    int src_shift = jcp.typesize_in * (jcp.ur_w / jcp.stride_w) * jcp.ngroups
+    dim_t src_shift = jcp.typesize_in * (jcp.ur_w / jcp.stride_w) * jcp.ngroups
             * jcp.ic_without_padding;
 
     const auto ur_w_blks_params = get_ur_w_blks_params();
-    const int nur_w = jcp.ow / jcp.ur_w - ur_w_blks_params.num_pre_blks
-            - ur_w_blks_params.num_post_blks;
+    const int nur_w = static_cast<int>(jcp.ow / jcp.ur_w
+            - ur_w_blks_params.num_pre_blks - ur_w_blks_params.num_post_blks);
 
     const auto &blks_params = ur_w_blks_params.blks_params;
     const auto num_pre_blks = ur_w_blks_params.num_pre_blks;
     const auto num_post_blks = ur_w_blks_params.num_post_blks;
 
-    for (int i = 0; i < num_pre_blks; i++) {
+    for (dim_t i = 0; i < num_pre_blks; i++) {
         const bool blk_process_carefully = blks_params[i].process_sp_carefully;
-        const int blk_l_overflow = blks_params[i].l_overflow;
-        const int blk_r_overflow = blks_params[i].r_overflow;
+        const dim_t blk_l_overflow = blks_params[i].l_overflow;
+        const dim_t blk_r_overflow = blks_params[i].r_overflow;
 
-        icb_loop(jcp.ur_w, blk_l_overflow, blk_r_overflow,
-                blk_process_carefully);
+        icb_loop(jcp.ur_w, static_cast<int>(blk_l_overflow),
+                static_cast<int>(blk_r_overflow), blk_process_carefully);
         add(reg_src, src_shift);
         add(reg_dst, dst_shift);
     }
@@ -1399,11 +1404,11 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
         for (size_t i = start_blk_idx; i < blks_params_size; i++) {
             const bool blk_process_carefully
                     = blks_params[i].process_sp_carefully;
-            const int blk_l_overflow = blks_params[i].l_overflow;
-            const int blk_r_overflow = blks_params[i].r_overflow;
+            const dim_t blk_l_overflow = blks_params[i].l_overflow;
+            const dim_t blk_r_overflow = blks_params[i].r_overflow;
 
-            icb_loop(jcp.ur_w, blk_l_overflow, blk_r_overflow,
-                    blk_process_carefully);
+            icb_loop(jcp.ur_w, static_cast<int>(blk_l_overflow),
+                    static_cast<int>(blk_r_overflow), blk_process_carefully);
             add(reg_src, src_shift);
             add(reg_dst, dst_shift);
         }
@@ -1414,14 +1419,14 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
         //              when computing the left-most (in w dim) output pixel
         int l_overflow = 0;
         if (jcp.ur_w == jcp.ow)
-            l_overflow = max(0,
+            l_overflow = static_cast<int>(max<dim_t>(0,
                     ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad)
-                            / jcp.stride_w);
+                            / jcp.stride_w));
         // r_overflow - no/ of spatial elements of weights standing out of src spatial
         //              when computing the right-most (in w dim) output pixel
-        const int r_overflow = max(0,
-                ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad))
-                        / jcp.stride_w);
+        const int r_overflow = static_cast<int>(max<dim_t>(0,
+                ((jcp.kw - 1) * (jcp.dilate_w + 1) - max<dim_t>(0, jcp.r_pad))
+                        / jcp.stride_w));
 
         icb_loop(jcp.ur_w_tail, l_overflow, r_overflow, true);
     }
@@ -1466,8 +1471,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jcp.post_ops, ctx);
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const void *src_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -1487,8 +1492,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1504,7 +1509,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0};
+        dim_t n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks);
         else if (jcp.loop_order == loop_cgn)
@@ -1513,9 +1518,9 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
 
             p.dst = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             p.src = src + src_d.blk_off(n, g_ic);
@@ -1587,8 +1592,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     size_t src_h_stride = src_d.blk_off(0, 0, 1);
     size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -1612,8 +1617,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1630,7 +1635,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     oh_s, jcp.oh);
@@ -1641,11 +1646,11 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
-            int work_rem = end - start;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            dim_t work_rem = end - start;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
 
             auto dst_w = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             auto src_w = src + src_d.blk_off(n, g_ic);
@@ -1656,17 +1661,18 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    int o_b_overflow
-                            = div_up(max(0,
+                    dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1674,15 +1680,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    int o_t_overflow = max(
+                    dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    int o_b_overflow = max(0,
+                    dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1690,7 +1696,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
+                dim_t wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
@@ -1700,10 +1706,10 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 p.compensation = compensation_w;
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
@@ -1772,8 +1778,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     size_t src_d_stride = src_d.blk_off(0, 0, 1);
     size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
@@ -1800,8 +1806,9 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount
+                = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1818,7 +1825,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     od_s, jcp.od, oh_s, jcp.oh);
@@ -1829,23 +1836,24 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
-            int work_rem = end - start;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-            int input_d_s = 0, kd_len = 0, kd_lo = 0;
-            int d_t_overflow, d_back_overflow;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            dim_t work_rem = end - start;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t input_d_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t d_t_overflow, d_back_overflow;
 
             if (jcp.dilate_d != 0 && jcp.stride_d == 1) {
                 /* dilation */
-                int dilate_d = jcp.dilate_d + 1;
+                dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
                 d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
                         dilate_d);
                 d_back_overflow
-                        = div_up(max(0,
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.od
                                                  + od_s - jcp.back_pad),
                                 dilate_d);
@@ -1853,15 +1861,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 kd_lo = d_back_overflow;
                 input_d_s = od_s + jcp.f_pad - d_back_overflow * dilate_d;
             } else {
-                int d_t_overflow = max(
+                dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - (od_s + 1 + jcp.f_pad)) / jcp.stride_d);
-                int d_back_overflow = max(0,
+                dim_t d_back_overflow = max<dim_t>(0,
                         ((od_s + jcp.kd) - (jcp.od + jcp.back_pad))
                                 / jcp.stride_d);
-                int overflow_kd_hi = jcp.kd - 1
+                dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
                                 jcp.stride_d);
-                int overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
+                dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_back_overflow;
@@ -1883,17 +1891,18 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    int o_b_overflow
-                            = div_up(max(0,
+                    dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1901,15 +1910,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    int o_t_overflow = max(
+                    dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    int o_b_overflow = max(0,
+                    dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1917,7 +1926,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
+                dim_t wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
@@ -1929,19 +1938,19 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 strides together */
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kd
                                           - (kd_lo
-                                                  + max(0, kd_len - 1)
+                                                  + max<dim_t>(0, kd_len - 1)
                                                           * jcp.stride_d
                                                   + 1));
                 p.back_overflow = kd_lo;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -105,12 +105,12 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     const bool is_2d = ndims == 4;
     const bool is_3d = ndims == 5;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.oc_without_padding = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic_without_padding = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.is_depthwise = true && with_groups
             && utils::everyone_is(
                     1, jcp.ic_without_padding, jcp.oc_without_padding);
@@ -200,21 +200,23 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     }
 
     jcp.prop_kind = cd.prop_kind;
-    jcp.mb = src_d.dims()[0];
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.ih = is_1d ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = is_1d ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = is_1d
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = is_1d ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = is_1d ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     if (jcp.is_depthwise) {
         jcp.ch_block = 16;
@@ -247,9 +249,9 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     VDISPATCH_DECONVOLUTION_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_TAG);
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = is_1d ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_DECONVOLUTION_IC(
             !(!IMPLICATION(jcp.dilate_d, jcp.stride_d == 1)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -258,9 +258,9 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
     , postops_injector_(nullptr) {
 
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        const dim_t tail_size = jcp.is_depthwise
+        const std::size_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
 
@@ -59,8 +59,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                Xbyak::Xmm(31).getIdx(), this->r14, this->r15, this->r13,
-                preserve_gpr, preserve_vmm,
+                static_cast<std::size_t>(Xbyak::Xmm(31).getIdx()), this->r14,
+                this->r15, this->r13, preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(dst_md), tail_size, ktail_mask,
                 use_exact_tail_scalar_bcast};
@@ -1689,7 +1689,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                                     / jcp.stride_h);
                     dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
-                                    jcp.stride_h);
+                                    static_cast<dim_t>(jcp.stride_h));
                     dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
@@ -1870,7 +1870,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                                 / jcp.stride_d);
                 dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
-                                jcp.stride_d);
+                                static_cast<dim_t>(jcp.stride_d));
                 dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
@@ -1919,7 +1919,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                                     / jcp.stride_h);
                     dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
-                                    jcp.stride_h);
+                                    static_cast<dim_t>(jcp.stride_h));
                     dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -49,25 +49,25 @@ enum ker_block_t {
 struct ur_w_blks_params_t {
     struct single_ur_w_blk_params_t {
         single_ur_w_blk_params_t(
-                int l_overflow, int r_overflow, bool process_sp_carefully)
+                dim_t l_overflow, dim_t r_overflow, bool process_sp_carefully)
             : l_overflow(l_overflow)
             , r_overflow(r_overflow)
             , process_sp_carefully(process_sp_carefully) {}
 
         // l_overflow - no. of spatial elements of weights standing out of
         // src spatial when computing the 1st output pixel in the current blk
-        int l_overflow;
+        dim_t l_overflow;
         // r_overflow - no. of spatial elements of weights standing out of
         // src spatial when computing the lst output pixel in the current blk
-        int r_overflow;
+        dim_t r_overflow;
         // process_sp_carefully - indicates if loading the last src sp
         // for computation of the last dst sp of the block can't be done
         // by fetching 4 src sp at once
         bool process_sp_carefully;
     };
     std::vector<single_ur_w_blk_params_t> blks_params;
-    int num_pre_blks; // num of blocks with l_overflow>0
-    int num_post_blks; // num of blocks with r_overflow>0 or that need to be
+    dim_t num_pre_blks; // num of blocks with l_overflow>0
+    dim_t num_post_blks; // num of blocks with r_overflow>0 or that need to be
             // processed carefully
 };
 
@@ -141,19 +141,19 @@ private:
     const Vmm vmm_scale_adjust = Vmm(31);
     const Vmm vmm_prev_dst = Vmm(31);
 
-    Vmm vmm_out(int i_ur, int i_oc) {
-        int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) const {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) const {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
-    int get_ow_start(int ki, int l_overflow) {
-        int res = (jcp.ow - 1 + jcp.r_pad) % jcp.stride_w
+    dim_t get_ow_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.ow - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -161,18 +161,18 @@ private:
         return res;
     }
 
-    int get_ow_end(int ur_w, int ki, int r_overflow) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.ow, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
         return ur_w - res;
     }
 
-    int get_blocking_size() const noexcept;
-    int get_tail_size() const noexcept;
+    dim_t get_blocking_size() const noexcept;
+    dim_t get_tail_size() const noexcept;
     void prepare_output(int ur_w);
     void store_output(int ur_w, bool last_oc_block);
     void compute(const Vmm &vreg_acc, const Vmm &vreg_wei, const Vmm &vreg_src);
@@ -200,7 +200,8 @@ struct jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t {
             const memory_desc_t &dst_md)
         : kernel_(nullptr) {
 
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the AVX512 x8s8s32x 1x1/general JIT convolution and deconvolution kernels (`jit_avx512_core_x8s8s32x_1x1_conv_kernel`, `jit_avx512_core_x8s8s32x_1x1_convolution`, `jit_avx512_core_x8s8s32x_conv_kernel`, `jit_avx512_core_x8s8s32x_convolution`, `jit_avx512_core_x8s8s32x_deconvolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5664 for review convenience; independently reviewable.