### PR TITLE
x64: xf16/fp8 conversion kernels: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -46,16 +46,16 @@ void fp8_conversion_e5m2_t::prepare_table() {
             case 2: index = i + 1; break;
             case 3: index = i - 2; break;
         }
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
     // Data for bf16
     for (size_t i = 0; i < 32; ++i) {
         size_t index = 4 * (i / 2) + (i % 2);
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
     for (size_t i = 32; i < 64; ++i) {
         size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
 
     // Other tables are not needed if fp8 is native
@@ -87,11 +87,11 @@ void fp8_conversion_e4m3_t::prepare_table() {
     host_->L(label_vnni_permute_index_table_);
     for (size_t i = 0; i < 32; ++i) {
         size_t index = 4 * (i / 2) + (i % 2);
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
     for (size_t i = 32; i < 64; ++i) {
         size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
 
     host_->L(label_table_from_f8_);

--- a/src/cpu/x64/jit_uni_convert_xf16.cpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.cpp
@@ -72,29 +72,31 @@ void jit_uni_cvt_ps_to_xf16_t<isa>::generate() {
 
         L(l_simd_notail);
     } else {
-        const size_t blocked_size = (nelems_ / simd_w_) * simd_w_;
-        constexpr size_t unroll_length = 1024;
-        const size_t number_of_loops = blocked_size / unroll_length;
-        const size_t loop_tail = blocked_size % unroll_length;
+        constexpr dim_t simd_w = simd_w_;
+        const dim_t blocked_size = (nelems_ / simd_w) * simd_w;
+        constexpr dim_t unroll_length = 1024;
+        const dim_t number_of_loops = blocked_size / unroll_length;
+        const dim_t loop_tail = blocked_size % unroll_length;
 
         if (number_of_loops > 0) {
             Xbyak::Label l_number_of_loops;
             mov(reg_nelems, number_of_loops);
             L(l_number_of_loops);
-            for (size_t i = 0; i < unroll_length; i += simd_w_)
-                cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * unroll_length);
-            add(reg_output, sizeof(float16_t) * unroll_length);
+            for (dim_t i = 0; i < unroll_length; i += simd_w)
+                cvt_ps_to_xf16(static_cast<int>(i), false);
+            add(reg_input, static_cast<dim_t>(sizeof(float)) * unroll_length);
+            add(reg_output,
+                    static_cast<dim_t>(sizeof(float16_t)) * unroll_length);
 
             dec(reg_nelems);
             cmp(reg_nelems, 0);
             jg(l_number_of_loops, T_NEAR);
         }
         if (loop_tail > 0) {
-            for (size_t i = 0; i < loop_tail; i += simd_w_)
-                cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * loop_tail);
-            add(reg_output, sizeof(float16_t) * loop_tail);
+            for (dim_t i = 0; i < loop_tail; i += simd_w)
+                cvt_ps_to_xf16(static_cast<int>(i), false);
+            add(reg_input, static_cast<dim_t>(sizeof(float)) * loop_tail);
+            add(reg_output, static_cast<dim_t>(sizeof(float16_t)) * loop_tail);
         }
         if (tail_size_ != 0) {
             setup_mask();

--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -18,6 +18,7 @@
 #define CPU_X64_JIT_UNI_CONVERT_XF16_HPP
 
 #include <assert.h>
+#include <limits>
 
 #include "common/c_types_map.hpp"
 #include "common/float16.hpp"
@@ -58,15 +59,15 @@ struct jit_uni_cvt_ps_to_xf16_t : public jit_generator_t {
     jit_uni_cvt_ps_to_xf16_t(impl::data_type_t dt, size_t nelems = 0)
         : jit_generator_t(jit_name())
         , output_dt_(dt)
-        , nelems_(nelems)
+        , nelems_(to_dim_t(nelems))
         , is_dynamic_size_(nelems_ == 0)
-        , tail_size_(nelems_ % simd_w_) {}
+        , tail_size_(static_cast<int>(nelems_ % simd_w_)) {}
 
     void generate() override;
 
 protected:
     const impl::data_type_t output_dt_; // bf16 or f16
-    const size_t nelems_;
+    const dim_t nelems_;
     const bool is_dynamic_size_;
     const int tail_size_;
 
@@ -95,6 +96,13 @@ protected:
     Xbyak::Reg64 reg_tail = rcx;
     Xbyak::Reg64 reg_tmp = r8;
     Xbyak::Reg64 reg_scratch = r9;
+
+    static dim_t to_dim_t(size_t nelems) {
+        JIT_ASSERT_RET(nelems <= static_cast<size_t>(
+                               std::numeric_limits<dim_t>::max()),
+                0);
+        return static_cast<dim_t>(nelems);
+    }
 
     void setup_mask();
     virtual void cvt_ps_to_xf16(const int idx, const bool is_tail);


### PR DESCRIPTION
Widens loop bounds/offsets in the xf16 and fp8 conversion JIT kernels (`jit_avx512_core_fp8cvt`, `jit_uni_convert_xf16`) to `dim_t`, eliminating implicit narrowing conversions.

Stacked on #5672 for review convenience; independently reviewable.