### PR TITLE
cpu: conv: AVX2: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -55,7 +55,7 @@ jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,
@@ -83,9 +83,9 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        const int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             if (i == num_substeps - 1) L(large_tail);
             generate_reduce_loop(load_loop_blk, jcp.ur);
             if (i < num_substeps - 1) {
@@ -132,7 +132,7 @@ static Ymm vreg_accum(const int load_loop_blk, int i, int j) {
 }
 
 template <typename F>
-void iterate(const int load_loop_blk, const int ur, const int load_dim_tail,
+void iterate(const int load_loop_blk, const int ur, const dim_t load_dim_tail,
         const F &f) {
     for (int i = 0; i < load_loop_blk; ++i) {
         const bool mask_flag = (load_dim_tail > 0) && (i == load_loop_blk - 1);
@@ -146,7 +146,7 @@ void iterate(const int load_loop_blk, const int ur, const F &f) {
 }
 
 void jit_avx2_1x1_conv_kernel_f32_t::apply_postops(
-        const int load_loop_blk, const int ur, const int load_dim_tail) {
+        const int load_loop_blk, const int ur, const dim_t load_dim_tail) {
     if (jcp.with_eltwise || jcp.with_binary) {
         assert(ur * load_loop_blk < 14);
 
@@ -217,14 +217,14 @@ void jit_avx2_1x1_conv_kernel_f32_t::apply_postops(
 
 void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         int load_loop_blk, int ur) {
-    const int load_dim_tail
+    const dim_t load_dim_tail
             = ((jcp.with_binary
                        && one_of(jcp.prop_kind, forward_training,
                                forward_inference))
                               ? jcp.oc_without_padding
                               : jcp.load_dim)
             % jcp.load_block;
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+    const dim_t reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
 
     auto vreg_load = [ur, load_loop_blk](
                              int i) { return Ymm(ur * load_loop_blk + i); };
@@ -233,24 +233,24 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         return ptr[reg_bias_data + sizeof(float) * jcp.oc_block * i];
     };
 
-    auto bcast_ptr = [this](int u, int j) {
+    auto bcast_ptr = [this](dim_t u, int j) {
         assert(j < jcp.ur);
         assert(u <= jcp.reduce_loop_unroll);
-        const size_t offset = get_bcast_offset(jcp, u, j);
+        const size_t offset = get_bcast_offset(jcp, static_cast<int>(u), j);
         return make_safe_addr(aux_reg_bcast_data, offset, reg_long_offt);
     };
 
-    auto get_load_offset_bwd_w = [this](int u, int i) {
-        size_t u0 = u % jcp.reduce_loop_unroll;
-        size_t u1 = u / jcp.reduce_loop_unroll;
+    auto get_load_offset_bwd_w = [this](dim_t u, int i) {
+        const int u0 = static_cast<int>(u % jcp.reduce_loop_unroll);
+        const dim_t u1 = u / jcp.reduce_loop_unroll;
         return u1 * jcp.reduce_loop_load_step
                 + sizeof(float) * get_load_bwd_w_offset(jcp, i, u0);
     };
 
-    auto load_ptr = [this](int u, int i) {
+    auto load_ptr = [this](dim_t u, int i) {
         size_t offt;
-        size_t u0 = u % jcp.reduce_loop_unroll;
-        size_t u1 = u / jcp.reduce_loop_unroll;
+        const int u0 = static_cast<int>(u % jcp.reduce_loop_unroll);
+        const dim_t u1 = u / jcp.reduce_loop_unroll;
         switch (jcp.prop_kind) {
             case backward_data:
                 offt = (i * jcp.oc_block + u0) * jcp.ic_block;
@@ -310,7 +310,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                         L(load_bias_tail);
                         load_bytes(vreg_accum(load_loop_blk, i, j),
                                 reg_bias_data, i * jcp.oc_block * sizeof(float),
-                                load_dim_tail * sizeof(float));
+                                static_cast<int>(
+                                        load_dim_tail * sizeof(float)));
                         L(load_bias_done);
                     } else {
                         vmovups(vreg_accum(load_loop_blk, i, j), bias_ptr(i));
@@ -341,7 +342,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                 L(load_init_tail);
                 load_bytes(vreg_load(i), aux_reg_load_data,
                         get_load_offset_bwd_w(0, i),
-                        load_dim_tail * sizeof(float));
+                        static_cast<int>(load_dim_tail * sizeof(float)));
                 L(load_init_done);
             } else {
                 vmovups(vreg_load(i), load_ptr(0, i));
@@ -373,7 +374,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                     L(sum_tail);
                     load_bytes(vtmp, aux_reg_output_data,
                             get_output_offset(i, j),
-                            load_dim_tail * sizeof(float));
+                            static_cast<int>(load_dim_tail * sizeof(float)));
                     vaddps(r, r, vtmp);
                     L(sum_done);
                 } else {
@@ -425,7 +426,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                         }
                         store_bytes(vreg_accum(load_loop_blk, i, j),
                                 aux_reg_output_data, get_output_offset(i, j),
-                                load_dim_tail * sizeof(float));
+                                static_cast<int>(
+                                        load_dim_tail * sizeof(float)));
                     }
                     L(store_done);
                 } else {
@@ -440,8 +442,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
 
     auto fma_block = [&](bool last_block) {
         const bool is_tail = reduce_dim_tail && last_block;
-        const int u_end = is_tail ? reduce_dim_tail : jcp.reduce_loop_unroll;
-        for (int u = 0; u < u_end; ++u) {
+        const dim_t u_end = is_tail ? reduce_dim_tail : jcp.reduce_loop_unroll;
+        for (dim_t u = 0; u < u_end; ++u) {
             for (int j = 0; j < ur; ++j) {
                 for (int i = 0; i < load_loop_blk; ++i) {
                     if (jcp.isa == avx2)
@@ -466,7 +468,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                             L(fma_load_tail);
                             load_bytes(vreg_load(i), aux_reg_load_data,
                                     get_load_offset_bwd_w(u + 1, i),
-                                    load_dim_tail * sizeof(float));
+                                    static_cast<int>(
+                                            load_dim_tail * sizeof(float)));
                             L(fma_load_done);
                         } else {
                             vmovups(vreg_load(i), load_ptr(u + 1, i));
@@ -557,7 +560,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_diff_bias_loop(
 
     for (int i = 0; i < load_loop_blk; i++)
         vmovups(diff_bias_ptr(i), diff_bias_reg(i));
-    add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float));
+    safe_add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float),
+            reg_long_offt);
     mov(ptr[rsp + reg_diff_bias_data_stack_offt], reg_diff_bias_data);
 
     L(diff_bias_loop_out);
@@ -598,7 +602,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
 
     auto generate_load_loop_body = [&](int load_loop_blk) {
         generate_bcast_loop(load_loop_blk);
-        add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
+        safe_add(reg_load_data, load_loop_blk * jcp.load_loop_load_step,
+                reg_long_offt);
         const size_t offst_with_dw_conv
                 = get_load_loop_output_fwd_offset(jcp, load_loop_blk);
         const size_t offst_wo_dw_conv
@@ -606,13 +611,15 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
         switch (jcp.prop_kind) {
             case forward_training:
             case forward_inference:
-                add(reg_bias_data,
-                        load_loop_blk * jcp.oc_block * sizeof(float));
+                safe_add(reg_bias_data,
+                        load_loop_blk * jcp.oc_block * sizeof(float),
+                        reg_long_offt);
                 safe_add(reg_output_data, offst_with_dw_conv, reg_long_offt);
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            static_cast<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(ptr[rsp + reg_dw_binary_output_off], aux_reg_load_data);
                 }
                 break;
@@ -691,8 +698,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     if (!mayiuse(avx)) return status::unimplemented;
     jcp.isa = mayiuse(avx2) ? avx2 : avx;
 
-    // Big int (> INT_MAX) values are unsupported and jcp fields may overflow
-    // TODO: change data type of jcp fields to size_t
+    // Values larger than INT_MAX are unsupported at JIT/API boundaries.
     VDISPATCH_CONV_IC(!has_large_size(cd, src_d, weights_d, dst_d),
             VERBOSE_BAD_PARAM, "large size is not supported");
 
@@ -736,8 +742,8 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
             != format_kind::undef;
 
-    jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
-    jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
+    jcp.os = jcp.od * jcp.oh * jcp.ow;
+    jcp.is = jcp.id * jcp.ih * jcp.iw;
 
     jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
     jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
@@ -836,14 +842,15 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.ic_block = jcp.oc_block = simd_w;
 
     jcp.ur = jcp.isa == avx2 ? 4 : 3; // Intel AVX support
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
-    int load_blocking {0};
-    int load_blocking_max {0};
-    int bcast_blocking {0};
-    int bcast_blocking_max {0};
-    int reduce_blocking {0};
-    int reduce_blocking_max {0};
+    dim_t load_blocking {0};
+    dim_t load_blocking_max {0};
+    dim_t bcast_blocking {0};
+    dim_t bcast_blocking_max {0};
+    dim_t reduce_blocking {0};
+    dim_t reduce_blocking_max {0};
 
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
         jcp.reduce_dim = jcp.ic;
@@ -964,7 +971,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
         bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        const int bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
+        const dim_t bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
         const bool no_bcast_tail = jcp.bcast_dim % jcp.bcast_block == 0;
         const bool small_size_for_bcast
                 = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw <= 1024;
@@ -989,7 +996,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 !is_data_layout_nxc, jcp.bcast_dim % bcast_blocking == 0));
 
         reduce_blocking = is_data_layout_nxc
-                ? rnd_up(nstl::min(jcp.ow, 128), jcp.reduce_block)
+                ? rnd_up(nstl::min<dim_t>(jcp.ow, 128), jcp.reduce_block)
                 : 128; // affects L1$ utilization
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
     } else
@@ -1002,7 +1009,8 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     assert(reduce_blocking);
 
     assert(jcp.bcast_block % jcp.ur == 0);
-    jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block;
+    jcp.ur_tail = static_cast<int>(
+            (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block);
 
     jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
     jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -55,7 +55,7 @@ jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const std::size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -711,32 +711,35 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc_without_padding = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc = jcp.oc_without_padding;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic_without_padding = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic = jcp.ic_without_padding;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.format_kind,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
@@ -1024,9 +1027,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_reduce_blocking_max
             = static_cast<int>(div_up(reduce_blocking_max, jcp.reduce_block));
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     if (jcp.prop_kind == backward_weights) {
         const auto mb_with_nb_reduce

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -1012,12 +1012,17 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.ur_tail = static_cast<int>(
             (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block);
 
-    jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
-    jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;
-    jcp.nb_load_blocking = div_up(load_blocking, jcp.load_block);
-    jcp.nb_load_blocking_max = div_up(load_blocking_max, jcp.load_block);
-    jcp.nb_reduce_blocking = div_up(reduce_blocking, jcp.reduce_block);
-    jcp.nb_reduce_blocking_max = div_up(reduce_blocking_max, jcp.reduce_block);
+    jcp.nb_bcast_blocking = static_cast<int>(bcast_blocking / jcp.bcast_block);
+    jcp.nb_bcast_blocking_max
+            = static_cast<int>(bcast_blocking_max / jcp.bcast_block);
+    jcp.nb_load_blocking
+            = static_cast<int>(div_up(load_blocking, jcp.load_block));
+    jcp.nb_load_blocking_max
+            = static_cast<int>(div_up(load_blocking_max, jcp.load_block));
+    jcp.nb_reduce_blocking
+            = static_cast<int>(div_up(reduce_blocking, jcp.reduce_block));
+    jcp.nb_reduce_blocking_max
+            = static_cast<int>(div_up(reduce_blocking_max, jcp.reduce_block));
 
     jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
@@ -89,7 +89,7 @@ private:
     ymm_t vtmp = ymm_t(14);
 
     void apply_postops(
-            const int load_loop_blk, const int ur, const int load_dim_tail);
+            const int load_loop_blk, const int ur, const dim_t load_dim_tail);
     void generate_bcast_loop(int load_loop_blk);
     void generate_reduce_loop(int load_loop_blk, int ur);
     void generate_diff_bias_loop(int load_loop_blk);

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -52,7 +52,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -101,32 +102,33 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     const int ndims = dst_d.ndims();
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     auto p = jit_1x1_conv_args_t();
     auto rp = rtus_driver_t<avx2>::call_params_t();
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
     // Begin: declare Variables needed for dw conv.
     data_t *pbuf;
     size_t row_offset;
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     auto jcp_dw = pd()->jcp_dw_;
     std::vector<data_t *> addrs;
     jit_generator_t *dw_jit_ker = nullptr;
@@ -136,23 +138,23 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
 
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os = osb * os_block;
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         od = os / (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
@@ -165,7 +167,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         // binary postop injector may override zero-padded areas, so proper
         // output masking needs to be performed base on exact number of channels
@@ -174,12 +176,13 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 ocb * jcp.oc_block, oc, load_step * jcp.oc_block);
     };
 
-    auto ker_1x1 = [&](int ocb, int icb, int ocb_start, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t icb, dim_t ocb_start, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
         p.output_data = jcp.with_dw_conv ? pbuf + (oh % jcp_dw->kh) * row_offset
                                          : &dst[dst_off];
         p.bias_data
@@ -196,7 +199,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
 
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
 
@@ -220,19 +223,20 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
-        int iwork = bcast_start;
+        dim_t iwork = bcast_start;
         while (iwork < bcast_end) {
-            int n {0}, g {0}, bcast_step, od, oh, ow, id, ih, iw;
+            dim_t n {0}, g {0}, od, oh, ow, id, ih, iw;
+            dim_t bcast_step;
             init_bcast(
                     iwork, bcast_end, n, g, bcast_step, od, oh, ow, id, ih, iw);
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                     ker_1x1(ocb, icb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                 }
                 ocb += load_step;
@@ -241,41 +245,42 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw->kh) * row_offset;
 
         const ptrdiff_t wch_stride
                 = static_cast<ptrdiff_t>(is_src_layout_nxc ? 1 : jcp_dw->iw)
                 * jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         const auto ocb_end = ocb_start + load_step;
-        const int dil_h = jcp_dw->dilate_h + 1;
-        const int str_h = jcp_dw->stride_h;
-        const int ch_num = jcp_dw->nb_ch_blocking;
-        const int ow = 0;
-        const int kw = 0;
+        const dim_t dil_h = jcp_dw->dilate_h + 1;
+        const dim_t str_h = jcp_dw->stride_h;
+        const dim_t ch_num = jcp_dw->nb_ch_blocking;
+        const dim_t ow = 0;
+        const dim_t kw = 0;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw->t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw->ih,
-                              (int)(dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
-                                      - jcp_dw->t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw->t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw->ih,
+                              dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
+                                      - jcp_dw->t_pad + 1)
                     - jcp_dw->ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw->ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -287,9 +292,11 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw->ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw->nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw->nb_ch) - ch)
                     * jcp_dw->ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -298,7 +305,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
             (*dw_jit_ker)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += wch_stride;
         }
     };
@@ -318,33 +325,34 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+                bcast_end, nb_oc, ocb_start, ocb_end, dim_t {1});
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -360,8 +368,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }
@@ -388,18 +396,18 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
     assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
     const int ndims = diff_dst_d.ndims();
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -408,11 +416,11 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx2>::call_params_t();
 
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int load_step = 0;
-        for (int icb = 0; icb < jcp.nb_load; icb += load_step) {
+        dim_t load_step = 0;
+        for (dim_t icb = 0; icb < jcp.nb_load; icb += load_step) {
             load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
                     jcp.nb_load_blocking_max);
 
@@ -420,9 +428,9 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                     icb * jcp.ic_block, jcp.ic, load_step * jcp.ic_block);
             rp.icb = p.load_dim;
 
-            int bcast_step;
-            for (int iwork = start; iwork < end; iwork += bcast_step) {
-                int n {0}, g {0}, osb {0};
+            dim_t bcast_step;
+            for (dim_t iwork = start; iwork < end; iwork += bcast_step) {
+                dim_t n {0}, g {0}, osb {0};
                 nd_iterator_init(
                         iwork, n, jcp.mb, g, jcp.ngroups, osb, jcp.nb_bcast);
 
@@ -430,23 +438,23 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                         jcp.nb_bcast_blocking_max);
                 bcast_step = nstl::min(bcast_step, end - iwork);
 
-                const int os = osb * os_block;
+                const dim_t os = osb * os_block;
                 p.bcast_dim
                         = this_block_size(os, jcp.os, bcast_step * os_block);
                 rp.os = p.bcast_dim;
 
-                const int od = os / (jcp.oh * jcp.ow);
-                const int os_2d = os % (jcp.oh * jcp.ow);
-                const int oh = os_2d / jcp.ow;
-                const int ow = os_2d % jcp.ow;
-                const int id = od * stride_d;
-                const int ih = oh * stride_h;
-                const int iw = ow * stride_w;
+                const dim_t od = os / (jcp.oh * jcp.ow);
+                const dim_t os_2d = os % (jcp.oh * jcp.ow);
+                const dim_t oh = os_2d / jcp.ow;
+                const dim_t ow = os_2d % jcp.ow;
+                const dim_t id = od * stride_d;
+                const dim_t ih = oh * stride_h;
+                const dim_t iw = ow * stride_w;
                 rp.iw_start = iw;
 
                 const bool is_dsrc_layout_nxc = utils::one_of(jcp.src_tag,
                         format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g * nb_ic + icb;
                 rp.src = diff_src
@@ -457,15 +465,15 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                 } else
                     p.output_data = rp.src;
 
-                for (int ocb = 0; ocb < jcp.nb_reduce;
+                for (dim_t ocb = 0; ocb < jcp.nb_reduce;
                         ocb += jcp.nb_reduce_blocking) {
                     const bool is_ddst_layout_nxc
                             = utils::one_of(jcp.dst_tag, format_tag::nwc,
                                     format_tag::nhwc, format_tag::ndhwc);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g * nb_oc + ocb;
-                    size_t diff_dst_off = data_blk_off(
+                    dim_t diff_dst_off = data_blk_off(
                             diff_dst_d, n, oc_off_idx, od, oh, ow);
                     p.bcast_data = &diff_dst[diff_dst_off];
 
@@ -553,33 +561,33 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic = jcp.nb_bcast;
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
-    const int bcast_work = div_up(nb_ic, nb_ic_blocking);
+    const dim_t nb_ic = jcp.nb_bcast;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t bcast_work = div_up(nb_ic, nb_ic_blocking);
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
-    const int load_work = div_up(nb_oc, nb_oc_blocking);
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t load_work = div_up(nb_oc, nb_oc_blocking);
 
-    const int sp_dim = jcp.reduce_dim;
-    const int mb_sp_work = jcp.mb * sp_dim;
+    const dim_t sp_dim = jcp.reduce_dim;
+    const dim_t mb_sp_work = jcp.mb * sp_dim;
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     const bool is_src_layout_nxc = utils::one_of(
             jcp.src_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
     const bool is_ddst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
     auto oc_ic_sp_loop
-            = [= COMPAT_THIS_CAPTURE](int sp_start, int sp_end,
+            = [= COMPAT_THIS_CAPTURE](dim_t sp_start, dim_t sp_end,
                       bool first_image, data_t *store_to, size_t store_to_ld,
                       const data_t *diff_dst, const data_t *src, int ithr) {
         auto p = jit_1x1_conv_args_t();
@@ -587,15 +595,15 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
         p.output_stride = store_to_ld * sizeof(float);
 
-        int oc_b_step = 0;
-        for (int oc_b = 0; oc_b < nb_oc_blocking; oc_b += oc_b_step) {
+        dim_t oc_b_step = 0;
+        for (dim_t oc_b = 0; oc_b < nb_oc_blocking; oc_b += oc_b_step) {
             oc_b_step = step(nb_oc_blocking, nb_oc_blocking - oc_b,
                     jcp.nb_load_blocking_max);
             p.load_dim = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, oc_b_step * jcp.oc_block);
 
-            int ic_b_step = 0;
-            for (int ic_b = 0; ic_b < nb_ic_blocking; ic_b += ic_b_step) {
+            dim_t ic_b_step = 0;
+            for (dim_t ic_b = 0; ic_b < nb_ic_blocking; ic_b += ic_b_step) {
                 ic_b_step = step(nb_ic_blocking, nb_ic_blocking - ic_b,
                         jcp.nb_bcast_blocking_max);
                 p.bcast_dim = this_block_size(
@@ -606,8 +614,8 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         + ic_b * jcp.ic_block * jcp.oc_block;
 
                 /* spatial reduction */
-                int sp_step = 0;
-                for (int sp = sp_start; sp < sp_end; sp += sp_step) {
+                dim_t sp_step = 0;
+                for (dim_t sp = sp_start; sp < sp_end; sp += sp_step) {
                     sp_step = step(jcp.nb_reduce_blocking, sp_end - sp,
                             jcp.nb_reduce_blocking_max);
                     p.reduce_dim = sp_step * jcp.reduce_block;
@@ -623,14 +631,14 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                                           : jcp.oc_block);
 
                     if (pd()->rtus_.reduce_src_) {
-                        const int od = sp / (jcp.oh * jcp.ow);
-                        const int sp_2d = sp % (jcp.oh * jcp.ow);
-                        const int oh = sp_2d / jcp.ow;
-                        const int ow = sp_2d % jcp.ow;
+                        const dim_t od = sp / (jcp.oh * jcp.ow);
+                        const dim_t sp_2d = sp % (jcp.oh * jcp.ow);
+                        const dim_t oh = sp_2d / jcp.ow;
+                        const dim_t ow = sp_2d % jcp.ow;
 
-                        const int id = od * stride_d;
-                        const int ih = oh * stride_h;
-                        const int iw = ow * stride_w;
+                        const dim_t id = od * stride_d;
+                        const dim_t ih = oh * stride_h;
+                        const dim_t iw = ow * stride_w;
                         rp.iw_start = iw;
 
                         rp.ws = rtus_space
@@ -662,23 +670,24 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     };
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (is_ddst_layout_nxc && ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = nb_ic - 1;
-                const size_t off = pd()->with_groups()
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for_(dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb)
+            {
+                const dim_t z_icb = nb_ic - 1;
+                const dim_t off = pd()->with_groups()
                         ? diff_weights_d.blk_off(g, z_ocb, z_icb)
                         : diff_weights_d.blk_off(z_ocb, z_icb);
                 data_t *z_wei = diff_weights + off + ic_tail * jcp.oc_block;
-                const int zero_work
+                const dim_t zero_work
                         = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -693,26 +702,26 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
         /* setup: independent work (oc, ic) */
         const int w_job_start = rw->balancer().ithr_job_off(ithr);
-        int g {0}, load_i {0}, bcast_i {0};
+        dim_t g {0}, load_i {0}, bcast_i {0};
         nd_iterator_init(w_job_start, g, jcp.ngroups, load_i, load_work,
                 bcast_i, bcast_work);
 
         /* setup: reduction work (mb, sp) */
-        int mb_sp_start {0}, mb_sp_end {0};
+        dim_t mb_sp_start {0}, mb_sp_end {0};
         balance211(mb_sp_work, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), mb_sp_start, mb_sp_end);
-        int img_start {0}, sp_start {0};
+        dim_t img_start {0}, sp_start {0};
         nd_iterator_init(mb_sp_start, img_start, jcp.mb, sp_start, sp_dim);
 
         /* independent work */
         for (int iwork = 0; iwork < w_njobs; ++iwork) {
-            const int oc_b = nb_oc_blocking * load_i;
-            const int ic_b = nb_ic_blocking * bcast_i;
+            const dim_t oc_b = nb_oc_blocking * load_i;
+            const dim_t ic_b = nb_ic_blocking * bcast_i;
 
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * nb_oc + oc_b;
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * nb_ic + ic_b;
 
@@ -726,17 +735,19 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 store_to = &diff_weights[off];
                 store_to_ld = rnd_up(jcp.ic, jcp.ic_block) * jcp.oc_block;
             } else {
-                const size_t off = (size_t)iwork * rw->balancer().job_size_;
+                const dim_t off
+                        = static_cast<dim_t>(iwork) * rw->balancer().job_size_;
                 store_to
                         = rw->get_local_ptr(ithr, reducer_wei_scratchpad) + off;
                 store_to_ld = nb_ic_blocking * jcp.ic_block * jcp.oc_block;
             }
 
             /* reduction work */
-            int img = img_start;
-            int sp = sp_start;
-            int sp_step = 0;
-            for (int mb_sp = mb_sp_start; mb_sp < mb_sp_end; mb_sp += sp_step) {
+            dim_t img = img_start;
+            dim_t sp = sp_start;
+            dim_t sp_step = 0;
+            for (dim_t mb_sp = mb_sp_start; mb_sp < mb_sp_end;
+                    mb_sp += sp_step) {
                 sp_step = nstl::min(sp_dim - sp, mb_sp_end - mb_sp);
 
                 const bool first_image = img == img_start;
@@ -780,18 +791,18 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
-        int g_start {0}, ocb_start {0};
+        dim_t g_start {0}, ocb_start {0};
         nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, nb_oc);
 
-        for (int img = img_start; img < img_end; ++img) {
-            int g = g_start, ocb = ocb_start;
+        for (dim_t img = img_start; img < img_end; ++img) {
+            dim_t g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g * nb_oc + ocb;
 
@@ -805,13 +816,13 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] = 0.;
 
-                const int spatial_shift
+                const dim_t spatial_shift
                         = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
-                const int max_oc = this_block_size(
+                const dim_t max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
                 for (dim_t hw = 0; hw < jcp.os; ++hw) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += spatial_shift;
                 }
@@ -857,9 +868,9 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* TODO: put this in ker_bias */
         if (is_bias_padded) {
             assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
-            const int padded_stride = utils::rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = utils::rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -106,7 +106,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
     const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_ic = jcp.nb_reduce;
     const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -325,9 +325,9 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, dim_t {1});
+                bcast_end, nb_oc, ocb_start, ocb_end, 1);
 
         while (ocb_start < ocb_end) {
             dim_t load_step;
@@ -368,8 +368,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        dim_t start {0}, end {0};
-        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        int start {0}, end {0};
+        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }
@@ -405,7 +405,7 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
     const dim_t os_block = jcp.bcast_block;
     const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
@@ -416,13 +416,13 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx2>::call_params_t();
 
-        dim_t start {0}, end {0};
+        int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        dim_t load_step = 0;
-        for (dim_t icb = 0; icb < jcp.nb_load; icb += load_step) {
-            load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
-                    jcp.nb_load_blocking_max);
+        int load_step = 0;
+        for (int icb = 0; icb < jcp.nb_load; icb += load_step) {
+            load_step = static_cast<int>(step(jcp.nb_load_blocking,
+                    jcp.nb_load - icb, jcp.nb_load_blocking_max));
 
             p.load_dim = this_block_size(
                     icb * jcp.ic_block, jcp.ic, load_step * jcp.ic_block);
@@ -569,8 +569,8 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     const dim_t nb_oc_blocking = jcp.nb_load_blocking;
     const dim_t load_work = div_up(nb_oc, nb_oc_blocking);
 
-    const dim_t sp_dim = jcp.reduce_dim;
-    const dim_t mb_sp_work = jcp.mb * sp_dim;
+    const int sp_dim = static_cast<int>(jcp.reduce_dim);
+    const int mb_sp_work = jcp.mb * sp_dim;
 
     const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
     const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
@@ -707,7 +707,7 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 bcast_i, bcast_work);
 
         /* setup: reduction work (mb, sp) */
-        dim_t mb_sp_start {0}, mb_sp_end {0};
+        int mb_sp_start {0}, mb_sp_end {0};
         balance211(mb_sp_work, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), mb_sp_start, mb_sp_end);
         dim_t img_start {0}, sp_start {0};
@@ -791,7 +791,7 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        dim_t img_start {0}, img_end {0};
+        int img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -278,8 +278,8 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw->nb_ch_blocking != 0)
                 --jcp_dw->nb_ch_blocking;
 
-            jcp_dw->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
 
             const auto dat_tag_nxc = utils::pick(ndims() - 3, format_tag::nwc,
                     format_tag::nhwc, format_tag::ndhwc);
@@ -553,34 +553,41 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
 
     private:
         void init_balancers() {
-            const int ic_block = jcp_.bcast_block;
-            const int nb_ic = jcp_.nb_bcast;
-            const int nb_ic_blocking = jcp_.nb_bcast_blocking;
-            const int bcast_work = utils::div_up(nb_ic, nb_ic_blocking);
+            const dim_t ic_block = jcp_.bcast_block;
+            const dim_t nb_ic = jcp_.nb_bcast;
+            const dim_t nb_ic_blocking = jcp_.nb_bcast_blocking;
+            const dim_t bcast_work = utils::div_up(nb_ic, nb_ic_blocking);
 
-            const int oc_block = jcp_.load_block;
-            const int nb_oc = jcp_.nb_load;
-            const int nb_oc_blocking = jcp_.nb_load_blocking;
-            const int load_work = utils::div_up(nb_oc, nb_oc_blocking);
+            const dim_t oc_block = jcp_.load_block;
+            const dim_t nb_oc = jcp_.nb_load;
+            const dim_t nb_oc_blocking = jcp_.nb_load_blocking;
+            const dim_t load_work = utils::div_up(nb_oc, nb_oc_blocking);
 
-            const int job_size
+            const dim_t job_size
                     = nb_oc_blocking * nb_ic_blocking * ic_block * oc_block;
-            const int njobs_x = bcast_work;
-            const int njobs_y = jcp_.ngroups * load_work;
+            const dim_t njobs_x = bcast_work;
+            const dim_t njobs_y = jcp_.ngroups * load_work;
 
             const int max_threads = dnnl_get_max_threads();
             const size_t max_buffer_size = (size_t)max_threads * job_size * 8;
 
             if (with_bias()) {
-                reducer_bia_conf_.init(reduce_balancer_t(max_threads, oc_block,
-                        jcp_.ngroups * nb_oc, jcp_.mb, max_buffer_size, true));
+                reducer_bia_conf_.init(reduce_balancer_t(max_threads,
+                        static_cast<int>(oc_block),
+                        static_cast<int>(jcp_.ngroups * nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
 
             reducer_wei_conf_.init(
-                    reduce_balancer_t(max_threads, job_size, njobs_y * njobs_x,
-                            jcp_.mb * jcp_.nb_reduce, max_buffer_size, true),
-                    job_size / nb_oc_blocking, nb_oc_blocking, ic_block,
-                    nb_ic * ic_block * oc_block, nb_oc);
+                    reduce_balancer_t(max_threads, static_cast<int>(job_size),
+                            static_cast<int>(njobs_y * njobs_x),
+                            static_cast<int>(jcp_.mb * jcp_.nb_reduce),
+                            max_buffer_size, true),
+                    static_cast<int>(job_size / nb_oc_blocking),
+                    static_cast<int>(nb_oc_blocking),
+                    static_cast<int>(ic_block),
+                    static_cast<int>(nb_ic * ic_block * oc_block),
+                    static_cast<int>(nb_oc));
         }
     };
 

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -60,7 +60,7 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,
@@ -77,18 +77,19 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
 
 void jit_avx2_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int dilate_w = jcp.dilate_w + 1;
-    int ic_block = jcp.ic_block;
+    const int kw = static_cast<int>(jcp.kw);
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    int ic_block = static_cast<int>(jcp.ic_block);
     int ic_tail = jcp.ic_tail;
 
     for (int ki = 0; ki < kw; ki++) {
-        int jj_start = div_up(nstl::max(0, pad_l - ki * dilate_w), stride_w);
-        int jj_end = ur_w
-                - div_up(nstl::max(0,
+        int jj_start = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, pad_l - ki * dilate_w), stride_w));
+        int jj_end = static_cast<int>(ur_w
+                - div_up(nstl::max<dim_t>(0,
                                  ki * dilate_w + pad_r - (kw - 1) * dilate_w),
-                        stride_w);
+                        stride_w));
 
         auto compute = [&](int cur_ic_blk) {
             for (int ifm2 = 0; ifm2 < cur_ic_blk; ifm2++) {
@@ -144,8 +145,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
-    int kw = jcp.kw;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    int ic_blk = static_cast<int>(jcp.ic_block);
 
     xor_(ki_iter, ki_iter);
     L(kw_loop);
@@ -258,8 +259,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::apply_postops(
 
 void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int oc_blk = jcp.oc_block;
+    const int kw = static_cast<int>(jcp.kw);
+    int oc_blk = static_cast<int>(jcp.oc_block);
     int oc_tail = jcp.oc_tail;
 
     if (oc_tail) {
@@ -412,7 +413,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     if (jcp.ndims == 5) {
         safe_add(aux_reg_inp_d, get_input_offset(0, filter_d_to_input(1)),
                 reg_long_offt);
-        safe_add(aux_reg_ker_d, get_kernel_offset(0, jcp.kw * jcp.kh, 0),
+        safe_add(aux_reg_ker_d,
+                get_kernel_offset(0, static_cast<int>(jcp.kw * jcp.kh), 0),
                 reg_long_offt);
 
         dec(reg_ki);
@@ -467,7 +469,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     } else {
         Label regular_store;
         Label store_done;
-        const int tail = jcp.oc_without_padding % jcp.oc_block;
+        const int tail
+                = static_cast<int>(jcp.oc_without_padding % jcp.oc_block);
         if (jcp.with_binary && tail) {
             test(reg_ci_flag, FLAG_IC_LAST);
             je(regular_store, T_NEAR);
@@ -490,24 +493,28 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
 inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int n_oi = jcp.ow / ur_w;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int str_w = jcp.stride_w;
+    int n_oi = static_cast<int>(jcp.ow / ur_w);
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t str_w = jcp.stride_w;
 
-    int l_pad = jcp.l_pad;
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, str_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    const dim_t l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
         n_oi--;
         if (n_oi < 0 && r_pad1 > 0)
-            width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), r_pad1,
+                    oc_blocks); // "lrpad"
         else
-            width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
+            width_blk_step(ur_w, static_cast<int>(l_pad), 0,
+                    oc_blocks); // "lpad"
+        add(reg_input,
+                get_input_offset(0,
+                        filter_w_to_input(0, ur_w, static_cast<int>(l_pad))));
         add(reg_output, get_output_offset(0, ur_w));
     }
 
@@ -631,9 +638,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -660,8 +667,10 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag_OIxio, wei_tag_Oxio);
     jcp.dst_tag = dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -691,8 +700,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     /* Grouped channel offset to support 'non-blocked data' format for
      * convolution sizes with '(input_channel / ngroups) < simd' */
     jcp.nonblk_group_off
-            = one_of(jcp.src_tag, ncw, nchw, ncdhw) && jcp.ngroups > 1 ? jcp.ic
-                                                                       : 1;
+            = one_of(jcp.src_tag, ncw, nchw, ncdhw) && jcp.ngroups > 1
+            ? static_cast<int>(jcp.ic)
+            : 1;
 
     bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1;
 
@@ -725,7 +735,7 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(flat,
                     jcp.wei_tag == wei_tag_Oxio
                             && ((tag_is_flat(jcp.src_tag, dat_tag_ncx,
-                                         dat_tag_nxc, jcp.ic)
+                                         dat_tag_nxc, static_cast<int>(jcp.ic))
                                         && jcp.dst_tag == dat_tag_nCx8c)
                                     || (jcp.src_tag == dat_tag_nxc
                                             && jcp.dst_tag == dat_tag_nxc)))
@@ -775,7 +785,7 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         }
     }
 
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     VDISPATCH_CONV_IC(IMPLICATION(!is_data_layout_nxc, jcp.oc % simd_w == 0),
@@ -796,20 +806,22 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             : (jcp.with_binary ? jcp.oc_without_padding % simd_w : 0);
 
     int r_pad_no_tail = nstl::max(0,
-            calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+            static_cast<int>(calculate_end_padding(jcp.l_pad,
+                    jcp.ow - jcp.ur_w_tail, jcp.iw, jcp.stride_w, ext_kw)));
 
     if (r_pad_no_tail > jcp.ur_w * jcp.stride_w && jcp.ow / jcp.ur_w > 1) {
         /* recalculate ur_w, nb_oc_blocking and ur_w_tail */
-        jcp.ur_w = nstl::min(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
-                nstl::min(jcp.ow, num_avail_regs / 2));
+        jcp.ur_w = static_cast<int>(
+                nstl::min<dim_t>(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
+                        nstl::min<dim_t>(jcp.ow, num_avail_regs / 2)));
         jcp.nb_oc_blocking = (num_avail_regs - jcp.ur_w) / jcp.ur_w;
-        jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+        jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
         /* check again ... */
         r_pad_no_tail = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                        jcp.stride_w, ext_kw));
-        VDISPATCH_CONV_IC((jcp.ur_w >= nstl::max(jcp.l_pad, r_pad_no_tail)),
+                static_cast<int>(calculate_end_padding(jcp.l_pad,
+                        jcp.ow - jcp.ur_w_tail, jcp.iw, jcp.stride_w, ext_kw)));
+        VDISPATCH_CONV_IC(
+                (jcp.ur_w >= nstl::max<dim_t>(jcp.l_pad, r_pad_no_tail)),
                 VERBOSE_UNSUPPORTED_PAD_FEATURE,
                 "width unroll exceeds padding size");
     }
@@ -852,13 +864,13 @@ void jit_avx2_conv_fwd_kernel_f32_t::init_scratchpad(
 
 void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
         int ur_w, int l_overflow, int r_overflow) {
-    int kw = jcp.kw;
-    int ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t ow = jcp.ow;
 
-    int oc_block = jcp.oc_block;
+    int oc_block = static_cast<int>(jcp.oc_block);
     int nb_ic_block = jcp.nb_ic_blocking;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t stride_h = jcp.stride_h;
     int oc_tail = jcp.oc_tail;
     int ic_tail = jcp.ic_tail;
 
@@ -918,14 +930,18 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     L(kh_loop);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow); // 0;
-            int jj_end = get_iw_end(ur_w, ki, r_overflow); // ur_w;
+            const int jj_start
+                    = static_cast<int>(get_iw_start(ki, l_overflow)); // 0;
+            const int jj_end = static_cast<int>(
+                    get_iw_end(ur_w, ki, r_overflow)); // ur_w;
 
             auto compute = [&](int cur_oc_blk) {
                 for (int ofm2 = 0; ofm2 < cur_oc_blk; ofm2++) {
                     for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        int aux_output_offset = get_ddst_offset(
-                                0, filter_w_to_ddst(ki, jj, jcp.l_pad), ofm2);
+                        dim_t aux_output_offset = get_ddst_offset(0,
+                                filter_w_to_ddst(
+                                        ki, jj, static_cast<int>(jcp.l_pad)),
+                                ofm2);
                         vbroadcastss(Ymm(nb_ic_block * ur_w + jj / stride_w),
                                 ptr[aux_reg_ddst + aux_output_offset]);
                     }
@@ -962,7 +978,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
             }
         }
 
-        add(aux_reg_kernel, get_kernel_offset(0, 0, stride_h * kw, 0));
+        add(aux_reg_kernel,
+                get_kernel_offset(0, 0, static_cast<int>(stride_h * kw), 0));
         sub(aux_reg_ddst, get_ddst_offset(0, (jcp.dilate_h + 1) * ow, 0));
 
         dec(kj);
@@ -974,7 +991,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     if (jcp.ndims == 5) {
         sub(aux_reg_dst_d,
                 get_ddst_offset(0, (jcp.dilate_d + 1) * jcp.oh * ow, 0));
-        add(aux_reg_ker_d, get_kernel_offset(0, 0, jcp.kw * jcp.kh, 0));
+        add(aux_reg_ker_d,
+                get_kernel_offset(0, 0, static_cast<int>(jcp.kw * jcp.kh), 0));
 
         dec(reg_ki);
         cmp(reg_ki, 0);
@@ -985,8 +1003,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     }
 
     if (one_of(jcp.ndims, 3, 4)) {
-        int ddst_oc_shift = get_ddst_offset(1, 0, 0);
-        int kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
+        dim_t ddst_oc_shift = get_ddst_offset(1, 0, 0);
+        dim_t kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
 
         add(aux_reg_ddst_oc_loop, ddst_oc_shift);
         add(aux_reg_kernel_oc_loop, kernel_oc_shift);
@@ -1062,18 +1080,20 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::generate() {
     mov(reg_channel, ptr[param1 + GET_OFF(channel)]);
     mov(reg_channel_work, ptr[param1 + GET_OFF(ch_blocks)]);
 
-    int ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
-    int dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
+    dim_t ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
+    dim_t dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kw = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
 
-    int l_overflow = nstl::max(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w);
-    int r_overflow = nstl::max(
-            0, (ext_kw - 1 - nstl::max(0, jcp.r_pad)) / jcp.stride_w);
-    int r_overflow1 = nstl::max(
-            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w));
+    int r_overflow = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - nstl::max<dim_t>(0, jcp.r_pad)) / jcp.stride_w));
+    int r_overflow1 = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w));
 
-    int n_oi = jcp.iw / jcp.ur_w;
+    int n_oi = static_cast<int>(jcp.iw / jcp.ur_w);
     if (r_overflow1 > 0) n_oi--;
 
     if (jcp.ur_w == jcp.iw) {
@@ -1193,8 +1213,10 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             = diff_dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
 
-    jcp.typesize_in = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -1244,9 +1266,9 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.src_tag == required_dat_tag && jcp.wei_tag == wei_tag;
     VDISPATCH_CONV_IC(tag_ok, VERBOSE_UNSUPPORTED_TAG);
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
@@ -1261,7 +1283,8 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    int l_overflow = nstl::max(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w));
 
     const int max_regs = 15; /* Maximum number of registers available for
                                 result accumulation and delta dst data.
@@ -1279,10 +1302,11 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     for (int b = 1; b <= 4; b++) {
         if (jcp.nb_ic % b != 0) continue;
 
-        for (int u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
+        for (int u = static_cast<int>(jcp.stride_w);
+                u * b + u / jcp.stride_w <= max_regs
                 && u < jcp.iw + jcp.stride_w;
                 u += jcp.stride_w) {
-            int ur_w = nstl::min(u, jcp.iw);
+            int ur_w = static_cast<int>(nstl::min<dim_t>(u, jcp.iw));
             /* maximum 1 step with l_overflow so far */
             if (l_overflow * jcp.stride_w > ur_w && ur_w != jcp.iw) continue;
             int nfmas = div_up(ur_w, jcp.stride_w) * b;
@@ -1297,10 +1321,10 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(best_nfmas > 0, VERBOSE_BLOCKING_FAIL,
             "cannot find appropriate blocking");
 
-    jcp.ur_w_tail = jcp.iw % jcp.ur_w;
+    jcp.ur_w_tail = static_cast<int>(jcp.iw % jcp.ur_w);
 
-    int r_overflow_no_tail = nstl::max(
-            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w);
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w));
 
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
@@ -1421,21 +1445,21 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     const int simd_w = 8;
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    jcp.r_pad = nstl::max(0,
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
-    const int max_h_pad = ext_kh;
-    const int max_w_pad = ext_kw;
+    const dim_t max_h_pad = ext_kh;
+    const dim_t max_w_pad = ext_kw;
     const bool boundaries_ok = true && jcp.t_pad < max_h_pad
             && jcp.b_pad < max_h_pad && jcp.l_pad < max_w_pad
             && jcp.r_pad < max_w_pad && jcp.f_pad == 0 && jcp.back_pad == 0;
@@ -1456,7 +1480,7 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(flat,
                     jcp.wei_tag == wei_tag_Oxio
                             && ((tag_is_flat(jcp.src_tag, dat_tag_ncx,
-                                         dat_tag_nxc, jcp.ic)
+                                         dat_tag_nxc, static_cast<int>(jcp.ic))
                                         && jcp.dst_tag == dat_tag_nCx8c)
                                     || (jcp.src_tag == dat_tag_nxc
                                             && jcp.dst_tag == dat_tag_nxc)))
@@ -1487,8 +1511,10 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     const bool is_src_layout_blocked = jcp.src_tag == dat_tag_nCx8c;
     const bool is_dst_layout_blocked = jcp.dst_tag == dat_tag_nCx8c;
@@ -1548,12 +1574,12 @@ jit_avx2_conv_bwd_weights_kernel_f32_t::oh_step_comeback_pointers() {
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset) {
 
     if (ic_block_step <= 0) return;
 
-    const int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     const int oc_tail = jcp.oc_tail;
 
     if (oc_tail) {
@@ -1584,7 +1610,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
                                 + output_offset]);
 
             for (int i_kw = 0; i_kw < kw; i_kw++) {
-                int i_iw = i_ur * jcp.stride_w + i_kw;
+                const dim_t i_iw = i_ur * jcp.stride_w + i_kw;
                 if (i_iw - pad_l < 0
                         || i_iw > (ur_w - 1) * jcp.stride_w + kw - 1 - pad_r)
                     continue;
@@ -1632,7 +1658,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
-    int ic_block_step;
+    dim_t ic_block_step;
     if (one_of(jcp.src_tag, ncw, nchw, ncdhw)) {
         ic_block_step = jcp.kw >= 5 ? 1 : jcp.ic_block;
     } else if (one_of(jcp.src_tag, nwc, nhwc, ndhwc)) {
@@ -1640,7 +1666,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
         if (jcp.ic_block % ic_block_step != 0) {
             ic_block_step = jcp.ic_block < ic_block_step ? jcp.ic_block : 1;
         }
-        if (jcp.ic < ic_block_step) ic_block_step = jcp.ic;
+        if (jcp.ic < ic_block_step) ic_block_step = static_cast<int>(jcp.ic);
     } else {
         ic_block_step = jcp.kw > 7 ? 1 : jcp.kw > 3 ? 2 : jcp.kw > 1 ? 4 : 8;
     }
@@ -1648,9 +1674,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
     const int max_ur_w = jcp.ow > 56 ? 14 : 28;
 
     if (jcp.ow <= max_ur_w || one_of(jcp.src_tag, nwc, nhwc, ndhwc))
-        compute_oh_step_unroll_ow(ic_block_step, max_ur_w);
+        compute_oh_step_unroll_ow(static_cast<int>(ic_block_step), max_ur_w);
     else
-        compute_oh_step_common(ic_block_step, max_ur_w);
+        compute_oh_step_common(static_cast<int>(ic_block_step), max_ur_w);
 
     if (jcp.ndims == 5) {
         od_step_comeback_pointers();
@@ -1665,9 +1691,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         int ic_block_step, int max_ur_w) {
     UNUSED(max_ur_w);
 
-    const int r_pad = jcp.r_pad;
+    const dim_t r_pad = jcp.r_pad;
     const int ic_tail = jcp.ic_tail;
-    const int ic_block = jcp.ic_block;
+    const int ic_block = static_cast<int>(jcp.ic_block);
     const int ic_block_step_tail = jcp.ic % ic_block_step;
     const size_t inp_icblk_stride = get_input_offset(ic_block_step, 0);
 
@@ -1699,8 +1725,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         Label ic_block_loop;
         L(ic_block_loop);
         {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
             add(reg_kernel, get_kernel_offset(0, ic_block_step));
             add(b_ic, ic_block_step);
@@ -1709,7 +1735,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         }
         add(reg_input,
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+        add(reg_kernel, get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1726,8 +1752,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         mov(b_ic, ic_tail);
         L(ic_block_loop);
         {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
             add(reg_kernel, get_kernel_offset(0, ic_block_step));
             sub(b_ic, ic_block_step);
@@ -1738,8 +1764,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         L(ic_block_loop_done);
 
         if (ic_block_step_tail) {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step_tail, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step_tail, 0, 0, 0);
             add(reg_input, get_input_offset(ic_block_step_tail, 0));
             add(reg_kernel, get_kernel_offset(0, ic_block_step_tail));
         }
@@ -1748,7 +1774,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_tail, 0));
         add(reg_kernel,
                 get_kernel_offset(0, ic_block - ic_tail)
-                        + get_kernel_offset((jcp.kw - 1), 0));
+                        + get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop_ic_tail, T_NEAR);
@@ -1770,15 +1796,15 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step, int max_ur_w) {
     // TODO: suppport channel tails for nxc format
 
-    const int ic_block = jcp.ic_block;
-    const int stride_w = jcp.stride_w;
+    const int ic_block = static_cast<int>(jcp.ic_block);
+    const int stride_w = static_cast<int>(jcp.stride_w);
     Label kd_loop;
 
-    const int r_pad = jcp.r_pad;
+    const int r_pad = static_cast<int>(jcp.r_pad);
 
-    int ur_w = nstl::min(jcp.ow, max_ur_w);
-    int ur_w_trips = jcp.ow / ur_w;
-    int ur_w_tail = jcp.ow % ur_w;
+    int ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, max_ur_w));
+    int ur_w_trips = static_cast<int>(jcp.ow / ur_w);
+    int ur_w_tail = static_cast<int>(jcp.ow % ur_w);
     if ((ur_w_tail == 0 && r_pad != 0) || r_pad >= ur_w_tail) {
         if (ur_w_trips > 1) {
             ur_w_tail += ur_w;
@@ -1789,9 +1815,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
     }
 
-    int input_comeback
+    dim_t input_comeback
             = get_input_offset(0, ur_w_trips * ur_w * stride_w - jcp.l_pad);
-    int output_comeback = get_output_offset(0, ur_w_trips * ur_w);
+    dim_t output_comeback = get_output_offset(0, ur_w_trips * ur_w);
 
     if (jcp.ndims == 5) {
         mov(aux_reg_input, reg_input);
@@ -1851,7 +1877,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
         add(reg_input,
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+        add(reg_kernel, get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1867,9 +1893,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
-    const int t_pad = jcp.t_pad;
-    const int stride_h = jcp.stride_h;
-    int b_pad = jcp.b_pad;
+    const dim_t t_pad = jcp.t_pad;
+    const dim_t stride_h = jcp.stride_h;
+    dim_t b_pad = jcp.b_pad;
 
     Label oh_tpad_loop, oh_loop, oh_loop_end;
 
@@ -1893,13 +1919,13 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
 
             /* the overlap between input and kernel may not reach kernel size.
              * so far we do not support that (until we put constant here) */
-            const int final_inp_ker_overlap = jcp.kh; /* [bwd_w:r2] */
+            const dim_t final_inp_ker_overlap = jcp.kh; /* [bwd_w:r2] */
             cmp(reg_kh, final_inp_ker_overlap);
             jl(oh_tpad_loop, T_NEAR);
         }
 
         if (t_pad % stride_h != 0) {
-            int inp_corr = stride_h - t_pad % stride_h;
+            const dim_t inp_corr = stride_h - t_pad % stride_h;
             add(reg_kernel, get_kernel_offset(inp_corr * jcp.kw, 0));
             add(reg_input, get_input_offset(0, inp_corr * jcp.iw));
         }

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -494,14 +494,14 @@ inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
     int n_oi = static_cast<int>(jcp.ow / ur_w);
-    const dim_t iw = jcp.iw;
-    const dim_t kw = jcp.kw;
-    const dim_t str_w = jcp.stride_w;
+    const int iw = jcp.iw;
+    const int kw = jcp.kw;
+    const int str_w = jcp.stride_w;
 
     const dim_t l_pad = jcp.l_pad;
     int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
-    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
-            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
+    int r_pad1 = calculate_end_padding(static_cast<int>(l_pad), ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
@@ -638,9 +638,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1266,9 +1266,9 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.src_tag == required_dat_tag && jcp.wei_tag == wei_tag;
     VDISPATCH_CONV_IC(tag_ok, VERBOSE_UNSUPPORTED_TAG);
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
@@ -1445,16 +1445,16 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     const int simd_w = 8;
 
-    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    jcp.r_pad = nstl::max<dim_t>(0,
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.r_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max<dim_t>(0,
+    jcp.b_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max<dim_t>(0,
+    jcp.back_pad = nstl::max(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -610,33 +610,36 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     int ndims = src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
@@ -1156,35 +1159,38 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     int ndims = diff_src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = diff_src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(diff_src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = diff_src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(diff_src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.id = (ndims == 5) ? diff_src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : diff_src_d.dims()[ndims - 2];
-    jcp.iw = diff_src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(diff_src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(diff_src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(diff_src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const bool dilate_ok = !((jcp.dilate_w != 0 && jcp.stride_w != 1)
             || (jcp.dilate_d != 0 && jcp.stride_d != 1)
@@ -1389,36 +1395,40 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     int ndims = src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? diff_weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(diff_weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = diff_dst_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(diff_dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
 
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? diff_dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
-    jcp.ow = diff_dst_d.dims()[ndims - 1];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(diff_dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(diff_dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(diff_dst_d.dims()[ndims - 1]);
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
+    jcp.kd = (ndims == 5)
+            ? static_cast<int>(diff_weights_d.dims()[with_groups + 2])
+            : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(diff_weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_d = (ndims == 5) ? cd.dilates[0] : 0;
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = (ndims == 5) ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const auto dat_tag_nxc = pick(ndims - 3, nwc, nhwc, ndhwc);
     const auto dat_tag_ncx = pick(ndims - 3, ncw, nchw, ncdhw);

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -60,7 +60,7 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const std::size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
@@ -98,16 +98,16 @@ private:
         return static_cast<dim_t>(ki) * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
     }
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(int i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
             offset = static_cast<dim_t>(i_ic) * jcp.id * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
@@ -190,8 +190,8 @@ private:
 
     void generate() override;
 
-    inline int get_iw_start(int ki, int l_overflow) const {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    inline dim_t get_iw_start(dim_t ki, dim_t l_overflow) const {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -200,10 +200,10 @@ private:
         return res;
     }
 
-    inline int get_iw_end(int ur_w, int ki, int r_overflow) const {
+    inline dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) const {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -215,12 +215,12 @@ private:
         return (oi + pad_l - ki * (jcp.dilate_w + 1)) / jcp.stride_w;
     }
 
-    inline dim_t get_ddst_offset(int i_oc_block, int i_ow, int i_oc) const {
+    inline dim_t get_ddst_offset(int i_oc_block, dim_t i_ow, int i_oc) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block + i_oc;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block
+                    + i_oc;
         } else {
             offset = static_cast<dim_t>(i_oc_block) * jcp.od * jcp.oh * jcp.ow
                             * jcp.oc_block
@@ -293,46 +293,43 @@ private:
 
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset);
     inline void compute_oh_step_disp();
     inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
     inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
     inline void compute_oh_loop_common();
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(int i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
             offset = static_cast<dim_t>(i_ic) * jcp.id * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_output_offset(int i_oc_block, int i_ow) const {
+    inline dim_t get_output_offset(dim_t i_oc_block, dim_t i_ow) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block;
         } else {
-            offset = static_cast<dim_t>(i_oc_block) * jcp.od * jcp.oh * jcp.ow
-                            * jcp.oc_block
+            offset = i_oc_block * jcp.od * jcp.oh * jcp.ow * jcp.oc_block
                     + i_ow * jcp.oc_block;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_kernel_offset(int ki, int i_ic) const {
+    inline dim_t get_kernel_offset(dim_t ki, dim_t i_ic) const {
         dim_t block_step_size = static_cast<dim_t>(jcp.ic_block) * jcp.oc_block;
-        dim_t offset = static_cast<dim_t>(ki) * block_step_size
-                + i_ic * jcp.oc_block;
+        dim_t offset = ki * block_step_size + i_ic * jcp.oc_block;
         return sizeof(float) * offset;
     }
     void generate() override;

--- a/src/cpu/x64/jit_avx2_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_convolution.cpp
@@ -57,9 +57,8 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const memory_desc_wrapper bias_d(pd()->weights_md(1));
 
-    const size_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
-    const size_t work_amount
-            = jcp.mb * jcp.ngroups * ocb_work * jcp.od * jcp.oh;
+    const dim_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const dim_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.od * jcp.oh;
 
     // Lambda captures by copy, the bias logic must stay afront the lambda,
     // otherwise, `bias` will be captured unmodified and lead to a crash inside
@@ -74,61 +73,63 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     }
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
                 format_tag::nChw8c, format_tag::nCdhw8c);
-        int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-        int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+        dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+        dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
         bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
                 format_tag::nChw8c, format_tag::nCdhw8c);
-        int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-        int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
-        int oc_bias_scale = is_oc_physically_blocked ? jcp.oc_block : 1;
+        dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+        dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+        dim_t oc_bias_scale = is_oc_physically_blocked ? jcp.oc_block : 1;
 
-        int icbb = 0;
+        dim_t icbb = 0;
         while (icbb < jcp.nb_ic) {
-            int icb_step = jcp.nb_ic_blocking;
-            int icb_step_rem = jcp.nb_ic - icbb;
+            dim_t icb_step = jcp.nb_ic_blocking;
+            dim_t icb_step_rem = jcp.nb_ic - icbb;
             if (icb_step_rem < jcp.nb_ic_blocking_max) icb_step = icb_step_rem;
 
-            size_t n {0}, g {0}, ocbb {0}, oh {0}, od {0};
+            dim_t n {0}, g {0}, ocbb {0}, oh {0}, od {0};
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     od, jcp.od, oh, jcp.oh);
-            for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
-                int ocb_num = jcp.nb_oc_blocking;
+            for (dim_t iwork = start; iwork < end; ++iwork) {
+                dim_t ocb = ocbb * jcp.nb_oc_blocking;
+                dim_t ocb_num = jcp.nb_oc_blocking;
 
-                for (int icb = icbb; icb < icbb + icb_step; ++icb) {
+                for (dim_t icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
-                    const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
-                    const int i_b_overflow
-                            = nstl::max(jcp.ih,
+                    const dim_t ij = oh * jcp.stride_h;
+                    const dim_t i_t_overflow
+                            = nstl::max<dim_t>(0, jcp.t_pad - ij);
+                    const dim_t i_b_overflow
+                            = nstl::max<dim_t>(jcp.ih,
                                       ij + (jcp.kh - 1) * (jcp.dilate_h + 1)
                                               - jcp.t_pad + 1)
                             - jcp.ih;
 
-                    const int dj = od * jcp.stride_d;
-                    const int d_t_overflow = nstl::max(0, jcp.f_pad - dj);
-                    const int d_b_overflow
-                            = nstl::max(jcp.id,
+                    const dim_t dj = od * jcp.stride_d;
+                    const dim_t d_t_overflow
+                            = nstl::max<dim_t>(0, jcp.f_pad - dj);
+                    const dim_t d_b_overflow
+                            = nstl::max<dim_t>(jcp.id,
                                       dj + (jcp.kd - 1) * (jcp.dilate_d + 1)
                                               - jcp.f_pad + 1)
                             - jcp.id;
 
-                    const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
-                    const size_t _ic = g * g_ic_offset + icb * icb_ic_scale;
+                    const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                    const dim_t _ic = g * g_ic_offset + icb * icb_ic_scale;
 
-                    const int ih = nstl::max(ij - jcp.t_pad
+                    const dim_t ih = nstl::max<dim_t>(ij - jcp.t_pad
                                     + div_up(i_t_overflow, (jcp.dilate_h + 1))
                                             * (jcp.dilate_h + 1),
                             0);
 
-                    const int id = nstl::max(dj - jcp.f_pad
+                    const dim_t id = nstl::max<dim_t>(dj - jcp.f_pad
                                     + div_up(d_t_overflow, (jcp.dilate_d + 1))
                                             * (jcp.dilate_d + 1),
                             0);
@@ -137,8 +138,8 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
                     par_conv.dst = &dst[src_blk_off(dst_d, n, _oc, od, oh, 0)];
 
-                    const int wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
-                    const int wd = div_up(d_t_overflow, (jcp.dilate_d + 1));
+                    const dim_t wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
+                    const dim_t wd = div_up(d_t_overflow, (jcp.dilate_d + 1));
                     par_conv.filt = &weights[wht_blk_off(
                             weights_d, g, ocb, icb, wd, wh, 0)];
 
@@ -158,20 +159,20 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                             icb * jcp.ic_block, jcp.ic, jcp.ic_block);
 
                     par_conv.oc_blocks
-                            = nstl::min(ocb + ocb_num, jcp.nb_oc) - ocb;
+                            = nstl::min<dim_t>(ocb + ocb_num, jcp.nb_oc) - ocb;
 
                     if (ocbb == ocb_work - 1) par_conv.oc_flag |= FLAG_OC_LAST;
 
                     par_conv.kw_padding = 0;
-                    const int kh_padding = jcp.kh
+                    const dim_t kh_padding = jcp.kh
                             - div_up(i_t_overflow, (jcp.dilate_h + 1))
                             - div_up(i_b_overflow, (jcp.dilate_h + 1));
-                    par_conv.kh_padding = nstl::max(0, kh_padding);
+                    par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-                    const int kd_padding = jcp.kd
+                    const dim_t kd_padding = jcp.kd
                             - div_up(d_t_overflow, (jcp.dilate_d + 1))
                             - div_up(d_b_overflow, (jcp.dilate_d + 1));
-                    par_conv.kd_padding = nstl::max(0, kd_padding);
+                    par_conv.kd_padding = nstl::max<dim_t>(0, kd_padding);
 
                     par_conv.post_ops_binary_rhs_arg_vec
                             = post_ops_binary_rhs_arg_vec.data();
@@ -201,10 +202,10 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
 
     const auto &jcp = kernel_->jcp;
 
-    int icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
-    int ih_block_size = jcp.ih;
-    int num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
-    size_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
+    dim_t icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ih_block_size = jcp.ih;
+    dim_t num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
+    dim_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
 
     const auto data_size = sizeof(data_t);
     const auto L2 = platform::get_per_core_cache_size(2) / data_size;
@@ -215,88 +216,95 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
             + (size_t)jcp.od * jcp.oh * jcp.ow * oc_chunk
             + (size_t)jcp.kd * jcp.kh * jcp.kw * ic_chunk * oc_chunk;
 
-    if (work_amount < (size_t)2 * jcp.nthr || iter_data_amount > L2) {
+    if (work_amount < 2 * static_cast<dim_t>(jcp.nthr)
+            || iter_data_amount > L2) {
         ih_block_size = 1;
         num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
         work_amount *= num_ih_blocks;
     }
 
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-    int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+    dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+    dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
     bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-    int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+    dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+    dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
 
     const bool is_ddst_layout_nxc = one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-    const int oc_step = is_ddst_layout_nxc ? jcp.nb_oc_blocking : 1;
+    const dim_t oc_step = is_ddst_layout_nxc ? jcp.nb_oc_blocking : 1;
 
     auto ker = [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        size_t n {0}, g {0}, icbb {0}, ihb {0};
+        dim_t n {0}, g {0}, icbb {0}, ihb {0};
         nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, icbb, icb_work, ihb,
                 num_ih_blocks);
-        for (size_t iwork = start; iwork < end; ++iwork) {
-            for_(int oc = 0; oc < jcp.nb_oc; oc += jcp.nb_oc_blocking)
-            for (int id = 0; id < jcp.id; ++id) {
-                int cur_nb_oc = nstl::min(jcp.nb_oc - oc, jcp.nb_oc_blocking);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            for_(dim_t oc = 0; oc < jcp.nb_oc; oc += jcp.nb_oc_blocking)
+            for (dim_t id = 0; id < jcp.id; ++id) {
+                const dim_t cur_nb_oc
+                        = nstl::min<dim_t>(jcp.nb_oc - oc, jcp.nb_oc_blocking);
 
                 auto par_conv = jit_conv_args_t();
 
-                int d_t_overflow, d_b_overflow, od;
+                dim_t d_t_overflow, d_b_overflow, od;
                 if (jcp.dilate_d != 0) { // stride == 1
-                    const int dilate_d = jcp.dilate_d + 1;
-                    d_t_overflow
-                            = div_up(nstl::max(0, ext_kd - 1 - id - jcp.f_pad),
-                                    dilate_d);
+                    const dim_t dilate_d = jcp.dilate_d + 1;
+                    d_t_overflow = div_up(
+                            nstl::max<dim_t>(0, ext_kd - 1 - id - jcp.f_pad),
+                            dilate_d);
                     d_b_overflow = div_up(
-                            nstl::max(0, ext_kd - jcp.id + id - jcp.back_pad),
+                            nstl::max<dim_t>(
+                                    0, ext_kd - jcp.id + id - jcp.back_pad),
                             dilate_d);
                     od = id + jcp.f_pad - d_b_overflow * dilate_d;
                 } else {
-                    d_t_overflow = nstl::max(0, jcp.kd - 1 - id - jcp.f_pad);
-                    d_b_overflow = nstl::max(
+                    d_t_overflow
+                            = nstl::max<dim_t>(0, jcp.kd - 1 - id - jcp.f_pad);
+                    d_b_overflow = nstl::max<dim_t>(
                             0, jcp.kd - 1 - (jcp.id - 1 - id) - jcp.back_pad);
                     od = id + jcp.f_pad - d_b_overflow;
                 }
                 par_conv.kd_padding = jcp.kd - d_t_overflow - d_b_overflow;
 
-                int ih_start = ihb * ih_block_size;
-                int ih_end = nstl::min(jcp.ih, ih_start + ih_block_size);
-                for (int ih = ih_start; ih < ih_end; ++ih) {
+                dim_t ih_start = ihb * ih_block_size;
+                dim_t ih_end
+                        = nstl::min<dim_t>(jcp.ih, ih_start + ih_block_size);
+                for (dim_t ih = ih_start; ih < ih_end; ++ih) {
 
-                    int k_lo, oh;
+                    dim_t k_lo, oh;
                     if (jcp.dilate_h != 0) { // stride == 1
-                        const int dilate_h = jcp.dilate_h + 1;
-                        int i_t_overflow = div_up(
-                                nstl::max(0, ext_kh - 1 - ih - jcp.t_pad),
-                                dilate_h);
-                        int i_b_overflow = div_up(
-                                nstl::max(0, ext_kh - jcp.ih + ih - jcp.b_pad),
+                        const dim_t dilate_h = jcp.dilate_h + 1;
+                        dim_t i_t_overflow
+                                = div_up(nstl::max<dim_t>(0,
+                                                 ext_kh - 1 - ih - jcp.t_pad),
+                                        dilate_h);
+                        dim_t i_b_overflow = div_up(
+                                nstl::max<dim_t>(
+                                        0, ext_kh - jcp.ih + ih - jcp.b_pad),
                                 dilate_h);
                         par_conv.kh_padding
                                 = jcp.kh - i_t_overflow - i_b_overflow;
                         k_lo = i_b_overflow;
                         oh = ih + jcp.t_pad - k_lo * dilate_h;
                     } else {
-                        int i_t_overflow = nstl::max(0,
+                        dim_t i_t_overflow = nstl::max<dim_t>(0,
                                 (jcp.kh - 1 - ih - jcp.t_pad) / jcp.stride_h);
-                        int i_b_overflow = nstl::max(0,
+                        dim_t i_b_overflow = nstl::max<dim_t>(0,
                                 (jcp.kh - jcp.ih + ih - jcp.b_pad)
                                         / jcp.stride_h);
-                        int overflow_kh_hi = jcp.kh - 1
+                        dim_t overflow_kh_hi = jcp.kh - 1
                                 - modulo(jcp.ih - 1 + jcp.b_pad - ih,
                                         jcp.stride_h);
-                        int overflow_kh_lo = (ih + jcp.t_pad) % jcp.stride_h;
+                        dim_t overflow_kh_lo = (ih + jcp.t_pad) % jcp.stride_h;
 
                         par_conv.kh_padding = (overflow_kh_hi - overflow_kh_lo)
                                         / jcp.stride_h
@@ -325,8 +333,7 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
                     if (is_ddst_layout_nxc) {
                         par_conv.load_work = this_block_size(
                                 icbb * jcp.nb_ic_blocking * jcp.ic_block,
-                                (size_t)jcp.ic,
-                                jcp.nb_ic_blocking * jcp.ic_block);
+                                jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
                         par_conv.reduce_work
                                 = this_block_size(oc * jcp.oc_block, jcp.oc,
                                         oc_step * jcp.oc_block);
@@ -380,50 +387,52 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
 
     bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-    int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+    dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+    dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
     bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
     bool is_ddst_layout_nxc = !is_oc_physically_blocked;
-    int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-    int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+    dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+    dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
 
     auto ker = [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         assert(nthr == rw->balancer().nthr_);
 
-        const int w_job_start = rw->balancer().ithr_job_off(ithr);
+        const dim_t w_job_start = rw->balancer().ithr_job_off(ithr);
         const int w_njobs = rw->balancer().ithr_njobs(ithr);
 
         if (w_njobs == 0) return;
 
         /* reduction dimension */
-        int img_od_start {0}, img_od_end {0}, img {0}, od_s {0};
+        dim_t img_od_start {0}, img_od_end {0};
+        dim_t img {0}, od_s {0};
         balance211(jcp.mb * jcp.od, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), img_od_start, img_od_end);
 
-        int img_start = img_od_start, img_end = img_od_end;
+        dim_t img_start = img_od_start;
+        dim_t img_end = img_od_end;
         nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-        const int img_first = img;
+        const dim_t img_first = img;
 
         /* jobs */
-        int g_start {0}, ocb_start {0}, icb_start {0};
+        dim_t g_start {0}, ocb_start {0}, icb_start {0};
         nd_iterator_init(w_job_start, g_start, jcp.ngroups, ocb_start,
                 jcp.nb_oc, icb_start, jcp.nb_ic);
 
         while (img_start < img_end) {
-            int g = g_start, ocb = ocb_start, icb = icb_start;
+            dim_t g = g_start, ocb = ocb_start, icb = icb_start;
 
-            const int work_rem = img_end - img_start;
-            const int od_e
+            const dim_t work_rem = img_end - img_start;
+            const dim_t od_e
                     = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-            const int id_s = od_s * jcp.stride_d;
-            const int idp = jcp.id + jcp.f_pad + jcp.back_pad;
+            const dim_t id_s = od_s * jcp.stride_d;
+            const dim_t idp = jcp.id + jcp.f_pad + jcp.back_pad;
 
             if (id_s < idp - jcp.back_pad - jcp.kd + 1)
                 for (int w_job_loc = 0; w_job_loc < w_njobs; ++w_job_loc) {
-                    const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
-                    const size_t _ic = g * g_ic_offset + icb * icb_ic_scale;
+                    const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                    const dim_t _ic = g * g_ic_offset + icb * icb_ic_scale;
 
                     /* TODO: put dw <-- 0 in kernel */
                     if (img == img_first)
@@ -432,8 +441,8 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                                         + w_job_loc * rw->balancer().job_size_,
                                 0, rw->balancer().job_size_);
 
-                    for (int od = od_s; od < od_e; ++od) {
-                        const int id = od * jcp.stride_d;
+                    for (dim_t od = od_s; od < od_e; ++od) {
+                        const dim_t id = od * jcp.stride_d;
                         if (id >= jcp.id - jcp.back_pad - jcp.kd + 1) break;
 
                         auto par_conv = jit_conv_args_t();
@@ -466,25 +475,25 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
     auto ker_bias = [=](int ithr, int nthr) {
         assert(nthr == rb->balancer().nthr_);
 
-        const int b_job_start = rb->balancer().ithr_job_off(ithr);
+        const dim_t b_job_start = rb->balancer().ithr_job_off(ithr);
         const int b_njobs = rb->balancer().ithr_njobs(ithr);
 
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
-        int g_start {0}, ocb_start {0};
+        dim_t g_start {0}, ocb_start {0};
         nd_iterator_init(
                 b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
 
-        for (int img = img_start; img < img_end; ++img) {
-            int g = g_start, ocb = ocb_start;
+        for (dim_t img = img_start; img < img_end; ++img) {
+            dim_t g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
 
                 const data_t *d_dst = &diff_dst[diff_dst_d.blk_off(img, _oc)];
                 data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
@@ -492,15 +501,15 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                         + b_job_loc * rb->balancer().job_size_;
 
                 if (img == img_start)
-                    for (int o = 0; o < jcp.oc_block; ++o)
+                    for (dim_t o = 0; o < jcp.oc_block; ++o)
                         d_bias[o] = 0.;
 
-                const int max_oc = this_block_size(
+                const dim_t max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
-                for (int dhw = 0; dhw < jcp.od * jcp.oh * jcp.ow; ++dhw) {
+                for (dim_t dhw = 0; dhw < jcp.od * jcp.oh * jcp.ow; ++dhw) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                                 : jcp.oc_block;
@@ -546,9 +555,9 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
     parallel(1, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         /* TODO: put this in ker_bias */
         if (pd()->with_bias() && (jcp.oc_without_padding % jcp.oc_block != 0)) {
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g)
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g)
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
         }

--- a/src/cpu/x64/jit_avx2_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_convolution.cpp
@@ -203,8 +203,8 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
     const auto &jcp = kernel_->jcp;
 
     dim_t icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
-    dim_t ih_block_size = jcp.ih;
-    dim_t num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
+    int ih_block_size = jcp.ih;
+    int num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
     dim_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
 
     const auto data_size = sizeof(data_t);
@@ -275,10 +275,9 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
                 }
                 par_conv.kd_padding = jcp.kd - d_t_overflow - d_b_overflow;
 
-                dim_t ih_start = ihb * ih_block_size;
-                dim_t ih_end
-                        = nstl::min<dim_t>(jcp.ih, ih_start + ih_block_size);
-                for (dim_t ih = ih_start; ih < ih_end; ++ih) {
+                int ih_start = static_cast<int>(ihb * ih_block_size);
+                int ih_end = nstl::min(jcp.ih, ih_start + ih_block_size);
+                for (int ih = ih_start; ih < ih_end; ++ih) {
 
                     dim_t k_lo, oh;
                     if (jcp.dilate_h != 0) { // stride == 1
@@ -405,8 +404,8 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
         if (w_njobs == 0) return;
 
         /* reduction dimension */
-        dim_t img_od_start {0}, img_od_end {0};
-        dim_t img {0}, od_s {0};
+        int img_od_start {0}, img_od_end {0};
+        int img {0}, od_s {0};
         balance211(jcp.mb * jcp.od, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), img_od_start, img_od_end);
 
@@ -481,7 +480,7 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        dim_t img_start {0}, img_end {0};
+        int img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -307,14 +307,17 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
 
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(max_threads,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
 
             reducer_wei_conf_.init(reduce_balancer_t(max_threads,
-                    jcp_.kd * jcp_.kh * jcp_.kw * jcp_.ic_block * jcp_.oc_block,
-                    jcp_.ngroups * jcp_.nb_ic * jcp_.nb_oc, jcp_.mb * jcp_.od,
-                    max_buffer_size, true));
+                    static_cast<int>(jcp_.kd * jcp_.kh * jcp_.kw * jcp_.ic_block
+                            * jcp_.oc_block),
+                    static_cast<int>(jcp_.ngroups * jcp_.nb_ic * jcp_.nb_oc),
+                    static_cast<int>(jcp_.mb * jcp_.od), max_buffer_size,
+                    true));
         }
     };
 


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the AVX2 1x1/general JIT convolution kernels (`jit_avx2_1x1_conv_kernel_f32`, `jit_avx2_1x1_convolution`, `jit_avx2_conv_kernel_f32`, `jit_avx2_convolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5665 for review convenience; independently reviewable.