### PR TITLE
cpu: conv: SSE41: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -47,7 +47,7 @@ jit_sse41_1x1_conv_kernel_f32_t::jit_sse41_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t tail_size = jcp.oc_without_padding % simd_w_;
+        const dim_t tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -77,7 +77,7 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const int num_substeps = static_cast<int>(jcp.bcast_block / jcp.ur);
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
             generate_reduce_loop(load_loop_blk, jcp.ur);
@@ -422,7 +422,9 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate_diff_bias_loop(
         movups(diff_bias_ptr(i, 1), diff_bias_reg(i, 1));
     }
 
-    add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float));
+    add(reg_diff_bias_data,
+            static_cast<uint32_t>(
+                    load_loop_blk * jcp.oc_block * sizeof(float)));
     mov(ptr[rsp + reg_diff_bias_data_stack_offt], reg_diff_bias_data);
 
     L(diff_bias_loop_out);
@@ -473,18 +475,21 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate() {
             case forward_training:
             case forward_inference:
                 add(reg_bias_data,
-                        load_loop_blk * jcp.oc_block * sizeof(float));
-                add(reg_output_data, offst_with_dw_conv);
+                        static_cast<uint32_t>(
+                                load_loop_blk * jcp.oc_block * sizeof(float)));
+                add(reg_output_data, static_cast<uint32_t>(offst_with_dw_conv));
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            static_cast<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(ptr[rsp + reg_dw_binary_output_off], aux_reg_load_data);
                 }
                 break;
             case backward_data:
                 add(reg_output_data,
-                        load_loop_blk * jcp.is * jcp.ic_block * sizeof(float));
+                        static_cast<uint32_t>(load_loop_blk * jcp.is
+                                * jcp.ic_block * sizeof(float)));
                 break;
             case backward_weights:
                 for (int i = 0; i < load_loop_blk; i++)
@@ -669,7 +674,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking parameters");
 
     jcp.ur = 1;
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
     int load_blocking {0};
     int load_blocking_max {0};
@@ -704,12 +710,13 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         jcp.load_loop_iter_step = jcp.oc_block;
 
         load_blocking = is_data_layout_nxc
-                ? jcp.load_dim
+                ? static_cast<int>(jcp.load_dim)
                 : 120; // assumes the kernel is jcp.ur x 3
-        load_blocking_max = is_data_layout_nxc ? jcp.load_dim : 144;
+        load_blocking_max
+                = is_data_layout_nxc ? static_cast<int>(jcp.load_dim) : 144;
         bcast_blocking = 128; // affects load balancing across threads
         bcast_blocking_max = 192;
-        reduce_blocking = is_data_layout_nxc ? jcp.reduce_dim
+        reduce_blocking = is_data_layout_nxc ? static_cast<int>(jcp.reduce_dim)
                                              : 128; // affects L1$ utilization
     } else if (jcp.prop_kind == backward_data) {
         jcp.reduce_dim = jcp.oc;
@@ -767,7 +774,7 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
         /* --- */
 
-        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
         while (true) {
             if (load_blocking <= 32)
                 break;
@@ -782,7 +789,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         load_blocking_max = load_blocking;
         assert(jcp.load_dim % load_blocking == 0);
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         while (true) {
             if (bcast_blocking <= 9)
                 break;
@@ -808,7 +816,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     assert(reduce_blocking);
 
     assert(jcp.bcast_block % jcp.ur == 0);
-    jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur;
+    jcp.ur_tail = static_cast<int>(
+            (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur);
 
     jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
     jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -47,7 +47,7 @@ jit_sse41_1x1_conv_kernel_f32_t::jit_sse41_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const dim_t tail_size = jcp.oc_without_padding % simd_w_;
+        const std::size_t tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -574,25 +574,26 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
     jcp.prop_kind = cd.prop_kind;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kh = (ndims == 3) ? 1
+                          : static_cast<int>(weights_d.dims()[with_groups + 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][0]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[0];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[0]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
@@ -825,9 +826,9 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_load_blocking_max = load_blocking_max / jcp.load_block;
     jcp.nb_reduce_blocking = reduce_blocking / jcp.reduce_block;
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     return status::success;
 }

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -86,7 +86,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     auto par_conv = jit_1x1_conv_args_t();
 
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     const dim_t nb_ic = jcp.nb_reduce;
     const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
@@ -277,9 +277,9 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, dim_t(1));
+                bcast_end, nb_oc, ocb_start, ocb_end, 1);
 
         while (ocb_start < ocb_end) {
             dim_t load_step;

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -48,7 +48,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward(
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_ != nullptr
             ? binary_injector::prepare_binary_args(
                       pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -85,18 +86,19 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     auto par_conv = jit_1x1_conv_args_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
     const bool is_dst_layout_nxc = utils::one_of(
@@ -107,25 +109,25 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     // Begin: declare Variables needed for dw conv.
     data_t *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<data_t *> addrs;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int &n, int &g, int &bcast_step, int bcast_end,
-                      int &oh, int &ow, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t &n, dim_t &g, dim_t &bcast_step,
+                              dim_t bcast_end, dim_t &oh, dim_t &ow, dim_t &ih,
+                              dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
 
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         ow = os % jcp.ow;
         oh = os / jcp.ow;
 
@@ -135,19 +137,19 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         par_conv.bcast_dim = this_block_size(os, jcp.os, bcast_step * os_block);
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         par_conv.load_dim = this_block_size(
                 ocb * jcp.oc_block, jcp.oc, load_step * jcp.oc_block);
     };
 
-    auto inner_ker = [&](int ocb, int icb, int n, int g, int oh, int ow, int ih,
-                             int iw) {
-        const size_t _ocb = g * nb_oc + ocb;
-        const size_t _icb = g * nb_ic + icb;
+    auto inner_ker = [&](dim_t ocb, dim_t icb, dim_t n, dim_t g, dim_t oh,
+                             dim_t ow, dim_t ih, dim_t iw) {
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g * nb_ic + icb;
 
-        const int oc_off_idx = (is_dst_layout_nxc ? jcp.oc_block : 1) * _ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, oh, ow);
+        const dim_t oc_off_idx = (is_dst_layout_nxc ? jcp.oc_block : 1) * _ocb;
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, oh, ow);
         par_conv.output_data = jcp.with_dw_conv
                 ? pbuf + (oh % pd()->dw_conv_pd_->jcp_.kh) * row_offset
                 : &dst[dst_off];
@@ -160,7 +162,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         par_conv.reduce_dim = this_block_size(
                 icb * jcp.ic_block, jcp.ic, nb_ic_blocking * jcp.ic_block);
 
-        const int ic_off_idx = (is_src_layout_nxc ? jcp.ic_block : 1) * _icb;
+        const dim_t ic_off_idx = (is_src_layout_nxc ? jcp.ic_block : 1) * _icb;
 
         const size_t src_off = data_blk_off(src_d, n, ic_off_idx, ih, iw);
         par_conv.bcast_data = &src[src_off];
@@ -176,19 +178,20 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         (*kernel_)(&par_conv);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
 
-        int iwork = bcast_start;
+        dim_t iwork = bcast_start;
         while (iwork < bcast_end) {
-            int n {0}, g {0}, bcast_step, oh, ow, ih, iw;
+            dim_t n {0}, g {0}, oh, ow, ih, iw;
+            dim_t bcast_step;
             init_bcast(iwork, n, g, bcast_step, bcast_end, oh, ow, ih, iw);
-            int ocb = 0;
+            dim_t ocb = 0;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                     inner_ker(ocb, icb, n, g, oh, ow, ih, iw);
                 }
                 ocb += load_step;
@@ -197,9 +200,10 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
 
         for (int i = 0; i < jcp_dw.kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw.kh) * row_offset;
@@ -207,31 +211,31 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         const auto ocb_end = ocb_start + load_step;
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw.iw)
                 * jcp_dw.nb_ch_blocking * jcp_dw.ch_block;
-        const int dil_h = jcp_dw.dilate_h + 1;
-        const int str_h = jcp_dw.stride_h;
-        const int ch_num = jcp_dw.nb_ch_blocking;
+        const dim_t dil_h = jcp_dw.dilate_h + 1;
+        const dim_t str_h = jcp_dw.stride_h;
+        const dim_t ch_num = jcp_dw.nb_ch_blocking;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw.t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw.ih,
-                              (int)(dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
-                                      - jcp_dw.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw.t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw.ih,
+                              dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
+                                      - jcp_dw.t_pad + 1)
                     - jcp_dw.ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            const int ow = 0;
-            const int kw = 0;
+            const dim_t ow = 0;
+            const dim_t kw = 0;
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw.ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -242,9 +246,10 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw.ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw.nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw.nb_ch) - ch)
                     * jcp_dw.ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -272,37 +277,40 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+                bcast_end, nb_oc, ocb_start, ocb_end, dim_t(1));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw.oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw.kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_range
+                        = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw.kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
                 oh_1x1 = oh_1x1_end;
-                ker_dw(n, g * nb_oc + ocb_start, load_step, oh_dw);
+                ker_dw(n, static_cast<int>(g * nb_oc + ocb_start), load_step,
+                        oh_dw);
 
                 bcast_iter += nb_bcast_blocking;
             }
@@ -313,8 +321,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int start {0}, end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -399,28 +399,29 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     const int ndims = src_d.ndims();
     jcp.ndims = ndims;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
 
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
 
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[2];
-    jcp.ow = dst_d.dims()[ndims - 1];
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
 
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
+    jcp.kh = (ndims == 3) ? 1
+                          : static_cast<int>(weights_d.dims()[with_groups + 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
 
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][0];
-    jcp.l_pad = cd.padding[0][ndims - 3];
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][0]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
 
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[0];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[0]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
-    jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[0];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_h = (ndims == 3) ? 0 : static_cast<int>(cd.dilates[0]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -297,14 +297,14 @@ inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     const int ur_w = jcp.ur_w;
     const int ur_w_tail = jcp.ur_w_tail;
     int n_oi = static_cast<int>(jcp.ow / ur_w);
-    const dim_t iw = jcp.iw;
-    const dim_t kw = jcp.kw;
-    const dim_t str_w = jcp.stride_w;
+    const int iw = jcp.iw;
+    const int kw = jcp.kw;
+    const int str_w = jcp.stride_w;
 
     const dim_t l_pad = jcp.l_pad;
     int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
-    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
-            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
+    int r_pad1 = calculate_end_padding(static_cast<int>(l_pad), ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
@@ -422,8 +422,8 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[0];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -46,7 +46,7 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const dim_t tail_size = jcp.oc_without_padding % simd_w_;
+        const std::size_t tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -46,7 +46,7 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t tail_size = jcp.oc_without_padding % simd_w_;
+        const dim_t tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -65,17 +65,18 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
 
 void jit_sse41_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int dilate_w = jcp.dilate_w + 1;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const int ic_blk = static_cast<int>(jcp.ic_block);
 
     for (int ki = 0; ki < kw; ki++) {
-        int jj_start = div_up(nstl::max(0, pad_l - ki * dilate_w), stride_w);
-        int jj_end = ur_w
-                - div_up(nstl::max(0,
+        int jj_start = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, pad_l - ki * dilate_w), stride_w));
+        int jj_end = static_cast<int>(ur_w
+                - div_up(nstl::max<dim_t>(0,
                                  ki * dilate_w + pad_r - (kw - 1) * dilate_w),
-                        stride_w);
+                        stride_w));
         for (int ifm2 = 0; ifm2 < ic_blk; ifm2++) {
             for (int jj = jj_start; jj < jj_end; jj++) {
                 size_t inp_off = get_input_offset(
@@ -103,8 +104,8 @@ void jit_sse41_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
-    int kw = jcp.kw;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    const int ic_blk = static_cast<int>(jcp.ic_block);
 
     xor_(ki_iter, ki_iter);
     L(kw_loop);
@@ -182,8 +183,8 @@ void jit_sse41_conv_fwd_kernel_f32_t::apply_postops(
 
 void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int oc_blk = jcp.oc_block;
+    const int kw = static_cast<int>(jcp.kw);
+    const int oc_blk = static_cast<int>(jcp.oc_block);
 
     xor_(simd_iter, simd_iter);
 
@@ -293,25 +294,27 @@ void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
 }
 
 inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
-    int ur_w = jcp.ur_w;
-    int ur_w_tail = jcp.ur_w_tail;
-    int n_oi = jcp.ow / ur_w;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int str_w = jcp.stride_w;
+    const int ur_w = jcp.ur_w;
+    const int ur_w_tail = jcp.ur_w_tail;
+    int n_oi = static_cast<int>(jcp.ow / ur_w);
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t str_w = jcp.stride_w;
 
-    int l_pad = jcp.l_pad;
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, str_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    const dim_t l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
         n_oi--;
         if (n_oi < 0 && r_pad1 > 0)
-            width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), r_pad1,
+                    oc_blocks); // "lrpad"
         else
-            width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), 0,
+                    oc_blocks); // "lpad"
         add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
         add(reg_output, get_output_offset(0, ur_w));
     }
@@ -419,8 +422,8 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[0];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -504,7 +507,7 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ur_h = 1; /* no code-unrolling by h so far */
     jcp.ur_w = 3;
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.nb_oc_blocking
@@ -517,24 +520,26 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(mimo, jcp.ic % simd_w == 0);
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BLOCKING_FAIL, "bad parameters");
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
 
     // kernel needs 1 temporary YMM register
     const int num_avail_regs = 15;
     if (r_pad_no_tail > jcp.ur_w * jcp.stride_w && jcp.ow / jcp.ur_w > 1) {
         /* recalculate ur_w, nb_oc_blocking and ur_w_tail */
-        jcp.ur_w = nstl::min(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
-                nstl::min(jcp.ow, num_avail_regs / 2));
+        jcp.ur_w = static_cast<int>(
+                nstl::min<dim_t>(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
+                        nstl::min<dim_t>(jcp.ow, num_avail_regs / 2)));
         jcp.nb_oc_blocking = (num_avail_regs - jcp.ur_w) / jcp.ur_w;
-        jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+        jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
         /* check again ... */
-        r_pad_no_tail = nstl::max(0,
+        r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                        jcp.stride_w, ext_kw));
+                        jcp.stride_w, ext_kw)));
 
-        VDISPATCH_CONV_IC(jcp.ur_w >= nstl::max(jcp.l_pad, r_pad_no_tail),
+        VDISPATCH_CONV_IC(
+                jcp.ur_w >= nstl::max<dim_t>(jcp.l_pad, r_pad_no_tail),
                 VERBOSE_UNSUPPORTED_PAD_FEATURE,
                 "width unroll exceeds padding size");
     }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
@@ -73,51 +73,47 @@ private:
     inline void width_blk_step(int ur_w, int pad_l, int pad_r, int oc_blocks);
     inline void solve_common(int oc_blocks);
 
-    inline dim_t filter_w_to_input(int ki, int oi = 0, int pad_l = 0) const {
-        return static_cast<dim_t>(ki) * (jcp.dilate_w + 1)
-                + static_cast<dim_t>(oi) * jcp.stride_w - pad_l;
+    inline dim_t filter_w_to_input(
+            dim_t ki, dim_t oi = 0, dim_t pad_l = 0) const {
+        return ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
     }
 
-    inline dim_t filter_h_to_input(int ki) const {
-        return static_cast<dim_t>(ki) * (jcp.dilate_h + 1) * jcp.iw;
+    inline dim_t filter_h_to_input(dim_t ki) const {
+        return ki * (jcp.dilate_h + 1) * jcp.iw;
     }
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(dim_t i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
-            offset = static_cast<dim_t>(i_ic) * jcp.ih * jcp.iw + i_iw;
+            offset = i_ic * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_output_offset(int i_oc_block, int i_ow) const {
+    inline dim_t get_output_offset(dim_t i_oc_block, dim_t i_ow) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block;
         } else {
-            offset = (static_cast<dim_t>(i_oc_block) * jcp.oh * jcp.ow + i_ow)
-                    * jcp.oc_block;
+            offset = (i_oc_block * jcp.oh * jcp.ow + i_ow) * jcp.oc_block;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_kernel_offset(int i_oc_block, int ki, int i_ic) const {
-        dim_t block_step_size = static_cast<dim_t>(jcp.ic_block) * jcp.oc_block;
-        dim_t ic_block_step_size
-                = static_cast<dim_t>(jcp.kh) * jcp.kw * block_step_size;
-        dim_t oc_block_step_size
-                = static_cast<dim_t>(jcp.nb_ic) * ic_block_step_size;
-        dim_t offset = static_cast<dim_t>(i_oc_block) * oc_block_step_size
-                + static_cast<dim_t>(ki) * block_step_size
-                + static_cast<dim_t>(i_ic) * jcp.oc_block;
+    inline dim_t get_kernel_offset(
+            dim_t i_oc_block, dim_t ki, dim_t i_ic) const {
+        dim_t block_step_size = jcp.ic_block * jcp.oc_block;
+        dim_t ic_block_step_size = jcp.kh * jcp.kw * block_step_size;
+        dim_t oc_block_step_size = jcp.nb_ic * ic_block_step_size;
+        dim_t offset = i_oc_block * oc_block_step_size + ki * block_step_size
+                + i_ic * jcp.oc_block;
         return sizeof(float) * offset;
     }
 

--- a/src/cpu/x64/jit_sse41_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_convolution.cpp
@@ -52,7 +52,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const memory_desc_wrapper bias_d(pd()->weights_md(1));
 
-    int ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const dim_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
     const size_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.oh;
 
     const bool is_src_layout_nxc
@@ -66,26 +66,27 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         size_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int icbb = 0;
+        dim_t icbb = 0;
         while (icbb < jcp.nb_ic) {
-            int icb_step = jcp.nb_ic_blocking;
-            int icb_step_rem = jcp.nb_ic - icbb;
+            dim_t icb_step = jcp.nb_ic_blocking;
+            const dim_t icb_step_rem = jcp.nb_ic - icbb;
             if (icb_step_rem < jcp.nb_ic_blocking_max) icb_step = icb_step_rem;
 
             size_t n {0}, g {0}, ocbb {0}, oh {0};
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     oh, jcp.oh);
             for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
-                int ocb_num = jcp.nb_oc_blocking;
+                const dim_t ocb = ocbb * jcp.nb_oc_blocking;
+                const dim_t ocb_num = jcp.nb_oc_blocking;
 
-                for (int icb = icbb; icb < icbb + icb_step; ++icb) {
+                for (dim_t icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
-                    const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
-                    const int i_b_overflow
-                            = nstl::max(jcp.ih,
+                    const dim_t ij = oh * jcp.stride_h;
+                    const dim_t i_t_overflow
+                            = nstl::max<dim_t>(0, jcp.t_pad - ij);
+                    const dim_t i_b_overflow
+                            = nstl::max<dim_t>(jcp.ih,
                                       ij + (jcp.kh - 1) * (jcp.dilate_h + 1)
                                               - jcp.t_pad + 1)
                             - jcp.ih;
@@ -97,7 +98,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                             = g * (is_src_layout_nxc ? jcp.ic : jcp.nb_ic)
                             + icb * (is_src_layout_nxc ? jcp.ic_block : 1);
 
-                    const int ih = nstl::max(ij - jcp.t_pad
+                    const dim_t ih = nstl::max<dim_t>(ij - jcp.t_pad
                                     + div_up(i_t_overflow, (jcp.dilate_h + 1))
                                             * (jcp.dilate_h + 1),
                             0);
@@ -105,7 +106,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
                     par_conv.dst = &dst[src_blk_off(dst_d, n, _oc, oh, 0)];
 
-                    const int wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
+                    const dim_t wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
                     par_conv.filt = &weights[wht_blk_off(
                             weights_d, g, ocb, icb, wh, 0)];
 
@@ -122,13 +123,13 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                     }
 
                     par_conv.oc_blocks
-                            = nstl::min(ocb + ocb_num, jcp.nb_oc) - ocb;
+                            = nstl::min<dim_t>(ocb + ocb_num, jcp.nb_oc) - ocb;
 
                     par_conv.kw_padding = 0;
-                    const int kh_padding = jcp.kh
+                    const dim_t kh_padding = jcp.kh
                             - div_up(i_t_overflow, (jcp.dilate_h + 1))
                             - div_up(i_b_overflow, (jcp.dilate_h + 1));
-                    par_conv.kh_padding = nstl::max(0, kh_padding);
+                    par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
                     par_conv.post_ops_binary_rhs_arg_vec
                             = post_ops_binary_rhs_arg_vec.data();


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the SSE41 1x1/general JIT convolution kernels (`jit_sse41_1x1_conv_kernel_f32`, `jit_sse41_1x1_convolution`, `jit_sse41_conv_kernel_f32`, `jit_sse41_convolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5666 for review convenience; independently reviewable.