### PR TITLE
x64: GEMM: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp
+++ b/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp
@@ -98,7 +98,8 @@ dnnl_status_t ref_gemm_s8x8s32(const char *transa, const char *transb,
         double coffset = OCisR ? i2d(co[j]) : OCisC ? i2d(co[i]) : i2d(co[0]);
         double val = ((*beta == 0.0f) ? 0.0 : f2d(*beta) * i2d(C[i + j * ldc]))
                 + f2d(*alpha) * dC[i + j * ldc] + coffset;
-        C[i + j * ldc] = q10n::out_round<int32_t>(q10n::saturate<int32_t>(val));
+        C[i + j * ldc] = q10n::out_round<int32_t>(
+                static_cast<float>(q10n::saturate<int32_t>(val)));
     });
 
     free(dA);

--- a/src/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp
+++ b/src/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp
@@ -65,8 +65,8 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                 val += a[(i + j * blocking_factor * lda) + jb * lda];
             }
             if (alpha != 1.0f) {
-                val = q10n::out_round<int32_t>(
-                        q10n::saturate<int32_t>((double)val * alpha * -128.0));
+                val = q10n::out_round<int32_t>(static_cast<float>(
+                        q10n::saturate<int32_t>((double)val * alpha * -128.0)));
             } else {
                 val *= -128;
             }
@@ -80,8 +80,9 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                     val += a[i + j * lda];
                 }
                 if (alpha != 1.0f) {
-                    val = q10n::out_round<int32_t>(q10n::saturate<int32_t>(
-                            (double)val * alpha * -128.0));
+                    val = q10n::out_round<int32_t>(
+                            static_cast<float>(q10n::saturate<int32_t>(
+                                    (double)val * alpha * -128.0)));
                 } else {
                     val *= -128;
                 }
@@ -95,8 +96,8 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                 val += a[j + i * lda];
             }
             if (alpha != 1.0f) {
-                val = q10n::out_round<int32_t>(
-                        q10n::saturate<int32_t>((double)val * alpha * -128.0));
+                val = q10n::out_round<int32_t>(static_cast<float>(
+                        q10n::saturate<int32_t>((double)val * alpha * -128.0)));
             } else {
                 val *= -128;
             }

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
@@ -63,13 +63,13 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     int kerneltype = ((typea << 1) | typeb);
 
-    dim_t SHIFT_UNROLL_M = 4, SHIFT_UNROLL_N = 4, SHIFT_UNROLL_K = 2;
-    dim_t SHIFT_UNROLL_MM = 5, SHIFT_UNROLL_NN = 5, SHIFT_UNROLL_KK = 6;
-    dim_t SHIFT_A = 0, SHIFT_B = 0, SHIFT_C = 2;
+    int SHIFT_UNROLL_M = 4, SHIFT_UNROLL_N = 4, SHIFT_UNROLL_K = 2;
+    int SHIFT_UNROLL_MM = 5, SHIFT_UNROLL_NN = 5, SHIFT_UNROLL_KK = 6;
+    int SHIFT_A = 0, SHIFT_B = 0, SHIFT_C = 2;
 
-    dim_t UNROLL_M = 0, UNROLL_N = 0, UNROLL_K = 0;
-    dim_t UNROLL_MM = 0, UNROLL_NN = 0, UNROLL_KK = 0;
-    dim_t SIZE_A = 0, SIZE_B = 0, SIZE_C = 0;
+    int UNROLL_M = 0, UNROLL_N = 0, UNROLL_K = 0;
+    int UNROLL_MM = 0, UNROLL_NN = 0, UNROLL_KK = 0;
+    int SIZE_A = 0, SIZE_B = 0, SIZE_C = 0;
 
     if (typec == 0) {
         // Floatingpoint Operation
@@ -81,17 +81,17 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
         kerneltype = 4;
     }
 
-    UNROLL_M = (((dim_t)1) << SHIFT_UNROLL_M);
-    UNROLL_N = (((dim_t)1) << SHIFT_UNROLL_N);
-    UNROLL_K = (((dim_t)1) << SHIFT_UNROLL_K);
+    UNROLL_M = (1 << SHIFT_UNROLL_M);
+    UNROLL_N = (1 << SHIFT_UNROLL_N);
+    UNROLL_K = (1 << SHIFT_UNROLL_K);
 
-    UNROLL_MM = (((dim_t)1) << SHIFT_UNROLL_MM);
-    UNROLL_NN = (((dim_t)1) << SHIFT_UNROLL_NN);
-    UNROLL_KK = (((dim_t)1) << SHIFT_UNROLL_KK);
+    UNROLL_MM = (1 << SHIFT_UNROLL_MM);
+    UNROLL_NN = (1 << SHIFT_UNROLL_NN);
+    UNROLL_KK = (1 << SHIFT_UNROLL_KK);
 
-    SIZE_A = (((dim_t)1) << SHIFT_A);
-    SIZE_B = (((dim_t)1) << SHIFT_B);
-    SIZE_C = (((dim_t)1) << SHIFT_C);
+    SIZE_A = (1 << SHIFT_A);
+    SIZE_B = (1 << SHIFT_B);
+    SIZE_C = (1 << SHIFT_C);
 
     Xbyak::Label loopE, loopM, loopN, loopK;
     Xbyak::Label l0, l1, l2, l3, l4, l5, l6, l7, l8, l9, la, lb;

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -731,7 +731,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
 
     static dnnl_status_t st = dnnl_success;
     std::call_once(initialized, [&] {
-        for (dim_t N : {1, 2, 3, 4}) {
+        for (int N : {1, 2, 3, 4}) {
             for (float al : {0.0f, 1.0f, 2.0f}) {
                 for (float be : {0.0f, 1.0f, 2.0f}) {
                     auto &kern = kernels[N - 1][(dim_t)al][(dim_t)be];
@@ -761,7 +761,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
 #define MROW_ALIGN 1
 #define MINROWS 16 // Min rows each thread should process
 
-static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
+static int smalln_set_num_threads(dim_t m, dim_t k, int nthr_to_use) {
     /**
      * Simple heuristics for determining num threads to use
      */
@@ -773,7 +773,7 @@ static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
     if ((m & 15) == 0) { // Special handling if m is multiple of 16
         // nthr_16: number of threads such that each thread works on
         // 2^n * 16 number of rows.
-        nthr_16 = m >> 4;
+        nthr_16 = static_cast<int>(m >> 4);
         while (nthr_16 > nthr_to_use && (nthr_16 & 1) == 0)
             nthr_16 = nthr_16 >> 1;
         // Ideal number of threads is more than what we can use.

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -1445,7 +1445,7 @@ struct xbyak_gemm_t : public jit_generator_t {
                             = AO1 + (ld_step + section * 4 - OFFSET) * SIZE;
                     for (int off = 0; off < 4; ++off)
                         pextrd(ptr[dst_addr + unroll_m * off * SIZE],
-                                Xmm(ld_step % 2), off);
+                                Xmm(ld_step % 2), static_cast<uint8_t>(off));
                 };
 
                 el_cp(0, 0);
@@ -2127,13 +2127,14 @@ private:
     const Address ARG_A = ptr[rsp + OFFSET_SHADOWSPACE + STACKSIZE];
     const Address ARG_LDA
             = qword[rsp + OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE];
-    const int stackOffset = OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE;
+    const int stackOffset = OFFSET_SHADOWSPACE + sizeof(float *)
+            + static_cast<int>(STACKSIZE);
     const Reg64 A = rsi;
     const Reg64 LDA = rdi;
 #else
     const Reg64 ARG_A = r8;
     const Reg64 ARG_LDA = r9;
-    const int stackOffset = STACKSIZE;
+    const int stackOffset = static_cast<int>(STACKSIZE);
     const Reg64 A = ARG_A;
     const Reg64 LDA = ARG_LDA;
 #endif

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -135,7 +135,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float += (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc]) * beta);
                         c_data[i + j * ldc] += ctemp;
                     }
                 }
@@ -149,7 +150,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float -= (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc]) * beta);
                         c_data[i + j * ldc] -= ctemp;
                     }
                 }
@@ -159,7 +161,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         double c_float = alpha * (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] = alpha * ctemp;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                alpha * static_cast<float>(ctemp));
                     }
 
                 } else {
@@ -168,8 +171,11 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                                 + beta * (double)c_data[i + j * ldc];
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
-                        c_data[i + j * ldc] += alpha * ctemp;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc]) * beta);
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc])
+                                + alpha * static_cast<float>(ctemp));
                     }
                 }
             }
@@ -423,8 +429,8 @@ void gemm_kernel(dim_t m, dim_t n, const dim_t k, const float alpha,
     c_type *row_offset = row_offset_ws ? row_offset_ws : row_offset_stk;
 
     if (is_int8) {
-        c_type ao = arg->ao;
-        c_type bo = arg->bo;
+        c_type ao = static_cast<c_type>(arg->ao);
+        c_type bo = static_cast<c_type>(arg->bo);
         c_type co_0 = offsetc == offset_type::none ? 0 : co[0];
 
         if (bo != 0 || offsetc == offset_type::column) col_req = true;
@@ -952,7 +958,9 @@ static inline bool nocopy_checker_avx2(const int nthr, const int transa,
     static const double FORCE_NOCOPY_THRESH = 0.0038;
 
     // Crude threshold to nocopy kernels if copy overhead is significant.
-    if (1.0 / m + 1.0 / n >= FORCE_NOCOPY_THRESH) { return true; }
+    if (1.0 / (double)m + 1.0 / (double)n >= FORCE_NOCOPY_THRESH) {
+        return true;
+    }
 
     const dim_t LIMIT = 378;
     if (m <= LIMIT && n <= LIMIT && k >= nthr * LIMIT) return false;
@@ -1008,7 +1016,7 @@ static inline bool nocopy_checker_avx512(int nthr, const int transa,
         return false;
 
     // Crude threshold for nocopy kernels if copy overhead is significant.
-    if (1.0 / m + 1.0 / n >= FORCE_NOCOPY_THRESH
+    if (1.0 / (double)m + 1.0 / (double)n >= FORCE_NOCOPY_THRESH
             && !(is_lda_verybad && is_NT)) {
         return true;
     }
@@ -1281,11 +1289,11 @@ static inline void set_thread_opts_pack(int nthrs,
         block_z = utils::rnd_up(block_z, block_align);
         thread_z = num_blk * block_z;
         if (thread_z * nthr_z > size_z)
-            nthr_z = utils::div_up(size_z, thread_z);
+            nthr_z = static_cast<int>(utils::div_up(size_z, thread_z));
     };
 
     auto choose_m_blocking = [&]() {
-        auto align = get_vector_length<c_type>();
+        dim_t align = get_vector_length<c_type>();
         align = do_m_blocking_only ? arg->um : align;
         choose_blocking(m, thread_m, nthr_m, arg->bm, block_m, align);
     };
@@ -1623,9 +1631,9 @@ static inline void adjust_thread_count(dim_t m, dim_t n, dim_t k, int *nthrs) {
     if (is_only_avx2)
         if (m > 10 * n && n < *nthrs)
             if (m / *nthrs < veclen * 3)
-                *nthrs = nstl::max(m / veclen / 3, dim_t(1));
+                *nthrs = static_cast<int>(nstl::max(m / veclen / 3, dim_t(1)));
 
-    double gemm_cycles = m * n * k / fp_per_cycle;
+    double gemm_cycles = (double)(m * n * k) / fp_per_cycle;
     gemm_cycles *= is_f32 ? 2.0 : 8.0;
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -378,7 +378,7 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
     }
 
     // Note: um is fixed for a given set of data types and ISA.
-    const int um = this->um;
+    const int um = static_cast<int>(this->um);
 
     static std::once_flag initialized;
     static std::atomic<dnnl_status_t> st(dnnl_success);

--- a/src/cpu/x64/gemm/gemv_driver.cpp
+++ b/src/cpu/x64/gemm/gemv_driver.cpp
@@ -404,8 +404,8 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
     // Quick return if possible.
     if (m <= 0 || n <= 0) return;
 
-    dim_t nthr_max = dnnl_get_current_num_threads();
-    dim_t nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
+    int nthr_max = dnnl_get_current_num_threads();
+    int nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
 
     if (nthr_goal == 1) {
         gemv_kernel_driver(
@@ -425,10 +425,11 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
 
     // Always use the maximum number of threads to avoid OMP overhead that can
     // occur due to change thread counts.
-    auto nthr_spawn = dnnl_thr_syncable() ? nthr_max : nthr_goal;
+    const int nthr_spawn
+            = static_cast<int>(dnnl_thr_syncable() ? nthr_max : nthr_goal);
     int nbufs_used = 0;
     parallel(nthr_spawn, [&](int ithr, int nthr) {
-        int nthr_eff = nstl::min(nthr_goal, static_cast<dim_t>(nthr));
+        int nthr_eff = nstl::min(nthr_goal, nthr);
 
         dim_t thread_m = m, off_m = 0;
         dim_t thread_n = n, off_n = 0;

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -14,7 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <cstdlib>
 #include <functional>
 
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
@@ -50,9 +49,9 @@ struct jit_pp_ker_t : pp_ker_t, public jit_generator_t {
 
 private:
     void apply_postops(
-            const Xbyak::Reg64 &reg_dst, const int idx, const size_t offset);
+            const Xbyak::Reg64 &reg_dst, const int idx, const dim_t offset);
     void generate() override;
-    void append_zp_src_comp(size_t offset, int idx, bool apply_mask);
+    void append_zp_src_comp(dim_t offset, int idx, bool apply_mask);
     void load_as_f32(const Xbyak::Zmm &dst, const Xbyak::Opmask &mask,
             const Xbyak::Address &src_addr, const data_type_t &src_dt);
 
@@ -74,14 +73,14 @@ private:
         float dst_scale;
         float sum_scale;
         float signed_scale;
-        size_t len;
-        size_t oc_offset;
+        dim_t len;
+        dim_t oc_offset;
         const int32_t *zp_src;
         const int32_t *zp_dst;
         const int32_t *zp_src_comp;
         const int32_t *zp_src_pad_comp;
-        size_t g_oc_offset_prologue;
-        size_t g_oc_offset;
+        dim_t g_oc_offset_prologue;
+        dim_t g_oc_offset;
         const void *post_ops_binary_rhs_arg_vec;
         const void *dst_orig;
         dim_t h;
@@ -95,9 +94,9 @@ private:
     std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
             postops_injector_;
 
-    size_t number_of_reserved_zmm_regs_;
-    const size_t bias_data_type_size_;
-    const size_t dst_data_type_size_;
+    int number_of_reserved_zmm_regs_;
+    const dim_t bias_data_type_size_;
+    const dim_t dst_data_type_size_;
     const bool saturation_needed_;
 
     const Xbyak::Reg64 &reg_param_ = rdi;
@@ -130,11 +129,11 @@ private:
     const Xbyak::Opmask &kreg_rem_mask_short_ = k3;
     const Xbyak::Opmask &kreg_rem_mask_vlen_ = k4;
 
-    static constexpr size_t def_unroll_ = 4u;
-    size_t zmm_step_;
-    const size_t bias_step_factor_;
-    const size_t sum_step_factor_;
-    const size_t max_unroll_;
+    static constexpr int def_unroll_ = 4;
+    int zmm_step_;
+    const int bias_step_factor_;
+    const int sum_step_factor_;
+    const int max_unroll_;
 
     std::unique_ptr<jit_gemm_x8s8s32x_zp_pad_comp_helper_t> zp_pad_comp_helper_;
 };
@@ -214,27 +213,29 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
 
     char *dst = (char *)void_dst;
 
+    const dim_t start_dim = static_cast<dim_t>(start);
+    const dim_t end_dim = static_cast<dim_t>(end);
     ker_args_t args;
-    const auto dv = std::div(start, jcp_.oc);
-    const size_t oc_offset = dv.rem;
-    const size_t os_offset = dv.quot;
-    args.acc = acc + start;
+    const dim_t oc_offset = start_dim % jcp_.oc;
+    const dim_t os_offset = start_dim / jcp_.oc;
+    const dim_t dst_os_stride = jcp_.dst_os_stride;
+    const dim_t scale_idx_mult = jcp_.scale_idx_mult;
+    args.acc = acc + start_dim;
     args.dst = dst
-            + (os_offset * jcp_.dst_os_stride + oc_offset)
-                    * dst_data_type_size_;
+            + (os_offset * dst_os_stride + oc_offset) * dst_data_type_size_;
 
-    const ptrdiff_t g_oc_offset = g * jcp_.oc;
-    const ptrdiff_t g_oc_offset_prologue = g_oc_offset + oc_offset;
+    const dim_t g_oc_offset = g * jcp_.oc;
+    const dim_t g_oc_offset_prologue = g_oc_offset + oc_offset;
     args.bias = bias + g_oc_offset_prologue * bias_data_type_size_;
     args.zp_src = zp.src + (jcp_.zp.src_is_common ? 0 : g_oc_offset_prologue);
     args.zp_src_comp
             = zp.src_comp ? zp.src_comp + g_oc_offset_prologue : nullptr;
     args.zp_dst = zp.dst;
-    args.scales = scales + jcp_.scale_idx_mult * g_oc_offset_prologue;
+    args.scales = scales + scale_idx_mult * g_oc_offset_prologue;
     args.dst_scale = dst_scale;
     args.sum_scale = sum_scale;
     args.signed_scale = signed_scale;
-    args.len = end - start;
+    args.len = end_dim - start_dim;
     args.oc_offset = oc_offset;
 
     args.g_oc_offset = g_oc_offset;
@@ -244,10 +245,8 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
     args.dst_orig = dst_orig;
 
     if (zp_pad_comp_helper_) {
-        const auto hw
-                = std::div(static_cast<dim_t>(os_offset), chunk_desc.w_size_);
-        args.h = hw.quot + chunk_desc.h_off_;
-        args.w = hw.rem + chunk_desc.w_off_;
+        args.h = os_offset / chunk_desc.w_size_ + chunk_desc.h_off_;
+        args.w = os_offset % chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_size = chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_off = chunk_desc.w_off_;
         args.zp_src_pad_comp = zp.src_pad_comp;
@@ -291,10 +290,11 @@ Xbyak::Zmm jit_pp_ker_t::get_masked_vreg_dst(int idx, bool apply_mask) const {
     return vreg_dst;
 }
 
-void jit_pp_ker_t::append_zp_src_comp(size_t offset, int idx, bool apply_mask) {
+void jit_pp_ker_t::append_zp_src_comp(dim_t offset, int idx, bool apply_mask) {
     const auto vreg_dst_masked = get_masked_vreg_dst(idx, apply_mask);
     const auto vreg_dst = get_vreg_dst(idx);
-    const auto zp_src_comp_offset = offset * sizeof(int32_t);
+    const dim_t zp_src_comp_offset
+            = offset * static_cast<dim_t>(sizeof(int32_t));
     const auto zp_src_comp_addr = ptr[reg_zp_src_comp_ + zp_src_comp_offset];
 
     vpaddd(vreg_dst_masked, vreg_dst, zp_src_comp_addr);
@@ -308,7 +308,7 @@ void jit_pp_ker_t::append_zp_src_comp(size_t offset, int idx, bool apply_mask) {
 }
 
 void jit_pp_ker_t::apply_postops(
-        const Xbyak::Reg64 &reg_dst, const int idx, const size_t offset) {
+        const Xbyak::Reg64 &reg_dst, const int idx, const dim_t offset) {
 #define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
@@ -316,8 +316,8 @@ void jit_pp_ker_t::apply_postops(
             const auto vmm_idx = vreg_dst_idx(idx);
 
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_dst);
-            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(vmm_idx,
-                    offset * types::data_type_size(jcp_.dst_data_type));
+            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
+                    vmm_idx, offset * dst_data_type_size_);
             rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
 
             postops_injector_->compute_vector(
@@ -350,8 +350,10 @@ void jit_pp_ker_t::generate() {
     using namespace Xbyak;
     using namespace utils;
 
-    size_t vlen = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
+    dim_t vlen = cpu_isa_traits_t<avx512_core>::vlen
+            / static_cast<dim_t>(sizeof(float));
     for (; vlen >= 1 && (jcp_.oc % vlen != 0); --vlen) {}
+    const dim_t dst_os_stride = jcp_.dst_os_stride;
 
     preamble();
 
@@ -393,7 +395,9 @@ void jit_pp_ker_t::generate() {
 #undef PARAM_OFF
 
     mov(reg_rem_mask_vlen_, 1);
-    shl(reg_rem_mask_vlen_, vlen);
+    // vlen is a SIMD-width-bounded shift count (<= 16 elements), so this
+    // narrowing is provably safe regardless of vlen's declared (dim_t) type.
+    shl(reg_rem_mask_vlen_, static_cast<int>(vlen));
     sub(reg_rem_mask_vlen_, 1);
     kmovq(kreg_rem_mask_vlen_, reg_rem_mask_vlen_);
 
@@ -405,15 +409,17 @@ void jit_pp_ker_t::generate() {
     // Load accumulated value, convert to float, apply sum (if any),
     // bias (if any), scaling, and relu (if any);
     // then convert to destination type and store
-    const auto compute = [&](size_t offset, int idx, bool apply_mask) {
-        auto acc_addr = ptr[reg_acc_ + offset * sizeof(acc_data_t)];
+    const auto compute = [&](dim_t offset, int idx, bool apply_mask) {
+        auto acc_addr = ptr[reg_acc_
+                + offset * static_cast<dim_t>(sizeof(acc_data_t))];
 
         const auto &mask_reg
                 = apply_mask ? kreg_rem_mask_short_ : kreg_rem_mask_vlen_;
 
         if (jcp_.scale_idx_mult > 0) {
             assert(jcp_.scale_idx_mult == 1);
-            const auto scale_addr = ptr[reg_scales_ + offset * sizeof(float)];
+            const auto scale_addr = ptr[reg_scales_
+                    + offset * static_cast<dim_t>(sizeof(float))];
             auto vreg_scale = vreg_scale_;
             vreg_scale = vreg_scale | mask_reg;
             vmovups(vreg_scale, scale_addr);
@@ -478,21 +484,22 @@ void jit_pp_ker_t::generate() {
 
     // Advance all pointers by an immediate
     const auto advance_ptrs_imm
-            = [&](const size_t offset, const size_t binary_offset) {
+            = [&](const dim_t offset, const dim_t binary_offset) {
         add(reg_dst_, offset * dst_data_type_size_);
-        add(reg_acc_, offset * sizeof(acc_data_t));
+        add(reg_acc_, offset * static_cast<dim_t>(sizeof(acc_data_t)));
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            add(reg_scales_, offset * sizeof(float));
+            add(reg_scales_, offset * static_cast<dim_t>(sizeof(float)));
         }
         if (jcp_.with_bias) add(reg_bias_, offset * bias_data_type_size_);
         if (jcp_.zp.src_exists) {
-            add(reg_zp_src_comp_, offset * sizeof(int32_t));
+            add(reg_zp_src_comp_, offset * static_cast<dim_t>(sizeof(int32_t)));
 
             if (zp_pad_comp_helper_) {
                 zp_pad_comp_helper_->zp_src_comp_pad_operation(
                         [&](const Xbyak::Reg64 &reg_zp_pad_comp) {
-                    add(reg_zp_pad_comp, offset * sizeof(int32_t));
+                    add(reg_zp_pad_comp,
+                            offset * static_cast<dim_t>(sizeof(int32_t)));
                 });
             }
         }
@@ -501,24 +508,34 @@ void jit_pp_ker_t::generate() {
     // Advance all pointers by a value stored in a register
     const auto advance_ptrs_reg
             = [&](const Reg64 offset, const Reg64 binary_offset) {
-        lea(reg_dst_, ptr[reg_dst_ + offset * dst_data_type_size_]);
-        lea(reg_acc_, ptr[reg_acc_ + offset * sizeof(acc_data_t)]);
+        lea(reg_dst_,
+                ptr[reg_dst_ + offset * static_cast<int>(dst_data_type_size_)]);
+        lea(reg_acc_,
+                ptr[reg_acc_ + offset * static_cast<int>(sizeof(acc_data_t))]);
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            lea(reg_scales_, ptr[reg_scales_ + offset * sizeof(float)]);
+            lea(reg_scales_,
+                    ptr[reg_scales_
+                            + offset * static_cast<int>(sizeof(float))]);
         }
         if (jcp_.with_bias)
-            lea(reg_bias_, ptr[reg_bias_ + offset * bias_data_type_size_]);
+            lea(reg_bias_,
+                    ptr[reg_bias_
+                            + offset * static_cast<int>(bias_data_type_size_)]);
 
         if (jcp_.zp.src_exists) {
             lea(reg_zp_src_comp_,
-                    ptr[reg_zp_src_comp_ + offset * sizeof(int32_t)]);
+                    ptr[reg_zp_src_comp_
+                            + offset * static_cast<int>(sizeof(int32_t))]);
 
             if (zp_pad_comp_helper_)
                 zp_pad_comp_helper_->zp_src_comp_pad_operation(
                         [&](const Xbyak::Reg64 &reg_zp_pad_comp) {
                     lea(reg_zp_pad_comp,
-                            ptr[reg_zp_pad_comp + offset * sizeof(int32_t)]);
+                            ptr[reg_zp_pad_comp
+                                    + offset
+                                            * static_cast<int>(
+                                                    sizeof(int32_t))]);
                 });
         }
     };
@@ -528,16 +545,16 @@ void jit_pp_ker_t::generate() {
     const auto rewind_ptrs = [&]() {
         if (jcp_.with_bias) sub(reg_bias_, jcp_.oc * bias_data_type_size_);
         if (jcp_.zp.src_exists) {
-            const auto offset = jcp_.oc * sizeof(int32_t);
+            const dim_t offset = jcp_.oc * static_cast<dim_t>(sizeof(int32_t));
             sub(reg_zp_src_comp_, offset);
             if (zp_pad_comp_helper_)
                 zp_pad_comp_helper_->load_next_point_zp_src_comp_pad_addr();
         }
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            sub(reg_scales_, jcp_.oc * sizeof(float));
+            sub(reg_scales_, jcp_.oc * static_cast<dim_t>(sizeof(float)));
         }
-        add(reg_dst_, (jcp_.dst_os_stride - jcp_.oc) * dst_data_type_size_);
+        add(reg_dst_, (dst_os_stride - jcp_.oc) * dst_data_type_size_);
     };
 
     //                    <--------- OC --------------->
@@ -601,8 +618,8 @@ void jit_pp_ker_t::generate() {
         Label main_loop;
         L(main_loop);
         {
-            size_t OC_loop, OC_tail;
-            if (static_cast<size_t>(jcp_.oc) < max_unroll_ * vlen) {
+            dim_t OC_loop, OC_tail;
+            if (jcp_.oc < max_unroll_ * vlen) {
                 // Fully unroll small loops
                 OC_loop = 0;
                 OC_tail = jcp_.oc;
@@ -613,9 +630,9 @@ void jit_pp_ker_t::generate() {
 
             assert(!!OC_loop || !!OC_tail);
 
-            const int vlen_tail = OC_tail % vlen;
+            const dim_t vlen_tail = OC_tail % vlen;
             if (vlen_tail) {
-                unsigned tail_mask = (1 << vlen_tail) - 1;
+                const uint32_t tail_mask = (uint32_t(1) << vlen_tail) - 1;
                 mov(reg_tmp_, tail_mask);
                 kmovq(kreg_rem_mask_short_, reg_tmp_);
             }
@@ -625,8 +642,8 @@ void jit_pp_ker_t::generate() {
                 Label oc_loop;
                 L(oc_loop);
                 {
-                    for (size_t offset = 0; offset < OC_loop; offset += vlen)
-                        compute(offset, offset / vlen, false);
+                    for (dim_t offset = 0; offset < OC_loop; offset += vlen)
+                        compute(offset, static_cast<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop, vlen);
                     sub(reg_tmp_, OC_loop);
                     jnz(oc_loop);
@@ -634,12 +651,12 @@ void jit_pp_ker_t::generate() {
             }
 
             if (OC_tail) {
-                for (size_t offset = 0; offset < OC_tail; offset += vlen) {
+                for (dim_t offset = 0; offset < OC_tail; offset += vlen) {
                     bool use_mask = (offset + vlen) > OC_tail;
-                    compute(offset, offset / vlen, use_mask);
+                    compute(offset, static_cast<int>(offset / vlen), use_mask);
                 }
-                const size_t oc_tail_rem = OC_tail % vlen;
-                const size_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
+                const dim_t oc_tail_rem = OC_tail % vlen;
+                const dim_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
                 advance_ptrs_imm(OC_tail, binary_offset);
             }
 


### PR DESCRIPTION
Widens loop bounds, offsets, and block-size fields in the x64 GEMM kernels/drivers (`ref_gemm_s8x8s32`, `simple_gemm_s8s8s32`, `jit_avx512_core_amx_gemm_kern`, `jit_avx512_core_gemm_smalln_tn_f32_kern`, `jit_avx_gemm_f32`, `gemm_driver`, `gemm_info`, `gemm_utils`, `gemv_driver`, `jit_gemm_x8s8s32x_convolution_utils`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5670 for review convenience; independently reviewable.