### PR TITLE
cpu: conv: GEMM and reference: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -87,7 +87,7 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
             + (ptrdiff_t)ithr * jcp.is * jcp.ic;
 
     dim_t g {0}, n {0}, ohb {0}, owb {0};
-    dim_t start = 0, end = 0;
+    dim_t start_i {0}, end_i {0};
     const bool is_problem_3d = pd()->ndims() == 5;
 
     assert(IMPLICATION(is_problem_3d,
@@ -99,7 +99,8 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
     const dim_t nb_ow = div_up(jcp.ow, jcp.ow_block);
     // threads share work across mini-batch, groups, and blocked width/height
     const dim_t work_amount = jcp.mb * jcp.ngroups * nb_oh * nb_ow;
-    balance211(work_amount, nthr, ithr, start, end);
+    balance211(work_amount, nthr, ithr, start_i, end_i);
+    dim_t start = start_i, end = end_i;
     nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ohb, nb_oh, owb, nb_ow);
 
     if (jcp.im2col_sz && is_problem_3d) {
@@ -116,8 +117,10 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const int h_step
+                = static_cast<int>(nstl::min<dim_t>(jcp.oh_block, jcp.oh - oh));
+        const int w_step
+                = static_cast<int>(nstl::min<dim_t>(jcp.ow_block, jcp.ow - ow));
         if (jcp.im2col_sz && is_problem_3d) {
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
         }
@@ -264,8 +267,9 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
             for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
                 _col[i] = (data_t)0;
         }
-        auto inner_ker = [&](int spatial, const im_pos_t &curr, im_pos_t &prev,
-                                 im_pos_t &step, const im_pos_t &end) {
+        auto inner_ker
+                = [&](dim_t spatial, const im_pos_t &curr, im_pos_t &prev,
+                          im_pos_t &step, const im_pos_t &end) {
             const data_t *_src
                     = src + curr.n * src_mb_stride + curr.g * src_g_stride;
             step.oc = nstl::min(
@@ -282,8 +286,8 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                     jit_gemm_convolution_utils::im2col<float>(jcp, _src, _col,
                             curr.sp, step.sp, curr.ic, step.ic);
                 else
-                    jit_gemm_convolution_utils::im2col_3d<float>(
-                            jcp, _src, _col, curr.od, 0, jcp.os);
+                    jit_gemm_convolution_utils::im2col_3d<float>(jcp, _src,
+                            _col, curr.od, 0, static_cast<int>(jcp.os));
             }
             const data_t one = 1.0;
 
@@ -312,7 +316,8 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                 // TODO: for "outer threading" we have parallel section within
                 // outermost "parallel". It is not good. Consider to use
                 // "parallel" here with number of threads passed as parameter
-                const int oc_start = curr.g * jcp.oc + curr.oc;
+                const int oc_start
+                        = static_cast<int>(curr.g * jcp.oc + curr.oc);
                 if (jcp.with_eltwise || jcp.with_binary) {
                     bool fast_relu_done = false;
                     if (jcp.with_eltwise && jcp.post_ops.len() == 1) {
@@ -479,9 +484,10 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_thr_nspc(
             : nullptr;
 
     dim_t n {0}, g {0};
-    dim_t start = 0, end = 0;
+    dim_t start_i {0}, end_i {0};
 
-    balance211(work_amount, nthr, ithr, start, end);
+    balance211(work_amount, nthr, ithr, start_i, end_i);
+    dim_t start = start_i, end = end_i;
     nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups);
 
     for (dim_t iwork = start; iwork < end; ++iwork) {
@@ -550,7 +556,7 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
     const dim_t K = jcp.oc;
     const dim_t N = jcp.ic * jcp.ks;
 
-    const dim_t work_amount = (size_t)jcp.ngroups * jcp.mb;
+    const dim_t work_amount = jcp.ngroups * jcp.mb;
     const bool is_problem_3d = pd()->ndims() == 5;
 
     std::atomic<status_t> st(status::success);
@@ -558,8 +564,9 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
         data_t *_col = col + (ptrdiff_t)ithr * jcp.im2col_sz;
 
         dim_t g {0}, n {0};
-        dim_t start = 0, end = 0;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
         nd_iterator_init(start, g, jcp.ngroups, n, jcp.mb);
         for (dim_t iwork = start; iwork < end; ++iwork) {
 
@@ -636,11 +643,13 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
     std::atomic<status_t> st(status::success);
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                ithr_mb, nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -651,8 +660,8 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                 + (ptrdiff_t)ithr * jcp.id * jcp.ic * jcp.is;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -670,11 +679,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             data_t *weights_reduce = weights_reduce_base
                     + ithr_mb * weights_g_size * jcp.ks * jcp.ic;
 
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 data_t *_diff_weights = need_reduction
                         ? weights_reduce
                         : diff_weights + g * weights_g_size;
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const data_t *_src
                             = src + mb * jcp.ngroups * src_step + g * jcp.ic;
                     if (jcp.im2col_sz && is_problem_3d)
@@ -730,17 +739,20 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
             size_t mb_start {0}, mb_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g,
+                    nthr_g, ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(static_cast<size_t>(jcp.ngroups), nthr_g, ithr_g,
+                        g_start, g_end);
+                balance211(static_cast<size_t>(jcp.mb), nthr_mb, ithr_mb,
+                        mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -765,7 +777,7 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                         + ((static_cast<size_t>(mb) * jcp.od + od) * jcp.oh
                                   + oh)
                                 * jcp.ow * jcp.ngroups * jcp.oc;
-                const int width_stride = jcp.ngroups * jcp.oc;
+                const dim_t width_stride = jcp.ngroups * jcp.oc;
 
                 PRAGMA_OMP_SIMD(reduction(+ : db))
                 for (dim_t ow = 0; ow < jcp.ow; ++ow) {
@@ -806,9 +818,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                ithr_mb, nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
@@ -897,10 +911,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g,
+                    nthr_g, ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -55,7 +55,7 @@ namespace jit_gemm_convolution_utils {
 
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
-        data_type_t *col, dim_t od, int spatial_step, int spatial_block) {
+        data_type_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block) {
     using data_t =
             typename conditional<data_traits_t<data_type_t>::data_type == bf16,
                     uint16_t, data_type_t>::type;
@@ -226,10 +226,10 @@ void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
 }
 
 template void im2col_3d(const conv_gemm_conf_t &jcp, const float *im,
-        float *col, dim_t od, int spatial_step, int spatial_block);
+        float *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 template void im2col_3d(const conv_gemm_conf_t &jcp, const bfloat16_t *im,
-        bfloat16_t *col, dim_t od, int spatial_step, int spatial_block);
+        bfloat16_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 /* imtr[ic][od][oh][ow] <-- im[id][ih][iw][ic]*/
 template <typename T>
@@ -253,11 +253,12 @@ void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
                 T *__restrict imtr_icb = imtr_w + icb * ic_block * ic_stride;
                 PRAGMA_OMP_SIMD()
                 for (dim_t ic = 0; ic < ic_block; ic++) {
-                    imtr_icb[ic * ic_stride] = im_icb[ic] + shift;
+                    imtr_icb[ic * ic_stride]
+                            = static_cast<T>(im_icb[ic] + shift);
                 }
             }
             for (dim_t ic = ic_blocked; ic < jcp.ic; ic++) {
-                imtr_w[ic * ic_stride] = im_w[ic] + shift;
+                imtr_w[ic * ic_stride] = static_cast<T>(im_w[ic] + shift);
             }
         }
     });
@@ -647,8 +648,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                         for (dim_t ow = 0; ow < ow_start; ++ow)
                             col[col_idx_oh + ow] = shift;
                         for (dim_t ow = ow_start; ow < ow_end; ++ow)
-                            col[col_idx_oh + ow]
-                                    = imtr[imtr_idx_oh + ow] + shift;
+                            col[col_idx_oh + ow] = static_cast<col_dt>(
+                                    imtr[imtr_idx_oh + ow] + shift);
                         for (dim_t ow = ow_end; ow < wb; ++ow)
                             col[col_idx_oh + ow] = shift;
                     }
@@ -683,7 +684,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                 for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const dim_t iw = iw_base + ow * sw;
                     const ptrdiff_t im_idx = im_idx_base + iw * im_iw_stride;
-                    col[col_idx_base + ow] = im[im_idx] + shift;
+                    col[col_idx_base + ow]
+                            = static_cast<col_dt>(im[im_idx] + shift);
                 }
                 for (dim_t ow = ow_end; ow < wb; ow++)
                     col[col_idx_base + ow] = shift;
@@ -790,7 +792,7 @@ template void col2im_dt<bfloat16_t>(const conv_gemm_conf_t &jcp,
         const bfloat16_t *__restrict col, bfloat16_t *__restrict im);
 
 void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        dim_t od, int spatial_step, int spatial_block) {
+        dim_t od, dim_t spatial_step, dim_t spatial_block) {
 
     auto sp_blocked_ker = [&](dim_t ic) {
         const size_t col_step = jcp.ks * spatial_block;
@@ -892,7 +894,7 @@ void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
 }
 
 void col2im(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        int spatial_step, int spatial_block) {
+        dim_t spatial_step, dim_t spatial_block) {
     const size_t col_step = jcp.ks * spatial_block;
     const size_t im_step = jcp.ih * jcp.iw;
     const dim_t iS = jcp.ih * jcp.iw;
@@ -1297,8 +1299,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         dim_t nb_h = div_up(oh, h_block);
                         dim_t work = jcp.ngroups * jcp.mb * jcp.od * nb_h;
-                        float disb = (float)oh / rnd_up(oh, h_block);
-                        thr_eff = (float)work / rnd_up(work, max_threads);
+                        float disb = (float)oh / (float)rnd_up(oh, h_block);
+                        thr_eff = (float)work
+                                / (float)rnd_up(work, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff >= thr_eff_treshold) break;
                         h_block = rnd_dn(h_block - 4, 4);
@@ -1308,13 +1311,13 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                         < thr_eff_treshold) // we didn't find suitable h_block
                 {
                     h_block = 1;
-                    int nb_h = oh;
+                    dim_t nb_h = oh;
                     do {
                         dim_t nb_w = div_up(ow, w_block);
                         dim_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
-                        float disb = (float)ow / rnd_up(ow, w_block);
+                        float disb = (float)ow / (float)rnd_up(ow, w_block);
                         thr_eff = (float)work_amount
-                                / rnd_up(work_amount, max_threads);
+                                / (float)rnd_up(work_amount, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff > thr_eff_treshold) break;
                         w_block = rnd_dn(w_block - simd_w, simd_w);
@@ -1323,8 +1326,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 h_block = nstl::max(dim_t(1), h_block);
                 w_block = nstl::max(dim_t(1), w_block);
                 dim_t inner_work = div_up(os, simd_w) * div_up(oc, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 if (thr_eff >= inner_thr_eff / 2 && h_block > 0
                         && w_block > 0) {
                     jcp.oh_block = h_block;
@@ -1346,12 +1349,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const dim_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / (float)rnd_up(outer_work, max_threads);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1377,12 +1380,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
             bool is_depthwise = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
             const size_t outer_work = jcp.ngroups * jcp.mb;
-            const float outer_thr_eff
-                    = (float)outer_work / rnd_up(outer_work, max_threads);
+            const float outer_thr_eff = (float)outer_work
+                    / (float)rnd_up(outer_work, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = !is_3d
                     && (is_depthwise
                             || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1459,8 +1462,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         size_t nb_h = div_up(oh, h_block);
                         size_t work = jcp.ngroups * jcp.mb * jcp.od * nb_h;
-                        float disb = (float)oh / rnd_up(oh, h_block);
-                        thr_eff = (float)work / rnd_up(work, max_threads);
+                        float disb = (float)oh / (float)rnd_up(oh, h_block);
+                        thr_eff = (float)work
+                                / (float)rnd_up(work, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff >= thr_eff_treshold) break;
 
@@ -1478,9 +1482,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         size_t nb_w = div_up(ow, w_block);
                         size_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
-                        float disb = (float)ow / rnd_up(ow, w_block);
+                        float disb = (float)ow / (float)rnd_up(ow, w_block);
                         thr_eff = (float)work_amount
-                                / rnd_up(work_amount, max_threads);
+                                / (float)rnd_up(work_amount, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff > thr_eff_treshold) break;
 
@@ -1494,8 +1498,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 w_block = nstl::max(size_t {1}, w_block);
                 const size_t inner_work
                         = div_up(os, simd_w) * div_up(oc, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 if (thr_eff >= inner_thr_eff / 2 && h_block > 0
                         && w_block > 0) {
                     jcp.oh_block = static_cast<int>(h_block);
@@ -1517,12 +1521,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const size_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / (float)rnd_up(outer_work, max_threads);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1571,7 +1575,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             // threading work
                             || jcp.os < jcp.mb * jcp.ngroups * jcp.od
                             // im2col is big
-                            || (sw == 1 && K <= 0.05 * jcp.oc))
+                            || (sw == 1 && (double)K <= 0.05 * (double)jcp.oc))
                     // heuristic condition
                     && (jcp.im2col_sz
                             || (jcp.ic / jcp.oc < 42
@@ -1704,7 +1708,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                                     = nstl::min(oc_max_os_min, oc_min_os_max);
                         }
                     }
-                    auto thr_disb = (float)min_thr_size / max_thr_size;
+                    auto thr_disb = (float)min_thr_size / (float)max_thr_size;
 
                     const dim_t oc_per_thr = max_oc;
                     const dim_t os_per_thr = max_os;
@@ -1717,8 +1721,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             nthr_oc, ocb, osb, oc_per_thr, os_per_thr);
                     // if we don't fit into cache then access to memory is
                     // expensive
-                    dim_t mem_access_cost
-                            = (max_ic_block < 1) ? non_cache_access : 1;
+                    dim_t mem_access_cost = static_cast<dim_t>(
+                            (max_ic_block < 1) ? non_cache_access : 1);
                     max_ic_block = nstl::max(dim_t(1), max_ic_block);
                     // "jcp.ic == 0 ? dim_t(1) : " is to avoid msvc warning 'potential divide by zero'
                     dim_t icb = nstl::max(dim_t(1),
@@ -1742,12 +1746,16 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     // TODO: simplify calculations
                     if (jcp.im2col_sz) {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
-                        const float col_tail_koeff = (float)osb_caligned / osb;
-                        col_ops = mem_access_cost
-                                * (jcp.ks * inp_size * col_tail_koeff
-                                        + jcp.ks * inp_size * col_tail_koeff);
+                        const float col_tail_koeff
+                                = (float)osb_caligned / (float)osb;
+                        col_ops = static_cast<size_t>((float)mem_access_cost
+                                * ((float)jcp.ks * (float)inp_size
+                                                * col_tail_koeff
+                                        + (float)jcp.ks * (float)inp_size
+                                                * col_tail_koeff));
                         if (sw != 1) // im2col with strides is much slower
-                            col_ops *= strided_im2col_k;
+                            col_ops = static_cast<size_t>(
+                                    (float)col_ops * strided_im2col_k);
                     } else {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
                     }
@@ -1756,23 +1764,28 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     const size_t wei_ops = mem_access_cost * wei_size;
                     // ratio of real FMA to number of memory ops
                     const float thr_mem_eff
-                            = (((float)os_per_thr / simd_w) * oc_per_thr * K)
-                            / (inp_ops + col_ops + wei_ops + out_ops);
+                            = (((float)os_per_thr / (float)simd_w)
+                                      * (float)oc_per_thr * (float)K)
+                            / (float)(inp_ops + col_ops + wei_ops + out_ops);
 
-                    auto oc_disb = (float)oc_per_thr / rnd_up(oc_per_thr, ocb);
-                    auto os_disb = (float)os_max / rnd_up(os_max, osb);
-                    auto ic_disb = (float)jcp.ic / rnd_up(jcp.ic, icb);
+                    auto oc_disb = (float)oc_per_thr
+                            / (float)rnd_up(oc_per_thr, ocb);
+                    auto os_disb = (float)os_max / (float)rnd_up(os_max, osb);
+                    auto ic_disb = (float)jcp.ic / (float)rnd_up(jcp.ic, icb);
 
-                    auto reg_osb_disb = (float)osb / rnd_up(osb, 3 * simd_w);
+                    auto reg_osb_disb
+                            = (float)osb / (float)rnd_up(osb, 3 * simd_w);
 
                     // Heuristics
-                    const float gemm_eff = ((float)osb * ocb * kb)
-                            / ((float)oc_per_thr * os_per_thr * K);
+                    const float gemm_eff = ((float)osb * (float)ocb * (float)kb)
+                            / ((float)oc_per_thr * (float)os_per_thr
+                                    * (float)K);
 
                     // number of FMA to memory size
                     const float gemm_calc_eff
-                            = (((float)osb / simd_w) * ocb * kb)
-                            / (osb_caligned * kb + ocb * kb_caligned
+                            = (((float)osb / (float)simd_w) * (float)ocb
+                                      * (float)kb)
+                            / (float)(osb_caligned * kb + ocb * kb_caligned
                                     + ocb * osb_caligned);
                     // optimization: remove pow, when corresponding weight is 1
                     const float res_eff = pow(pow(thr_disb, thr_disb_k)
@@ -1900,7 +1913,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     }
                 }
                 jcp.outer_threading = true;
-                jcp.nthr_oc = best_nthr_oc;
+                jcp.nthr_oc = static_cast<int>(best_nthr_oc);
                 jcp.oc_block = best_ocb;
                 jcp.os_block = best_osb;
                 jcp.ic_block = best_icb;
@@ -1912,11 +1925,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
             } else {
                 const size_t outer_work_amount = jcp.ngroups * jcp.mb * jcp.od;
                 const float outer_thr_eff = (float)outer_work_amount
-                        / rnd_up(outer_work_amount, max_threads);
+                        / (float)rnd_up(outer_work_amount, max_threads);
                 const size_t inner_work_amount
                         = div_up(jcp.os, simd_w) * div_up(jcp.oc, simd_w);
                 const float inner_thr_eff = (float)inner_work_amount
-                        / rnd_up(inner_work_amount, max_threads);
+                        / (float)rnd_up(inner_work_amount, max_threads);
                 jcp.outer_threading = jcp.os / max_threads < 512
                         && IMPLICATION(
                                 jcp.od == 1, jcp.mb != 1 || jcp.ngroups > 2)
@@ -1944,12 +1957,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
             bool is_depthwise = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
             const size_t outer_work = jcp.ngroups * jcp.mb;
-            const float outer_thr_eff
-                    = (float)outer_work / rnd_up(outer_work, max_threads);
+            const float outer_thr_eff = (float)outer_work
+                    / (float)rnd_up(outer_work, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = !is_3d
                     && (is_depthwise
                             || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1967,11 +1980,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
         } else if (!jcp.is_nspc && is_bwd_d) {
             const size_t outer_work_amount = jcp.ngroups * jcp.mb;
             const float outer_thr_eff = (float)outer_work_amount
-                    / rnd_up(outer_work_amount, max_threads);
+                    / (float)rnd_up(outer_work_amount, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = (jcp.os / max_threads < 512 || jcp.ks < 64)
                     && (jcp.mb != 1 || jcp.ngroups > 2)
                     && (outer_thr_eff / inner_thr_eff >= 1.f
@@ -2107,9 +2120,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     // dimensions.
                     // TODO: better heuristic to determine os_block based
                     // on cache efficiency
-                    float _coef = is_bwd_w ? 0.05 : 0.1;
+                    float _coef = is_bwd_w ? 0.05f : 0.1f;
                     jcp.os_block = nstl::max(
-                            min_os_block, (int)(max_os_block * _coef));
+                            min_os_block, (int)((float)max_os_block * _coef));
                     jcp.os_nb_block = div_up(jcp.os, jcp.os_block);
                     jcp.im2col_sz = (ptrdiff_t)jcp.ic * jcp.ks * jcp.os_block;
                     gemm_col_memory_sz = jcp.nthr * jcp.im2col_sz;

--- a/src/cpu/gemm_convolution_utils.hpp
+++ b/src/cpu/gemm_convolution_utils.hpp
@@ -87,7 +87,7 @@ struct single_gemm_conv_chunk_desc_t {
 namespace jit_gemm_convolution_utils {
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
-        data_type_t *col, dim_t od, int spatial_step, int spatial_block);
+        data_type_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 template <typename T>
 void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
@@ -110,9 +110,9 @@ template <typename T>
 void col2im_dt(
         const conv_gemm_conf_t &jcp, const T *__restrict col, T *__restrict im);
 void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        dim_t od, int spatial_step, int spatial_block);
+        dim_t od, dim_t spatial_step, dim_t spatial_block);
 void col2im(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        int spatial_step, int spatial_block);
+        dim_t spatial_step, dim_t spatial_block);
 
 status_t init_conf(conv_gemm_conf_t &jcp,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -92,9 +92,9 @@ static zero_point_call_params_t prepare_zp_params(const conv_gemm_conf_t &jcp,
         const auto zp_comp_size = jcp.oc * jcp.ngroups;
 
         if (jcp.zp.src_is_common) {
-            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(zp_comp_size,
-                    zp_src_comp_scratch, zp_src_comp_from_wei,
-                    *src_zero_points);
+            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(
+                    static_cast<int>(zp_comp_size), zp_src_comp_scratch,
+                    zp_src_comp_from_wei, *src_zero_points);
         } else
             zp_src_comp = zp_src_comp_from_wei;
 
@@ -228,15 +228,15 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
     status_t st = status::success;
 
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        const int oh = ohb * jcp.oh_block;
-        const int ow = owb * jcp.ow_block;
+        const dim_t oh = ohb * jcp.oh_block;
+        const dim_t ow = owb * jcp.ow_block;
         const char *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const int8_t *__restrict wei = wei_base + g * wei_g_stride;
         const int32_t *__restrict wei_comp
                 = _wei_comp ? _wei_comp + g * jcp.oc : nullptr;
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt<char>(jcp, src, imtr);
 
@@ -308,7 +308,8 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
                 balance211(N * jcp.oc, nthr, ithr, _start, _end);
 
                 (*pp_ker_)(dst, acc, bia_base, scales, dst_scales[0], sum_scale,
-                        1.f / wei_adj_scale, g, n, _start, _end, zp,
+                        1.f / wei_adj_scale, static_cast<int>(g),
+                        static_cast<int>(n), _start, _end, zp,
                         post_ops_binary_rhs_arg_vec, dst_base, ctx,
                         *pd()->dst_md(), chunk_desc);
             });

--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -218,8 +218,8 @@ status_t ref_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         args.dst_md = pd()->dst_md();
         ref_post_ops->execute(d, args);
         if (dst_rnd_mode == rounding_mode::stochastic)
-            d = math::stochastic_round_fwd(
-                    d, dst_off, rnd_seed[0], dst_d.data_type());
+            d = math::stochastic_round_fwd(d, static_cast<uint32_t>(dst_off),
+                    rnd_seed[0], dst_d.data_type());
 
         io::store_float_value(dst_d.data_type(), d, dst, dst_off);
     });

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -365,8 +365,8 @@ prepare_zp_pad_comp_ker(const dim_t ndims, const int32_t *src_zero_points,
     const memory_desc_wrapper wei_d(deconv_pd->weights_md());
     const auto get_wei_off
             = [=](dim_t g, dim_t oc, dim_t ic, dim_t kd, dim_t kh, dim_t kw) {
-        return get_weights_off(
-                wei_d, with_groups, ndims, g, oc, ic, kd, kh, kw);
+        return get_weights_off(wei_d, with_groups, static_cast<int>(ndims), g,
+                oc, ic, kd, kh, kw);
     };
 
     return [=](const dim_t g, const dim_t oc, const dim_t od, const dim_t oh,


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the GEMM-based and reference convolution/deconvolution implementations (`gemm_convolution`, `gemm_convolution_utils`, `gemm_x8s8s32x_convolution`, `ref_convolution`, `ref_deconvolution`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5668 for review convenience; independently reviewable.