### PR TITLE
cpu: conv: universal x8s8s32x: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -59,13 +59,14 @@ void jit_uni_deconv_zp_pad_str_kernel_base_t::compute() {
     for (dim_t icb = 0; icb < jcp_.nb_ic; ++icb) {
         const bool is_last_icb = icb == jcp_.nb_ic - 1;
 
-        const int n_inner_ic_blk = jcp_.is_depthwise
-                ? 1
-                : (is_last_icb && ic_tail_exists
-                                  ? utils::div_up(jcp_.ic_without_padding
-                                                    % jcp_.ic_block,
-                                            4)
-                                  : (jcp_.ic_block / 4));
+        const int n_inner_ic_blk = static_cast<int>(jcp_.is_depthwise
+                        ? 1
+                        : (is_last_icb && ic_tail_exists
+                                          ? utils::div_up(
+                                                    jcp_.ic_without_padding
+                                                            % jcp_.ic_block,
+                                                    4)
+                                          : (jcp_.ic_block / 4)));
 
         const dim_t outer_wei_offset = icb * outer_icb_step;
 
@@ -82,10 +83,14 @@ template <cpu_isa_t isa, typename Vmm>
 jit_uni_deconv_zp_pad_str_kernel_t<isa,
         Vmm>::jit_uni_deconv_zp_pad_str_kernel_t(const jit_conv_conf_t &jcp)
     : jit_uni_deconv_zp_pad_str_kernel_base_t(jcp)
-    , result_acc_(reserve_vmm())
-    , vmm_tmp_((jcp.has_vnni || jcp.is_depthwise) ? 0 : reserve_vmm())
-    , vmm_one_bytes_(jcp.is_depthwise ? 0 : reserve_vmm())
-    , vmm_one_words_((jcp.has_vnni || jcp.is_depthwise) ? 0 : reserve_vmm())
+    , result_acc_(static_cast<int>(reserve_vmm()))
+    , vmm_tmp_((jcp.has_vnni || jcp.is_depthwise)
+                      ? 0
+                      : static_cast<int>(reserve_vmm()))
+    , vmm_one_bytes_(jcp.is_depthwise ? 0 : static_cast<int>(reserve_vmm()))
+    , vmm_one_words_((jcp.has_vnni || jcp.is_depthwise)
+                      ? 0
+                      : static_cast<int>(reserve_vmm()))
     , current_vmm_(number_reserved_vmms_) {}
 
 template <cpu_isa_t isa, typename Vmm>
@@ -158,7 +163,7 @@ template <cpu_isa_t isa, typename Vmm,
         typename T = std::integral_constant<bool, (isa < avx512_core)>>
 struct helper_store_t {
     static void store(jit_generator_t *gen, const Vmm &vmm,
-            const Xbyak::Reg64 &reg_dst, const size_t size,
+            const Xbyak::Reg64 &reg_dst, const int size,
             const Xbyak::Opmask &opmask) {
         gen->store_bytes(vmm, reg_dst, 0, size);
     }
@@ -168,7 +173,7 @@ using isa_at_least_avx512_core = std::false_type;
 template <cpu_isa_t isa, typename Vmm>
 struct helper_store_t<isa, Vmm, isa_at_least_avx512_core> {
     static void store(jit_generator_t *gen, const Vmm &vmm,
-            const Xbyak::Reg64 &reg_dst, const size_t size,
+            const Xbyak::Reg64 &reg_dst, const int size,
             const Xbyak::Opmask &opmask) {
         using namespace Xbyak::util;
         gen->vmovups(gen->ptr[reg_dst], vmm | opmask);
@@ -184,7 +189,7 @@ void jit_uni_deconv_zp_pad_str_kernel_t<isa, Vmm>::store_result() {
         cmp(reg_last_oc_block_, 0);
         je(store_no_tail, T_NEAR);
         helper_store_t<isa, Vmm>::store(this, result_acc_, reg_dst_,
-                tail_size_ * sizeof(int32_t), ktail_mask_);
+                static_cast<int>(tail_size_ * sizeof(int32_t)), ktail_mask_);
         jmp(end, T_NEAR);
     }
 
@@ -220,7 +225,7 @@ struct helper_create_deconv_ker_t {
     static jit_uni_deconv_zp_pad_str_kernel_base_t *
     create_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp) {
 
-        const int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+        const dim_t ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
         switch (ch_block) {
             case 8:
                 if (isa == avx2) {
@@ -242,7 +247,7 @@ template <cpu_isa_t isa>
 struct helper_create_deconv_ker_t<isa, isa_at_least_avx512_core> {
     static jit_uni_deconv_zp_pad_str_kernel_base_t *
     create_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp) {
-        const int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+        const dim_t ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
         switch (ch_block) {
             case 16:
                 return new jit_uni_deconv_zp_pad_str_kernel_t<avx512_core,
@@ -325,10 +330,10 @@ void compute_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp,
             : 1;
 
     parallel(nthrs, [=](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
+        dim_t ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, ch_b, jcp.nb_ch, oc_b, jcp.nb_oc, d, jcp.kd,
                     h, jcp.kh, w, jcp.kw);

--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -330,7 +330,7 @@ void compute_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp,
             : 1;
 
     parallel(nthrs, [=](const int ithr, const int nthr) {
-        dim_t start {0}, end {0};
+        int start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         dim_t ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -54,7 +54,7 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
-        const size_t tail_size = get_tail_size();
+        const dim_t tail_size = get_tail_size();
         static constexpr bool use_exact_tail_scalar_bcast = false;
         rhs_arg_static_params_t rhs_arg_static_params {15, r13, r14, r15,
                 preserve_gpr, preserve_vmm,
@@ -115,9 +115,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::bcast_loop(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
+dim_t jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
         const int i_load, const int i_ur) {
-    const size_t ur_stride = jcp.with_dw_conv
+    const dim_t ur_stride = jcp.with_dw_conv
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * i_ur;
 
@@ -163,7 +163,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_sum(const int ur,
 
             const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
             cvt2ps(jcp.sum_dt, ymm_prev_dst, aux_reg_output_data,
-                    output_ptr(i_load, i_ur),
+                    static_cast<int>(output_ptr(i_load, i_ur)),
                     mask_flag ? get_tail_size() : simd_w);
 
             if (sum_zp != 0) {
@@ -202,9 +202,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
         vmm_index_set_t vmm_idxs;
         if (jcp.with_binary) {
             iterate(ur, load_loop_blk, [&](const int i_ur, const int i_load) {
-                const int ur_stride
+                const dim_t ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
-                const size_t aux_output_offset = jcp.typesize_out
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (ur_stride + i_load * jcp.load_block);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -213,7 +213,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
                 rhs_arg_params_tail.vmm_idx_to_out_reg.emplace(
                         vmm_idx, aux_reg_output_data);
                 rhs_arg_params_tail.vmm_idx_to_out_elem_off_val.emplace(
-                        vmm_idx, aux_output_offset);
+                        vmm_idx, static_cast<size_t>(aux_output_offset));
                 if (mask_flag_in && (i_load + 1 == load_loop_blk))
                     rhs_arg_params_tail.vmm_tail_idx_.emplace(vmm_idx);
             });
@@ -266,19 +266,20 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
         assert(i_reduce <= jcp.reduce_loop_unroll);
         assert(jcp.reduce_loop_unroll == jcp.reduce_block);
 
-        int offt = (jcp.ic_without_padding * i_ur + i_reduce);
+        const dim_t offt = jcp.ic_without_padding * i_ur + i_reduce;
 
-        return ptr[aux_reg_bcast_data + jcp.typesize_in * offt];
+        return ptr[aux_reg_bcast_data
+                + static_cast<int>(jcp.typesize_in * offt)];
     };
 
     auto load_ptr = [&](int i_reduce, int i_load) {
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        const dim_t offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
 
         return ptr[aux_reg_load_data + u1 * jcp.reduce_loop_load_step
-                + jcp.typesize_in * offt];
+                + static_cast<int>(jcp.typesize_in * offt)];
     };
 
     auto init = [&]() {
@@ -323,10 +324,13 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
             if (jcp.signed_input) {
                 mov(reg_comp_data, ptr[rsp + reg_comp_data_off]);
                 cvt2ps(data_type::s32, vmm_comp, reg_comp_data,
-                        sizeof(int32_t) * jcp.oc_block * i_load, load_size);
+                        static_cast<int>(
+                                sizeof(int32_t) * jcp.oc_block * i_load),
+                        load_size);
             }
             if (jcp.src_zero_point) {
-                const int zp_offset = sizeof(int32_t) * i_load * jcp.oc_block;
+                const int zp_offset = static_cast<int>(
+                        sizeof(int32_t) * i_load * jcp.oc_block);
                 load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation,
                         zp_offset, load_size);
                 uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_zp);
@@ -363,8 +367,8 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                 if (!jcp.is_oc_scale) {
                     uni_vbroadcastss(vmm_scales_tmp, ptr[reg_wei_scales]);
                 } else {
-                    int scale_offset = jcp.is_oc_scale
-                            * (sizeof(float) * jcp.oc_block * i_load);
+                    const int scale_offset = static_cast<int>(jcp.is_oc_scale
+                            * (sizeof(float) * jcp.oc_block * i_load));
                     if (mask_flag) {
                         uni_vpxor(
                                 vmm_scales_tmp, vmm_scales_tmp, vmm_scales_tmp);
@@ -403,7 +407,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                 if (jcp.signed_input || jcp.with_dst_scales)
                     mov(reg_bias_data, ptr[rsp + reg_bias_data_off]);
                 cvt2ps(jcp.bia_dt, vmm_bias, reg_bias_data,
-                        jcp.typesize_bia * jcp.oc_block * i_load, load_size);
+                        static_cast<int>(
+                                jcp.typesize_bia * jcp.oc_block * i_load),
+                        load_size);
             }
 
             for (int i_ur = 0; i_ur < ur; ++i_ur) {
@@ -466,7 +472,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                         = mask_flag_in && i_load == load_loop_blk - 1;
                 auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                 store_data(jcp.dst_dt, r, aux_reg_output_data,
-                        output_ptr(i_load, i_ur),
+                        static_cast<int>(output_ptr(i_load, i_ur)),
                         mask_flag ? get_tail_size() : simd_w);
             }
         }
@@ -488,9 +494,10 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
     auto fma_block = [&](bool last_block) {
         int reduce_step = 4;
         int ic_tail_size = jcp.ic_without_padding % reduce_step;
-        int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
-                ? rnd_up(jcp.ic_without_padding % jcp.ic_block, reduce_step)
-                : jcp.reduce_loop_unroll;
+        const int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
+                ? static_cast<int>(rnd_up(
+                          jcp.ic_without_padding % jcp.ic_block, reduce_step))
+                : static_cast<int>(jcp.reduce_loop_unroll);
         for (int i_reduce = 0; i_reduce < loop_unroll;
                 i_reduce += reduce_step) {
             for (int i_load = 0; i_load < load_loop_blk; ++i_load)
@@ -625,21 +632,23 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::generate() {
         if (jcp.signed_input) {
             mov(reg_comp_data, ptr[rsp + reg_comp_data_off]);
             add(reg_comp_data,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(ptr[rsp + reg_comp_data_off], reg_comp_data);
         }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[rsp + reg_zp_compensation_off]);
             add(reg_zp_compensation,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(ptr[rsp + reg_zp_compensation_off], reg_zp_compensation);
         }
         mov(ptr[rsp + reg_bcast_data_off], reg_bcast_data);
         if (jcp.with_wei_scales) {
             mov(reg_wei_scales, ptr[rsp + reg_wei_scales_off]);
             add(reg_wei_scales,
-                    jcp.is_oc_scale * load_loop_blk * jcp.load_block
-                            * sizeof(float));
+                    static_cast<uint32_t>(jcp.is_oc_scale * load_loop_blk
+                            * jcp.load_block * sizeof(float)));
             mov(ptr[rsp + reg_wei_scales_off], reg_wei_scales);
         }
         mov(reg_bcast_data, ptr[rsp + reg_bcast_data_off]);
@@ -815,10 +824,13 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 512;
@@ -844,9 +856,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             && (jcp.oh <= size_threshold && jcp.ow <= size_threshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs = 3;
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
-        const int spatial = jcp.od * jcp.oh;
+        const dim_t spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
         for (int ur_w = max_regs; ur_w >= min_regs; ur_w--) {
             if ((spatial >= size_threshold && spatial % ur_w == 0)
@@ -856,7 +868,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -869,7 +881,8 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
         }
     }
 
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
     jcp.reduce_dim = jcp.ic;
     jcp.reduce_block = jcp.ic_block;
 
@@ -897,8 +910,10 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_bcast
+            = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    const int nb_reduce
+            = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -911,7 +926,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     bool cmp_reduce = reduce_blocking <= jcp.reduce_dim;
     if (cmp_reduce) jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
-    load_blocking = jcp.load_dim;
+    load_blocking = static_cast<int>(jcp.load_dim);
 
     jcp.load_grp_count = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
     jcp.load_grp_count = best_divider(
@@ -923,24 +938,26 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     } else if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.mb <= jcp.nthr
             && jcp.load_dim > 256 && jcp.load_dim / jcp.reduce_dim >= 4) {
         jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
-        load_blocking = jcp.load_block;
+        load_blocking = static_cast<int>(jcp.load_block);
     }
 
-    bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                             div_up(jcp.nthr, jcp.load_grp_count))
-            * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
-    bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                       div_up(jcp.nthr, jcp.load_grp_count))
+                    * jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
+    bcast_blocking = static_cast<int>(rnd_up(bcast_blocking, jcp.bcast_block));
 
-    int space_for_bcast = (L2_capacity - /* kernel_size - */
+    dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
             2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
             - 3 * 1024);
     if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
 
-    int bcast_in_cache
-            = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-    bcast_blocking = nstl::min(
-            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+    const dim_t bcast_in_cache = nstl::max<dim_t>(
+            jcp.bcast_block, space_for_bcast / reduce_blocking);
+    bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
     load_blocking_max = load_blocking;
     bcast_blocking_max = bcast_blocking * 3 / 2;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -54,7 +54,7 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
-        const dim_t tail_size = get_tail_size();
+        const std::size_t tail_size = get_tail_size();
         static constexpr bool use_exact_tail_scalar_bcast = false;
         rhs_arg_static_params_t rhs_arg_static_params {15, r13, r14, r15,
                 preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -728,27 +728,30 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     const int ndims = src_d.ndims();
     jcp.nthr = nthreads;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = (ndims == 5) ? src_d.dims()[2] : 1;
-    jcp.ih = (ndims == 3) ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
-    jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
-    jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = (ndims == 5) ? cd.strides[0] : 1;
-    jcp.stride_h = (ndims == 3) ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = (ndims == 5) ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = (ndims == 3) ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = (ndims == 5) ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = (ndims == 3) ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = (ndims == 5) ? static_cast<int>(weights_d.dims()[with_groups + 2])
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = (ndims == 5) ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = (ndims == 3) ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = (ndims == 5) ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = (ndims == 3) ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     jcp.signed_input = (src_d.data_type() == data_type::s8);
@@ -904,7 +907,8 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     jcp.bcast_loop_bcast_step
             = jcp.ur * jcp.ic_without_padding * jcp.typesize_in;
 
-    jcp.load_loop_load_step = jcp.reduce_dim * jcp.load_block * jcp.typesize_in;
+    jcp.load_loop_load_step = static_cast<int>(
+            jcp.reduce_dim * jcp.load_block * jcp.typesize_in);
 
     jcp.load_loop_iter_step = jcp.load_block;
 
@@ -987,9 +991,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     jcp.nb_reduce_blocking = reduce_blocking / jcp.reduce_block;
     jcp.nb_reduce_blocking_max = reduce_blocking_max / jcp.reduce_block;
 
-    jcp.nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    jcp.nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
-    jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    jcp.nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     // miniumum size of load dim chunk for work distribution within threads
     jcp.nb_load_chunk = 1;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -36,7 +36,9 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t : public jit_generator_t {
     jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    int get_tail_size() { return jcp.oc_without_padding % jcp.oc_block; }
+    int get_tail_size() {
+        return static_cast<int>(jcp.oc_without_padding % jcp.oc_block);
+    }
 
     jit_1x1_conv_conf_t jcp;
     const primitive_attr_t &attr_;
@@ -115,7 +117,7 @@ private:
     int vreg_accum_idx(
             const int load_loop_blk, const int i_load, const int i_ur);
     Vmm vreg_accum(const int load_loop_blk, const int i_load, const int i_ur);
-    int output_ptr(const int i_load, const int i_ur);
+    dim_t output_ptr(const int i_load, const int i_ur);
     void bcast_loop(int load_loop_blk);
     void apply_sum(const int ur, const int load_loop_blk,
             const bool mask_flag_in, const float *p_sum_scale,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -115,7 +115,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const int ndims = dst_d.ndims();
     const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
@@ -143,7 +143,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = typename rtus_driver_t<isa>::call_params_t();
-    const dim_t nb_oc = jcp.nb_load;
+    const int nb_oc = jcp.nb_load;
     // override some constants for fused dw_conv
     const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
     const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
@@ -435,10 +435,9 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end,
-                static_cast<dim_t>(jcp.load_grp_count));
+                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
 
         while (ocb_start < ocb_end) {
             dim_t load_step;
@@ -480,10 +479,10 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                static_cast<dim_t>(jcp.load_grp_count));
+                jcp.load_grp_count);
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -54,7 +54,8 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const int32_t *src_zero_points = CTX_IN_MEM(
@@ -114,12 +115,12 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const int ndims = dst_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     auto offset = weights_d.size() - weights_d.additional_buffer_size();
     char *w = const_cast<char *>(weights);
@@ -142,15 +143,16 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = typename rtus_driver_t<isa>::call_params_t();
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -185,27 +187,27 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
     char *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<char *> addrs;
     // End
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto dim_step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
-        bcast_step = step(
+        bcast_step = dim_step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -218,8 +220,9 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
-        load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
+        load_step = dim_step(
+                nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         p.load_dim = this_block_size(ocb * jcp.oc_block, ocb_end * jcp.oc_block,
                 load_step * jcp.oc_block);
 
@@ -231,15 +234,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
     auto init_reduce = [&]() {
         p.reduce_dim = this_block_size(
-                0, jcp.ic_without_padding, jcp.ic_without_padding);
+                dim_t {0}, jcp.ic_without_padding, jcp.ic_without_padding);
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int n, int g, int od, int oh,
-                           int ow, int id, int ih, int iw) {
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t n, dim_t g, dim_t od,
+                           dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
         const int icb = 0; // Start from the first IC block
-        const int _ocb = g * nb_oc + ocb;
-        const int _icb = g;
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g;
 
         const auto src_offset
                 = data_blk_off(src_d, n, _icb * jcp.ic_block, id, ih, iw);
@@ -286,18 +289,18 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_rlb) {
             init_reduce();
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                    dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                             id {0}, ih {0}, iw {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
@@ -307,13 +310,13 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                    dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                             id {0}, ih {0}, iw {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
@@ -325,15 +328,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             }
         } else if (jcp.loop_order == loop_rbl) {
             init_reduce();
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                         id {0}, ih {0}, iw {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                     ocb += load_step;
@@ -341,15 +344,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                 iwork += bcast_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                         id {0}, ih {0}, iw {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     init_reduce();
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -362,21 +365,22 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
-        int oh_1x1_begin = nstl::max(oh_1x1, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
+        dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1_begin++) % jcp_dw->kh) * row_offset;
 
         const auto ocb_end = ocb_start + load_step;
         const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         auto par_conv_dw = jit_conv_args_t();
 
-        par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
-        par_conv_dw.b_overflow = nstl::min(
-                jcp_dw->kh, nstl::max(0, oh_1x1 - jcp.oh + jcp_dw->kh));
-        par_conv_dw.kh_padding = nstl::max<int>(0,
+        par_conv_dw.t_overflow
+                = nstl::max<dim_t>(0, nstl::min<dim_t>(jcp_dw->kh, -oh_1x1));
+        par_conv_dw.b_overflow = nstl::max<dim_t>(
+                0, nstl::min<dim_t>(jcp_dw->kh, oh_1x1 - jcp.oh + jcp_dw->kh));
+        par_conv_dw.kh_padding = nstl::max<dim_t>(0,
                 jcp_dw->kh - par_conv_dw.t_overflow - par_conv_dw.b_overflow);
 
         const size_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
@@ -385,7 +389,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         const auto wht_h_stride = dw_weights_d.blk_off(0, 0, 0, 1);
         const auto wei_stride = (!jcp_dw->signed_input) * par_conv_dw.t_overflow
                 * wht_h_stride;
-        for (int ocb = ocb_start; ocb < ocb_end;
+        for (dim_t ocb = ocb_start; ocb < ocb_end;
                 ocb += jcp_dw->nb_ch_blocking) {
 
             par_conv_dw.src = addrs.data();
@@ -416,7 +420,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
             (*kernel_dw_)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += src_ch_stride;
         }
     };
@@ -431,38 +435,41 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+                bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
                 oh_1x1 = nstl::max(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
                 oh_1x1 = oh_1x1_end;
-                ker_dw(n, g * nb_oc + ocb_start, load_step, oh_dw);
+                ker_dw(n, static_cast<int>(g * nb_oc + ocb_start), load_step,
+                        oh_dw);
 
                 bcast_iter += nb_bcast_blocking;
             }
@@ -473,10 +480,10 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                jcp.load_grp_count);
+                static_cast<dim_t>(jcp.load_grp_count));
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -314,8 +314,8 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw_->nb_ch_blocking != 0)
                 --jcp_dw_->nb_ch_blocking;
 
-            jcp_dw_->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw_->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
             jcp_1x1.bcast_loop_output_step = jcp_1x1.ur
                     * (jcp_1x1.nb_load_blocking * jcp_1x1.oc_block)
                     * jcp_1x1.typesize_out;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -63,10 +63,10 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t block_tail
+        const dim_t block_tail
                 = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const size_t tail_size = block_tail
+        const dim_t tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;
@@ -144,10 +144,12 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_sum(
         const auto sum_injector_lam
                 = [this, oc_block, sum_scale, sum_zp](
                           const bool mask_flag, const int k, const int j) {
-            const int aux_output_offset = jcp.typesize_out
+            const dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
-            cvt2ps(jcp.sum_dt, vmm_prev_dst, reg_out, aux_output_offset,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+            cvt2ps(jcp.sum_dt, vmm_prev_dst, reg_out,
+                    static_cast<int>(aux_output_offset),
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
             const Vmm vmm = vmm_out(j, k);
             if (sum_zp != 0) {
                 uni_vbroadcastss(vmm_tmp, ptr[reg_ptr_sum_zp]);
@@ -192,7 +194,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
                     oc_blk_is_smaller_than_vmm,
                     [&](const bool mask_flag, const int k, const int j) {
-                const size_t aux_output_offset = jcp.typesize_out
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 const auto vmm_idx = vmm_out_idx(j, k);
@@ -200,7 +202,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
 
                 rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_out);
                 rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
-                        vmm_idx, aux_output_offset);
+                        vmm_idx, static_cast<size_t>(aux_output_offset));
 
                 if (mask_flag) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
             });
@@ -220,9 +222,10 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         int ur_w, bool last_oc_block_flag) {
-    int nb_oc_block
-            = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-    int oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
+    const int nb_oc_block = static_cast<int>(
+            jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking);
+    const int oc_block
+            = static_cast<int>(jcp.is_depthwise ? jcp.ch_block : jcp.oc_block);
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
     if (jcp.signed_input)
@@ -246,16 +249,17 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
 
     for (int k = 0; k < nb_oc_block; ++k) {
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-        const int load_size = mask_flag ? get_tail_size() : get_blocking_size();
+        const int load_size = static_cast<int>(
+                mask_flag ? get_tail_size() : get_blocking_size());
         if (jcp.signed_input) {
-            const int comp_offset = sizeof(int32_t) * k * oc_block;
-            load_data(data_type::s32, vmm_comp, reg_compensation, comp_offset,
-                    load_size);
+            const dim_t comp_offset = sizeof(int32_t) * k * oc_block;
+            load_data(data_type::s32, vmm_comp, reg_compensation,
+                    static_cast<int>(comp_offset), load_size);
         }
         if (jcp.src_zero_point) {
-            const int zp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * k * oc_block;
             load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation,
-                    zp_offset, load_size);
+                    static_cast<int>(zp_offset), load_size);
             uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_zp);
         }
         // TODO: scales support is done not in the most optimal way.
@@ -286,14 +290,15 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
             if (!jcp.is_oc_scale) {
                 uni_vbroadcastss(vmm_scales_tmp, ptr[reg_wei_scales]);
             } else {
-                int scale_offset
+                const dim_t scale_offset
                         = jcp.is_oc_scale * (sizeof(float) * k * oc_block);
                 if (mask_flag) {
                     load_data(data_type::s32, vmm_scales_tmp, reg_wei_scales,
-                            scale_offset, get_tail_size());
+                            static_cast<int>(scale_offset), get_tail_size());
                 } else {
-                    uni_vmovups(
-                            vmm_scales_tmp, ptr[reg_wei_scales + scale_offset]);
+                    uni_vmovups(vmm_scales_tmp,
+                            ptr[reg_wei_scales
+                                    + static_cast<int>(scale_offset)]);
                 }
             }
             if (is_vmm_scales_set) {
@@ -321,8 +326,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         // temporary vector register for scales. Load bias data into it after
         // scales are processed.
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * k * oc_block;
-            cvt2ps(jcp.bia_dt, vmm_bias, reg_bias, bias_offset, load_size);
+            const dim_t bias_offset = jcp.typesize_bia * k * oc_block;
+            cvt2ps(jcp.bia_dt, vmm_bias, reg_bias,
+                    static_cast<int>(bias_offset), load_size);
         }
 
         for (int j = 0; j < ur_w; ++j) {
@@ -414,17 +420,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
         for (int j = 0; j < ur_w; ++j) {
             Vmm r_vmm = vmm_out(j, k);
-            int aux_output_offset = jcp.typesize_out
+            const dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
-            store_data(jcp.dst_dt, r_vmm, reg_out, aux_output_offset,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+            store_data(jcp.dst_dt, r_vmm, reg_out,
+                    static_cast<int>(aux_output_offset),
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
         }
     }
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
 
     if (!(utils::one_of(isa, avx2) && std::is_same<Vmm, Xbyak::Ymm>::value)
             && !(utils::one_of(isa, sse41)
@@ -439,11 +448,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         uni_vpbroadcastd(vmm_zp, ptr[reg_src_zero_point]);
     }
 
-    auto input_spatial_index = [this, pad_l](int oi, int ki) {
+    auto input_spatial_index = [this, pad_l](dim_t oi, int ki) -> dim_t {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](dim_t ii, int ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);
@@ -452,11 +461,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
     };
 
     auto input_offset3 = [this, input_offset2, input_spatial_index](
-                                 int oi, int ci, int ki) {
+                                 dim_t oi, int ci, int ki) {
         return jcp.typesize_in * input_offset2(input_spatial_index(oi, ki), ci);
     };
 
-    auto kernel_offset = [this](int ci, int ki) {
+    auto kernel_offset = [this](int ci, int ki) -> dim_t {
         return jcp.typesize_in * ((ci * jcp.kh * jcp.kw + ki) * jcp.ch_block);
     };
 
@@ -470,16 +479,16 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         }
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise && !h_padded) {
         // find bounds of input spatial indices
         bool first = true;
         for (int ki = 0; ki < jcp.kw; ++ki) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; ++oi) {
-                int ii = input_spatial_index(oi, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; ++oi) {
+                const dim_t ii = input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -492,21 +501,23 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
                 && ci == jcp.nb_ch_blocking - 1;
         if (jcp.is_resrc_depthwise && !h_padded) {
             // now we can load input once and reuse up to jcp.kw times
-            for (int ii = ii_start; ii <= ii_end; ++ii) {
-                int aux_input_offset = input_offset2(ii, ci);
-                const Vmm vmm_inp_tmp = vmm_inp(ii, jcp.nb_ch_blocking);
+            for (dim_t ii = ii_start; ii <= ii_end; ++ii) {
+                dim_t aux_input_offset = input_offset2(ii, ci);
+                const Vmm vmm_inp_tmp
+                        = vmm_inp(static_cast<int>(ii), jcp.nb_ch_blocking);
 
                 load_data(data_type::u8, vmm_inp_tmp, aux_reg_inp,
                         aux_input_offset,
-                        mask_flag ? get_tail_size() : get_blocking_size());
+                        static_cast<int>(mask_flag ? get_tail_size()
+                                                   : get_blocking_size()));
                 if (jcp.signed_input)
                     uni_vpaddb(vmm_inp_tmp, vmm_inp_tmp, vmm_shift);
             }
         }
         for (int ki = 0; ki < jcp.kw; ++ki) {
-            int aux_kernel_offset = kernel_offset(ci, ki);
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
+            dim_t aux_kernel_offset = kernel_offset(ci, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
 
             if (compute_kernel) {
                 uni_vpmovsxbd(vmm_wei, ptr[aux_reg_ker + aux_kernel_offset]);
@@ -515,28 +526,33 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
                     for (int oi = 0; oi < ur_w; ++oi)
                         compute(vmm_out(oi, ci), vmm_wei, vmm_shift);
                 } else {
-                    int start = jcp.signed_input ? 0 : oi_start;
-                    int end = jcp.signed_input ? ur_w : oi_end;
-                    for (int oi = start; oi < end; ++oi) {
+                    const dim_t start = jcp.signed_input ? 0 : oi_start;
+                    const dim_t end = jcp.signed_input ? ur_w : oi_end;
+                    for (dim_t oi = start; oi < end; ++oi) {
                         if (oi >= oi_start && oi < oi_end) {
                             if (jcp.is_resrc_depthwise) {
-                                int ii = input_spatial_index(oi, ki);
-                                vmm_dw_src = vmm_inp(ii, jcp.nb_ch_blocking);
+                                const dim_t ii = input_spatial_index(oi, ki);
+                                vmm_dw_src = vmm_inp(static_cast<int>(ii),
+                                        jcp.nb_ch_blocking);
                             } else {
-                                int aux_input_offset
+                                const dim_t aux_input_offset
                                         = input_offset3(oi, ci, ki);
                                 load_data(data_type::u8, vmm_dw_src,
-                                        aux_reg_inp, aux_input_offset,
-                                        mask_flag ? get_tail_size()
-                                                  : get_blocking_size());
+                                        aux_reg_inp,
+                                        static_cast<int>(aux_input_offset),
+                                        static_cast<int>(mask_flag
+                                                        ? get_tail_size()
+                                                        : get_blocking_size()));
                                 if (jcp.signed_input)
                                     uni_vpaddb(
                                             vmm_dw_src, vmm_dw_src, vmm_shift);
                             }
-                            compute(vmm_out(oi, ci), vmm_wei, vmm_dw_src);
+                            compute(vmm_out(static_cast<int>(oi), ci), vmm_wei,
+                                    vmm_dw_src);
                         } else {
                             assert(jcp.signed_input);
-                            compute(vmm_out(oi, ci), vmm_wei, vmm_shift);
+                            compute(vmm_out(static_cast<int>(oi), ci), vmm_wei,
+                                    vmm_shift);
                         }
                     }
                 }
@@ -565,17 +581,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int ch_block_all = jcp.ch_block * ic_block * oc_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const int ic_block = static_cast<int>(jcp.ic_block);
+    const int oc_block = static_cast<int>(jcp.oc_block);
+    const int ch_block_all
+            = static_cast<int>(jcp.ch_block * ic_block * oc_block);
 
-    int nb_oc_block = jcp.nb_oc_blocking;
+    const int nb_oc_block = static_cast<int>(jcp.nb_oc_blocking);
 
     const bool compute_kernel = IMPLICATION(h_padded, jcp.signed_input);
 
@@ -586,14 +604,15 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    auto input_offset = [this, stride_w, pad_l](int oi, int ic, int ki) {
+    auto input_offset
+            = [this, stride_w, pad_l](dim_t oi, int ic, int ki) -> dim_t {
         return jcp.typesize_in
                 * ((ki * (jcp.dilate_w + 1) + oi * stride_w - pad_l)
                                 * jcp.ic_without_padding * jcp.ngroups
                         + ic_sub_step * ic);
     };
     auto kernel_offset
-            = [this, ch_block_all, oc_block](int ii, int ic, int ki) {
+            = [this, ch_block_all, oc_block](int ii, int ic, int ki) -> dim_t {
         return jcp.typesize_in
                 * ((ii * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
@@ -610,18 +629,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
     };
 
     for (int ki = 0; ki < kw; ++ki) {
-        const int ow_start = get_ow_start(ki, pad_l);
-        const int ow_end = get_ow_end(ur_w, ki, pad_r);
+        const dim_t ow_start = get_ow_start(ki, pad_l);
+        const dim_t ow_end = get_ow_end(ur_w, ki, pad_r);
         const int ic_tail_size = jcp.ic_without_padding % ic_sub_step;
 
-        const int _start = jcp.signed_input ? 0 : ow_start;
-        const int _end = jcp.signed_input ? ur_w : ow_end;
+        const dim_t _start = jcp.signed_input ? 0 : ow_start;
+        const dim_t _end = jcp.signed_input ? ur_w : ow_end;
 
         /* Skip the last loads of input
             if (ic % 8) / ic_sub_step < ic_block / ic_sub_step */
-        const int icb = (last_ic_block_flag != no_last_block)
-                ? div_up((jcp.ic_without_padding % ic_block), ic_sub_step)
-                : ic_block / ic_sub_step;
+        const int icb = static_cast<int>((last_ic_block_flag != no_last_block)
+                        ? div_up((jcp.ic_without_padding % ic_block),
+                                  ic_sub_step)
+                        : ic_block / ic_sub_step);
 
         if (compute_kernel) {
             for (int ic = 0; ic < icb; ++ic) {
@@ -632,45 +652,54 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                         uni_vmovups(inp, vmm_shift);
                     }
                 } else {
-                    for (int jj = _start; jj < _end; ++jj) {
-                        int aux_input_offset = input_offset(jj, ic, ki);
+                    for (dim_t jj = _start; jj < _end; ++jj) {
+                        dim_t aux_input_offset = input_offset(jj, ic, ki);
                         if (jj >= ow_start && jj < ow_end) {
                             const bool need_partial_ic_bcast = true
                                     && last_ic_block_flag == last_sp_block
                                     && ic_tail_size != 0 && ic == icb - 1;
 
                             if (need_partial_ic_bcast) {
-                                const auto inp_bcastd_vmm
-                                        = vmm_inp(jj, nb_oc_block);
+                                const auto inp_bcastd_vmm = vmm_inp(
+                                        static_cast<int>(jj), nb_oc_block);
                                 const auto inp_bcastd
                                         = Xmm(inp_bcastd_vmm.getIdx());
                                 load_bytes(inp_bcastd_vmm, aux_reg_inp,
                                         aux_input_offset, ic_tail_size);
-                                uni_vpbroadcastd(
-                                        vmm_inp(jj, nb_oc_block), inp_bcastd);
+                                uni_vpbroadcastd(vmm_inp(static_cast<int>(jj),
+                                                         nb_oc_block),
+                                        inp_bcastd);
                             } else {
-                                uni_vpbroadcastd(vmm_inp(jj, nb_oc_block),
+                                uni_vpbroadcastd(vmm_inp(static_cast<int>(jj),
+                                                         nb_oc_block),
                                         ptr[aux_reg_inp + aux_input_offset]);
                             }
                             if (jcp.signed_input)
-                                uni_vpaddb(vmm_inp(jj, nb_oc_block),
-                                        vmm_inp(jj, nb_oc_block), vmm_shift);
+                                uni_vpaddb(vmm_inp(static_cast<int>(jj),
+                                                   nb_oc_block),
+                                        vmm_inp(static_cast<int>(jj),
+                                                nb_oc_block),
+                                        vmm_shift);
                         } else {
                             // fill padded area with shifted value in
                             // first iteration
                             if (jcp.signed_input && ic == 0) {
-                                const Vmm inp = vmm_inp(jj, nb_oc_block);
+                                const Vmm inp = vmm_inp(
+                                        static_cast<int>(jj), nb_oc_block);
                                 uni_vmovups(inp, vmm_shift);
                             }
                         }
                     }
                 }
                 for (int ii = 0; ii < nb_oc_block; ++ii) {
-                    const int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                    const dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                     uni_vmovdqu(vmm_wei, ptr[aux_reg_ker + aux_kernel_offset]);
-                    for (int jj = _start; jj < _end; ++jj) {
-                        const Vmm inp = vmm_inp(h_padded ? 0 : jj, nb_oc_block);
-                        compute(vmm_out(jj, ii), vmm_wei, inp);
+                    for (dim_t jj = _start; jj < _end; ++jj) {
+                        const Vmm inp
+                                = vmm_inp(static_cast<int>(h_padded ? 0 : jj),
+                                        nb_oc_block);
+                        compute(vmm_out(static_cast<int>(jj), ii), vmm_wei,
+                                inp);
                     }
                 }
             }
@@ -685,7 +714,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                     for (int ii = 0; ii < nb_oc_block; ii++) {
                         uni_vpxor(vmm_tmp, vmm_tmp, vmm_tmp);
                         for (int ic = 0; ic < icb; ic++) {
-                            const int aux_kernel_offset
+                            const dim_t aux_kernel_offset
                                     = kernel_offset(ii, ic, ki);
                             if (jcp.has_vnni) {
                                 vpdpbusd(vmm_tmp, vmm_zp_one,
@@ -710,7 +739,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
-        int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
+        int ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag) {
 
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
@@ -718,9 +747,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
             no_b_overflow_label, back_overflow_label, no_back_overflow_label,
             d_h_back_overflow_label;
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
-    int shift_input_ptr
+    const dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    const dim_t shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
+    const dim_t shift_input_ptr
             = jcp.typesize_in * jcp.iw * jcp.ic_without_padding * jcp.ngroups;
 
     if (jcp.src_zero_point && !jcp.is_depthwise) {
@@ -867,7 +896,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+        int ur_w, dim_t pad_l, dim_t pad_r, bool is_last_sp_block) {
     prepare_output(ur_w);
 
     // IC loop
@@ -900,7 +929,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        int inp_step = jcp.ic_block;
+        const int inp_step = static_cast<int>(jcp.ic_block);
         const size_t ker_step = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
                 * jcp.ic_block;
         add(reg_inp, jcp.typesize_in * inp_step);
@@ -940,17 +969,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     Label permute_index_table;
-    int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
-                                        : jcp.ic_without_padding * jcp.ngroups;
-    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
-    const int n_urw_l_pad = nstl::min(
-            div_up(nstl::max(0, jcp.l_pad), urw_inp_stride), jcp.ow / jcp.ur_w);
-    const int inp_shift_pad = nstl::max(0,
+    int in_ic_shift = static_cast<int>(jcp.is_fused_conv
+                    ? jcp.dw_conv_buffer_oc
+                    : jcp.ic_without_padding * jcp.ngroups);
+    const int urw_inp_stride = static_cast<int>(jcp.ur_w * jcp.stride_w);
+    const int n_urw_l_pad = static_cast<int>(nstl::min<dim_t>(
+            div_up(nstl::max<dim_t>(0, jcp.l_pad), urw_inp_stride),
+            jcp.ow / jcp.ur_w));
+    const int inp_shift_pad = static_cast<int>(nstl::max<dim_t>(0,
             jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
-                    * in_ic_shift);
-    int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
-    int out_shift = jcp.typesize_out
-            * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
+                    * in_ic_shift));
+    int inp_shift = static_cast<int>(
+            jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift));
+    int out_shift = static_cast<int>(jcp.typesize_out
+            * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups));
     preamble();
 
     if (jcp.is_depthwise) {
@@ -999,19 +1031,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
     }
 
-    const int extended_filter_size
-            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int extended_filter_size = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     const int ow_with_no_rpad = 1
-            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
-                      - extended_filter_size)
-                    / jcp.stride_w;
-    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
-    const int max_safe_iw = nstl::max(0,
+            + static_cast<int>(
+                    (jcp.iw + jcp.l_pad + nstl::min<dim_t>(0, jcp.r_pad)
+                            - extended_filter_size)
+                    / jcp.stride_w);
+    const int n_urw_per_ow_block = static_cast<int>(jcp.ow_block / jcp.ur_w);
+    const int max_safe_iw = static_cast<int>(nstl::max<dim_t>(0,
             jcp.iw
                     - div_up(static_cast<int>(ic_sub_step),
-                            jcp.ic_without_padding));
-    const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
+                            jcp.ic_without_padding)));
+    const dim_t max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
             ? jcp.ow
             : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
     Label middle_block_label, done_compute;
@@ -1072,13 +1105,14 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
             n_urw_middle_block_loop
-                    = nstl::max(0,
-                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    = static_cast<int>(nstl::max<dim_t>(0,
+                              nstl::min<dim_t>(ow_with_no_rpad, max_safe_ow)
+                                      - cur_ow))
                     / jcp.ur_w;
             cur_ow += n_urw_middle_block_loop * jcp.ur_w;
         }
@@ -1088,11 +1122,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
         // r_pad or last_sp_block
         if (cur_ow + jcp.ur_w <= jcp.ow) {
             if (r_pad_fall_through_n_urw == 0) ++n_labels;
-            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
-            n_labels += nstl::max(0,
+            const dim_t n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
+            n_labels += static_cast<int>(nstl::max<dim_t>(0,
                     div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
                             n_urw_per_ow_block)
-                            - 1);
+                            - 1));
         }
 
         if (jcp.ur_w_tail != 0) {
@@ -1116,9 +1150,10 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             L(middle_or_rpad_check);
             // harness passes shifted src pointer that does not take
             // left-padding into account. So, we must re-shift here.
-            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
-                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
-                    * in_ic_shift;
+            const int inp_shift_pad_middle_block = static_cast<int>(-1
+                    * jcp.typesize_in
+                    * nstl::min<dim_t>(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift);
             add(reg_inp, inp_shift_pad_middle_block);
         }
         if (r_pad_fall_through_n_urw != 0) {
@@ -1161,7 +1196,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     int label_cntr = 0;
     int cur_l_pad = 0;
     if (jcp.l_pad > 0) {
-        for (cur_l_pad = jcp.l_pad;
+        for (cur_l_pad = static_cast<int>(jcp.l_pad);
                 cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
                 cur_l_pad -= urw_inp_stride) {
             if (jcp.nb_ow > 1 && cur_n_oi == 0) {
@@ -1177,9 +1212,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = nstl::max(0,
+            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                            jcp.stride_w, extended_filter_size));
+                            jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_out, out_shift);
             dec(reg_oi);
@@ -1199,13 +1234,14 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
             int n_oi_middle_block_loop
-                    = nstl::max(0,
-                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    = static_cast<int>(nstl::max<dim_t>(0,
+                              nstl::min<dim_t>(ow_with_no_rpad, max_safe_ow)
+                                      - cur_ow))
                     / jcp.ur_w;
             if (jcp.nb_ow == 1 && n_oi_middle_block_loop > 1)
                 mov(reg_oi, n_oi_middle_block_loop);
@@ -1242,8 +1278,8 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
                 L(ow_block_jmp_table[label_cntr++]);
             }
             cur_ow += jcp.ur_w;
-            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                    jcp.stride_w, extended_filter_size);
+            const dim_t cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow,
+                    jcp.iw, jcp.stride_w, extended_filter_size);
             assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
             icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_inp, inp_shift);
@@ -1354,9 +1390,9 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1536,10 +1572,13 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, false, false, false));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1556,7 +1595,8 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     // factor smaller than the left padding (special requirement for SSD:fc6),
     // then search for a smaller OC blocking that satisfies both constraints.
     auto is_oc_blocking_ok = [&](int block) {
-        int ur_w = nstl::min(jcp.ow, jcp.max_regs_ur / (block + 1));
+        int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jcp.ow, jcp.max_regs_ur / (block + 1)));
         return jcp.nb_oc % block == 0 && jcp.l_pad <= ur_w
                 && jcp.ow % ur_w != 1;
     };
@@ -1564,28 +1604,28 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     // choose nb_oc work chunk size for distribution within threads
     int max_threading_nb_oc_chunk = 4;
 
-    jcp.nb_oc_blocking_thr_chunk
-            = nstl::min(max_threading_nb_oc_chunk, jcp.nb_oc);
+    jcp.nb_oc_blocking_thr_chunk = static_cast<int>(
+            nstl::min<dim_t>(max_threading_nb_oc_chunk, jcp.nb_oc));
     for (; jcp.nb_oc_blocking_thr_chunk > 1; --jcp.nb_oc_blocking_thr_chunk) {
         if (is_oc_blocking_ok(jcp.nb_oc_blocking_thr_chunk)) break;
     }
 
-    auto get_thr_eff = [&](int nb_ow, int nthr) {
-        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+    auto get_thr_eff = [&](dim_t nb_ow, int nthr) {
+        const dim_t base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
                 * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-        auto work_amount = base_work_amount * nb_ow;
-        return float(work_amount) / rnd_up(work_amount, nthr);
+        const dim_t work_amount = base_work_amount * nb_ow;
+        return float(work_amount) / float(rnd_up(work_amount, nthr));
     };
 
     auto get_ow_block = [&jcp, get_thr_eff](int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+        dim_t res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
 
-        int max_nb_ow = div_up(jcp.ow, ur_w);
-        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
+        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1597,20 +1637,20 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
             }
             if (best_thr_eff > 0.9f) break;
         }
-        return res_ow_block;
+        return static_cast<int>(res_ow_block);
     };
 
     // choose oc blocking for computational kernel
     jcp.nb_oc_blocking = jcp.nb_oc_blocking_thr_chunk;
 
     if (jcp.is_resrc_depthwise)
-        jcp.ur_w = (jcp.max_regs_ur - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        jcp.ur_w = static_cast<int>((jcp.max_regs_ur - jcp.kw + jcp.stride_w)
+                / (jcp.nb_ch_blocking + jcp.stride_w));
     else
-        jcp.ur_w = jcp.max_regs_ur
+        jcp.ur_w = static_cast<int>(jcp.max_regs_ur
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
-                                    : jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+                                    : jcp.nb_oc_blocking + 1));
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.ow_block = jcp.ow;
@@ -1632,10 +1672,10 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
     if (jcp.ngroups < jcp.nthr && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        int ow_block = static_cast<int>(jcp.ow_block);
         float best_thr_eff = thr_eff;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
             ow_block = get_ow_block(jcp.ur_w, nthr);
             eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -1105,7 +1105,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
+        int cur_r_pad = static_cast<int>(nstl::max(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
                         jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
@@ -1212,7 +1212,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
+            int cur_r_pad = static_cast<int>(nstl::max(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
                             jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
@@ -1234,7 +1234,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
+        int cur_r_pad = static_cast<int>(nstl::max(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
                         jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
@@ -1390,9 +1390,9 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -1361,34 +1361,36 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.nthr = nthreads;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.mb = src_d.dims()[0];
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
     jcp.oc_without_padding = jcp.oc;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.ic_without_padding = jcp.ic;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.ih = is_1d ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = is_1d ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = is_1d
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = is_1d ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = is_1d ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     jcp.ur_h = 1; /* no code-unrolling by h so far */
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = is_1d ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
     const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -66,7 +66,7 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
         const dim_t block_tail
                 = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const dim_t tail_size = block_tail
+        const std::size_t tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -150,33 +150,37 @@ private:
         assert(idx < ker_max_reg);
         return Vmm(ker_max_reg - idx);
     }
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
-    int get_blocking_size() {
+    dim_t get_blocking_size() {
         return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
     }
     int get_tail_size() {
-        return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
-                                : jcp.oc_without_padding % jcp.oc_block;
+        return static_cast<int>(jcp.is_depthwise
+                        ? jcp.ngroups % jcp.ch_block
+                        : jcp.oc_without_padding % jcp.oc_block);
     }
 
     void prepare_output(int ur_w);
     void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker_dw(int ur_w, int pad_l, int pad_r,
+    void compute_ker_dw(int ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void compute_ker(int ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded = false);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool is_last_spatial_block);
+    void kh_loop(
+            int ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag);
+    void icb_loop(
+            int ur_w, dim_t pad_l, dim_t pad_r, bool is_last_spatial_block);
     void generate() override;
 
     void cvt2ps(data_type_t type_in, const Vmm &vmm_in, const Xbyak::Reg64 &reg,
@@ -195,7 +199,8 @@ struct jit_uni_x8s8s32x_fwd_kernel_t {
     jit_uni_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 8:
                 if (utils::one_of(isa, avx2)) {

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -85,13 +85,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_conv_args_t();
 
@@ -110,7 +112,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -129,18 +131,19 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
         while (start < end) {
             for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                const dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                const dim_t ow_s = owb * jcp.ow_block;
+                const dim_t iw_s = ow_s * jcp.stride_w;
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -152,17 +155,17 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
                 auto src_w = src + src_d.blk_off(n, g_ic, ih_s, iw_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow = nstl::min(
-                            jcp.kh, div_up(nstl::max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0,
+                    const dim_t dilate_h = jcp.dilate_h + 1;
+                    const dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(nstl::max<dim_t>(0, -ij), dilate_h));
+                    const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(nstl::max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    const dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     const size_t wei_stride
@@ -269,13 +272,14 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
                     + (jcp.signed_input ? ch_offset : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
+    const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_conv_args_t();
 
@@ -290,7 +294,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -311,13 +315,13 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int gb = gg * jcp.nb_ch_blocking;
-            int g = gb * group_block;
-            int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.nb_ic * jcp.ic_block;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t gb = gg * jcp.nb_ch_blocking;
+            const dim_t g = gb * group_block;
+            const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+            const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
+            const dim_t ow_s = owb * jcp.ow_block;
+            const dim_t iw_s = ow_s * jcp.stride_w;
 
             p.bias = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                           : nullptr;
@@ -419,8 +423,8 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.nb_ch * jcp.ch_block : 0)
             : nullptr;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [= COMPAT_THIS_CAPTURE](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
@@ -429,12 +433,12 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
-        int g = gb * group_block;
+        const dim_t gb = gg * jcp.nb_ch_blocking;
+        const dim_t g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
-        int iw_s = ow_s * jcp.stride_w;
+        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const dim_t ow_s = owb * jcp.ow_block;
+        const dim_t iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;
         const int32_t *compensation_w
@@ -459,14 +463,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
                 ? static_cast<const float *>(wei_scales) + jcp.is_oc_scale * g
                 : nullptr;
 
-        int dilate_h = jcp.dilate_h + 1;
-        int i_t_overflow
-                = nstl::min(jcp.kh, div_up(nstl::max(0, -ih_s), dilate_h));
-        int i_b_overflow = nstl::min(jcp.kh,
-                div_up(nstl::max(
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t i_t_overflow = nstl::min<dim_t>(
+                jcp.kh, div_up(nstl::max<dim_t>(0, -ih_s), dilate_h));
+        const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                div_up(nstl::max<dim_t>(
                                0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h));
-        int kh_padding = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+        const dim_t kh_padding
+                = nstl::max<dim_t>(0, jcp.kh - i_t_overflow - i_b_overflow);
 
         size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
                 ? 0
@@ -542,14 +547,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_conv_args_t();
 
@@ -570,7 +576,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -589,30 +595,31 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         while (start < end) {
             for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                const dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-                int dilate_d = jcp.dilate_d + 1;
-                int d_f_overflow = nstl::min(
-                        jcp.kd, div_up(nstl::max(0, -id_s), dilate_d));
-                int d_back_overflow = nstl::min(jcp.kd,
-                        div_up(nstl::max(0,
+                const dim_t ow_s = owb * jcp.ow_block;
+                const dim_t iw_s = ow_s * jcp.stride_w;
+                const dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                const dim_t dilate_d = jcp.dilate_d + 1;
+                const dim_t d_f_overflow = nstl::min<dim_t>(
+                        jcp.kd, div_up(nstl::max<dim_t>(0, -id_s), dilate_d));
+                const dim_t d_back_overflow = nstl::min<dim_t>(jcp.kd,
+                        div_up(nstl::max<dim_t>(0,
                                        id_s - jcp.id + (jcp.kd - 1) * dilate_d
                                                + 1),
                                 dilate_d));
 
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+                const dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_f_overflow - d_back_overflow);
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -634,17 +641,17 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
                                           : d_f_overflow)
                                 * wht_d_stride;
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow = nstl::min(
-                            jcp.kh, div_up(nstl::max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0,
+                    const dim_t dilate_h = jcp.dilate_h + 1;
+                    const dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(nstl::max<dim_t>(0, -ij), dilate_h));
+                    const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(nstl::max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    const dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -239,9 +239,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -280,10 +280,13 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -293,18 +296,18 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     const int regs = jcp.has_vnni ? 14 : 12;
 
     jcp.nb_ch_blocking = 1;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
                 && jcp.l_pad <= regs / (jcp.nb_oc_blocking + 1))
             break;
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    const int l_overflow = max(
+    const dim_t l_overflow = max<dim_t>(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
     if (jcp.ow < jcp.ur_w) {
-        jcp.ur_w = jcp.ow;
+        jcp.ur_w = static_cast<int>(jcp.ow);
         jcp.ur_w_tail = 0;
     } else {
         for (; jcp.ur_w >= 1; jcp.ur_w--) {
@@ -318,9 +321,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             const bool left_boundary_covered
                     = jcp.ur_w >= l_overflow * jcp.stride_w;
             jcp.ur_w_tail = jcp.ow % jcp.ur_w;
-            const int r_overflow_no_tail = max(0,
-                    ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad)
-                            - jcp.ur_w_tail)
+            const dim_t r_overflow_no_tail = max<dim_t>(0,
+                    ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                            - max<dim_t>(0, jcp.r_pad) - jcp.ur_w_tail)
                             / jcp.stride_w);
             const bool right_boundary_covered
                     = jcp.ur_w >= r_overflow_no_tail * jcp.stride_w;
@@ -358,7 +361,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::jit_uni_x8s8s32x_deconv_fwd_kernel_t(
         const memory_desc_wrapper &dst_d)
     : kernel_(nullptr) {
 
-    const int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+    const dim_t ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
     switch (ch_block) {
         case 8:
             if (isa == avx2) {
@@ -429,7 +432,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
     , ker_max_regs_(jcp_.has_vnni ? 14 : 12) {
 
     if (jcp_.with_eltwise || jcp_.with_binary || jcp_.with_sum) {
-        const std::size_t tail_size = get_tail_size();
+        const dim_t tail_size = get_tail_size();
 
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
@@ -455,25 +458,25 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 Vmm jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::vmm_out(
-        int i_ur, int i_oc) const {
-    const int idx = i_ur * jcp_.nb_oc_blocking + i_oc;
+        dim_t i_ur, dim_t i_oc) const {
+    const dim_t idx = i_ur * jcp_.nb_oc_blocking + i_oc;
     assert(idx < ker_max_regs_);
     /* remap the reg indices to avoid using xmm0 in eltwise injector */
-    return Vmm(15 - idx);
+    return Vmm(15 - static_cast<int>(idx));
 }
 
 template <cpu_isa_t isa, typename Vmm>
 Vmm jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::vmm_inp(
-        int i_ic, int nb_x_blocking) const {
-    const int idx = i_ic + nb_x_blocking * jcp_.ur_w;
+        dim_t i_ic, dim_t nb_x_blocking) const {
+    const dim_t idx = i_ic + nb_x_blocking * jcp_.ur_w;
     assert(idx < ker_max_regs_);
-    return Vmm(15 - idx);
+    return Vmm(15 - static_cast<int>(idx));
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
-        int ki, int l_overflow) const noexcept {
-    int res = (jcp_.ow - 1 + jcp_.r_pad) % jcp_.stride_w
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
+        dim_t ki, dim_t l_overflow) const noexcept {
+    dim_t res = (jcp_.ow - 1 + jcp_.r_pad) % jcp_.stride_w
             + l_overflow * jcp_.stride_w
             - (jcp_.kw - 1 - ki) * (jcp_.dilate_w + 1);
     while (res < 0)
@@ -482,11 +485,11 @@ int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
-        int ur_w, int ki, int r_overflow) const noexcept {
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
+        dim_t ur_w, dim_t ki, dim_t r_overflow) const noexcept {
     if (utils::one_of(ur_w, jcp_.ow, jcp_.ur_w_tail))
-        ur_w += nstl::min(0, jcp_.r_pad); // remove negative padding
-    int res = (ur_w - 1 + jcp_.l_pad) % jcp_.stride_w
+        ur_w += nstl::min<dim_t>(0, jcp_.r_pad); // remove negative padding
+    dim_t res = (ur_w - 1 + jcp_.l_pad) % jcp_.stride_w
             + r_overflow * jcp_.stride_w - ki * (jcp_.dilate_w + 1);
     while (res < 0)
         res += jcp_.stride_w;
@@ -494,13 +497,13 @@ int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_blocking_size()
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_blocking_size()
         const noexcept {
     return jcp_.is_depthwise ? jcp_.ch_block : jcp_.oc_block;
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_tail_size()
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_tail_size()
         const noexcept {
     return jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
                              : jcp_.oc_without_padding % jcp_.oc_block;
@@ -525,7 +528,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute(
 
 template <cpu_isa_t isa, typename Vmm>
 std::function<Vmm()> jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::prepare_round_robin_vmm_inp_generator(int ur_w) const noexcept {
+        Vmm>::prepare_round_robin_vmm_inp_generator(dim_t ur_w) const noexcept {
 
     const int start_vmm_idx = vmm_inp(ur_w - 1, jcp_.nb_oc_blocking).getIdx();
     const int end_vmm_idx = vmm_inp(0, jcp_.nb_oc_blocking).getIdx() + 1;
@@ -542,8 +545,8 @@ std::function<Vmm()> jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::apply_zp_src_pad_str_comp(int ur_w, int l_overflow,
-        int r_overflow, bool h_padded) {
+        Vmm>::apply_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+        dim_t r_overflow, bool h_padded) {
     Xbyak::Label end_zp_pad, no_tail;
 
     // apply once per icb loop, zp src stride paddding compensation calculate as
@@ -573,8 +576,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::append_zp_src_pad_str_comp(int ur_w, int l_overflow,
-        int r_overflow, bool h_padded, bool last_oc_block) {
+        Vmm>::append_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+        dim_t r_overflow, bool h_padded, bool last_oc_block) {
 
     const auto &reg_zp_src_pad_comp = reg_scratch_;
     const auto get_next_comp_vmm = prepare_round_robin_vmm_inp_generator(ur_w);
@@ -596,35 +599,35 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
     const auto load_zp_src_pad_comp
             = [&](const Vmm zp_pad_comp_vmm, const Xbyak::Address &comp_addr,
-                      const int ocb) {
+                      const dim_t ocb) {
         const bool is_tail = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
 
         if (is_tail)
             load_data(data_type::s32, zp_pad_comp_vmm, comp_addr,
-                    get_tail_size());
+                    static_cast<int>(get_tail_size()));
         else
             uni_vmovups(zp_pad_comp_vmm, comp_addr);
     };
 
-    const auto get_zp_src_comp_pad_off = [&](int it_kw, int ocb) {
-        const auto kw_offset = it_kw * jcp_.oc_without_padding * jcp_.ngroups;
-        const auto oc_offset = ocb * jcp_.oc_block;
+    const auto get_zp_src_comp_pad_off = [&](dim_t it_kw, dim_t ocb) {
+        const dim_t kw_offset = it_kw * jcp_.oc_without_padding * jcp_.ngroups;
+        const dim_t oc_offset = ocb * jcp_.oc_block;
 
         return (kw_offset + oc_offset) * sizeof(int32_t);
     };
 
-    for (int it_kw = 0; it_kw < jcp_.kw; ++it_kw) {
-        const int ow_start = get_ow_start(it_kw, l_overflow);
-        const int ow_end = get_ow_end(ur_w, it_kw, r_overflow);
+    for (dim_t it_kw = 0; it_kw < jcp_.kw; ++it_kw) {
+        const dim_t ow_start = get_ow_start(it_kw, l_overflow);
+        const dim_t ow_end = get_ow_end(ur_w, it_kw, r_overflow);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             Vmm zp_src_comp_pad_vmm; // will be assigned later
             bool ocb_zp_loaded = false;
 
             const auto zp_src_comp_pad_off
                     = get_zp_src_comp_pad_off(it_kw, ocb);
 
-            for (int it_ow = 0; it_ow < ur_w; ++it_ow) {
+            for (dim_t it_ow = 0; it_ow < ur_w; ++it_ow) {
 
                 const bool inside_padded_area = h_padded
                         || !(it_ow >= ow_start && it_ow < ow_end
@@ -656,7 +659,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
         const auto kh_offset = jcp_.kw * jcp_.oc_without_padding * jcp_.ngroups
                 * sizeof(int32_t);
 
-        add(reg_zp_src_pad_comp, kh_offset);
+        add(reg_zp_src_pad_comp, static_cast<uint32_t>(kh_offset));
         mov(zp_src_pad_comp_addr_, reg_zp_src_pad_comp);
     }
 
@@ -665,17 +668,17 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
-        int l_overflow, int r_overflow, ker_block_t last_ic_block_flag,
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(dim_t ur_w,
+        dim_t l_overflow, dim_t r_overflow, ker_block_t last_ic_block_flag,
         bool h_padded) {
 
     const bool signed_input_or_src_zp
             = (jcp_.signed_input || jcp_.src_zero_point);
 
-    const int ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
-    const int ur_w_stride = signed_input_or_src_zp ? 1 : jcp_.stride_w;
+    const dim_t ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
+    const dim_t ur_w_stride = signed_input_or_src_zp ? 1 : jcp_.stride_w;
 
-    const auto src_offset = [this](int oj, int icb, int ki) {
+    const auto src_offset = [this](dim_t oj, dim_t icb, dim_t ki) {
         return jcp_.typesize_in
                 * (((oj + jcp_.l_pad - ki * (jcp_.dilate_w + 1))
                            / jcp_.stride_w)
@@ -683,24 +686,25 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                         + icb * 4);
     };
 
-    const auto kernel_offset = [this, ch_block_all](int ocb, int icb, int ki) {
+    const auto kernel_offset
+            = [this, ch_block_all](dim_t ocb, dim_t icb, dim_t ki) {
         return jcp_.typesize_in
                 * ((ocb * jcp_.nb_ic * jcp_.kd * jcp_.kh * jcp_.kw + ki)
                                 * ch_block_all
                         + icb * jcp_.oc_block * IC_SUB_STEP);
     };
 
-    for (int ki = 0; ki < jcp_.kw; ki++) {
+    for (dim_t ki = 0; ki < jcp_.kw; ki++) {
 
-        const int jj_start = get_ow_start(ki, l_overflow);
-        const int jj_end = get_ow_end(ur_w, ki, r_overflow);
+        const dim_t jj_start = get_ow_start(ki, l_overflow);
+        const dim_t jj_end = get_ow_end(ur_w, ki, r_overflow);
 
-        const int _start = (signed_input_or_src_zp) ? 0 : jj_start;
-        const int _end = (signed_input_or_src_zp) ? ur_w : jj_end;
+        const dim_t _start = (signed_input_or_src_zp) ? 0 : jj_start;
+        const dim_t _end = (signed_input_or_src_zp) ? ur_w : jj_end;
 
-        const int tail_size = jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
-                                                : jcp_.ic_without_padding % 4;
-        const int n_ic_blocks = jcp_.is_depthwise
+        const dim_t tail_size = jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
+                                                  : jcp_.ic_without_padding % 4;
+        const dim_t n_ic_blocks = jcp_.is_depthwise
                 ? 1
                 : (last_ic_block_flag != no_last_block
                                   ? div_up(jcp_.ic_without_padding
@@ -708,7 +712,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                             4)
                                   : jcp_.ic_block / 4);
 
-        for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
+        for (dim_t icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded) {
                 /* fill padded area with shifted values */
                 if (jcp_.signed_input) {
@@ -718,9 +722,9 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                 }
             } else {
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
-                    const int aux_src_off = src_offset(jj, icb1, ki);
+                    const dim_t aux_src_off = src_offset(jj, icb1, ki);
                     const auto vmm_src = vmm_inp(jj, jcp_.nb_oc_blocking);
 
                     if (jj >= jj_start && jj < jj_end
@@ -733,12 +737,14 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                     && tail_size;
                             load_data(data_type::u8, vmm_src, aux_reg_src_,
                                     aux_src_off,
-                                    mask_flag ? tail_size : jcp_.ch_block);
+                                    static_cast<int>(mask_flag
+                                                    ? tail_size
+                                                    : jcp_.ch_block));
                         } else if ((last_ic_block_flag == last_sp_block)
                                 && tail_size != 0 && icb1 == n_ic_blocks - 1) {
                             const auto vmm_inp_tmp = Xmm(vmm_src.getIdx());
                             load_bytes(vmm_inp_tmp, aux_reg_src_, aux_src_off,
-                                    tail_size);
+                                    static_cast<int>(tail_size));
                             uni_vpbroadcastd(vmm_src, vmm_inp_tmp);
                         } else {
                             uni_vpbroadcastd(
@@ -755,8 +761,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                     }
                 }
             }
-            for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-                const int aux_filt_off = kernel_offset(ocb, icb1, ki);
+            for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+                const dim_t aux_filt_off = kernel_offset(ocb, icb1, ki);
 
                 if (_end - _start > 0) {
                     if (jcp_.is_depthwise) {
@@ -767,7 +773,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                 vmm_wei_, ptr[aux_reg_filt_ + aux_filt_off]);
                 }
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
                     const bool inside_padded_area = h_padded
                             || !(jj >= jj_start && jj < jj_end
@@ -789,22 +795,22 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
-        int l_overflow, int r_overflow, ker_block_t last_ic_block_flag) {
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(dim_t ur_w,
+        dim_t l_overflow, dim_t r_overflow, ker_block_t last_ic_block_flag) {
 
     const bool signed_input_or_src_zp
             = (jcp_.signed_input || jcp_.src_zero_point);
 
-    const int ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
-    const int shift_src_ih = jcp_.typesize_in * (jcp_.dilate_h + 1) * jcp_.iw
+    const dim_t ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
+    const dim_t shift_src_ih = jcp_.typesize_in * (jcp_.dilate_h + 1) * jcp_.iw
             * jcp_.ngroups * jcp_.ic_without_padding;
-    const int shift_src_id = jcp_.typesize_in * (jcp_.dilate_d + 1) * jcp_.ih
+    const dim_t shift_src_id = jcp_.typesize_in * (jcp_.dilate_d + 1) * jcp_.ih
             * jcp_.iw * jcp_.ngroups * jcp_.ic_without_padding;
-    const int stride_h = signed_input_or_src_zp ? 1 : jcp_.stride_h;
-    const int shift_filt_kh
+    const dim_t stride_h = signed_input_or_src_zp ? 1 : jcp_.stride_h;
+    const dim_t shift_filt_kh
             = jcp_.typesize_in * jcp_.kw * ch_block_all * stride_h;
-    const int stride_d = signed_input_or_src_zp ? 1 : jcp_.stride_d;
-    const int shift_filt_kd
+    const dim_t stride_d = signed_input_or_src_zp ? 1 : jcp_.stride_d;
+    const dim_t shift_filt_kd
             = jcp_.typesize_in * jcp_.kw * ch_block_all * jcp_.kh * stride_d;
 
     Label kd_loop_label, kh_loop_label, skip_kh_loop, skip_kd_loop;
@@ -847,7 +853,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
                 || ((!signed_input_or_src_zp)
                         && ((min(jcp_.f_pad, jcp_.back_pad) < 0)
                                 || ((jcp_.kd - 1) * (jcp_.dilate_d + 1)
-                                        < nstl::max(
+                                        < nstl::max<dim_t>(
                                                 jcp_.f_pad, jcp_.back_pad))))) {
             cmp(reg_ki_, 0);
             je(skip_kd_loop, T_NEAR);
@@ -885,7 +891,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
             || ((!signed_input_or_src_zp)
                     && ((min(jcp_.t_pad, jcp_.b_pad) < 0)
                             || ((jcp_.kh - 1) * (jcp_.dilate_h + 1)
-                                    < nstl::max(jcp_.t_pad, jcp_.b_pad))))) {
+                                    < nstl::max<dim_t>(
+                                            jcp_.t_pad, jcp_.b_pad))))) {
         cmp(reg_kh_, 0);
         je(skip_kh_loop, T_NEAR);
     }
@@ -988,9 +995,9 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(
-        int ur_w) {
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-        for (int ur = 0; ur < ur_w; ur++) {
+        dim_t ur_w) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const Vmm vmm = vmm_out(ur, ocb);
             uni_vpxor(vmm, vmm, vmm);
         }
@@ -1005,23 +1012,25 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::cvt2ps(
-        data_type_t type_in, const Vmm vmm_in, const Reg64 reg, int offset,
-        int load_size) {
+        data_type_t type_in, const Vmm vmm_in, const Reg64 reg, dim_t offset,
+        dim_t load_size) {
 
-    load_data(type_in, vmm_in, reg, offset, load_size);
+    load_data(type_in, vmm_in, reg, static_cast<int>(offset),
+            static_cast<int>(load_size));
     if (type_in != data_type::f32) uni_vcvtdq2ps(vmm_in, vmm_in);
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
-        bool last_oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
+        dim_t ur_w, bool last_oc_block, const float *p_sum_scale,
+        const int32_t *p_sum_zp) {
     const auto sum_injector = [&]() {
         if (p_sum_scale) { // post_op: sum
-            for (int k = 0; k < jcp_.nb_oc_blocking; k++) {
+            for (dim_t k = 0; k < jcp_.nb_oc_blocking; k++) {
                 const bool mask_flag
                         = last_oc_block == 1 && k == jcp_.nb_oc_blocking - 1;
-                for (int j = 0; j < ur_w; j++) {
-                    const int aux_output_offset = jcp_.typesize_out
+                for (dim_t j = 0; j < ur_w; j++) {
+                    const dim_t aux_output_offset = jcp_.typesize_out
                             * (k * jcp_.oc_block
                                     + j * jcp_.oc_without_padding
                                             * jcp_.ngroups);
@@ -1051,10 +1060,10 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
 
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     if (jcp_.with_binary) {
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-            for (int ur = 0; ur < ur_w; ur++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const int vmm_idx = vmm_out(ur, ocb).getIdx();
                 const size_t aux_output_offset = jcp_.typesize_out
                         * (ocb * jcp_.oc_block
@@ -1067,15 +1076,15 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
             }
         }
     }
-    const int nb_oc_block
+    const dim_t nb_oc_block
             = jcp_.is_depthwise ? jcp_.nb_ch_blocking : jcp_.nb_oc_blocking;
     postops_injector_->compute_vector_range(
-            16 - nb_oc_block * ur_w, 16, rhs_arg_params);
+            static_cast<int>(16 - nb_oc_block * ur_w), 16, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
-        int ur_w, bool last_oc_block) {
+        dim_t ur_w, bool last_oc_block) {
     mov(reg_bias_, ptr[param1_ + GET_OFF(bias)]);
 
     if (jcp_.signed_input)
@@ -1098,24 +1107,24 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         const auto &vmm_zp_comp = vmm_scales_;
         uni_vbroadcastss(vmm_src_zp, ptr[reg_zp_src_]);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            const int zp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            const dim_t zp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-            const int load_size
+            const dim_t load_size
                     = mask_flag ? get_tail_size() : get_blocking_size();
             load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation_,
-                    zp_offset, load_size);
+                    static_cast<int>(zp_offset), static_cast<int>(load_size));
             uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_src_zp);
 
-            for (int ur = 0; ur < ur_w; ur++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const auto vmm_dst = vmm_out(ur, ocb);
                 uni_vpaddd(vmm_dst, vmm_dst, vmm_zp_comp);
             }
         }
     }
 
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
 
         // TODO: scales support is done not in the most optimal way.
@@ -1146,7 +1155,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
             if (!jcp_.is_oc_scale) {
                 uni_vbroadcastss(vmm_scales_tmp_, ptr[reg_wei_scales_]);
             } else {
-                const int scale_offset = jcp_.is_oc_scale
+                const dim_t scale_offset = jcp_.is_oc_scale
                         * (sizeof(float) * ocb * jcp_.oc_block);
                 if (mask_flag) {
                     uni_vpxor(
@@ -1184,18 +1193,18 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         // after scales are processed.
         const auto vmm_bias_ = vmm_tmp_;
         if (jcp_.with_bias) {
-            int bias_offset = jcp_.typesize_bia * ocb * jcp_.oc_block;
+            dim_t bias_offset = jcp_.typesize_bia * ocb * jcp_.oc_block;
             cvt2ps(jcp_.bia_dt, vmm_bias_, reg_bias_, bias_offset,
                     mask_flag ? get_tail_size() : get_blocking_size());
         }
 
         if (jcp_.signed_input) {
-            const int comp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
             cvt2ps(data_type::s32, vmm_comp_, reg_compensation_, comp_offset,
                     mask_flag ? get_tail_size() : get_blocking_size());
         }
 
-        for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const Vmm vmm = vmm_out(ur, ocb);
             uni_vcvtdq2ps(vmm, vmm);
             if (jcp_.signed_input) uni_vaddps(vmm, vmm, vmm_comp_);
@@ -1218,8 +1227,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         mov(reg_dst_scales_, ptr[param1_ + GET_OFF(dst_scales)]);
         uni_vbroadcastss(vmm_dst_scales_, ptr[reg_dst_scales_]);
 
-        for_(int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
-        for (int ur = 0; ur < ur_w; ur++) {
+        for_(dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const auto vmm = vmm_out(ur, ocb);
             uni_vmulps(vmm, vmm, vmm_dst_scales_);
         }
@@ -1231,8 +1240,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         uni_vbroadcastss(vmm_zp_dst, ptr[reg_zp_dst_]);
         uni_vcvtdq2ps(vmm_zp_dst, vmm_zp_dst);
 
-        for_(int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
-        for (int ur = 0; ur < ur_w; ur++) {
+        for_(dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const auto vmm_dst = vmm_out(ur, ocb);
             uni_vaddps(vmm_dst, vmm_dst, vmm_zp_dst);
         }
@@ -1245,8 +1254,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     // saturation will happen when storing data
     if (jcp_.dst_dt == data_type::u8) {
         uni_vpxor(vmm_zero_, vmm_zero_, vmm_zero_);
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vmaxps(vmm, vmm, vmm_zero_);
             }
@@ -1260,8 +1269,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         uni_vmovq(xmm_saturation, reg_ptr_saturation_ubound_);
         uni_vbroadcastss(vmm_saturation_, xmm_saturation);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vminps(vmm, vmm, vmm_saturation_);
             }
@@ -1269,8 +1278,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     }
 
     if (one_of(jcp_.dst_dt, data_type::u8, data_type::s8, data_type::s32)) {
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vcvtps2dq(vmm, vmm);
             }
@@ -1278,24 +1287,26 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     }
 
     /* write out register to output_addr */
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-        for (int ur = 0; ur < ur_w; ur++) {
-            const int aux_dst_off = jcp_.typesize_out
+        for (dim_t ur = 0; ur < ur_w; ur++) {
+            const dim_t aux_dst_off = jcp_.typesize_out
                     * (ur * jcp_.ngroups * jcp_.oc_without_padding
                             + ocb * jcp_.oc_block);
             const Vmm r_vmm = vmm_out(ur, ocb);
-            store_data(jcp_.dst_dt, r_vmm, reg_dst_, aux_dst_off,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+            store_data(jcp_.dst_dt, r_vmm, reg_dst_,
+                    static_cast<int>(aux_dst_off),
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
         }
     }
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
-        int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
+        dim_t ur_w, dim_t l_overflow, dim_t r_overflow, bool is_last_sp_block) {
 
-    const int shift_src_icb = jcp_.typesize_in * jcp_.ic_block;
+    const dim_t shift_src_icb = jcp_.typesize_in * jcp_.ic_block;
     const size_t shift_filt_icb = (size_t)jcp_.typesize_in * jcp_.kd * jcp_.kh
             * jcp_.kw * jcp_.ic_block * jcp_.oc_block;
 
@@ -1387,22 +1398,22 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     mov(reg_filt_, ptr[param1_ + GET_OFF(filt)]);
     mov(reg_dst_, ptr[param1_ + GET_OFF(dst)]);
 
-    const int dst_shift = jcp_.typesize_out * jcp_.ur_w * jcp_.ngroups
+    const dim_t dst_shift = jcp_.typesize_out * jcp_.ur_w * jcp_.ngroups
             * jcp_.oc_without_padding;
-    const int src_shift = jcp_.typesize_in * (jcp_.ur_w / jcp_.stride_w)
+    const dim_t src_shift = jcp_.typesize_in * (jcp_.ur_w / jcp_.stride_w)
             * jcp_.ngroups * jcp_.ic_without_padding;
 
-    const int l_overflow = max(0,
+    const dim_t l_overflow = max<dim_t>(0,
             ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - jcp_.l_pad) / jcp_.stride_w);
-    const int r_overflow = max(0,
-            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - max(0, jcp_.r_pad))
+    const dim_t r_overflow = max<dim_t>(0,
+            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - max<dim_t>(0, jcp_.r_pad))
                     / jcp_.stride_w);
 
-    const int r_overflow1 = nstl::max(0,
-            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - nstl::max(0, jcp_.r_pad)
-                    - jcp_.ur_w_tail)
+    const dim_t r_overflow1 = nstl::max<dim_t>(0,
+            ((jcp_.kw - 1) * (jcp_.dilate_w + 1)
+                    - nstl::max<dim_t>(0, jcp_.r_pad) - jcp_.ur_w_tail)
                     / jcp_.stride_w);
-    int nur_w = jcp_.ow / jcp_.ur_w;
+    dim_t nur_w = jcp_.ow / jcp_.ur_w;
     if (r_overflow1 > 0) nur_w--;
 
     if (jcp_.ur_w == jcp_.ow) {
@@ -1567,8 +1578,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const void *src_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -1588,9 +1599,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * nb_groups * oc_chunks;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks;
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_deconv_args_t();
 
@@ -1605,7 +1617,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0};
+        dim_t n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks);
         else if (jcp.loop_order == loop_cgn)
@@ -1614,10 +1626,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
 
             p.dst = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             p.src = src + src_d.blk_off(n, g_ic);
@@ -1692,8 +1704,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const size_t src_h_stride = src_d.blk_off(0, 0, 1);
     const size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -1717,9 +1729,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_deconv_args_t();
 
@@ -1735,7 +1748,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     oh_s, jcp.oh);
@@ -1746,12 +1759,12 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
-            const int work_rem = end - start;
-            const int oh_e
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t work_rem = end - start;
+            const dim_t oh_e
                     = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
 
             const auto dst_w = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
@@ -1763,17 +1776,18 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             const int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    const int dilate_h = jcp.dilate_h + 1;
+                    const dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    const int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    const dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    const int o_b_overflow
-                            = div_up(max(0,
+                    const dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1781,15 +1795,16 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    const int o_t_overflow = max(
+                    const dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    const int o_b_overflow = max(0,
+                    const dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    const int overflow_kh_hi = jcp.kh - 1
+                    const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    const int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    const dim_t overflow_kh_lo
+                            = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1797,21 +1812,21 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                const int wei_stride
+                const dim_t wei_stride
                         = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
-                p.src = src_w + ih_max * src_h_stride;
+                p.src = src_w + static_cast<size_t>(ih_max * src_h_stride);
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
-                p.filt = wht_w + wei_stride;
+                p.filt = wht_w + static_cast<size_t>(wei_stride);
                 p.bias = bias_w;
                 p.compensation = compensation_w;
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
@@ -1881,8 +1896,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int &nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t &nb_groups = jcp.nb_ch;
 
     const size_t src_d_stride = src_d.blk_off(0, 0, 1);
     const size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
@@ -1909,9 +1924,11 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        const dim_t work_amount
+                = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_deconv_args_t();
 
@@ -1927,7 +1944,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     od_s, jcp.od, oh_s, jcp.oh);
@@ -1938,25 +1955,26 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
-            const int work_rem = end - start;
-            const int oh_e
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t work_rem = end - start;
+            const dim_t oh_e
                     = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-            int input_d_s = 0, kd_len = 0, kd_lo = 0;
-            int d_t_overflow, d_back_overflow;
+            dim_t input_d_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t d_t_overflow, d_back_overflow;
 
             if (jcp.dilate_d != 0 && jcp.stride_d == 1) {
                 /* dilation */
-                int dilate_d = jcp.dilate_d + 1;
+                const dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
                 d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
                         dilate_d);
                 d_back_overflow
-                        = div_up(max(0,
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.od
                                                  + od_s - jcp.back_pad),
                                 dilate_d);
@@ -1964,15 +1982,15 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 kd_lo = d_back_overflow;
                 input_d_s = od_s + jcp.f_pad - d_back_overflow * dilate_d;
             } else {
-                const int d_t_overflow = max(
+                const dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - (od_s + 1 + jcp.f_pad)) / jcp.stride_d);
-                const int d_back_overflow = max(0,
+                const dim_t d_back_overflow = max<dim_t>(0,
                         ((od_s + jcp.kd) - (jcp.od + jcp.back_pad))
                                 / jcp.stride_d);
-                const int overflow_kd_hi = jcp.kd - 1
+                const dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
                                 jcp.stride_d);
-                const int overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
+                const dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_back_overflow;
@@ -1994,17 +2012,18 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             const int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    const int dilate_h = jcp.dilate_h + 1;
+                    const dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    const int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    const dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    const int o_b_overflow
-                            = div_up(max(0,
+                    const dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -2012,15 +2031,16 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    const int o_t_overflow = max(
+                    const dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    const int o_b_overflow = max(0,
+                    const dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    const int overflow_kh_hi = jcp.kh - 1
+                    const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    const int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    const dim_t overflow_kh_lo
+                            = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -2028,32 +2048,32 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                const int wei_stride
+                const dim_t wei_stride
                         = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
-                p.src = src_w + ih_max * src_h_stride;
+                p.src = src_w + static_cast<size_t>(ih_max * src_h_stride);
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
-                p.filt = wht_w + wei_stride;
+                p.filt = wht_w + static_cast<size_t>(wei_stride);
                 p.bias = bias_w;
                 p.compensation = compensation_w;
                 /* Note: Currently this kernel doesn't support dilations and
                 strides together */
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kd
                                           - (kd_lo
-                                                  + max(0, kd_len - 1)
+                                                  + max<dim_t>(0, kd_len - 1)
                                                           * jcp.stride_d
                                                   + 1));
                 p.back_overflow = kd_lo;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -434,7 +434,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
     , ker_max_regs_(jcp_.has_vnni ? 14 : 12) {
 
     if (jcp_.with_eltwise || jcp_.with_binary || jcp_.with_sum) {
-        const dim_t tail_size = get_tail_size();
+        const std::size_t tail_size = get_tail_size();
 
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
@@ -1804,7 +1804,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                                     / jcp.stride_h);
                     const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
-                                    jcp.stride_h);
+                                    static_cast<dim_t>(jcp.stride_h));
                     const dim_t overflow_kh_lo
                             = (oj + jcp.t_pad) % jcp.stride_h;
 
@@ -1991,7 +1991,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                                 / jcp.stride_d);
                 const dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
-                                jcp.stride_d);
+                                static_cast<dim_t>(jcp.stride_d));
                 const dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
@@ -2040,7 +2040,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                                     / jcp.stride_h);
                     const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
-                                    jcp.stride_h);
+                                    static_cast<dim_t>(jcp.stride_h));
                     const dim_t overflow_kh_lo
                             = (oj + jcp.t_pad) % jcp.stride_h;
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -239,9 +239,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -78,12 +78,12 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     const bool is_3d = ndims == 5;
     const bool is_avx2 = isa == avx2;
 
-    jcp.ngroups = with_groups ? weights_d.dims()[0] : 1;
-    jcp.oc = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic = src_d.dims()[1] / jcp.ngroups;
-    jcp.id = is_3d ? src_d.dims()[2] : 1;
-    jcp.oc_without_padding = dst_d.dims()[1] / jcp.ngroups;
-    jcp.ic_without_padding = src_d.dims()[1] / jcp.ngroups;
+    jcp.ngroups = with_groups ? static_cast<int>(weights_d.dims()[0]) : 1;
+    jcp.oc = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
+    jcp.id = is_3d ? static_cast<int>(src_d.dims()[2]) : 1;
+    jcp.oc_without_padding = static_cast<int>(dst_d.dims()[1]) / jcp.ngroups;
+    jcp.ic_without_padding = static_cast<int>(src_d.dims()[1]) / jcp.ngroups;
     jcp.is_depthwise = true && with_groups
             && utils::everyone_is(
                     1, jcp.ic_without_padding, jcp.oc_without_padding);
@@ -183,21 +183,23 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     }
 
     jcp.prop_kind = cd.prop_kind;
-    jcp.mb = src_d.dims()[0];
-    jcp.ih = is_1d ? 1 : src_d.dims()[ndims - 2];
-    jcp.iw = src_d.dims()[ndims - 1];
-    jcp.od = is_3d ? dst_d.dims()[2] : 1;
-    jcp.oh = is_1d ? 1 : dst_d.dims()[ndims - 2];
-    jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = is_3d ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = is_1d ? 1 : weights_d.dims()[with_groups + ndims - 2];
-    jcp.kw = weights_d.dims()[with_groups + ndims - 1];
-    jcp.f_pad = is_3d ? cd.padding[0][0] : 0;
-    jcp.t_pad = is_1d ? 0 : cd.padding[0][ndims - 4];
-    jcp.l_pad = cd.padding[0][ndims - 3];
-    jcp.stride_d = is_3d ? cd.strides[0] : 1;
-    jcp.stride_h = is_1d ? 1 : cd.strides[ndims - 4];
-    jcp.stride_w = cd.strides[ndims - 3];
+    jcp.mb = static_cast<int>(src_d.dims()[0]);
+    jcp.ih = is_1d ? 1 : static_cast<int>(src_d.dims()[ndims - 2]);
+    jcp.iw = static_cast<int>(src_d.dims()[ndims - 1]);
+    jcp.od = is_3d ? static_cast<int>(dst_d.dims()[2]) : 1;
+    jcp.oh = is_1d ? 1 : static_cast<int>(dst_d.dims()[ndims - 2]);
+    jcp.ow = static_cast<int>(dst_d.dims()[ndims - 1]);
+    jcp.kd = is_3d ? static_cast<int>(weights_d.dims()[with_groups + 2]) : 1;
+    jcp.kh = is_1d
+            ? 1
+            : static_cast<int>(weights_d.dims()[with_groups + ndims - 2]);
+    jcp.kw = static_cast<int>(weights_d.dims()[with_groups + ndims - 1]);
+    jcp.f_pad = is_3d ? static_cast<int>(cd.padding[0][0]) : 0;
+    jcp.t_pad = is_1d ? 0 : static_cast<int>(cd.padding[0][ndims - 4]);
+    jcp.l_pad = static_cast<int>(cd.padding[0][ndims - 3]);
+    jcp.stride_d = is_3d ? static_cast<int>(cd.strides[0]) : 1;
+    jcp.stride_h = is_1d ? 1 : static_cast<int>(cd.strides[ndims - 4]);
+    jcp.stride_w = static_cast<int>(cd.strides[ndims - 3]);
 
     if (jcp.is_depthwise) {
         jcp.ch_block = is_avx2 ? 8 : 4;
@@ -228,9 +230,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     VDISPATCH_DECONVOLUTION_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_TAG_S, "weights");
 
-    jcp.dilate_d = is_3d ? cd.dilates[0] : 0;
-    jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
-    jcp.dilate_w = cd.dilates[ndims - 3];
+    jcp.dilate_d = is_3d ? static_cast<int>(cd.dilates[0]) : 0;
+    jcp.dilate_h = is_1d ? 0 : static_cast<int>(cd.dilates[ndims - 4]);
+    jcp.dilate_w = static_cast<int>(cd.dilates[ndims - 3]);
 
     VDISPATCH_DECONVOLUTION_IC(
             !(!IMPLICATION(jcp.dilate_d, jcp.stride_d == 1)

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -123,32 +123,33 @@ private:
     const Vmm vmm_prev_dst_ = vmm_zero_;
     const Vmm vmm_sum_zp_ = vmm_tmp_;
 
-    Vmm vmm_out(int i_ur, int i_oc) const;
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) const;
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) const;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) const;
 
-    int get_ow_start(int ki, int l_overflow) const noexcept;
-    int get_ow_end(int ur_w, int ki, int r_overflow) const noexcept;
-    int get_blocking_size() const noexcept;
-    int get_tail_size() const noexcept;
+    dim_t get_ow_start(dim_t ki, dim_t l_overflow) const noexcept;
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t r_overflow) const noexcept;
+    dim_t get_blocking_size() const noexcept;
+    dim_t get_tail_size() const noexcept;
 
-    void prepare_output(int ur_w);
-    void apply_postops(int ur_w, bool last_oc_block, const float *p_sum_scale,
+    void prepare_output(dim_t ur_w);
+    void apply_postops(dim_t ur_w, bool last_oc_block, const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void store_output(int ur_w, bool last_oc_block);
-    void compute_ker(int ur_w, int l_overflow, int r_overflow,
+    void store_output(dim_t ur_w, bool last_oc_block);
+    void compute_ker(dim_t ur_w, dim_t l_overflow, dim_t r_overflow,
             ker_block_t last_ic_block_flag, bool h_padded = false);
     void compute(const Vmm vreg_acc, const Vmm vreg_wei, const Vmm vreg_src);
     std::function<Vmm()> prepare_round_robin_vmm_inp_generator(
-            int ur_w) const noexcept;
+            dim_t ur_w) const noexcept;
     void apply_zp_src_pad_str_comp(
-            int ur_w, int l_overflow, int r_overflow, bool h_padded);
-    void append_zp_src_pad_str_comp(int ur_w, int l_overflow, int r_overflow,
-            bool h_padded, bool last_oc_block);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ker_block_t last_ker_block);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool last_block);
+            dim_t ur_w, dim_t l_overflow, dim_t r_overflow, bool h_padded);
+    void append_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+            dim_t r_overflow, bool h_padded, bool last_oc_block);
+    void kh_loop(
+            dim_t ur_w, dim_t pad_l, dim_t pad_r, ker_block_t last_ker_block);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r, bool last_block);
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Reg64 reg,
-            int offset, int load_size);
+            dim_t offset, dim_t load_size);
 };
 
 template <cpu_isa_t isa>


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the universal x8s8s32x JIT convolution/deconvolution kernels (`jit_uni_deconv_zp_pad_str_kernel`, `jit_uni_x8s8s32x_1x1_conv_kernel`, `jit_uni_x8s8s32x_1x1_convolution`, `jit_uni_x8s8s32x_conv_kernel`, `jit_uni_x8s8s32x_convolution`, `jit_uni_x8s8s32x_deconvolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5667 for review convenience; independently reviewable.